### PR TITLE
Qualcomm AI Engine Direct - Fused Activation

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
@@ -42,6 +42,7 @@ using ::testing::Values;
 // TODO: Add support and uncomment these models.
 const auto kSupportedOps =
                   Values(
+                    "simple_conv_2d_fused_relu_op.tflite",
                     "simple_transpose_conv_op.tflite",
                     "simple_cumsum.tflite",
                     "simple_floor_div.tflite",

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
@@ -32,11 +32,11 @@ LiteRtStatus ConvertTensor(const litert::Tensor& litert_tensor,
                            ::qnn::TensorWrapper*& tensor_wrapper,
                            bool is_tensor_read_and_write = false);
 
-LiteRtStatus ConvertOp(
-    const litert::Op& litert_op, ::qnn::TensorPool& tensor_pool,
-    const std::vector<::qnn::TensorWrapperRef>& input_tensors,
-    const std::vector<::qnn::TensorWrapperRef>& output_tensors,
-    std::vector<::qnn::OpWrapper>& op_wrappers);
+LiteRtStatus ConvertOp(const litert::Op& litert_op,
+                       ::qnn::TensorPool& tensor_pool,
+                       std::vector<::qnn::TensorWrapperRef>& input_tensors,
+                       std::vector<::qnn::TensorWrapperRef>& output_tensors,
+                       std::vector<::qnn::OpWrapper>& op_wrappers);
 
 // Composes a new QNN Graph from given LiteRt Graph. Qnn Graph is written to
 // context behind "qnn". Uses given graph_name to name entry point.

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -15,6 +15,7 @@ cc_library(
         "nobuilder",
     ],
     deps = [
+        "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/utils:log",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",

--- a/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
@@ -36,8 +36,7 @@ std::vector<OpWrapper> BuildConv2dOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs, const std::uint32_t stride_h,
     const std::uint32_t stride_w, const std::uint32_t dilation_h,
-    const std::uint32_t dilation_w, const std::uint32_t fused_activation,
-    const PaddingType padding_type) {
+    const std::uint32_t dilation_w, const PaddingType padding_type) {
   std::vector<OpWrapper> res;
 
   // transpose filter
@@ -94,19 +93,6 @@ std::vector<OpWrapper> BuildConv2dOp(
     transpose_op.AddTensorParam(QNN_OP_TRANSPOSE_PARAM_PERM, permute_tensor);
   }
 
-  TensorWrapper* conv2d_output_tensor = nullptr;
-
-  // If Conv2d fused activation is available, create a new tensor for the
-  // output of Conv2d, which is also the input of the activation op.
-  if (fused_activation != FusedActivationNone) {
-    conv2d_output_tensor = &tensor_pool.CreateNativeTensor(
-        outputs[kOutputIndex].get().GetDataType(),
-        outputs[kOutputIndex].get().GetQuantParams(),
-        outputs[kOutputIndex].get().GetDims());
-  } else {
-    conv2d_output_tensor = &outputs[kOutputIndex].get();
-  }
-
   // conv
   OpWrapper& conv_op = CreateOpWrapper(res, QNN_OP_CONV_2D);
   TensorWrapper& input_tensor = inputs[kInputIndex];
@@ -120,7 +106,7 @@ std::vector<OpWrapper> BuildConv2dOp(
     conv_op.AddInputTensor(bias_tensor);
   }
 
-  conv_op.AddOutputTensor(*conv2d_output_tensor);
+  conv_op.AddOutputTensor(outputs[kOutputIndex]);
 
   // stride param
   const std::array<std::uint32_t, 2> stride_data{stride_h, stride_w};
@@ -170,12 +156,6 @@ std::vector<OpWrapper> BuildConv2dOp(
                                    filter_tensor.GetDim(kChannelIndex);
       groups > 1) {
     conv_op.AddScalarParam<std::uint32_t>(QNN_OP_CONV_2D_PARAM_GROUP, groups);
-  }
-
-  // Fused activation if available.
-  if (fused_activation != FusedActivationNone) {
-    AddFusedActivationNode(res, fused_activation, *conv2d_output_tensor,
-                           outputs[0].get());
   }
 
   return res;

--- a/litert/vendors/qualcomm/core/builders/conv2d_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/conv2d_op_builder.h
@@ -18,8 +18,7 @@ std::vector<OpWrapper> BuildConv2dOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs, const std::uint32_t stride_h,
     const std::uint32_t stride_w, const std::uint32_t dilation_h,
-    const std::uint32_t dilation_w, const std::uint32_t fused_activation,
-    const PaddingType padding_type);
+    const std::uint32_t dilation_w, const PaddingType padding_type);
 
 }  // namespace qnn
 

