### PR TITLE
Disable pypi nightly build on macos-13 due to build error

### DIFF
--- a/.github/workflows/release_pypi_macos.yml
+++ b/.github/workflows/release_pypi_macos.yml
@@ -25,7 +25,7 @@ jobs:
     name: Build and Release Python Wheel for MacOS
     strategy:
       matrix:
-        runner: [macos-latest, macos-13]
+        runner: [macos-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.runner }}
 


### PR DESCRIPTION
There was a build error "clang: error: unknown argument: '-mavxvnniint8'" when building latest TF codes on macos-13.

https://github.com/google-ai-edge/LiteRT/actions/runs/11015482791/job/30588762709

We will re-enable macos-13 build once we fix this error later.