### PR TITLE
Qualcomm AI Engine Direct - Add LiteRt Tensor Index

### DIFF
--- a/litert/c/litert_model.cc
+++ b/litert/c/litert_model.cc
@@ -469,6 +469,14 @@ LiteRtStatus LiteRtGetTensorName(LiteRtTensor tensor, const char** name) {
   return kLiteRtStatusOk;
 }
 
+LiteRtStatus LiteRtGetTensorIndex(LiteRtTensor tensor, uint32_t* tensor_index) {
+  if (!tensor || !tensor_index) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+  *tensor_index = tensor->TensorIndex();
+  return kLiteRtStatusOk;
+}
+
 LiteRtStatus LiteRtGetQuantizationTypeId(LiteRtTensor tensor,
                                          LiteRtQuantizationTypeId* q_type_id) {
   if (!tensor || !q_type_id) {

--- a/litert/c/litert_model.h
+++ b/litert/c/litert_model.h
@@ -36,6 +36,9 @@ extern "C" {
 // attribute and if not set will return a zero-length string.
 LiteRtStatus LiteRtGetTensorName(LiteRtTensor tensor, const char** name);
 
+// Get the index associated with this tensor.
+LiteRtStatus LiteRtGetTensorIndex(LiteRtTensor tensor, uint32_t* tensor_index);
+
 // TENSOR TYPES
 
 // Primitive types for elements in a tensor.

--- a/litert/c/litert_model_test.cc
+++ b/litert/c/litert_model_test.cc
@@ -187,6 +187,17 @@ TEST(LiteRtTensorTest, Name) {
   EXPECT_STREQ(name, kName);
 }
 
+TEST(LiteRtTensorTest, Index) {
+  static constexpr const std::uint32_t kTensorIndex = 1;
+
+  LiteRtTensorT tensor;
+  tensor.SetTensorIndex(kTensorIndex);
+
+  std::uint32_t index;
+  LITERT_ASSERT_OK(LiteRtGetTensorIndex(&tensor, &index));
+  EXPECT_EQ(index, kTensorIndex);
+}
+
 TEST(LiteRtTensorTest, QuantizationNone) {
   LiteRtTensorT tensor;
 

--- a/litert/cc/litert_model.h
+++ b/litert/cc/litert_model.h
@@ -175,6 +175,12 @@ class Tensor : public internal::NonOwnedHandle<LiteRtTensor> {
     return absl::string_view(name);
   }
 
+  std::uint32_t TensorIndex() const {
+    std::uint32_t tensor_index;
+    internal::AssertOk(LiteRtGetTensorIndex, Get(), &tensor_index);
+    return tensor_index;
+  }
+
   struct TensorUse;
   using TensorUses =
       absl::InlinedVector<TensorUse, kExpectedMaxNumOfTensorUses>;

--- a/litert/cc/litert_model_test.cc
+++ b/litert/cc/litert_model_test.cc
@@ -257,6 +257,15 @@ TEST(CcTensorTest, Name) {
   EXPECT_EQ(cc_tensor.Name(), kName);
 }
 
+TEST(CcTensorTest, Index) {
+  static constexpr std::uint32_t kIndex = 1;
+  LiteRtTensorT tensor;
+  tensor.SetTensorIndex(kIndex);
+
+  Tensor cc_tensor(&tensor);
+  EXPECT_EQ(cc_tensor.TensorIndex(), kIndex);
+}
+
 TEST(CcTensorTest, QuantizationNone) {
   LiteRtTensorT litert_tensor;
   litert_tensor.Qparams().first = kLiteRtQuantizationNone;

--- a/litert/core/model/model.h
+++ b/litert/core/model/model.h
@@ -343,6 +343,12 @@ class LiteRtTensorT {
   // Update the name associated with this tensor.
   void SetName(std::string name) { name_ = std::move(name); }
 
+  // Get tensor index associated with this tensor.
+  std::uint32_t TensorIndex() const {return tensor_index_; }
+
+  // Update the index associated with this tensor.
+  void SetTensorIndex(std::uint32_t tensor_index) { tensor_index_ = tensor_index; }
+
   // Get quantization information for this tensor.
   const Quantization& Qparams() const { return quantization_; }
   Quantization& Qparams() { return quantization_; }
@@ -399,6 +405,8 @@ class LiteRtTensorT {
   TensorType tensor_type_;
 
   std::string name_;
+
+  std::uint32_t tensor_index_;
 
   std::vector<UserData> user_data_;
 };

--- a/litert/core/model/model_graph.cc
+++ b/litert/core/model/model_graph.cc
@@ -45,6 +45,7 @@ void CloneTo(const LiteRtTensorT& src, LiteRtTensorT& dest) {
   dest.SetName({src.Name().cbegin(), src.Name().cend()});
   dest.SetQarams(src.Qparams());
   dest.SetType(src.Type());
+  dest.SetTensorIndex(src.TensorIndex());
 
   // Manully copy per-channel quantization params,quant array is owned by
   // tensor.

--- a/litert/core/model/model_graph_test.cc
+++ b/litert/core/model/model_graph_test.cc
@@ -91,9 +91,11 @@ static constexpr absl::Span<const int32_t> kDimsSpan(kDims);
 static constexpr auto kType = kLiteRtElementTypeInt32;
 static constexpr absl::string_view kCustomOptions = "OPTIONS";
 static constexpr auto kOpCode = kLiteRtOpCodeTflMul;
+static constexpr uint32_t kIndex = 1;
 
 LiteRtTensorT TestTensor() {
   LiteRtTensorT tensor;
+  tensor.SetTensorIndex(kIndex);
   tensor.Type().first = kLiteRtRankedTensorType;
   tensor.Type().second.ranked_tensor_type.element_type = kType;
   tensor.Type().second.ranked_tensor_type.layout.dimensions[0] = kDims[0];
@@ -120,6 +122,7 @@ TEST(ModelGraphTest, CloneTensor) {
   LiteRtTensorT dest;
   CloneTo(TestTensor(), dest);
   EXPECT_THAT(dest, HasRankedType(kType, kDimsSpan));
+  EXPECT_THAT(dest.TensorIndex(), kIndex);
 }
 
 TEST(ModelQuantizationTypeTest, ClonePerChannelQuantization) {

--- a/litert/core/model/model_load.cc
+++ b/litert/core/model/model_load.cc
@@ -259,8 +259,9 @@ LiteRtStatus UnpackSubgraph(FlatbufferContext& context,
   const auto num_tensors = tfl_subgraph.tensors()->size();
   for (auto i = 0; i < num_tensors; ++i) {
     const auto* tfl_tensor = tfl_subgraph.tensors()->Get(i);
-    LITERT_RETURN_IF_ERROR(
-        UnpackTensor(context, *tfl_tensor, litert_subgraph.EmplaceTensor()));
+    auto& litert_tensor = litert_subgraph.EmplaceTensor();
+    LITERT_RETURN_IF_ERROR(UnpackTensor(context, *tfl_tensor, litert_tensor));
+    litert_tensor.SetTensorIndex(i);
   }
 
   // Unpack ops, pass litert_subgraph so they can look up the new litert


### PR DESCRIPTION
# What
Add `tensor_index` to `LiteRtTensor` which matches the index shows in model_explorer. 
Required by future vendor feature and provide better debug experience.

# Tests
```
//litert/cc:litert_model_test
[----------] Global test environment tear-down
[==========] 21 tests from 8 test suites ran. (1 ms total)
[  PASSED  ] 21 tests.

//litert/c:litert_model_test
[----------] Global test environment tear-down
[==========] 23 tests from 6 test suites ran. (0 ms total)
[  PASSED  ] 23 tests.

//litert/core/model:model_graph_test
[----------] Global test environment tear-down
[==========] 22 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

//litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test
[----------] Global test environment tear-down
[==========] 174 tests from 5 test suites ran. (12132 ms total)
[  PASSED  ] 174 tests.

//litert/vendors/qualcomm:qnn_manager_test
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (32 ms total)
[  PASSED  ] 2 tests.
```