### PR TITLE
Qualcomm AI Engine Direct - Fix FC->Conv2D

### DIFF
--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder_htp.cc
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder_htp.cc
@@ -58,10 +58,11 @@ std::vector<OpWrapper> BuildFullyConnectedOpHtp(
   conv_op.AddInputTensor(conv_input_tensor);
   auto& quant_params = weight_tensor.GetQuantParams();
   if (std::holds_alternative<AxisScaleOffsetQuantizeParamsWrapper>(
-          quant_params)) {
-    auto& axis_quant_param =
-        std::get<AxisScaleOffsetQuantizeParamsWrapper>(quant_params);
-    axis_quant_param.SetAxis(3);
+          quant_params))
+    std::get<AxisScaleOffsetQuantizeParamsWrapper>(quant_params).SetAxis(3);
+  else if (std::holds_alternative<BwAxisScaleOffsetQuantizeParamsWrapper>(
+               quant_params)) {
+    std::get<BwAxisScaleOffsetQuantizeParamsWrapper>(quant_params).SetAxis(3);
   }
   std::vector<uint32_t> weight_dims{1, 1, weight_tensor.GetDim(1),
                                     weight_tensor.GetDim(0)};

--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
@@ -199,4 +199,8 @@ void BwAxisScaleOffsetQuantizeParamsWrapper::CloneTo(
   dst = qnn_quantize_param_;
 }
 
+void BwAxisScaleOffsetQuantizeParamsWrapper::SetAxis(const std::int32_t axis) {
+  qnn_quantize_param_.bwAxisScaleOffsetEncoding.axis = axis;
+}
+
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
@@ -118,6 +118,8 @@ class BwAxisScaleOffsetQuantizeParamsWrapper final {
 
   void CloneTo(Qnn_QuantizeParams_t& dst);
 
+  void SetAxis(const std::int32_t axis);
+
  private:
   Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
   std::vector<float> scales_;


### PR DESCRIPTION
# What
Fix FC -> Conv2D conversion on 4-bit quant ops.

# How
```
==== Build Summary ====
If there is any build failed, please check log before and fix it.

SUCCESS //litert/vendors/qualcomm/core/backends:all
SUCCESS //litert/vendors/qualcomm/core/builders:all
SUCCESS //litert/vendors/qualcomm/core/schema:all
SUCCESS //litert/vendors/qualcomm/core/utils:all
SUCCESS //litert/vendors/qualcomm/core/wrappers:all
SUCCESS //litert/vendors/qualcomm/core:all
SUCCESS //litert/vendors/qualcomm/compiler/IR:all
SUCCESS //litert/vendors/qualcomm/compiler/legalizations:all
SUCCESS //litert/vendors/qualcomm/compiler:all
SUCCESS //litert/vendors/qualcomm/dispatch:all
SUCCESS //litert/vendors/qualcomm/tools:all
SUCCESS //litert/vendors/qualcomm:all

==== Test Summary ====
If there is any test failed, please check log before and fix it.

SUCCESS //litert/vendors/qualcomm/core/utils:utils_test
SUCCESS //litert/vendors/qualcomm/core/utils:utils_test
SUCCESS //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
SUCCESS //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
SUCCESS //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
SUCCESS //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
SUCCESS //litert/vendors/qualcomm/core:tensor_pool_test
SUCCESS //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
SUCCESS //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
SUCCESS //litert/vendors/qualcomm:qnn_manager_test
```

Handle axis correctly in 4-bit quantization.
# Tests
Model E2E accuracy exactly same with no FC -> Conv2D conversion
```
_107_native.raw v.s. _111_native.raw
cosine_similarity: 1.0 MSE: 0.0

_109_native.raw v.s. _113_native.raw
cosine_similarity: 1.0 MSE: 0.0

_210_native.raw v.s. _234_native.raw
cosine_similarity: 1.0 MSE: 0.0

_211_native.raw v.s. _235_native.raw
cosine_similarity: 1.0 MSE: 0.0

_302_native.raw v.s. _346_native.raw
cosine_similarity: 1.0 MSE: 0.0

_303_native.raw v.s. _347_native.raw
cosine_similarity: 1.0 MSE: 0.0

_394_native.raw v.s. _458_native.raw
cosine_similarity: 1.0 MSE: 0.0

_395_native.raw v.s. _459_native.raw
cosine_similarity: 1.0 MSE: 0.0

_486_native.raw v.s. _570_native.raw
cosine_similarity: 1.0 MSE: 0.0

_487_native.raw v.s. _571_native.raw
cosine_similarity: 1.0 MSE: 0.0

_578_native.raw v.s. _682_native.raw
cosine_similarity: 1.0 MSE: 0.0

_579_native.raw v.s. _683_native.raw
cosine_similarity: 1.0 MSE: 0.0

_670_native.raw v.s. _794_native.raw
cosine_similarity: 1.0 MSE: 0.0

_671_native.raw v.s. _795_native.raw
cosine_similarity: 1.0 MSE: 0.0

_762_native.raw v.s. _906_native.raw
cosine_similarity: 1.0 MSE: 0.0

_763_native.raw v.s. _907_native.raw
cosine_similarity: 1.0 MSE: 0.0

_854_native.raw v.s. _1018_native.raw
cosine_similarity: 1.0 MSE: 0.0

_855_native.raw v.s. _1019_native.raw
cosine_similarity: 1.0 MSE: 0.0

_946_native.raw v.s. _1130_native.raw
cosine_similarity: 1.0 MSE: 0.0

_947_native.raw v.s. _1131_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1038_native.raw v.s. _1242_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1039_native.raw v.s. _1243_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1130_native.raw v.s. _1354_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1131_native.raw v.s. _1355_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1222_native.raw v.s. _1466_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1223_native.raw v.s. _1467_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1314_native.raw v.s. _1578_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1315_native.raw v.s. _1579_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1406_native.raw v.s. _1690_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1407_native.raw v.s. _1691_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1498_native.raw v.s. _1802_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1499_native.raw v.s. _1803_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1590_native.raw v.s. _1914_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1591_native.raw v.s. _1915_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1682_native.raw v.s. _2026_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1683_native.raw v.s. _2027_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1774_native.raw v.s. _2138_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1775_native.raw v.s. _2139_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1866_native.raw v.s. _2250_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1867_native.raw v.s. _2251_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1958_native.raw v.s. _2362_native.raw
cosine_similarity: 1.0 MSE: 0.0

_1959_native.raw v.s. _2363_native.raw
cosine_similarity: 1.0 MSE: 0.0

_2050_native.raw v.s. _2474_native.raw
cosine_similarity: 1.0 MSE: 0.0

_2051_native.raw v.s. _2475_native.raw
cosine_similarity: 1.0 MSE: 0.0

_2142_native.raw v.s. _2586_native.raw
cosine_similarity: 1.0 MSE: 0.0

_2143_native.raw v.s. _2587_native.raw
cosine_similarity: 1.0 MSE: 0.0

_2234_native.raw v.s. _2698_native.raw
cosine_similarity: 1.0 MSE: 0.0

_2235_native.raw v.s. _2699_native.raw
cosine_similarity: 1.0 MSE: 0.0

_2326_native.raw v.s. _2810_native.raw
cosine_similarity: 1.0 MSE: 0.0

_2327_native.raw v.s. _2811_native.raw
cosine_similarity: 1.0 MSE: 0.0

_2404_native.raw v.s. _2908_native.raw
cosine_similarity: 1.0 MSE: 0.0

_2405_native.raw v.s. _2909_native.raw
cosine_similarity: 1.0 MSE: 0.0
```