### PR TITLE
Qualcomm AI Engine Direct - Enable BroadcastTo OP

### DIFF
--- a/litert/test/testdata/simple_broadcast_to_op_boolean.mlir
+++ b/litert/test/testdata/simple_broadcast_to_op_boolean.mlir
@@ -1,0 +1,6 @@
+module {
+  func.func @main(%arg0: tensor<1x1x1x196xi1>, %arg1: tensor<4xi64>) -> tensor<1x1x196x196xi1> {
+    %0 = "tfl.broadcast_to"(%arg0, %arg1) : (tensor<1x1x1x196xi1>, tensor<4xi64>) -> tensor<1x1x196x196xi1>
+    return %0 : tensor<1x1x196x196xi1>
+  }
+}

--- a/litert/test/testdata/simple_broadcast_to_op_fp32.mlir
+++ b/litert/test/testdata/simple_broadcast_to_op_fp32.mlir
@@ -1,0 +1,6 @@
+module {
+  func.func @main(%arg0: tensor<1x1x1x196xf32>, %arg1: tensor<4xi64>) -> tensor<1x1x196x196xf32> {
+    %0 = "tfl.broadcast_to"(%arg0, %arg1) : (tensor<1x1x1x196xf32>, tensor<4xi64>) -> tensor<1x1x196x196xf32>
+    return %0 : tensor<1x1x196x196xf32>
+  }
+}

--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 load("//litert/build_common:litert_build_defs.bzl", "litert_dynamic_lib", "litert_lib", "litert_test")
 
