### PR TITLE
Qualcomm AI Engine Direct - Integrate with LiteRtOption.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "litert/c/options/litert_qualcomm_options.h"
 
@@ -27,9 +29,12 @@
 
 struct LiteRtQualcommOptionsT {
   LiteRtQualcommOptionsLogLevel log_level = kLiteRtQualcommLogLevelInfo;
-  bool enable_weight_sharing = true;
-  LiteRtQualcommOptionsPowerMode power_mode =
-      kLiteRtQualcommPowerModePerformance;
+  LiteRtQualcommOptionsProfiling profiling = kLiteRtQualcommProfilingOff;
+  bool use_htp_preference = false;
+  bool use_qint16_as_quint16 = false;
+  bool enable_weight_sharing = false;
+  LiteRtQualcommOptionsHtpPerformanceMode htp_performance_mode =
+      kLiteRtQualcommHtpPerformanceModeDefault;
 };
 
 LiteRtStatus LiteRtQualcommOptionsCreate(LiteRtOpaqueOptions* options) {
@@ -101,6 +106,50 @@ LiteRtStatus LiteRtQualcommOptionsGetLogLevel(
 
 // COMPILATION OPTIONS /////////////////////////////////////////////////////////
 
+LiteRtStatus LiteRtQualcommOptionsSetUseHtpPreference(
+    LiteRtQualcommOptions options, bool use_htp_preference) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->use_htp_preference = use_htp_preference;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetUseHtpPreference(
+    LiteRtQualcommOptions options, bool* use_htp_preference) {
+  if (use_htp_preference == nullptr || options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *use_htp_preference = options->use_htp_preference;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetUseQint16AsQuint16(
+    LiteRtQualcommOptions options, bool use_qint16_as_quint16) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->use_qint16_as_quint16 = use_qint16_as_quint16;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetUseQint16AsQuint16(
+    LiteRtQualcommOptions options, bool* use_qint16_as_quint16) {
+  if (use_qint16_as_quint16 == nullptr || options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *use_qint16_as_quint16 = options->use_qint16_as_quint16;
+
+  return kLiteRtStatusOk;
+}
+
 // enable_weight_sharing -------------------------------------------------------
 
 LiteRtStatus LiteRtQualcommOptionsSetEnableWeightSharing(
@@ -127,26 +176,48 @@ LiteRtStatus LiteRtQualcommOptionsGetEnableWeightSharing(
 
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////
 
-// power_mode ------------------------------------------------------------------
-
-LiteRtStatus LiteRtQualcommOptionsSetPowerMode(
-    LiteRtQualcommOptions options, LiteRtQualcommOptionsPowerMode power_mode) {
+LiteRtStatus LiteRtQualcommOptionsSetHtpPerformanceMode(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsHtpPerformanceMode htp_performance_mode) {
   if (options == nullptr) {
     return kLiteRtStatusErrorInvalidArgument;
   }
 
-  options->power_mode = power_mode;
+  options->htp_performance_mode = htp_performance_mode;
 
   return kLiteRtStatusOk;
 }
 
-LiteRtStatus LiteRtQualcommOptionsGetPowerMode(
-    LiteRtQualcommOptions options, LiteRtQualcommOptionsPowerMode* power_mode) {
-  if (power_mode == nullptr || options == nullptr) {
+LiteRtStatus LiteRtQualcommOptionsGetHtpPerformanceMode(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsHtpPerformanceMode* htp_performance_mode) {
+  if (options == nullptr || htp_performance_mode == nullptr) {
     return kLiteRtStatusErrorInvalidArgument;
   }
 
-  *power_mode = options->power_mode;
+  *htp_performance_mode = options->htp_performance_mode;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetProfiling(
+    LiteRtQualcommOptions options, LiteRtQualcommOptionsProfiling profiling) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->profiling = profiling;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetProfiling(
+    LiteRtQualcommOptions options, LiteRtQualcommOptionsProfiling* profiling) {
+  if (options == nullptr || profiling == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *profiling = options->profiling;
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef THIRD_PARTY_ODML_LITERT_LITERT_C_OPTIONS_LITERT_QUALCOMM_OPTIONS_H_
 #define THIRD_PARTY_ODML_LITERT_LITERT_C_OPTIONS_LITERT_QUALCOMM_OPTIONS_H_
@@ -28,11 +30,11 @@
 extern "C" {
 #endif  // __cplusplus
 
+LITERT_DEFINE_HANDLE(LiteRtQualcommOptions);
+
 // Create a qualcomm options object that is type erased. The actual option
 // data can be accessed from the payload.
 LiteRtStatus LiteRtQualcommOptionsCreate(LiteRtOpaqueOptions* options);
-
-LITERT_DEFINE_HANDLE(LiteRtQualcommOptions);
 
 // The a string identifier that discriminates qualcomm options within
 // type erased options.
@@ -67,6 +69,18 @@ LiteRtStatus LiteRtQualcommOptionsGetLogLevel(
 
 // COMPILATION OPTIONS /////////////////////////////////////////////////////////
 
+LiteRtStatus LiteRtQualcommOptionsSetUseHtpPreference(
+    LiteRtQualcommOptions options, bool use_htp_preference);
+
+LiteRtStatus LiteRtQualcommOptionsGetUseHtpPreference(
+    LiteRtQualcommOptions options, bool* use_htp_preference);
+
+LiteRtStatus LiteRtQualcommOptionsSetUseQint16AsQuint16(
+    LiteRtQualcommOptions options, bool use_qint16_as_quint16);
+
+LiteRtStatus LiteRtQualcommOptionsGetUseQint16AsQuint16(
+    LiteRtQualcommOptions options, bool* use_qint16_as_quint16);
+
 // enable_weight_sharing -------------------------------------------------------
 
 // Weight sharing indicates whether different subgraphs may share weight
@@ -86,19 +100,42 @@ LiteRtStatus LiteRtQualcommOptionsGetEnableWeightSharing(
 // See QnnHtpPerfInfrastructure_PowerMode_t in qnn_sdk. By default, it will
 // be decided by the backend (unknown).
 
-typedef enum LiteRtQualcommOptionsPowerMode {
-  kLiteRtQualcommPowerModeUnknown = 0,
-  kLiteRtQualcommPowerModePerformance = 1,
-  kLiteRtQualcommPowerModePowerSaver = 2,
-} LiteRtQualcommOptionsPowerMode;
+typedef enum LiteRtQualcommOptionsHtpPerformanceMode {
+  kLiteRtQualcommHtpPerformanceModeDefault = 0,
+  kLiteRtQualcommHtpPerformanceModeSustainedHighPerformance = 1,
+  kLiteRtQualcommHtpPerformanceModeBurst = 2,
+  kLiteRtQualcommHtpPerformanceModeHighPerformance = 3,
+  kLiteRtQualcommHtpPerformanceModePowerSaver = 4,
+  kLiteRtQualcommHtpPerformanceModeLowPowerSaver = 5,
+  kLiteRtQualcommHtpPerformanceModeHighPowerSaver = 6,
+  kLiteRtQualcommHtpPerformanceModeLowBalanced = 7,
+  kLiteRtQualcommHtpPerformanceModeBalanced = 8,
+  kLiteRtQualcommHtpPerformanceModeExtremePowerSaver = 9,
+} LiteRtQualcommOptionsHtpPerformanceMode;
 
-LiteRtStatus LiteRtQualcommOptionsSetPowerMode(
-    LiteRtQualcommOptions options, LiteRtQualcommOptionsPowerMode power_mode);
+LiteRtStatus LiteRtQualcommOptionsSetHtpPerformanceMode(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsHtpPerformanceMode htp_performance_mode);
 
-LiteRtStatus LiteRtQualcommOptionsGetPowerMode(
-    LiteRtQualcommOptions options, LiteRtQualcommOptionsPowerMode* power_mode);
+LiteRtStatus LiteRtQualcommOptionsGetHtpPerformanceMode(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsHtpPerformanceMode* htp_performance_mode);
+
+typedef enum LiteRtQualcommOptionsProfiling {
+  kLiteRtQualcommProfilingOff = 0,
+  kLiteRtQualcommProfilingBasic,
+  kLiteRtQualcommProfilingDetailed,
+  kLiteRtQualcommProfilingLinting,
+} LiteRtQualcommOptionsProfiling;
+
+LiteRtStatus LiteRtQualcommOptionsSetProfiling(
+    LiteRtQualcommOptions options, LiteRtQualcommOptionsProfiling profiling);
+
+LiteRtStatus LiteRtQualcommOptionsGetProfiling(
+    LiteRtQualcommOptions options, LiteRtQualcommOptionsProfiling* profiling);
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
+
 #endif  // THIRD_PARTY_ODML_LITERT_LITERT_C_OPTIONS_LITERT_QUALCOMM_OPTIONS_H_

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -47,7 +47,7 @@ LiteRtStatus LiteRtQualcommOptionsGet(LiteRtOpaqueOptions options,
 
 // GENERAL SDK SETTINGS ////////////////////////////////////////////////////////
 
-// log_level -------------------------------------------------------------------
+// log_level
 
 // This determines the logging level of all underlying qualcomm sdk libraries.
 // Does not effect litert logging. Defaults to INFO.
@@ -69,11 +69,21 @@ LiteRtStatus LiteRtQualcommOptionsGetLogLevel(
 
 // COMPILATION OPTIONS /////////////////////////////////////////////////////////
 
+// use_htp_preference
+
+// This option controls whether to convert a LiteRt operation to QNN operations
+// which are preferred by the HTP backend. Defaults to false.
+
 LiteRtStatus LiteRtQualcommOptionsSetUseHtpPreference(
     LiteRtQualcommOptions options, bool use_htp_preference);
 
 LiteRtStatus LiteRtQualcommOptionsGetUseHtpPreference(
     LiteRtQualcommOptions options, bool* use_htp_preference);
+
+// use_qint16_as_quint16
+
+// This option controls whether to convert a quantized int16 model to a
+// quantized uint16 model. Defaults to false.
 
 LiteRtStatus LiteRtQualcommOptionsSetUseQint16AsQuint16(
     LiteRtQualcommOptions options, bool use_qint16_as_quint16);
@@ -81,10 +91,10 @@ LiteRtStatus LiteRtQualcommOptionsSetUseQint16AsQuint16(
 LiteRtStatus LiteRtQualcommOptionsGetUseQint16AsQuint16(
     LiteRtQualcommOptions options, bool* use_qint16_as_quint16);
 
-// enable_weight_sharing -------------------------------------------------------
+// enable_weight_sharing
 
 // Weight sharing indicates whether different subgraphs may share weight
-// tensors. This is only supported on x86 AOT. Defaults to true.
+// tensors. This is only supported on x86 AOT. Defaults to false.
 
 LiteRtStatus LiteRtQualcommOptionsSetEnableWeightSharing(
     LiteRtQualcommOptions options, bool enable_weight_sharing);
@@ -94,11 +104,11 @@ LiteRtStatus LiteRtQualcommOptionsGetEnableWeightSharing(
 
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////
 
-// power_mode ------------------------------------------------------------------
+// htp_performance_mode
 
 // Configures the HTP device to optimize for performance or power efficiency.
-// See QnnHtpPerfInfrastructure_PowerMode_t in qnn_sdk. By default, it will
-// be decided by the backend (unknown).
+// See QnnHtpPerfInfrastructure_SetPowerConfigFn_t in qnn_sdk. By default, it
+// will be decided by the backend (unknown).
 
 typedef enum LiteRtQualcommOptionsHtpPerformanceMode {
   kLiteRtQualcommHtpPerformanceModeDefault = 0,
@@ -120,6 +130,11 @@ LiteRtStatus LiteRtQualcommOptionsSetHtpPerformanceMode(
 LiteRtStatus LiteRtQualcommOptionsGetHtpPerformanceMode(
     LiteRtQualcommOptions options,
     LiteRtQualcommOptionsHtpPerformanceMode* htp_performance_mode);
+
+// profiling
+
+// This option controls the profiling level. A higher level results in a more
+// detailed report after execution. Defaults to off.
 
 typedef enum LiteRtQualcommOptionsProfiling {
   kLiteRtQualcommProfilingOff = 0,

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -61,7 +61,43 @@ TEST(LiteRtQualcommOptionsTest, LogLevel) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
-TEST(LiteRtQualcommOptionsTest, WeightSharing) {
+TEST(LiteRtQualcommOptionsTest, UseHtpPreference) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsSetUseHtpPreference(qualcomm_options, true));
+
+  bool use_htp_preference;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetUseHtpPreference(
+      qualcomm_options, &use_htp_preference));
+  EXPECT_TRUE(use_htp_preference);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
+TEST(LiteRtQualcommOptionsTest, UseQint16AsQuint16) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsSetUseQint16AsQuint16(qualcomm_options, false));
+
+  bool use_qint16_as_quint16;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetUseQint16AsQuint16(
+      qualcomm_options, &use_qint16_as_quint16));
+  EXPECT_FALSE(use_qint16_as_quint16);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
+TEST(LiteRtQualcommOptionsTest, EnableWeightSharing) {
   LiteRtOpaqueOptions options;
   LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
 
@@ -79,20 +115,38 @@ TEST(LiteRtQualcommOptionsTest, WeightSharing) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
-TEST(LiteRtQualcommOptionsTest, PowerMode) {
+TEST(LiteRtQualcommOptionsTest, HtpPerformanceMode) {
   LiteRtOpaqueOptions options;
   LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
 
   LiteRtQualcommOptions qualcomm_options;
   LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
 
-  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetPowerMode(
-      qualcomm_options, kLiteRtQualcommPowerModePowerSaver));
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetHtpPerformanceMode(
+      qualcomm_options, kLiteRtQualcommHtpPerformanceModeBurst));
 
-  LiteRtQualcommOptionsPowerMode power_mode;
+  LiteRtQualcommOptionsHtpPerformanceMode htp_performance_mode;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetHtpPerformanceMode(
+      qualcomm_options, &htp_performance_mode));
+  EXPECT_EQ(htp_performance_mode, kLiteRtQualcommHtpPerformanceModeBurst);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
+TEST(LiteRtQualcommOptionsTest, Profiling) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetProfiling(
+      qualcomm_options, kLiteRtQualcommProfilingDetailed));
+
+  LiteRtQualcommOptionsProfiling profiling;
   LITERT_ASSERT_OK(
-      LiteRtQualcommOptionsGetPowerMode(qualcomm_options, &power_mode));
-  EXPECT_EQ(power_mode, kLiteRtQualcommPowerModePowerSaver);
+      LiteRtQualcommOptionsGetProfiling(qualcomm_options, &profiling));
+  EXPECT_EQ(profiling, kLiteRtQualcommProfilingDetailed);
 
   LiteRtDestroyOpaqueOptions(options);
 }
@@ -105,13 +159,27 @@ TEST(QualcommOptionsTest, CppApi) {
   options->SetLogLevel(kLiteRtQualcommLogLevelWarn);
   EXPECT_EQ(options->GetLogLevel(), kLiteRtQualcommLogLevelWarn);
 
-  EXPECT_TRUE(options->GetEnableWeightSharing());
-  options->SetEnableWeightSharing(false);
   EXPECT_FALSE(options->GetEnableWeightSharing());
+  options->SetEnableWeightSharing(true);
+  EXPECT_TRUE(options->GetEnableWeightSharing());
 
-  EXPECT_EQ(options->GetPowerMode(), kLiteRtQualcommPowerModePerformance);
-  options->SetPowerMode(kLiteRtQualcommPowerModePowerSaver);
-  EXPECT_EQ(options->GetPowerMode(), kLiteRtQualcommPowerModePowerSaver);
+  EXPECT_FALSE(options->GetUseHtpPreference());
+  options->SetUseHtpPreference(true);
+  EXPECT_TRUE(options->GetUseHtpPreference());
+
+  EXPECT_FALSE(options->GetUseQint16AsQuint16());
+  options->SetUseQint16AsQuint16(true);
+  EXPECT_TRUE(options->GetUseQint16AsQuint16());
+
+  EXPECT_EQ(options->GetHtpPerformanceMode(),
+            kLiteRtQualcommHtpPerformanceModeDefault);
+  options->SetHtpPerformanceMode(kLiteRtQualcommHtpPerformanceModeBurst);
+  EXPECT_EQ(options->GetHtpPerformanceMode(),
+            kLiteRtQualcommHtpPerformanceModeBurst);
+
+  EXPECT_EQ(options->GetProfiling(), kLiteRtQualcommProfilingOff);
+  options->SetProfiling(kLiteRtQualcommProfilingDetailed);
+  EXPECT_EQ(options->GetProfiling(), kLiteRtQualcommProfilingDetailed);
 }
 
 TEST(QualcommOptionsTest, FindFromChain) {

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "litert/cc/options/litert_qualcomm_options.h"
 
@@ -42,24 +44,28 @@ Expected<QualcommOptions> QualcommOptions::Create() {
   return QualcommOptions(options, litert::OwnHandle::kYes);
 }
 
-void QualcommOptions::SetLogLevel(QualcommOptions::LogLevel log_level) {
+void QualcommOptions::SetLogLevel(LiteRtQualcommOptionsLogLevel log_level) {
   internal::AssertOk(LiteRtQualcommOptionsSetLogLevel, Data(), log_level);
 }
 
-QualcommOptions::LogLevel QualcommOptions::GetLogLevel() {
-  QualcommOptions::LogLevel log_level;
+LiteRtQualcommOptionsLogLevel QualcommOptions::GetLogLevel() {
+  LiteRtQualcommOptionsLogLevel log_level;
   internal::AssertOk(LiteRtQualcommOptionsGetLogLevel, Data(), &log_level);
   return log_level;
 }
 
-void QualcommOptions::SetPowerMode(QualcommOptions::PowerMode power_mode) {
-  internal::AssertOk(LiteRtQualcommOptionsSetPowerMode, Data(), power_mode);
+void QualcommOptions::SetHtpPerformanceMode(
+    LiteRtQualcommOptionsHtpPerformanceMode htp_performance_mode) {
+  internal::AssertOk(LiteRtQualcommOptionsSetHtpPerformanceMode, Data(),
+                     htp_performance_mode);
 }
 
-QualcommOptions::PowerMode QualcommOptions::GetPowerMode() {
-  QualcommOptions::PowerMode power_mode;
-  internal::AssertOk(LiteRtQualcommOptionsGetPowerMode, Data(), &power_mode);
-  return power_mode;
+LiteRtQualcommOptionsHtpPerformanceMode
+QualcommOptions::GetHtpPerformanceMode() {
+  LiteRtQualcommOptionsHtpPerformanceMode htp_performance_mode;
+  internal::AssertOk(LiteRtQualcommOptionsGetHtpPerformanceMode, Data(),
+                     &htp_performance_mode);
+  return htp_performance_mode;
 }
 
 void QualcommOptions::SetEnableWeightSharing(bool weight_sharing_enabled) {
@@ -74,6 +80,40 @@ bool QualcommOptions::GetEnableWeightSharing() {
   return enable_weight_sharing;
 }
 
+void QualcommOptions::SetUseHtpPreference(bool use_htp_preference) {
+  internal::AssertOk(LiteRtQualcommOptionsSetUseHtpPreference, Data(),
+                     use_htp_preference);
+}
+
+bool QualcommOptions::GetUseHtpPreference() {
+  bool use_htp_preference;
+  internal::AssertOk(LiteRtQualcommOptionsGetUseHtpPreference, Data(),
+                     &use_htp_preference);
+  return use_htp_preference;
+}
+
+void QualcommOptions::SetUseQint16AsQuint16(bool use_qin16_as_quint16) {
+  internal::AssertOk(LiteRtQualcommOptionsSetUseQint16AsQuint16, Data(),
+                     use_qin16_as_quint16);
+}
+
+bool QualcommOptions::GetUseQint16AsQuint16() {
+  bool use_qin16_as_quint16;
+  internal::AssertOk(LiteRtQualcommOptionsGetUseQint16AsQuint16, Data(),
+                     &use_qin16_as_quint16);
+  return use_qin16_as_quint16;
+}
+
+void QualcommOptions::SetProfiling(LiteRtQualcommOptionsProfiling profiling) {
+  internal::AssertOk(LiteRtQualcommOptionsSetProfiling, Data(), profiling);
+}
+
+LiteRtQualcommOptionsProfiling QualcommOptions::GetProfiling() {
+  LiteRtQualcommOptionsProfiling profiling;
+  internal::AssertOk(LiteRtQualcommOptionsGetProfiling, Data(), &profiling);
+  return profiling;
+}
+
 Expected<QualcommOptions> QualcommOptions::Create(OpaqueOptions& options) {
   const auto id = options.GetIdentifier();
   if (!id || *id != Discriminator()) {
@@ -81,7 +121,5 @@ Expected<QualcommOptions> QualcommOptions::Create(OpaqueOptions& options) {
   }
   return QualcommOptions(options.Get(), OwnHandle::kNo);
 }
-
-namespace {}  // namespace
 
 }  // namespace litert::qualcomm

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef THIRD_PARTY_ODML_LITERT_LITERT_CC_OPTIONS_LITERT_QUALCOMM_OPTIONS_H_
 #define THIRD_PARTY_ODML_LITERT_LITERT_CC_OPTIONS_LITERT_QUALCOMM_OPTIONS_H_
@@ -26,9 +28,6 @@ namespace litert::qualcomm {
 // Wraps a LiteRtQualcommOptions object for convenience.
 class QualcommOptions : public OpaqueOptions {
  public:
-  using LogLevel = LiteRtQualcommOptionsLogLevel;
-  using PowerMode = LiteRtQualcommOptionsPowerMode;
-
   using OpaqueOptions::OpaqueOptions;
 
   static const char* Discriminator() {
@@ -39,14 +38,24 @@ class QualcommOptions : public OpaqueOptions {
 
   static Expected<QualcommOptions> Create();
 
-  void SetLogLevel(LogLevel log_level);
-  LogLevel GetLogLevel();
+  void SetLogLevel(LiteRtQualcommOptionsLogLevel log_level);
+  LiteRtQualcommOptionsLogLevel GetLogLevel();
 
-  void SetPowerMode(PowerMode power_mode);
-  PowerMode GetPowerMode();
+  void SetHtpPerformanceMode(
+      LiteRtQualcommOptionsHtpPerformanceMode htp_performance_mode);
+  LiteRtQualcommOptionsHtpPerformanceMode GetHtpPerformanceMode();
+
+  void SetUseHtpPreference(bool use_htp_preference);
+  bool GetUseHtpPreference();
+
+  void SetUseQint16AsQuint16(bool use_qin16_as_quint16);
+  bool GetUseQint16AsQuint16();
 
   void SetEnableWeightSharing(bool weight_sharing_enabled);
   bool GetEnableWeightSharing();
+
+  void SetProfiling(LiteRtQualcommOptionsProfiling profiling);
+  LiteRtQualcommOptionsProfiling GetProfiling();
 
  private:
   LiteRtQualcommOptions Data() const;

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -22,9 +22,11 @@
 #include "litert/cc/litert_macros.h"
 #include "litert/cc/options/litert_qualcomm_options.h"
 
-// NOLINTBEGIN(*alien-types*)
 // TODO: Move absl parse/unparse function to same file as enum types if
 // it becomes an issue.
+
+ABSL_FLAG(LiteRtQualcommOptionsLogLevel, qualcomm_log_level,
+          kLiteRtQualcommLogLevelInfo, "Log level for Qualcomm.");
 
 bool AbslParseFlag(absl::string_view text,
                    LiteRtQualcommOptionsLogLevel* options, std::string* error) {
@@ -73,61 +75,156 @@ std::string AbslUnparseFlag(LiteRtQualcommOptionsLogLevel options) {
   }
 }
 
-bool AbslParseFlag(absl::string_view text,
-                   LiteRtQualcommOptionsPowerMode* options,
-                   std::string* error) {
-  if (text == "unknown") {
-    *options = kLiteRtQualcommPowerModeUnknown;
-    return true;
-  }
-  if (text == "performance") {
-    *options = kLiteRtQualcommPowerModePerformance;
-    return true;
-  }
-  if (text == "power_saver") {
-    *options = kLiteRtQualcommPowerModePowerSaver;
-    return true;
-  }
-  *error = "Unknown power mode";
-  return false;
-}
-
-std::string AbslUnparseFlag(LiteRtQualcommOptionsPowerMode options) {
-  switch (options) {
-    case kLiteRtQualcommPowerModeUnknown:
-      return "unknown";
-    case kLiteRtQualcommPowerModePerformance:
-      return "performance";
-    case kLiteRtQualcommPowerModePowerSaver:
-      return "power_saver";
-  }
-}
-
-ABSL_FLAG(bool, enable_weight_sharing, true,
+ABSL_FLAG(bool, qualcomm_enable_weight_sharing, true,
           "Whether to enable weight sharing, this is unsupported on mobile "
           "platforms.");
 
-ABSL_FLAG(LiteRtQualcommOptionsLogLevel, qualcomm_log_level,
-          kLiteRtQualcommLogLevelInfo, "Log level for Qualcomm.");
+ABSL_FLAG(bool, qualcomm_use_htp_preference, false,
+          "Whether to transform ops into the HTP prefered pattern.");
 
-ABSL_FLAG(LiteRtQualcommOptionsPowerMode, qualcomm_power_mode,
-          kLiteRtQualcommPowerModeUnknown, "Power preference for HTP device.");
+ABSL_FLAG(bool, qualcomm_use_qint16_as_quint16, true,
+          "Whether to automatically convert int16 model into uin16 model.");
 
-// NOLINTEND(*alien-types*)
+ABSL_FLAG(LiteRtQualcommOptionsHtpPerformanceMode,
+          qualcomm_htp_performance_mode,
+          kLiteRtQualcommHtpPerformanceModeDefault, "HTP performance mode.");
+
+bool AbslParseFlag(absl::string_view text,
+                   LiteRtQualcommOptionsHtpPerformanceMode* options,
+                   std::string* error) {
+  if (text == "default") {
+    *options = kLiteRtQualcommHtpPerformanceModeDefault;
+    return true;
+  }
+  if (text == "sustained_high_performance") {
+    *options = kLiteRtQualcommHtpPerformanceModeSustainedHighPerformance;
+    return true;
+  }
+  if (text == "burst") {
+    *options = kLiteRtQualcommHtpPerformanceModeBurst;
+    return true;
+  }
+  if (text == "high_performance") {
+    *options = kLiteRtQualcommHtpPerformanceModeHighPerformance;
+    return true;
+  }
+  if (text == "power_saver") {
+    *options = kLiteRtQualcommHtpPerformanceModePowerSaver;
+    return true;
+  }
+  if (text == "low_power_saver") {
+    *options = kLiteRtQualcommHtpPerformanceModeLowPowerSaver;
+    return true;
+  }
+  if (text == "high_power_saver") {
+    *options = kLiteRtQualcommHtpPerformanceModeHighPowerSaver;
+    return true;
+  }
+  if (text == "low_balanced") {
+    *options = kLiteRtQualcommHtpPerformanceModeLowBalanced;
+    return true;
+  }
+  if (text == "balanced") {
+    *options = kLiteRtQualcommHtpPerformanceModeBalanced;
+    return true;
+  }
+  if (text == "extreme_power_saver") {
+    *options = kLiteRtQualcommHtpPerformanceModeExtremePowerSaver;
+    return true;
+  }
+  *error = "Unknown htp performance mode";
+  return false;
+}
+
+std::string AbslUnparseFlag(LiteRtQualcommOptionsHtpPerformanceMode options) {
+  switch (options) {
+    case kLiteRtQualcommHtpPerformanceModeDefault:
+      return "default";
+    case kLiteRtQualcommHtpPerformanceModeSustainedHighPerformance:
+      return "sustained_high_performance";
+    case kLiteRtQualcommHtpPerformanceModeBurst:
+      return "burst";
+    case kLiteRtQualcommHtpPerformanceModeHighPerformance:
+      return "high_performance";
+    case kLiteRtQualcommHtpPerformanceModePowerSaver:
+      return "power_saver";
+    case kLiteRtQualcommHtpPerformanceModeLowPowerSaver:
+      return "low_power_saver";
+    case kLiteRtQualcommHtpPerformanceModeHighPowerSaver:
+      return "high_power_saver";
+    case kLiteRtQualcommHtpPerformanceModeLowBalanced:
+      return "low_balanced";
+    case kLiteRtQualcommHtpPerformanceModeBalanced:
+      return "balanced";
+    case kLiteRtQualcommHtpPerformanceModeExtremePowerSaver:
+      return "extreme_power_saver";
+  }
+}
+
+ABSL_FLAG(LiteRtQualcommOptionsProfiling, qualcomm_profiling,
+          kLiteRtQualcommProfilingOff, "QNN profiling mode");
+
+bool AbslParseFlag(absl::string_view text,
+                   LiteRtQualcommOptionsProfiling* options,
+                   std::string* error) {
+  if (text == "off") {
+    *options = kLiteRtQualcommProfilingOff;
+    return true;
+  }
+  if (text == "basic") {
+    *options = kLiteRtQualcommProfilingBasic;
+    return true;
+  }
+  if (text == "detailed") {
+    *options = kLiteRtQualcommProfilingDetailed;
+    return true;
+  }
+  if (text == "linting") {
+    *options = kLiteRtQualcommProfilingLinting;
+    return true;
+  }
+  *error = "Unknown htp performance mode";
+  return false;
+}
+
+std::string AbslUnparseFlag(LiteRtQualcommOptionsProfiling options) {
+  switch (options) {
+    case kLiteRtQualcommProfilingOff:
+      return "off";
+    case kLiteRtQualcommProfilingBasic:
+      return "basic";
+    case kLiteRtQualcommProfilingDetailed:
+      return "detailed";
+    case kLiteRtQualcommProfilingLinting:
+      return "linting";
+  }
+}
 
 namespace litert::qualcomm {
 
 Expected<QualcommOptions> QualcommOptionsFromFlags() {
   LITERT_ASSIGN_OR_RETURN(auto opts, QualcommOptions::Create());
 
-  const auto weight_share = absl::GetFlag(FLAGS_enable_weight_sharing);
+  const auto weight_share = absl::GetFlag(FLAGS_qualcomm_enable_weight_sharing);
   opts.SetEnableWeightSharing(weight_share);
 
   const auto log_level = absl::GetFlag(FLAGS_qualcomm_log_level);
   opts.SetLogLevel(log_level);
 
-  const auto power_mode = absl::GetFlag(FLAGS_qualcomm_power_mode);
-  opts.SetPowerMode(power_mode);
+  const auto use_htp_preference =
+      absl::GetFlag(FLAGS_qualcomm_use_htp_preference);
+  opts.SetUseHtpPreference(use_htp_preference);
+
+  const auto use_qint16_as_quint16 =
+      absl::GetFlag(FLAGS_qualcomm_use_qint16_as_quint16);
+  opts.SetUseQint16AsQuint16(use_qint16_as_quint16);
+
+  const auto htp_performance_mode =
+      absl::GetFlag(FLAGS_qualcomm_htp_performance_mode);
+  opts.SetHtpPerformanceMode(htp_performance_mode);
+
+  const auto profiling = absl::GetFlag(FLAGS_qualcomm_profiling);
+  opts.SetProfiling(profiling);
 
   return opts;
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -75,15 +75,16 @@ std::string AbslUnparseFlag(LiteRtQualcommOptionsLogLevel options) {
   }
 }
 
-ABSL_FLAG(bool, qualcomm_enable_weight_sharing, true,
+ABSL_FLAG(bool, qualcomm_enable_weight_sharing, false,
           "Whether to enable weight sharing, this is unsupported on mobile "
           "platforms.");
 
 ABSL_FLAG(bool, qualcomm_use_htp_preference, false,
-          "Whether to transform ops into the HTP prefered pattern.");
+          "Whether to transform a litert op into the HTP prefered pattern.");
 
-ABSL_FLAG(bool, qualcomm_use_qint16_as_quint16, true,
-          "Whether to automatically convert int16 model into uin16 model.");
+ABSL_FLAG(bool, qualcomm_use_qint16_as_quint16, false,
+          "Whether to automatically convert a quantized int16 model into a "
+          "quantized uin16 model.");
 
 ABSL_FLAG(LiteRtQualcommOptionsHtpPerformanceMode,
           qualcomm_htp_performance_mode,

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -25,26 +25,31 @@
 // GENERAL SDK SETTINGS ////////////////////////////////////////////////////////
 
 ABSL_DECLARE_FLAG(LiteRtQualcommOptionsLogLevel, qualcomm_log_level);
-
-// COMPILATION OPTIONS /////////////////////////////////////////////////////////
-
-ABSL_DECLARE_FLAG(bool, enable_weight_sharing);
-
-// DISPATCH OPTIONS ////////////////////////////////////////////////////////////
-
-ABSL_DECLARE_FLAG(LiteRtQualcommOptionsPowerMode, qualcomm_power_mode);
-
-// PARSERS (internal) //////////////////////////////////////////////////////////
-
+std::string AbslUnparseFlag(LiteRtQualcommOptionsLogLevel options);
 bool AbslParseFlag(absl::string_view text,
                    LiteRtQualcommOptionsLogLevel* options, std::string* error);
 
-std::string AbslUnparseFlag(LiteRtQualcommOptionsLogLevel options);
+// COMPILATION OPTIONS /////////////////////////////////////////////////////////
 
+ABSL_DECLARE_FLAG(bool, qualcomm_enable_weight_sharing);
+
+ABSL_DECLARE_FLAG(bool, qualcomm_use_htp_preference);
+
+ABSL_DECLARE_FLAG(bool, qualcomm_use_qint16_as_quint16);
+
+// DISPATCH OPTIONS ////////////////////////////////////////////////////////////
+
+ABSL_DECLARE_FLAG(LiteRtQualcommOptionsHtpPerformanceMode,
+                  qualcomm_htp_performance_mode);
 bool AbslParseFlag(absl::string_view text,
-                   LiteRtQualcommOptionsPowerMode* options, std::string* error);
+                   LiteRtQualcommOptionsHtpPerformanceMode* options,
+                   std::string* error);
+std::string AbslUnparseFlag(LiteRtQualcommOptionsHtpPerformanceMode options);
 
-std::string AbslUnparseFlag(LiteRtQualcommOptionsPowerMode options);
+ABSL_DECLARE_FLAG(LiteRtQualcommOptionsProfiling, qualcomm_profiling);
+bool AbslParseFlag(absl::string_view text,
+                   LiteRtQualcommOptionsProfiling* options, std::string* error);
+std::string AbslUnparseFlag(LiteRtQualcommOptionsProfiling options);
 
 // TO OBJECT (internal) ////////////////////////////////////////////////////////
 

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -88,30 +88,48 @@ TEST(LogLevelFlagTest, Parse) {
   }
 }
 
-TEST(PowerModeFlagTest, Malformed) {
+TEST(HtpPerformanceModeTest, Malformed) {
   std::string error;
-  LiteRtQualcommOptionsPowerMode value;
+  LiteRtQualcommOptionsHtpPerformanceMode value;
 
   EXPECT_FALSE(AbslParseFlag("boogabooga", &value, &error));
 }
 
-TEST(PowerModeFlagTest, Parse) {
+TEST(HtpPerformanceModeTest, Parse) {
   std::string error;
-  LiteRtQualcommOptionsPowerMode value;
+  LiteRtQualcommOptionsHtpPerformanceMode value;
 
   {
-    static constexpr absl::string_view kMode = "unknown";
-    static constexpr LiteRtQualcommOptionsPowerMode kModeEnum =
-        kLiteRtQualcommPowerModeUnknown;
+    static constexpr absl::string_view kMode = "default";
+    static constexpr LiteRtQualcommOptionsHtpPerformanceMode kModeEnum =
+        kLiteRtQualcommHtpPerformanceModeDefault;
     EXPECT_TRUE(AbslParseFlag(kMode, &value, &error));
     EXPECT_EQ(value, kModeEnum);
     EXPECT_EQ(kMode, AbslUnparseFlag(value));
   }
 
   {
-    static constexpr absl::string_view kMode = "performance";
-    static constexpr LiteRtQualcommOptionsPowerMode kModeEnum =
-        kLiteRtQualcommPowerModePerformance;
+    static constexpr absl::string_view kMode = "sustained_high_performance";
+    static constexpr LiteRtQualcommOptionsHtpPerformanceMode kModeEnum =
+        kLiteRtQualcommHtpPerformanceModeSustainedHighPerformance;
+    EXPECT_TRUE(AbslParseFlag(kMode, &value, &error));
+    EXPECT_EQ(value, kModeEnum);
+    EXPECT_EQ(kMode, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kMode = "burst";
+    static constexpr LiteRtQualcommOptionsHtpPerformanceMode kModeEnum =
+        kLiteRtQualcommHtpPerformanceModeBurst;
+    EXPECT_TRUE(AbslParseFlag(kMode, &value, &error));
+    EXPECT_EQ(value, kModeEnum);
+    EXPECT_EQ(kMode, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kMode = "high_performance";
+    static constexpr LiteRtQualcommOptionsHtpPerformanceMode kModeEnum =
+        kLiteRtQualcommHtpPerformanceModeHighPerformance;
     EXPECT_TRUE(AbslParseFlag(kMode, &value, &error));
     EXPECT_EQ(value, kModeEnum);
     EXPECT_EQ(kMode, AbslUnparseFlag(value));
@@ -119,11 +137,104 @@ TEST(PowerModeFlagTest, Parse) {
 
   {
     static constexpr absl::string_view kMode = "power_saver";
-    static constexpr LiteRtQualcommOptionsPowerMode kModeEnum =
-        kLiteRtQualcommPowerModePowerSaver;
+    static constexpr LiteRtQualcommOptionsHtpPerformanceMode kModeEnum =
+        kLiteRtQualcommHtpPerformanceModePowerSaver;
     EXPECT_TRUE(AbslParseFlag(kMode, &value, &error));
     EXPECT_EQ(value, kModeEnum);
     EXPECT_EQ(kMode, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kMode = "low_power_saver";
+    static constexpr LiteRtQualcommOptionsHtpPerformanceMode kModeEnum =
+        kLiteRtQualcommHtpPerformanceModeLowPowerSaver;
+    EXPECT_TRUE(AbslParseFlag(kMode, &value, &error));
+    EXPECT_EQ(value, kModeEnum);
+    EXPECT_EQ(kMode, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kMode = "high_power_saver";
+    static constexpr LiteRtQualcommOptionsHtpPerformanceMode kModeEnum =
+        kLiteRtQualcommHtpPerformanceModeHighPowerSaver;
+    EXPECT_TRUE(AbslParseFlag(kMode, &value, &error));
+    EXPECT_EQ(value, kModeEnum);
+    EXPECT_EQ(kMode, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kMode = "low_balanced";
+    static constexpr LiteRtQualcommOptionsHtpPerformanceMode kModeEnum =
+        kLiteRtQualcommHtpPerformanceModeLowBalanced;
+    EXPECT_TRUE(AbslParseFlag(kMode, &value, &error));
+    EXPECT_EQ(value, kModeEnum);
+    EXPECT_EQ(kMode, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kMode = "balanced";
+    static constexpr LiteRtQualcommOptionsHtpPerformanceMode kModeEnum =
+        kLiteRtQualcommHtpPerformanceModeBalanced;
+    EXPECT_TRUE(AbslParseFlag(kMode, &value, &error));
+    EXPECT_EQ(value, kModeEnum);
+    EXPECT_EQ(kMode, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kMode = "extreme_power_saver";
+    static constexpr LiteRtQualcommOptionsHtpPerformanceMode kModeEnum =
+        kLiteRtQualcommHtpPerformanceModeExtremePowerSaver;
+    EXPECT_TRUE(AbslParseFlag(kMode, &value, &error));
+    EXPECT_EQ(value, kModeEnum);
+    EXPECT_EQ(kMode, AbslUnparseFlag(value));
+  }
+}
+
+TEST(ProfilingTest, Malformed) {
+  std::string error;
+  LiteRtQualcommOptionsProfiling value;
+
+  EXPECT_FALSE(AbslParseFlag("boogabooga", &value, &error));
+}
+
+TEST(ProfilingTest, Parse) {
+  std::string error;
+  LiteRtQualcommOptionsProfiling value;
+
+  {
+    static constexpr absl::string_view kProfiling = "off";
+    static constexpr LiteRtQualcommOptionsProfiling kProfilingEnum =
+        kLiteRtQualcommProfilingOff;
+    EXPECT_TRUE(AbslParseFlag(kProfiling, &value, &error));
+    EXPECT_EQ(value, kProfilingEnum);
+    EXPECT_EQ(kProfiling, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kProfiling = "basic";
+    static constexpr LiteRtQualcommOptionsProfiling kProfilingEnum =
+        kLiteRtQualcommProfilingBasic;
+    EXPECT_TRUE(AbslParseFlag(kProfiling, &value, &error));
+    EXPECT_EQ(value, kProfilingEnum);
+    EXPECT_EQ(kProfiling, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kProfiling = "detailed";
+    static constexpr LiteRtQualcommOptionsProfiling kProfilingEnum =
+        kLiteRtQualcommProfilingDetailed;
+    EXPECT_TRUE(AbslParseFlag(kProfiling, &value, &error));
+    EXPECT_EQ(value, kProfilingEnum);
+    EXPECT_EQ(kProfiling, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kProfiling = "linting";
+    static constexpr LiteRtQualcommOptionsProfiling kProfilingEnum =
+        kLiteRtQualcommProfilingLinting;
+    EXPECT_TRUE(AbslParseFlag(kProfiling, &value, &error));
+    EXPECT_EQ(value, kProfilingEnum);
+    EXPECT_EQ(kProfiling, AbslUnparseFlag(value));
   }
 }
 

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -238,5 +238,17 @@ TEST(ProfilingTest, Parse) {
   }
 }
 
+TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
+  Expected<QualcommOptions> options = QualcommOptionsFromFlags();
+  ASSERT_TRUE(options.HasValue());
+  EXPECT_EQ(options.Value().GetLogLevel(), kLiteRtQualcommLogLevelInfo);
+  EXPECT_EQ(options.Value().GetProfiling(), kLiteRtQualcommProfilingOff);
+  EXPECT_FALSE(options.Value().GetUseHtpPreference());
+  EXPECT_FALSE(options.Value().GetUseQint16AsQuint16());
+  EXPECT_FALSE(options.Value().GetEnableWeightSharing());
+  EXPECT_EQ(options.Value().GetHtpPerformanceMode(),
+            kLiteRtQualcommHtpPerformanceModeDefault);
+}
+
 }  // namespace
 }  // namespace litert::qualcomm

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -298,8 +298,8 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
 
     std::vector<::qnn::OpWrapper> op_wrappers;
     LITERT_RETURN_IF_ERROR(litert::qnn::ConvertOp(
-      compiler_plugin->Options().GetUseHtpPreference(), op, tensor_pool,
-      input_tensors, output_tensors, op_wrappers));
+        compiler_plugin->Options().GetUseHtpPreference(), op, tensor_pool,
+        input_tensors, output_tensors, op_wrappers));
 
     if (compiler_plugin->Options().GetUseQint16AsQuint16()) {
       tensor_pool.ForEach([](::qnn::TensorWrapper& tensor_wrapper) {

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
@@ -33,7 +33,8 @@ LiteRtStatus ConvertTensor(const litert::Tensor& litert_tensor,
                            ::qnn::TensorWrapper*& tensor_wrapper,
                            bool is_tensor_read_and_write = false);
 
-LiteRtStatus ConvertOp(const litert::Op& litert_op,
+LiteRtStatus ConvertOp(const bool use_htp_preferences,
+                       const litert::Op& litert_op,
                        ::qnn::TensorPool& tensor_pool,
                        std::vector<::qnn::TensorWrapperRef>& input_tensors,
                        std::vector<::qnn::TensorWrapperRef>& output_tensors,
@@ -43,7 +44,8 @@ LiteRtStatus ConvertOp(const litert::Op& litert_op,
 // context behind "qnn". Uses given graph_name to name entry point.
 LiteRtStatus ComposeGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
                           LiteRtSubgraph subgraph,
-                          absl::string_view qnn_graph_name);
+                          absl::string_view qnn_graph_name,
+                          const ::qnn::Options& options);
 
 }  // namespace litert::qnn
 

--- a/litert/vendors/qualcomm/core/BUILD
+++ b/litert/vendors/qualcomm/core/BUILD
@@ -47,5 +47,9 @@ litert_device_exec(
 
 cc_library(
     name = "common",
+    srcs = ["common.cc"],
     hdrs = ["common.h"],
+    deps = [
+        "@com_google_absl//absl/strings:str_format",
+    ],
 )

--- a/litert/vendors/qualcomm/core/backends/htp_perf_control.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_perf_control.cc
@@ -87,25 +87,25 @@ bool SetQnnHtpPerfInfrastructure(
   return true;
 }
 
-bool HandleDownvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
+bool HandleDownvoteConfig(const ::qnn::HtpPerformanceMode perf_mode,
                           QnnHtpPerfInfrastructure_DcvsV3_t& dcvs_v3) {
   bool status = true;
   dcvs_v3.dcvsEnable = kDcvsEnable;
 
   switch (perf_mode) {
-    case LiteRtQnnHtpPerformanceMode::kHtpBurst:
-    case LiteRtQnnHtpPerformanceMode::kHtpSustainedHighPerformance:
-    case LiteRtQnnHtpPerformanceMode::kHtpHighPerformance:
-    case LiteRtQnnHtpPerformanceMode::kHtpBalanced:
+    case ::qnn::HtpPerformanceMode::kBurst:
+    case ::qnn::HtpPerformanceMode::kSustainedHighPerformance:
+    case ::qnn::HtpPerformanceMode::kHighPerformance:
+    case ::qnn::HtpPerformanceMode::kBalanced:
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_ADJUST_UP_DOWN,
           kSleepMaxLatency, DCVS_VOLTAGE_VCORNER_SVS2, DCVS_VOLTAGE_VCORNER_SVS,
           DCVS_VOLTAGE_VCORNER_SVS, DCVS_VOLTAGE_VCORNER_SVS2,
           DCVS_VOLTAGE_VCORNER_SVS, DCVS_VOLTAGE_VCORNER_SVS);
       break;
-    case LiteRtQnnHtpPerformanceMode::kHtpPowerSaver:
-    case LiteRtQnnHtpPerformanceMode::kHtpLowPowerSaver:
-    case LiteRtQnnHtpPerformanceMode::kHtpHighPowerSaver:
+    case ::qnn::HtpPerformanceMode::kPowerSaver:
+    case ::qnn::HtpPerformanceMode::kLowPowerSaver:
+    case ::qnn::HtpPerformanceMode::kHighPowerSaver:
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_POWER_SAVER_MODE,
           kSleepMaxLatency, DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
@@ -115,14 +115,14 @@ bool HandleDownvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
           DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
           DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER);
       break;
-    case LiteRtQnnHtpPerformanceMode::kHtpLowBalanced:
+    case ::qnn::HtpPerformanceMode::kLowBalanced:
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_POWER_SAVER_MODE,
           kSleepMaxLatency, DCVS_VOLTAGE_VCORNER_SVS2, DCVS_VOLTAGE_VCORNER_SVS,
           DCVS_VOLTAGE_VCORNER_SVS, DCVS_VOLTAGE_VCORNER_SVS2,
           DCVS_VOLTAGE_VCORNER_SVS, DCVS_VOLTAGE_VCORNER_SVS);
       break;
-    case LiteRtQnnHtpPerformanceMode::kHtpExtremePowerSaver:
+    case ::qnn::HtpPerformanceMode::kExtremePowerSaver:
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_POWER_SAVER_MODE,
           kSleepMaxLatency, DCVS_VOLTAGE_CORNER_DISABLE,
@@ -137,11 +137,11 @@ bool HandleDownvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
   return status;
 }
 
-bool HandleUpvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
+bool HandleUpvoteConfig(const ::qnn::HtpPerformanceMode perf_mode,
                         QnnHtpPerfInfrastructure_DcvsV3_t& dcvs_v3) {
   bool status = true;
   switch (perf_mode) {
-    case LiteRtQnnHtpPerformanceMode::kHtpBurst:
+    case ::qnn::HtpPerformanceMode::kBurst:
       dcvs_v3.dcvsEnable = kDcvsDisable;
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_ADJUST_UP_DOWN,
@@ -152,8 +152,8 @@ bool HandleUpvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
           DCVS_VOLTAGE_VCORNER_MAX_VOLTAGE_CORNER,
           DCVS_VOLTAGE_VCORNER_MAX_VOLTAGE_CORNER);
       break;
-    case LiteRtQnnHtpPerformanceMode::kHtpSustainedHighPerformance:
-    case LiteRtQnnHtpPerformanceMode::kHtpHighPerformance:
+    case ::qnn::HtpPerformanceMode::kSustainedHighPerformance:
+    case ::qnn::HtpPerformanceMode::kHighPerformance:
       dcvs_v3.dcvsEnable = kDcvsDisable;
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_ADJUST_UP_DOWN,
@@ -162,7 +162,7 @@ bool HandleUpvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
           DCVS_VOLTAGE_VCORNER_TURBO, DCVS_VOLTAGE_VCORNER_TURBO,
           DCVS_VOLTAGE_VCORNER_TURBO);
       break;
-    case LiteRtQnnHtpPerformanceMode::kHtpPowerSaver:
+    case ::qnn::HtpPerformanceMode::kPowerSaver:
       dcvs_v3.dcvsEnable = kDcvsEnable;
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_PERFORMANCE_MODE,
@@ -171,7 +171,7 @@ bool HandleUpvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
           DCVS_VOLTAGE_VCORNER_SVS, DCVS_VOLTAGE_VCORNER_SVS,
           DCVS_VOLTAGE_VCORNER_SVS);
       break;
-    case LiteRtQnnHtpPerformanceMode::kHtpLowPowerSaver:
+    case ::qnn::HtpPerformanceMode::kLowPowerSaver:
       dcvs_v3.dcvsEnable = kDcvsEnable;
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_PERFORMANCE_MODE,
@@ -180,7 +180,7 @@ bool HandleUpvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
           DCVS_VOLTAGE_VCORNER_SVS2, DCVS_VOLTAGE_VCORNER_SVS2,
           DCVS_VOLTAGE_VCORNER_SVS2);
       break;
-    case LiteRtQnnHtpPerformanceMode::kHtpHighPowerSaver:
+    case ::qnn::HtpPerformanceMode::kHighPowerSaver:
       dcvs_v3.dcvsEnable = kDcvsEnable;
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_PERFORMANCE_MODE,
@@ -189,7 +189,7 @@ bool HandleUpvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
           DCVS_VOLTAGE_VCORNER_SVS_PLUS, DCVS_VOLTAGE_VCORNER_SVS_PLUS,
           DCVS_VOLTAGE_VCORNER_SVS_PLUS);
       break;
-    case LiteRtQnnHtpPerformanceMode::kHtpLowBalanced:
+    case ::qnn::HtpPerformanceMode::kLowBalanced:
       dcvs_v3.dcvsEnable = kDcvsEnable;
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_PERFORMANCE_MODE,
@@ -198,7 +198,7 @@ bool HandleUpvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
           DCVS_VOLTAGE_VCORNER_NOM, DCVS_VOLTAGE_VCORNER_NOM,
           DCVS_VOLTAGE_VCORNER_NOM);
       break;
-    case LiteRtQnnHtpPerformanceMode::kHtpBalanced:
+    case ::qnn::HtpPerformanceMode::kBalanced:
       dcvs_v3.dcvsEnable = kDcvsEnable;
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_PERFORMANCE_MODE,
@@ -207,7 +207,7 @@ bool HandleUpvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
           DCVS_VOLTAGE_VCORNER_NOM_PLUS, DCVS_VOLTAGE_VCORNER_NOM_PLUS,
           DCVS_VOLTAGE_VCORNER_NOM_PLUS);
       break;
-    case LiteRtQnnHtpPerformanceMode::kHtpExtremePowerSaver:
+    case ::qnn::HtpPerformanceMode::kExtremePowerSaver:
       dcvs_v3.dcvsEnable = kDcvsEnable;
       status = SetQnnHtpPerfInfrastructure(
           dcvs_v3, QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_PERFORMANCE_MODE,
@@ -226,7 +226,7 @@ bool HandleUpvoteConfig(const LiteRtQnnHtpPerformanceMode& perf_mode,
 
 std::vector<QnnHtpPerfInfrastructure_PowerConfig_t> SetVotePowerConfig(
     const std::uint32_t power_config_id,
-    const LiteRtQnnHtpPerformanceMode perf_mode,
+    const ::qnn::HtpPerformanceMode perf_mode,
     const PerformanceModeVoteType vote_type) {
   constexpr const int kNumConfigs = 1;
   std::vector<QnnHtpPerfInfrastructure_PowerConfig_t> power_configs(
@@ -245,7 +245,7 @@ std::vector<QnnHtpPerfInfrastructure_PowerConfig_t> SetVotePowerConfig(
 
   dcvs_v3.setSleepLatency = 1;  // true
 
-  dcvs_v3.setBusParams = 1;   // true
+  dcvs_v3.setBusParams = 1;  // true
   dcvs_v3.setCoreParams = 1;  // true
 
   // Check DownVote before performance mode
@@ -283,8 +283,8 @@ struct PerfControl::BackendConfig {
 };
 
 PerfControl::PerfControl(const QNN_INTERFACE_VER_TYPE* api,
-                         const LiteRtQnnHtpBackendOptions& htp_options)
-    : api_(api), performance_mode_(htp_options.performance_mode) {
+                         const ::qnn::HtpPerformanceMode htp_performance_mode)
+    : api_(api), performance_mode_(htp_performance_mode) {
   backend_config_ = std::make_unique<BackendConfig>();
 }
 
@@ -292,7 +292,7 @@ PerfControl::~PerfControl() = default;
 
 bool PerfControl::CreatePerfPowerConfigPtr(
     const std::uint32_t power_config_id,
-    const LiteRtQnnHtpPerformanceMode perf_mode,
+    const ::qnn::HtpPerformanceMode perf_mode,
     const PerformanceModeVoteType vote_type) {
   if (vote_type == PerformanceModeVoteType::kUpVote) {
     backend_config_->perf_power_configs_ =
@@ -325,7 +325,7 @@ void PerfControl::PerformanceVote() {
 };
 
 std::vector<QnnHtpPerfInfrastructure_PowerConfig_t> SetRpcPollingPowerConfig(
-    LiteRtQnnHtpPerformanceMode perf_mode) {
+    ::qnn::HtpPerformanceMode perf_mode) {
   std::vector<QnnHtpPerfInfrastructure_PowerConfig_t> power_configs;
 
   QnnHtpPerfInfrastructure_PowerConfig_t rpc_control_latency;
@@ -336,22 +336,22 @@ std::vector<QnnHtpPerfInfrastructure_PowerConfig_t> SetRpcPollingPowerConfig(
       QNN_HTP_PERF_INFRASTRUCTURE_POWER_CONFIGOPTION_UNKNOWN;
 
   switch (perf_mode) {
-    case LiteRtQnnHtpPerformanceMode::kHtpBurst:
-    case LiteRtQnnHtpPerformanceMode::kHtpSustainedHighPerformance:
-    case LiteRtQnnHtpPerformanceMode::kHtpHighPerformance:
+    case ::qnn::HtpPerformanceMode::kBurst:
+    case ::qnn::HtpPerformanceMode::kSustainedHighPerformance:
+    case ::qnn::HtpPerformanceMode::kHighPerformance:
       rpc_polling_time.option =
           QNN_HTP_PERF_INFRASTRUCTURE_POWER_CONFIGOPTION_RPC_POLLING_TIME;
       rpc_polling_time.rpcPollingTimeConfig = kRpcPollingTimeHighPower;
       power_configs.emplace_back(rpc_polling_time);
       ABSL_FALLTHROUGH_INTENDED;
       // intentionally no break here.
-    case LiteRtQnnHtpPerformanceMode::kHtpPowerSaver:
-    case LiteRtQnnHtpPerformanceMode::kHtpLowPowerSaver:
-    case LiteRtQnnHtpPerformanceMode::kHtpHighPowerSaver:
-    case LiteRtQnnHtpPerformanceMode::kHtpLowBalanced:
-    case LiteRtQnnHtpPerformanceMode::kHtpBalanced:
-    case LiteRtQnnHtpPerformanceMode::kHtpDefault:
-    case LiteRtQnnHtpPerformanceMode::kHtpExtremePowerSaver:
+    case ::qnn::HtpPerformanceMode::kPowerSaver:
+    case ::qnn::HtpPerformanceMode::kLowPowerSaver:
+    case ::qnn::HtpPerformanceMode::kHighPowerSaver:
+    case ::qnn::HtpPerformanceMode::kLowBalanced:
+    case ::qnn::HtpPerformanceMode::kBalanced:
+    case ::qnn::HtpPerformanceMode::kDefault:
+    case ::qnn::HtpPerformanceMode::kExtremePowerSaver:
       rpc_control_latency.option =
           QNN_HTP_PERF_INFRASTRUCTURE_POWER_CONFIGOPTION_RPC_CONTROL_LATENCY;
       rpc_control_latency.rpcControlLatencyConfig = kRpcControlLatency;

--- a/litert/vendors/qualcomm/core/backends/htp_perf_control.h
+++ b/litert/vendors/qualcomm/core/backends/htp_perf_control.h
@@ -33,7 +33,7 @@ enum PerformanceModeVoteType {
 class PerfControl {
  public:
   explicit PerfControl(const QNN_INTERFACE_VER_TYPE* api,
-                       const LiteRtQnnHtpBackendOptions& htp_options);
+                       const ::qnn::HtpPerformanceMode htp_performance_mode);
   PerfControl(const PerfControl&) = delete;
   PerfControl(PerfControl&&) = delete;
   PerfControl& operator=(const PerfControl&) = delete;
@@ -45,12 +45,12 @@ class PerfControl {
   // Direct vote is only supported in manual mode.
   void PerformanceVote();
   bool CreatePerfPowerConfigPtr(const std::uint32_t power_config_id,
-                                const LiteRtQnnHtpPerformanceMode perf_mode,
+                                const ::qnn::HtpPerformanceMode perf_mode,
                                 const PerformanceModeVoteType vote_type);
 
  private:
   inline bool IsPerfModeEnabled() const {
-    return performance_mode_ != LiteRtQnnHtpPerformanceMode::kHtpDefault;
+    return performance_mode_ != ::qnn::HtpPerformanceMode::kDefault;
   }
   const QNN_INTERFACE_VER_TYPE* api_{nullptr};
   struct BackendConfig;
@@ -58,7 +58,8 @@ class PerfControl {
   std::uint32_t powerconfig_client_id_{0};
   PerformanceModeVoteType manual_voting_type_{kNoVote};
   // HTPBackendOptions
-  LiteRtQnnHtpPerformanceMode performance_mode_{kHtpDefault};
+  ::qnn::HtpPerformanceMode performance_mode_{
+      ::qnn::HtpPerformanceMode::kDefault};
   std::uint32_t device_id_{0};
 };
 

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -1,0 +1,63 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/common.h"
+
+#include "absl/strings/str_format.h"  // from @com_google_absl
+
+namespace qnn {
+
+void Options::SetLogLevel(const LogLevel log_level) { log_level_ = log_level; }
+
+LogLevel Options::GetLogLevel() const { return log_level_; }
+
+void Options::SetProfiling(const Profiling profiling) {
+  profiling_ = profiling;
+}
+
+Profiling Options::GetProfiling() const { return profiling_; }
+
+void Options::SetUseHtpPreference(const bool use_htp_preference) {
+  use_htp_preference_ = use_htp_preference;
+}
+
+bool Options::GetUseHtpPreference() const { return use_htp_preference_; }
+
+void Options::SetUseQint16AsQuint16(const bool use_qint16_as_quint16) {
+  use_qint16_as_quint16_ = use_qint16_as_quint16;
+}
+
+bool Options::GetUseQint16AsQuint16() const { return use_qint16_as_quint16_; }
+
+void Options::SetEnableWeightSharing(const bool enable_weight_sharing) {
+  enable_weight_sharing_ = enable_weight_sharing;
+}
+
+bool Options::GetEnableWeightSharing() const { return enable_weight_sharing_; }
+
+void Options::SetHtpPerformanceMode(
+    const HtpPerformanceMode htp_performance_mode) {
+  htp_performance_mode_ = htp_performance_mode;
+}
+
+HtpPerformanceMode Options::GetHtpPerformanceMode() const {
+  return htp_performance_mode_;
+}
+
+std::string Options::Dump() const {
+  static constexpr absl::string_view kQnnOptionsDumpFormat =
+      "\
+::qnn::Options:\n\
+LogLevel: %d\n\
+Profiling: %d\n\
+UseHtpPreference: %v\n\
+UseQint16AsQuint16: %v\n\
+EnableWeightSharing: %v\n\
+HtpPerformanceMode: %d\n";
+
+  return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, profiling_,
+                         use_htp_preference_, use_qint16_as_quint16_,
+                         enable_weight_sharing_, htp_performance_mode_);
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -1,78 +1,71 @@
-
 // Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_COMMON_H_
 #define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_COMMON_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif  // __cplusplus
+#include <string>
 
-typedef enum LiteRtQnnProfilingOptions {
-  kQnnProfilingOff = 0,
-  kQnnProfilingBasic = 1,
-  kQnnProfilingDetailed = 2
-} LiteRtQnnProfilingOptions;
+// c++ enum and wrapper without dependency.
+namespace qnn {
 
-typedef enum LiteRtQnnLogLevel {
-  /// Disable delegate and QNN backend logging messages.
-  kQnnLogOff = 0,
-  kQnnLogLevelError = 1,
-  kQnnLogLevelWarn = 2,
-  kQnnLogLevelInfo = 3,
-  kQnnLogLevelVerbose = 4,
-  kQnnLogLevelDebug = 5,
-} LiteRtQnnLogLevel;
+enum class LogLevel {
+  kOff = 0,
+  kError = 1,
+  kWarn = 2,
+  kInfo = 3,
+  kVerbose = 4,
+  kDebug = 5,
+};
 
-typedef enum LiteRtQnnHtpPerformanceMode {
-  kHtpDefault = 0,
-  kHtpSustainedHighPerformance = 1,
-  kHtpBurst = 2,
-  kHtpHighPerformance = 3,
-  kHtpPowerSaver = 4,
-  kHtpLowPowerSaver = 5,
-  kHtpHighPowerSaver = 6,
-  kHtpLowBalanced = 7,
-  kHtpBalanced = 8,
-  kHtpExtremePowerSaver = 9,
-} LiteRtQnnHtpPerformanceMode;
+enum class Profiling { kOff = 0, kBasic = 1, kDetailed = 2 };
 
-typedef struct {
-  /// The default performance mode sets no configurations on the HTP.
-  LiteRtQnnHtpPerformanceMode performance_mode;
-} LiteRtQnnHtpBackendOptions;
+enum class HtpPerformanceMode {
+  kDefault = 0,
+  kSustainedHighPerformance = 1,
+  kBurst = 2,
+  kHighPerformance = 3,
+  kPowerSaver = 4,
+  kLowPowerSaver = 5,
+  kHighPowerSaver = 6,
+  kLowBalanced = 7,
+  kBalanced = 8,
+  kExtremePowerSaver = 9,
+};
 
-// clang-format off
-#define LITERT_QNN_HTP_OPTION_INIT {kHtpDefault /*performance_mode*/}
-// clang-format on
+class Options {
+ public:
+  Options() = default;
 
-typedef struct {
-  /// Apply HTP-friendly op builder.
-  bool use_htp_preferences;
-  /// This option will treat quantized int16 tensor as quantized uint16 tensor
-  /// for better backend compatibility.
-  bool use_qint16_as_quint16;
-  /// Optional backend specific options for the HTP backend.
-  LiteRtQnnHtpBackendOptions htp_options;
-  /// Log level
-  LiteRtQnnLogLevel log_level;
-} LiteRtQnnOptions;
+  void SetLogLevel(const LogLevel log_level);
+  LogLevel GetLogLevel() const;
 
-// This option can be used to specify QNN options.
-static const char* kDispatchOptionLiteRtQnnOptions = "litert_qnn_options";
+  void SetProfiling(const Profiling profiling);
+  Profiling GetProfiling() const;
 
-// clang-format off
-#define LITERT_QNN_OPTIONS_INIT                                  \
-  {                                                              \
-      false,                      /*use_htp_preferences*/        \
-      true,                       /*use_qint16_as_quint16*/      \
-      LITERT_QNN_HTP_OPTION_INIT, /*LiteRtQnnHtpBackendOptions*/ \
-      kQnnLogOff,                 /*log_level*/                  \
-  }
-// clang-format on
-#ifdef __cplusplus
-}
-#endif  // __cplusplus
+  void SetUseHtpPreference(const bool use_htp_preference);
+  bool GetUseHtpPreference() const;
+
+  void SetUseQint16AsQuint16(const bool use_qint16_as_quint16);
+  bool GetUseQint16AsQuint16() const;
+
+  void SetEnableWeightSharing(const bool enable_weight_sharing);
+  bool GetEnableWeightSharing() const;
+
+  void SetHtpPerformanceMode(const HtpPerformanceMode htp_performance_mode);
+  HtpPerformanceMode GetHtpPerformanceMode() const;
+
+  std::string Dump() const;
+
+ private:
+  LogLevel log_level_ = LogLevel::kInfo;
+  Profiling profiling_ = Profiling::kOff;
+  bool use_htp_preference_ = false;
+  bool use_qint16_as_quint16_ = false;
+  bool enable_weight_sharing_ = false;
+  HtpPerformanceMode htp_performance_mode_ = HtpPerformanceMode::kDefault;
+};
+
+}  // namespace qnn
 
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_COMMON_H_

--- a/litert/vendors/qualcomm/core/utils/log.h
+++ b/litert/vendors/qualcomm/core/utils/log.h
@@ -13,45 +13,45 @@ namespace qnn {
 class QNNLogger {
  public:
   // Logging hook that takes variadic args.
-  static void Log(LiteRtQnnLogLevel severity, const char* format, ...);
+  static void Log(::qnn::LogLevel severity, const char* format, ...);
 
   // Set file descriptor
   static void SetLogFilePointer(FILE* fp);
 
   // Set log level
-  static void SetLogLevel(LiteRtQnnLogLevel log_level);
+  static void SetLogLevel(::qnn::LogLevel log_level);
 
  private:
   // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
   static FILE* log_file_pointer_;
-  static LiteRtQnnLogLevel log_level_;
+  static ::qnn::LogLevel log_level_;
   // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 };
 }  // namespace qnn
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define QNN_LOG_VERBOSE(format, ...)                                     \
-  ::qnn::QNNLogger::Log(kQnnLogLevelVerbose, ("VERBOSE: [Qnn] " format), \
+#define QNN_LOG_VERBOSE(format, ...)                                           \
+  ::qnn::QNNLogger::Log(::qnn::LogLevel::kVerbose, ("VERBOSE: [Qnn] " format), \
                         ##__VA_ARGS__);
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define QNN_LOG_INFO(format, ...)                                  \
-  ::qnn::QNNLogger::Log(kQnnLogLevelInfo, ("INFO: [Qnn] " format), \
+#define QNN_LOG_INFO(format, ...)                                        \
+  ::qnn::QNNLogger::Log(::qnn::LogLevel::kInfo, ("INFO: [Qnn] " format), \
                         ##__VA_ARGS__);
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define QNN_LOG_WARNING(format, ...)                                  \
-  ::qnn::QNNLogger::Log(kQnnLogLevelWarn, ("WARNING: [Qnn] " format), \
+#define QNN_LOG_WARNING(format, ...)                                        \
+  ::qnn::QNNLogger::Log(::qnn::LogLevel::kWarn, ("WARNING: [Qnn] " format), \
                         ##__VA_ARGS__);
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define QNN_LOG_ERROR(format, ...)                                   \
-  ::qnn::QNNLogger::Log(kQnnLogLevelError, ("ERROR: [Qnn] " format), \
+#define QNN_LOG_ERROR(format, ...)                                         \
+  ::qnn::QNNLogger::Log(::qnn::LogLevel::kError, ("ERROR: [Qnn] " format), \
                         ##__VA_ARGS__);
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define QNN_LOG_DEBUG(format, ...)                                   \
-  ::qnn::QNNLogger::Log(kQnnLogLevelDebug, ("DEBUG: [Qnn] " format), \
+#define QNN_LOG_DEBUG(format, ...)                                         \
+  ::qnn::QNNLogger::Log(::qnn::LogLevel::kDebug, ("DEBUG: [Qnn] " format), \
                         ##__VA_ARGS__);
 
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_UTILS_LOG_H_

--- a/litert/vendors/qualcomm/core/utils/log_android.cc
+++ b/litert/vendors/qualcomm/core/utils/log_android.cc
@@ -8,15 +8,15 @@
 namespace qnn {
 namespace {
 
-int GetPlatformSeverity(LiteRtQnnLogLevel severity) {
+int GetPlatformSeverity(::qnn::LogLevel severity) {
   switch (severity) {
-    case kQnnLogLevelError:
+    case ::qnn::LogLevel::kError:
       return ANDROID_LOG_ERROR;
-    case kQnnLogLevelWarn:
+    case ::qnn::LogLevel::kWarn:
       return ANDROID_LOG_WARN;
-    case kQnnLogLevelInfo:
+    case ::qnn::LogLevel::kInfo:
       return ANDROID_LOG_INFO;
-    case kQnnLogLevelVerbose:
+    case ::qnn::LogLevel::kVerbose:
       return ANDROID_LOG_VERBOSE;
     default:
       return ANDROID_LOG_DEBUG;
@@ -27,14 +27,14 @@ int GetPlatformSeverity(LiteRtQnnLogLevel severity) {
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 FILE* QNNLogger::log_file_pointer_ = stderr;
-LiteRtQnnLogLevel QNNLogger::log_level_ = kQnnLogLevelInfo;
+::qnn::LogLevel QNNLogger::log_level_ = ::qnn::LogLevel::kInfo;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 void QNNLogger::SetLogFilePointer(FILE* fp) { log_file_pointer_ = fp; }
-void QNNLogger::SetLogLevel(LiteRtQnnLogLevel log_level) {
+void QNNLogger::SetLogLevel(::qnn::LogLevel log_level) {
   log_level_ = log_level;
 }
 // NOLINTNEXTLINE(cert-dcl50-cpp)
-void QNNLogger::Log(LiteRtQnnLogLevel severity, const char* format, ...) {
+void QNNLogger::Log(::qnn::LogLevel severity, const char* format, ...) {
   if (severity > log_level_) {
     return;
   }

--- a/litert/vendors/qualcomm/core/utils/log_default.cc
+++ b/litert/vendors/qualcomm/core/utils/log_default.cc
@@ -11,14 +11,14 @@ namespace qnn {
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 FILE* QNNLogger::log_file_pointer_ = stderr;
-LiteRtQnnLogLevel QNNLogger::log_level_ = kQnnLogLevelInfo;
+::qnn::LogLevel QNNLogger::log_level_ = ::qnn::LogLevel::kInfo;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 void QNNLogger::SetLogFilePointer(FILE* fp) { log_file_pointer_ = fp; }
-void QNNLogger::SetLogLevel(LiteRtQnnLogLevel log_level) {
+void QNNLogger::SetLogLevel(::qnn::LogLevel log_level) {
   log_level_ = log_level;
 }
 // NOLINTNEXTLINE(cert-dcl50-cpp)
-void QNNLogger::Log(LiteRtQnnLogLevel severity, const char* format, ...) {
+void QNNLogger::Log(::qnn::LogLevel severity, const char* format, ...) {
   if (severity > log_level_) {
     return;
   }

--- a/litert/vendors/qualcomm/core/utils/utils_test.cc
+++ b/litert/vendors/qualcomm/core/utils/utils_test.cc
@@ -20,25 +20,25 @@ bool IsPrefix(std::string_view prefix, std::string_view full) {
   return prefix == full.substr(0, prefix.size());
 }
 
-bool CheckLoggoing(const std::string log_path, LiteRtQnnLogLevel log_level) {
+bool CheckLoggoing(const std::string log_path, ::qnn::LogLevel log_level) {
   std::ifstream fin(log_path);
   std::string msg;
   while (std::getline(fin, msg)) {
     // Log severity: DEBUG > VERBOSE > INFO > WARN > ERROR
     switch (log_level) {
-      case kQnnLogOff:
+      case ::qnn::LogLevel::kOff:
         if (IsPrefix("ERROR:", msg)) return false;
         [[fallthrough]];
-      case kQnnLogLevelError:
+      case ::qnn::LogLevel::kError:
         if (IsPrefix("WARNING:", msg)) return false;
         [[fallthrough]];
-      case kQnnLogLevelWarn:
+      case ::qnn::LogLevel::kWarn:
         if (IsPrefix("INFO:", msg)) return false;
         [[fallthrough]];
-      case kQnnLogLevelInfo:
+      case ::qnn::LogLevel::kInfo:
         if (IsPrefix("VERBOSE:", msg)) return false;
         [[fallthrough]];
-      case kQnnLogLevelVerbose:
+      case ::qnn::LogLevel::kVerbose:
         if (IsPrefix("DEBUG:", msg)) return false;
         [[fallthrough]];
       default:
@@ -50,12 +50,12 @@ bool CheckLoggoing(const std::string log_path, LiteRtQnnLogLevel log_level) {
 
 }  // namespace
 
-class LiteRtLog : public ::testing::TestWithParam<LiteRtQnnLogLevel> {};
-INSTANTIATE_TEST_SUITE_P(, LiteRtLog,
-                         ::testing::Values(kQnnLogOff, kQnnLogLevelError,
-                                           kQnnLogLevelWarn, kQnnLogLevelInfo,
-                                           kQnnLogLevelVerbose,
-                                           kQnnLogLevelDebug));
+class LiteRtLog : public ::testing::TestWithParam<::qnn::LogLevel> {};
+INSTANTIATE_TEST_SUITE_P(
+    , LiteRtLog,
+    ::testing::Values(::qnn::LogLevel::kOff, ::qnn::LogLevel::kError,
+                      ::qnn::LogLevel::kWarn, ::qnn::LogLevel::kInfo,
+                      ::qnn::LogLevel::kVerbose, ::qnn::LogLevel::kDebug));
 
 TEST_P(LiteRtLog, SanityTest) {
   // Create temp file for log
@@ -70,7 +70,7 @@ TEST_P(LiteRtLog, SanityTest) {
   qnn::QNNLogger::SetLogFilePointer(file_ptr);
 
   // Set log_level and print message to file
-  LiteRtQnnLogLevel log_level = GetParam();
+  auto log_level = GetParam();
   qnn::QNNLogger::SetLogLevel(log_level);
   QNN_LOG_VERBOSE("This is a verbose message.");
   QNN_LOG_INFO("This is an info message.");

--- a/litert/vendors/qualcomm/dispatch/dispatch_api.cc
+++ b/litert/vendors/qualcomm/dispatch/dispatch_api.cc
@@ -66,13 +66,15 @@ LiteRtStatus Initialize(const LiteRtDispatchOption* options, int num_options) {
                          : std::nullopt;
 
   auto configs = QnnManager::DefaultBackendConfigs();
-  LiteRtQnnOptions qnn_options = LITERT_QNN_OPTIONS_INIT;
-  qnn_options.htp_options.performance_mode = kHtpBurst;
+  // TODO(Alen): initialize qnn_options from LiteRtOptions
+  ::qnn::Options qnn_options;
+  qnn_options.SetHtpPerformanceMode(::qnn::HtpPerformanceMode::kBurst);
+  qnn_options.SetLogLevel(::qnn::LogLevel::kOff);
   if (auto qnn_manager = QnnManager::Create(
           /*configs=*/configs,
+          /*options=*/qnn_options,
           /*shared_library_dir=*/shared_library_dir_opt,
-          /*soc_model*/ std::nullopt,
-          /*options=*/qnn_options);
+          /*soc_model*/ std::nullopt);
       !qnn_manager) {
     LITERT_LOG(LITERT_ERROR, "%s", qnn_manager.Error().Message().c_str());
     return qnn_manager.Error().Status();

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
@@ -126,12 +126,13 @@ LiteRtDispatchInvocationContextT::Create(
 
   // TODO: Add profiling_level as an option & related test code with different
   // profiling level after having option interface
-  int profiling_level = LiteRtQnnProfilingOptions::kQnnProfilingOff;
+  auto profiling_level = ::qnn::Profiling::kOff;
 
   Qnn_ProfileHandle_t profile_handle = nullptr;
-  if (profiling_level != LiteRtQnnProfilingOptions::kQnnProfilingOff) {
+  if (profiling_level != ::qnn::Profiling::kOff) {
     if (auto status = qnn.Api()->profileCreate(
-            qnn.BackendHandle(), profiling_level, &profile_handle);
+            qnn.BackendHandle(),
+            static_cast<QnnProfile_Level_t>(profiling_level), &profile_handle);
         status != QNN_SUCCESS) {
       return Unexpected(kLiteRtStatusErrorRuntimeFailure,
                         "Failed to create profile handle");

--- a/litert/vendors/qualcomm/qnn_manager.h
+++ b/litert/vendors/qualcomm/qnn_manager.h
@@ -91,9 +91,9 @@ class QnnManager {
 
   static Expected<Ptr> Create(
       absl::Span<const QnnBackend_Config_t*> configs,
+      const ::qnn::Options& options,
       std::optional<std::string> shared_library_dir = std::nullopt,
-      std::optional<::qnn::SocInfo> soc_info = std::nullopt,
-      const LiteRtQnnOptions& options = LITERT_QNN_OPTIONS_INIT);
+      std::optional<::qnn::SocInfo> soc_info = std::nullopt);
 
   static absl::Span<const QnnBackend_Config_t*> DefaultBackendConfigs();
   static absl::Span<const QnnContext_Config_t*> DefaultContextConfigs();
@@ -145,7 +145,7 @@ class QnnManager {
   LiteRtStatus Init(absl::Span<const QnnBackend_Config_t*> configs,
                     std::optional<std::string> shared_library_dir,
                     std::optional<::qnn::SocInfo> soc_info,
-                    const LiteRtQnnOptions& options);
+                    const ::qnn::Options& options);
 
   //
   // Manage libQnn*.so Loading

--- a/litert/vendors/qualcomm/qnn_manager_test.cc
+++ b/litert/vendors/qualcomm/qnn_manager_test.cc
@@ -13,9 +13,11 @@
 
 #include "litert/vendors/qualcomm/qnn_manager.h"
 
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include "litert/test/common.h"
+#include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/tools/dump.h"
 
 namespace {
@@ -29,13 +31,15 @@ using ::testing::HasSubstr;
 
 TEST(QnnManagerTest, SetupQnnManager) {
   auto configs = QnnManager::DefaultBackendConfigs();
-  auto qnn = QnnManager::Create(configs);
+  auto options = ::qnn::Options();
+  auto qnn = QnnManager::Create(configs, options);
   ASSERT_TRUE(qnn);
 }
 
 TEST(QnnManagerTest, Dump) {
   auto configs = QnnManager::DefaultBackendConfigs();
-  auto qnn = QnnManager::Create(configs);
+  auto options = ::qnn::Options();
+  auto qnn = QnnManager::Create(configs, options);
   ASSERT_TRUE(qnn);
 
   auto dump = Dump(**qnn);


### PR DESCRIPTION
1. Support more options in `LiteRtQualcommOptions` and `QualcommOptions`, unit tests.
2. Use c++ enum and define `::qnn::Options`, `::qnn::Options` will be used  in `vendors/qualcomm/core/` to prevent LiteRt dependency.
3. Convert `QualcommOptions` to `::qnn::Options`, and use it in compiler plugin.
4. Implement absl Qualcomm flags, unit tests

# TEST
- litert_qualcomm_options_test
```
[----------] 2 tests from QualcommOptionsTest (0 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 9 tests.
```

- qualcomm_flags_test
```
[----------] 2 tests from ProfilingTest (0 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 6 tests.
```

- qnn_manager_test
```
[----------] 2 tests from QnnManagerTest (28 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (28 ms total)
[  PASSED  ] 2 tests
```


- qnn_compiler_plugin_test
```
[----------] 79 tests from SupportedOpsTest/QnnPluginOpCompatibilityTest (10054 ms total)

[----------] Global test environment tear-down
[==========] 174 tests from 5 test suites ran. (10819 ms total)
[  PASSED  ] 174 tests.
```