### PR TITLE
Qualcomm AI Engine Direct - Enable QNN profiler in LiteRt

### DIFF
--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -9,14 +9,20 @@
 extern "C" {
 #endif  // __cplusplus
 
+typedef enum LiteRtQnnProfilingOptions {  // NOLINT(modernize-use-using)
+  kQnnProfilingOff = 0,
+  kQnnProfilingBasic = 1,
+  kQnnProfilingDetailed = 2
+} LiteRtQnnProfilingOptions;
+
 typedef enum LiteRtQnnLogLevel {  // NOLINT(modernize-use-using)
   /// Disable delegate and QNN backend logging messages.
-  kLogOff = 0,
-  kLogLevelError = 1,
-  kLogLevelWarn = 2,
-  kLogLevelInfo = 3,
-  kLogLevelVerbose = 4,
-  kLogLevelDebug = 5,
+  kQnnLogOff = 0,
+  kQnnLogLevelError = 1,
+  kQnnLogLevelWarn = 2,
+  kQnnLogLevelInfo = 3,
+  kQnnLogLevelVerbose = 4,
+  kQnnLogLevelDebug = 5,
 } LiteRtQnnLogLevel;
 
 typedef struct {  // NOLINT(modernize-use-using)

--- a/litert/vendors/qualcomm/core/utils/log.h
+++ b/litert/vendors/qualcomm/core/utils/log.h
@@ -30,27 +30,28 @@ class QNNLogger {
 }  // namespace qnn
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define QNN_LOG_VERBOSE(format, ...)                                  \
-  ::qnn::QNNLogger::Log(kLogLevelVerbose, ("VERBOSE: [Qnn] " format), \
+#define QNN_LOG_VERBOSE(format, ...)                                     \
+  ::qnn::QNNLogger::Log(kQnnLogLevelVerbose, ("VERBOSE: [Qnn] " format), \
                         ##__VA_ARGS__);
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define QNN_LOG_INFO(format, ...) \
-  ::qnn::QNNLogger::Log(kLogLevelInfo, ("INFO: [Qnn] " format), ##__VA_ARGS__);
-
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define QNN_LOG_WARNING(format, ...)                               \
-  ::qnn::QNNLogger::Log(kLogLevelWarn, ("WARNING: [Qnn] " format), \
+#define QNN_LOG_INFO(format, ...)                                  \
+  ::qnn::QNNLogger::Log(kQnnLogLevelInfo, ("INFO: [Qnn] " format), \
                         ##__VA_ARGS__);
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define QNN_LOG_ERROR(format, ...)                                \
-  ::qnn::QNNLogger::Log(kLogLevelError, ("ERROR: [Qnn] " format), \
+#define QNN_LOG_WARNING(format, ...)                                  \
+  ::qnn::QNNLogger::Log(kQnnLogLevelWarn, ("WARNING: [Qnn] " format), \
                         ##__VA_ARGS__);
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define QNN_LOG_DEBUG(format, ...)                                \
-  ::qnn::QNNLogger::Log(kLogLevelDebug, ("DEBUG: [Qnn] " format), \
+#define QNN_LOG_ERROR(format, ...)                                   \
+  ::qnn::QNNLogger::Log(kQnnLogLevelError, ("ERROR: [Qnn] " format), \
+                        ##__VA_ARGS__);
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define QNN_LOG_DEBUG(format, ...)                                   \
+  ::qnn::QNNLogger::Log(kQnnLogLevelDebug, ("DEBUG: [Qnn] " format), \
                         ##__VA_ARGS__);
 
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_UTILS_LOG_H_

--- a/litert/vendors/qualcomm/core/utils/log_android.cc
+++ b/litert/vendors/qualcomm/core/utils/log_android.cc
@@ -10,13 +10,13 @@ namespace {
 
 int GetPlatformSeverity(LiteRtQnnLogLevel severity) {
   switch (severity) {
-    case kLogLevelError:
+    case kQnnLogLevelError:
       return ANDROID_LOG_ERROR;
-    case kLogLevelWarn:
+    case kQnnLogLevelWarn:
       return ANDROID_LOG_WARN;
-    case kLogLevelInfo:
+    case kQnnLogLevelInfo:
       return ANDROID_LOG_INFO;
-    case kLogLevelVerbose:
+    case kQnnLogLevelVerbose:
       return ANDROID_LOG_VERBOSE;
     default:
       return ANDROID_LOG_DEBUG;
@@ -27,7 +27,7 @@ int GetPlatformSeverity(LiteRtQnnLogLevel severity) {
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 FILE* QNNLogger::log_file_pointer_ = stderr;
-LiteRtQnnLogLevel QNNLogger::log_level_ = kLogLevelInfo;
+LiteRtQnnLogLevel QNNLogger::log_level_ = kQnnLogLevelInfo;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 void QNNLogger::SetLogFilePointer(FILE* fp) { log_file_pointer_ = fp; }
 void QNNLogger::SetLogLevel(LiteRtQnnLogLevel log_level) {

--- a/litert/vendors/qualcomm/core/utils/log_default.cc
+++ b/litert/vendors/qualcomm/core/utils/log_default.cc
@@ -11,7 +11,7 @@ namespace qnn {
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 FILE* QNNLogger::log_file_pointer_ = stderr;
-LiteRtQnnLogLevel QNNLogger::log_level_ = kLogLevelInfo;
+LiteRtQnnLogLevel QNNLogger::log_level_ = kQnnLogLevelInfo;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 void QNNLogger::SetLogFilePointer(FILE* fp) { log_file_pointer_ = fp; }
 void QNNLogger::SetLogLevel(LiteRtQnnLogLevel log_level) {

--- a/litert/vendors/qualcomm/core/utils/utils_test.cc
+++ b/litert/vendors/qualcomm/core/utils/utils_test.cc
@@ -26,19 +26,19 @@ bool CheckLoggoing(const std::string log_path, LiteRtQnnLogLevel log_level) {
   while (std::getline(fin, msg)) {
     // Log severity: DEBUG > VERBOSE > INFO > WARN > ERROR
     switch (log_level) {
-      case kLogOff:
+      case kQnnLogOff:
         if (IsPrefix("ERROR:", msg)) return false;
         [[fallthrough]];
-      case kLogLevelError:
+      case kQnnLogLevelError:
         if (IsPrefix("WARNING:", msg)) return false;
         [[fallthrough]];
-      case kLogLevelWarn:
+      case kQnnLogLevelWarn:
         if (IsPrefix("INFO:", msg)) return false;
         [[fallthrough]];
-      case kLogLevelInfo:
+      case kQnnLogLevelInfo:
         if (IsPrefix("VERBOSE:", msg)) return false;
         [[fallthrough]];
-      case kLogLevelVerbose:
+      case kQnnLogLevelVerbose:
         if (IsPrefix("DEBUG:", msg)) return false;
         [[fallthrough]];
       default:
@@ -52,9 +52,10 @@ bool CheckLoggoing(const std::string log_path, LiteRtQnnLogLevel log_level) {
 
 class LiteRtLog : public ::testing::TestWithParam<LiteRtQnnLogLevel> {};
 INSTANTIATE_TEST_SUITE_P(, LiteRtLog,
-                         ::testing::Values(kLogOff, kLogLevelError,
-                                           kLogLevelWarn, kLogLevelInfo,
-                                           kLogLevelVerbose, kLogLevelDebug));
+                         ::testing::Values(kQnnLogOff, kQnnLogLevelError,
+                                           kQnnLogLevelWarn, kQnnLogLevelInfo,
+                                           kQnnLogLevelVerbose,
+                                           kQnnLogLevelDebug));
 
 TEST_P(LiteRtLog, SanityTest) {
   // Create temp file for log

--- a/litert/vendors/qualcomm/dispatch/BUILD
+++ b/litert/vendors/qualcomm/dispatch/BUILD
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 load("//litert/build_common:litert_build_defs.bzl", "litert_dynamic_lib")
 load("//litert/integration_test:litert_device.bzl", "litert_device_test")
@@ -66,6 +69,7 @@ litert_dynamic_lib(
         "//litert/core/util:tensor_type_util",
         "//litert/vendors/c:litert_dispatch_c_api",
         "//litert/vendors/qualcomm:common",
+        "//litert/vendors/qualcomm/core:common",
         "//litert/vendors/qualcomm:context_binary_info",
         "//litert/vendors/qualcomm:qnn_manager",
         "//litert/vendors/qualcomm/core/utils:miscs",

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h"
 
@@ -33,15 +36,33 @@
 #include "litert/core/util/tensor_type_util.h"
 #include "litert/vendors/c/litert_dispatch.h"
 #include "litert/vendors/qualcomm/context_binary_info.h"
+#include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/core/utils/miscs.h"
 #include "litert/vendors/qualcomm/dispatch/litert_dispatch_device_context.h"
 #include "litert/vendors/qualcomm/qnn_manager.h"
+#include "third_party/qairt/latest/include/QNN/HTP/QnnHtpProfile.h"
 #include "third_party/qairt/latest/include/QNN/QnnCommon.h"
 #include "third_party/qairt/latest/include/QNN/QnnTypes.h"
 
 using litert::Expected;
 using litert::Unexpected;
 using litert::qnn::QnnManager;
+
+std::string_view inline GetEventUnit(QnnProfile_EventUnit_t unit) {
+  switch (unit) {
+    case QNN_PROFILE_EVENTUNIT_MICROSEC:
+      return "us";
+    case QNN_PROFILE_EVENTUNIT_BYTES:
+      return "bytes";
+    case QNN_PROFILE_EVENTUNIT_CYCLES:
+      return "cycles";
+    case QNN_PROFILE_EVENTUNIT_COUNT:
+      return "count";
+    case QNN_PROFILE_EVENTUNIT_BACKEND:
+    default:
+      return "";
+  }
+}
 
 LiteRtDispatchInvocationContextT::LiteRtDispatchInvocationContextT(
     litert::qnn::QnnManager& qnn_manager,
@@ -102,7 +123,21 @@ LiteRtDispatchInvocationContextT::Create(
   }
 
   auto configs = QnnManager::DefaultContextConfigs();
+
+  // TODO: Add profiling_level as an option & related test code with different
+  // profiling level after having option interface
+  int profiling_level = LiteRtQnnProfilingOptions::kQnnProfilingOff;
+
   Qnn_ProfileHandle_t profile_handle = nullptr;
+  if (profiling_level != LiteRtQnnProfilingOptions::kQnnProfilingOff) {
+    if (auto status = qnn.Api()->profileCreate(
+            qnn.BackendHandle(), profiling_level, &profile_handle);
+        status != QNN_SUCCESS) {
+      return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                        "Failed to create profile handle");
+    }
+  }
+
   auto context_handle = qnn.CreateContextHandle(
       configs,
       absl::MakeSpan(static_cast<const uint8_t*>(exec_bytecode_ptr),
@@ -246,17 +281,23 @@ Expected<void> LiteRtDispatchInvocationContextT::Execute() {
   }
 
   if (auto status = qnn_manager_.Api()->graphExecute(
-          graph_handle_, inputs, num_ins, outputs, num_outs,
-          /*profileHandle=*/nullptr, /*signalHandle=*/nullptr);
+          graph_handle_, inputs, num_ins, outputs, num_outs, profile_handle_,
+          /*signalHandle=*/nullptr);
       status != QNN_SUCCESS) {
     return Unexpected(kLiteRtStatusErrorRuntimeFailure,
                       "Failed to execute graph");
   }
+
+  if (profile_handle_ != nullptr) {
+    LITERT_RETURN_IF_ERROR(Profile());
+  }
+
   for (int i = 0; i < outputs_.size(); ++i) {
     if (outputs_[i].IsQuantU16()) {
       ConvertToInt16(output_buffer_handles_[i], outputs_[i].GetTensorBytes());
     }
   }
+
   return {};
 }
 
@@ -303,5 +344,68 @@ Expected<void> LiteRtDispatchInvocationContextT::ConvertToInt16(
       status != kLiteRtStatusOk) {
     return Unexpected(status, "Failed to unlock the tensor buffer");
   }
+  return {};
+}
+
+Expected<void> LiteRtDispatchInvocationContextT::Profile() {
+  // TODO: Implement a viewer class to beautify the format of profiling output
+  std::stringstream data_ss;
+  data_ss << "\nExecute Stats:\n"
+          << "----------------" << std::endl;
+  const QnnProfile_EventId_t* events_ptr = nullptr;
+  const QnnProfile_EventId_t* sub_events_ptr = nullptr;
+  std::uint32_t num_events = 0;
+  std::uint32_t num_sub_events = 0;
+
+  if (auto status = qnn_manager_.Api()->profileGetEvents(
+          profile_handle_, &events_ptr, &num_events);
+      status != QNN_SUCCESS) {
+    return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                      "Failed to get the profile events");
+  }
+
+  QnnProfile_EventData_t event_data;
+  for (std::uint32_t i = 0; i < num_events; ++i) {
+    if (auto status =
+            qnn_manager_.Api()->profileGetEventData(events_ptr[i], &event_data);
+        status != QNN_SUCCESS) {
+      return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                        "Failed to get the event data from profiling result");
+    }
+    data_ss << "    " << event_data.identifier << ": " << event_data.value
+            << " " << GetEventUnit(event_data.unit) << std::endl;
+
+    // Check the sub events only related to graph execution time
+    if (event_data.type ==
+        QNN_HTP_PROFILE_EVENTTYPE_GRAPH_EXECUTE_ACCEL_TIME_CYCLE) {
+      if (auto status = qnn_manager_.Api()->profileGetSubEvents(
+              events_ptr[i], &sub_events_ptr, &num_sub_events);
+          status != QNN_SUCCESS) {
+        return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                          "Failed to get the event data from profiling result");
+      }
+
+      QnnProfile_EventData_t sub_event_data;
+      for (std::uint32_t j = 0; j < num_sub_events; ++j) {
+        if (auto status = qnn_manager_.Api()->profileGetEventData(
+                sub_events_ptr[j], &sub_event_data);
+            status != QNN_SUCCESS) {
+          return Unexpected(
+              kLiteRtStatusErrorRuntimeFailure,
+              "Failed to get the sub event data from profiling result");
+        }
+        if (sub_event_data.type == QNN_PROFILE_EVENTTYPE_NODE &&
+            (sub_event_data.unit == QNN_PROFILE_EVENTUNIT_MICROSEC ||
+             sub_event_data.unit == QNN_PROFILE_EVENTUNIT_CYCLES)) {
+          data_ss << "        " << sub_event_data.identifier << ": "
+                  << sub_event_data.value << " "
+                  << GetEventUnit(sub_event_data.unit) << std::endl;
+        }
+      }
+    }
+  }
+
+  LITERT_LOG(LITERT_INFO, "%s", data_ss.str().c_str());
+
   return {};
 }

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_DISPATCH_LITERT_DISPATCH_INVOCATION_CONTEXT_H_
 #define ODML_LITERT_LITERT_VENDORS_QUALCOMM_DISPATCH_LITERT_DISPATCH_INVOCATION_CONTEXT_H_
@@ -54,6 +57,8 @@ class LiteRtDispatchInvocationContextT {
       int graph_output_index, LiteRtTensorBufferHandle tensor_buffer_handle);
 
   litert::Expected<void> Execute();
+
+  litert::Expected<void> Profile();
 
   Qnn_ContextHandle_t ContextHandle() { return context_handle_.get(); }
 

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -371,7 +371,7 @@ Expected<QnnManager::ContextHandle> QnnManager::CreateContextHandle(
                       "Failed to create QNN context");
   }
   auto deleter = Api()->contextFree;
-  return ContextHandle{context_handle, /*profile=*/nullptr, deleter};
+  return ContextHandle{context_handle, /*profile=*/nullptr, deleter, nullptr};
 }
 
 Expected<QnnManager::ContextHandle> QnnManager::CreateContextHandle(
@@ -386,8 +386,10 @@ Expected<QnnManager::ContextHandle> QnnManager::CreateContextHandle(
     return Unexpected(kLiteRtStatusErrorRuntimeFailure,
                       "Failed to create QNN context");
   }
-  auto deleter = Api()->contextFree;
-  return ContextHandle{context_handle, profile_handle, deleter};
+  auto context_deleter = Api()->contextFree;
+  auto profile_deleter = Api()->profileFree;
+  return ContextHandle{context_handle, profile_handle, context_deleter,
+                       profile_deleter};
 }
 
 Expected<QnnManager::Ptr> QnnManager::Create(


### PR DESCRIPTION
Summary:
- Use kProfilingOff profiling_level as default for now
- Implement QNN profiler with simple format
- Can be tested with dispatch_api_qualcomm_test
- Need to add into dispatch option after header interface merged