### PR TITLE
Qualcomm AI Engine Direct - Fix x86 Unit Tests

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
@@ -159,8 +159,7 @@ TEST(TestQnnPlugin, PartitionMulOps) {
 
   LiteRtOpListT selected_op_list;
   LITERT_ASSERT_OK(LiteRtCompilerPluginPartition(
-      plugin.get(), /*soc_model=*/nullptr, model.Subgraph(0)->Get(),
-      &selected_op_list));
+      plugin.get(), "SM8650", model.Subgraph(0)->Get(), &selected_op_list));
   const auto selected_ops = selected_op_list.Values();
 
   ASSERT_EQ(selected_ops.size(), 1);
@@ -370,7 +369,7 @@ TEST_P(QnnPlyginSupportedSocCompilationTest, CompileMulSubgraph) {
   auto plugin = CreatePlugin();
   auto model = testing::LoadTestFileModel("one_mul.tflite");
   auto soc_model = GetParam();
-  #ifdef __ANDROID__
+#ifdef __ANDROID__
   if (soc_model != "V75") {
     // TODO: Make this dynamic when device cloud testing has more devices.
     GTEST_SKIP() << "On device tests only support V75s.";
@@ -421,7 +420,7 @@ TEST_P(QnnPluginOpValidationTest, SupportedOpsTest) {
 
   LiteRtOpListT selected_ops;
   LITERT_ASSERT_OK(LiteRtCompilerPluginPartition(
-      plugin.get(), /*soc_model=*/nullptr, litert_subgraph, &selected_ops));
+      plugin.get(), "SM8650", litert_subgraph, &selected_ops));
 
   EXPECT_EQ(selected_ops.Values().size(), litert_subgraph->Ops().size());
 }

--- a/litert/vendors/qualcomm/qnn_manager_test.cc
+++ b/litert/vendors/qualcomm/qnn_manager_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 
 #include "litert/vendors/qualcomm/qnn_manager.h"
-
+#include "litert/vendors/qualcomm/core/schema/soc_table.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -29,13 +29,25 @@ using ::testing::HasSubstr;
 
 TEST(QnnManagerTest, SetupQnnManager) {
   auto configs = QnnManager::DefaultBackendConfigs();
+#ifdef __ANDROID__
+  // Query SoC info from device.
   auto qnn = QnnManager::Create(configs);
+#else
+  std::optional< ::qnn::SocInfo> soc_info = ::qnn::kSocInfos[6];
+  auto qnn = QnnManager::Create(configs, std::nullopt, soc_info);
+#endif  // __ANDROID__
   ASSERT_TRUE(qnn);
 }
 
 TEST(QnnManagerTest, Dump) {
   auto configs = QnnManager::DefaultBackendConfigs();
+#ifdef __ANDROID__
+  // Query SoC info from device.
   auto qnn = QnnManager::Create(configs);
+#else
+  std::optional< ::qnn::SocInfo> soc_info = ::qnn::kSocInfos[6];
+  auto qnn = QnnManager::Create(configs, std::nullopt, soc_info);
+#endif  // __ANDROID__
   ASSERT_TRUE(qnn);
 
   auto dump = Dump(**qnn);


### PR DESCRIPTION
# WHAT
- Provide SoC model to prevent `QnnManager` from querying platform info on x86 machine.
- error log:
```
INFO: [litert/vendors/qualcomm/qnn_manager.cc:340] Apply deviceGetPlatformInfo for SoC info.
ERROR: [litert/vendors/qualcomm/qnn_manager.cc:344] Fail to get platforminfo: 1000
ERROR: [litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc:281] Failed to set up QNN manager
     0.0ms [  INFO ]   <I> QnnLog_create started.
     0.0ms [WARNING]   <W> Initializing HtpProvider
     0.0ms [  INFO ]   <I> Applying log level 3 to 0 hardware devices
     0.0ms [  INFO ]   <I> QnnLog_create exit.
     0.0ms [  INFO ]   <I> QnnBackend_create started. backend = 0x7d027d98
     0.0ms [  INFO ]   <I> QnnBackend_create done successfully. backend = 0x7d027d98
     0.0ms [  INFO ]   <I> QnnDevice_getPlatformInfo started.
     0.0ms [ ERROR ]   <E> QnnDevice_getPlatformInfo API not supported
     0.0ms [  INFO ]   <I> QnnDevice_getPlatformInfo done. status 0x3e8
```

# TEST
- qnn_compiler_plugin_test
```
[----------] 79 tests from SupportedOpsTest/QnnPluginOpCompatibilityTest (8406 ms total)

[----------] Global test environment tear-down
[==========] 174 tests from 5 test suites ran. (9170 ms total)
[  PASSED  ] 174 tests.
```
- qnn_manager_test
```
[----------] 2 tests from QnnManagerTest (28 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (28 ms total)
[  PASSED  ] 2 tests.
```