--- a/litert/vendors/qualcomm/core/builders/depthwise_conv2d_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/depthwise_conv2d_op_builder.h
@@ -18,8 +18,7 @@ std::vector<OpWrapper> BuildDepthwiseConv2dOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs, const std::uint32_t stride_h,
     const std::uint32_t stride_w, const std::uint32_t dilation_h,
-    const std::uint32_t dilation_w, const std::uint32_t fused_activation,
-    const PaddingType padding_type);
+    const std::uint32_t dilation_w, const PaddingType padding_type);
 
 }  // namespace qnn
 

--- a/litert/vendors/qualcomm/core/builders/elementwise_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/elementwise_op_builder.cc
@@ -25,7 +25,6 @@ std::vector<OpWrapper> BuildElementwiseAddOp(
   }
   elementwise_op.AddOutputTensor(outputs[0]);
 
-  // TODO: fused activation
   return res;
 }
 
@@ -40,7 +39,6 @@ std::vector<OpWrapper> BuildElementwiseSubOp(
   }
   elementwise_op.AddOutputTensor(outputs[0]);
 
-  // TODO: fused activation
   return res;
 }
 
@@ -55,7 +53,6 @@ std::vector<OpWrapper> BuildElementwiseMulOp(
   }
   elementwise_op.AddOutputTensor(outputs[0]);
 
-  // TODO: fused activation
   return res;
 }
 
@@ -70,7 +67,6 @@ std::vector<OpWrapper> BuildElementwiseDivOp(
   }
   elementwise_op.AddOutputTensor(outputs[0]);
 
-  // TODO: fused activation
   return res;
 }
 

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
@@ -51,14 +51,12 @@ std::vector<OpWrapper> BuildFullyConnectedOp(
         output_tensor, {batch_size, num_units});
 
     fully_connected_op.AddOutputTensor(fully_connected_out);
-    // TODO: fused activation
 
     qnn::OpWrapper& reshape_op = CreateOpWrapper(res, QNN_OP_RESHAPE);
     reshape_op.AddInputTensor(fully_connected_out);
     reshape_op.AddOutputTensor(output_tensor);
   } else {
     fully_connected_op.AddOutputTensor(outputs[0]);
-    // TODO: fused activation
   }
 
   return res;

--- a/litert/vendors/qualcomm/core/builders/op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/op_builder.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 #include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
 
@@ -39,6 +40,10 @@ OpWrapper& CreateSimpleActivationOp(std::vector<OpWrapper>& ops,
                                     const char* op_type,
                                     const TensorWrapper& input_tensor,
                                     const TensorWrapper& output_tensor);
+
+TensorWrapper& ReplaceOutputTensorForFusedActivation(
+    TensorPool& tensor_pool, const uint32_t fused_activation_function,
+    std::vector<TensorWrapperRef>& output_tensors);
 
 void AddFusedActivationNode(std::vector<OpWrapper>& res,
                             const uint32_t fused_activation_function,

--- a/litert/vendors/qualcomm/core/builders/pool2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/pool2d_op_builder.cc
@@ -77,7 +77,6 @@ std::vector<OpWrapper> BuildPool2dOp(
 
   TensorWrapper& output_tensor = outputs[kOutputIndex];
   pool_op.AddOutputTensor(output_tensor);
-  // TODO: fused activation
 
   return res;
 }

--- a/litert/vendors/qualcomm/core/builders/relu6_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/relu6_op_builder.cc
@@ -16,7 +16,12 @@ std::vector<OpWrapper> BuildRelu6Op(
     const std::vector<TensorWrapperRef>& outputs) {
   std::vector<OpWrapper> res;
 
-  CreateSimpleActivationOp(res, QNN_OP_RELU6, inputs[0], outputs[0]);
+  // QNN_OP_RELU6 is deprecated, use QNN_OP_RELU_MIN_MAX instead.
+  auto& activation_op = CreateOpWrapper(res, QNN_OP_RELU_MIN_MAX);
+  activation_op.AddScalarParam<float>(QNN_OP_RELU_MIN_MAX_PARAM_MIN_VALUE, 0);
+  activation_op.AddScalarParam<float>(QNN_OP_RELU_MIN_MAX_PARAM_MAX_VALUE, 6);
+  activation_op.AddInputTensor(inputs[0]);
+  activation_op.AddOutputTensor(outputs[0]);
 
   return res;
 }

--- a/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.cc
@@ -108,7 +108,6 @@ std::vector<OpWrapper> BuildTransposeConvOp(
 
   TensorWrapper& output_tensor = outputs[kOutputIndex];
   conv_op.AddOutputTensor(output_tensor);
-  // TODO: fused activation
 
   // stride param
   const std::array<std::uint32_t, 2> stride_data{stride_h, stride_w};


### PR DESCRIPTION
1. Support Relu, ReluN1To1, Relu6, Tanh
2. If activation is not none, replace output tensor before op builder and add fused activation node after op builder.
3. Support fused activation for the covered ops, remove TDOO in op builder.