@@ -155,6 +158,7 @@ litert_lib(
         "//litert/vendors/qualcomm/core/builders:quantize_op_builder",
         "//litert/vendors/qualcomm/core/builders:reduce_op_builder",
         "//litert/vendors/qualcomm/core/builders:relu6_op_builder",
+        "//litert/vendors/qualcomm/core/builders:broadcast_to_op_builder",
         "//litert/vendors/qualcomm/core/builders:relu_op_builder",
         "//litert/vendors/qualcomm/core/builders:reshape_op_builder",
         "//litert/vendors/qualcomm/core/builders:resize_op_builder",

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -39,6 +39,7 @@
 #include "litert/tools/dump.h"
 #include "litert/vendors/qualcomm/common.h"
 #include "litert/vendors/qualcomm/compiler/graph_mapper.h"
+#include "litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/cast_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/concatenation_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/conv2d_op_builder.h"
@@ -292,6 +293,11 @@ LiteRtStatus ConvertOp(
     case LiteRtOpCode::kLiteRtOpCodeTflLogicalAnd: {
       op_wrappers = ::qnn::BuildElementwiseAndOp(tensor_pool, input_tensors,
                                                  output_tensors);
+      break;
+    }
+    case LiteRtOpCode::kLiteRtOpCodeTflBroadcastTo: {
+      op_wrappers =
+          ::qnn::BuildBroadcastToOp(tensor_pool, input_tensors, output_tensors);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflCos: {

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -200,6 +200,23 @@ cc_library(
 )
 
 cc_library(
+    name = "broadcast_to_op_builder",
+    srcs = ["broadcast_to_op_builder.cc"],
+    hdrs = ["broadcast_to_op_builder.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        ":op_builder",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        # copybara:uncomment "//third_party/qairt/latest:qnn_lib_headers",
+    ],
+)
+
+cc_library(
     name = "matmul_op_builder",
     srcs = ["matmul_op_builder.cc"],
     hdrs = ["matmul_op_builder.h"],

--- a/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.cc
@@ -1,0 +1,144 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.h"
+
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "third_party/qairt/latest/include/QNN/QnnOpDef.h"
+
+namespace qnn {
+namespace {
+std::vector<std::uint32_t> GetStaticTensorDimention(
+    const std::vector<std::uint32_t>& input_dimensions,
+    const std::vector<std::uint32_t>& output_dimensions) {
+  std::uint32_t input_size = input_dimensions.size();
+  std::uint32_t output_size = output_dimensions.size();
+  std::vector<std::uint32_t> final_dimensions;
+
+  if (input_size < output_size) {
+    int padding_size = output_size - input_size;
+    final_dimensions = std::vector<std::uint32_t>(padding_size, 1);
+    final_dimensions.insert(final_dimensions.end(), input_dimensions.begin(),
+                            input_dimensions.end());
+  } else {
+    final_dimensions = input_dimensions;
+  }
+
+  for (std::size_t i = 0; i < output_size; ++i) {
+    final_dimensions[i] =
+        (output_dimensions[i] > final_dimensions[i]) ? output_dimensions[i] : 1;
+  }
+
+  return final_dimensions;
+}
+
+template <typename T>
+TensorWrapper& CreateStaticTensor(TensorPool& tensor_pool,
+                                  const Qnn_DataType_t data_type,
+                                  TensorWrapper& input, TensorWrapper& output,
+                                  bool is_quant) {
+  std::vector<std::uint32_t> static_dims =
+      GetStaticTensorDimention(input.GetDims(), output.GetDims());
+  std::uint32_t static_size =
+      std::accumulate(static_dims.begin(), static_dims.end(), 1,
+                      std::multiplies<std::uint32_t>());
+
+  T static_value{0};
+  QuantizeParamsWrapperVariant quant_param{};
+  if (is_quant) {
+    auto input_quant_param =
+        std::get<ScaleOffsetQuantizeParamsWrapper>(input.GetQuantParams());
+    quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(input_quant_param);
+    static_value = -input_quant_param.GetZeroPoint();
+  }
+  std::vector<T> static_data(static_size, static_value);
+
+  return tensor_pool.CreateStaticTensor(data_type, quant_param, static_dims,
+                                        sizeof(T) * static_size,
+                                        static_data.data());
+}
+}  // namespace
+
+std::vector<OpWrapper> BuildBroadcastToOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  // TODO: handle per-channel case
+  if (std::holds_alternative<AxisScaleOffsetQuantizeParamsWrapper>(
+          inputs[0].get().GetQuantParams())) {
+    return res;
+  }
+
+  const char* qnn_op = nullptr;
+  if (inputs[0].get().GetDataType() == QNN_DATATYPE_BOOL_8) {
+    qnn_op = QNN_OP_ELEMENT_WISE_OR;
+  } else {
+    qnn_op = QNN_OP_ELEMENT_WISE_ADD;
+  }
+
+  auto& broadcast_op = CreateOpWrapper(res, qnn_op);
+  broadcast_op.AddInputTensor(inputs[0]);
+
+  switch (inputs[0].get().GetDataType()) {
+    case QNN_DATATYPE_BOOL_8: {
+      TensorWrapper& static_tensor = CreateStaticTensor<std::uint8_t>(
+          tensor_pool, inputs[0].get().GetDataType(), inputs[0], outputs[0],
+          false);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    case QNN_DATATYPE_UFIXED_POINT_8: {
+      TensorWrapper& static_tensor = CreateStaticTensor<std::uint8_t>(
+          tensor_pool, inputs[0].get().GetDataType(), inputs[0], outputs[0],
+          true);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    case QNN_DATATYPE_SFIXED_POINT_8: {
+      TensorWrapper& static_tensor = CreateStaticTensor<std::int8_t>(
+          tensor_pool, inputs[0].get().GetDataType(), inputs[0], outputs[0],
+          true);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    case QNN_DATATYPE_UFIXED_POINT_16: {
+      TensorWrapper& static_tensor = CreateStaticTensor<std::uint16_t>(
+          tensor_pool, inputs[0].get().GetDataType(), inputs[0], outputs[0],
+          true);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    case QNN_DATATYPE_SFIXED_POINT_16: {
+      TensorWrapper& static_tensor = CreateStaticTensor<std::int16_t>(
+          tensor_pool, inputs[0].get().GetDataType(), inputs[0], outputs[0],
+          true);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    case QNN_DATATYPE_FLOAT_32: {
+      TensorWrapper& static_tensor =
+          CreateStaticTensor<float>(tensor_pool, inputs[0].get().GetDataType(),
+                                    inputs[0], outputs[0], false);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    default: {
+      QNN_LOG_ERROR("Unsupported QNN data type when creating static tensor");
+      break;
+    }
+  }
+
+  broadcast_op.AddOutputTensor(outputs[0]);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.h
@@ -1,0 +1,20 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_BROADCAST_TO_OP_BUILDER_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_BROADCAST_TO_OP_BUILDER_H_
+
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+std::vector<OpWrapper> BuildBroadcastToOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_BROADCAST_TO_OP_BUILDER_H_


### PR DESCRIPTION
Summary:
- Enable op builder for broadcast to op
- Add 2 mlir model for different data type