### PR TITLE
Qualcomm AI Engine Direct - Optimize MHA for Gemma3.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -810,6 +810,20 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
   return kLiteRtStatusOk;
 }
 
+void AddTensorToQnn(
+    const QnnApi* qnn_api, Qnn_GraphHandle_t& graph_handle,
+    ::qnn::TensorWrapper& tensor,
+    std::unordered_set<const ::qnn::TensorWrapper*>& created_tensors,
+    bool use_qint16_as_quint16) {
+  if (!created_tensors.count(&tensor)) {
+    if (use_qint16_as_quint16) {
+      tensor.ConvertQint16ToQuint16();
+    }
+    qnn_api->tensorCreateGraphTensor(graph_handle, &(tensor.GetQnnTensor()));
+    created_tensors.emplace(&tensor);
+  }
+}
+
 LiteRtStatus MapGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
                       LiteRtSubgraph subgraph, absl::string_view qnn_graph_name,
                       const ::qnn::Options& options) {
@@ -824,12 +838,14 @@ LiteRtStatus MapGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
   ::qnn::TensorPool tensor_pool;
   absl::flat_hash_map<LiteRtTensor, ::qnn::TensorWrapper*>
       litert_tensor_to_wrapper;
-
+  std::unordered_set<const ::qnn::TensorWrapper*> created_tensors;
   for (const auto& subgraph_input : graph_mapper.Graph().Inputs()) {
     ::qnn::TensorWrapper* tensor_wrapper{nullptr};
     LITERT_RETURN_IF_ERROR(
         ConvertTensor(subgraph_input, tensor_pool, tensor_wrapper));
     litert_tensor_to_wrapper.emplace(subgraph_input.Get(), tensor_wrapper);
+    AddTensorToQnn(qnn.Api(), graph_mapper.QnnGraph(), *tensor_wrapper,
+                   created_tensors, options.GetUseQint16AsQuint16());
   }
 
   for (const auto& subgraph_output : graph_mapper.Graph().Outputs()) {
@@ -876,22 +892,21 @@ LiteRtStatus MapGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
               std::back_inserter(graph_op_wrappers));
   }
   // TODO (jiunkaiy): Set this graph-to-graph transformation as a compile flag.
-  GraphToGraphTransform(graph_op_wrappers);
+  const ::qnn::G2GConfig g2g_option = ::qnn::G2GConfig::kMHAOptPrefill;
+  GraphToGraphTransform(g2g_option, graph_op_wrappers, tensor_pool,
+                        [api = qnn.Api(), backend = qnn.BackendHandle()](
+                            ::qnn::OpWrapper& op) -> bool {
+                          return QNN_SUCCESS == api->backendValidateOpConfig(
+                                                    backend, op.GetOpConfig());
+                        });
 
-  if (options.GetUseQint16AsQuint16()) {
-    tensor_pool.ForEach([](::qnn::TensorWrapper& tensor_wrapper) {
-      tensor_wrapper.ConvertQint16ToQuint16();
-    });
-  }
-
-  // Insert all tensors into Qnn graph and update the id of Qnn_Tensor_t inside.
-  tensor_pool.ForEach(
-      [&qnn, &graph_mapper](::qnn::TensorWrapper& tensor_wrapper) {
-        qnn.Api()->tensorCreateGraphTensor(graph_mapper.QnnGraph(),
-                                           &tensor_wrapper.GetQnnTensor());
-      });
-  // Then op can be added into Qnn graph after the tensor ids are updated.
+  // Create ops and their corresponding tensors.
   for (auto& op_wrapper : graph_op_wrappers) {
+    for (const auto& tensor_wrapper_ref : op_wrapper.GetAllTensors()) {
+      AddTensorToQnn(qnn.Api(), graph_mapper.QnnGraph(),
+                     tensor_wrapper_ref.get(), created_tensors,
+                     options.GetUseQint16AsQuint16());
+    }
     qnn.Api()->graphAddNode(graph_mapper.QnnGraph(), op_wrapper.GetOpConfig());
   }
 

--- a/litert/vendors/qualcomm/core/transformation/BUILD
+++ b/litert/vendors/qualcomm/core/transformation/BUILD
@@ -19,7 +19,15 @@ cc_test(
         ":graph_to_graph",
         "//litert/vendors/qualcomm/core:op_code",
         "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:concatenation_op_builder",
+        "//litert/vendors/qualcomm/core/builders:elementwise_op_builder",
         "//litert/vendors/qualcomm/core/builders:matmul_op_builder",
+        "//litert/vendors/qualcomm/core/builders:op_builder",
+        "//litert/vendors/qualcomm/core/builders:reshape_op_builder",
+        "//litert/vendors/qualcomm/core/builders:slice_op_builder",
+        "//litert/vendors/qualcomm/core/builders:softmax_op_builder",
+        "//litert/vendors/qualcomm/core/builders:split_op_builder",
+        "//litert/vendors/qualcomm/core/builders:transpose_op_builder",
         "//litert/vendors/qualcomm/core/builders:quantize_op_builder",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
@@ -38,8 +46,47 @@ cc_library(
         "nobuilder",
     ],
     deps = [
+        ":matmul_convert",
+        ":mha_to_sha",
         "//litert/vendors/qualcomm/core:op_code",
         "//litert/vendors/qualcomm/core/utils:log",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "matmul_convert",
+    srcs = ["matmul_convert.cc"],
+    hdrs = ["matmul_convert.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        "//litert/vendors/qualcomm/core:op_code",
+        "//litert/vendors/qualcomm/core/utils:log",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+    ],
+)
+
+cc_library(
+    name = "mha_to_sha",
+    srcs = ["mha_to_sha.cc"],
+    hdrs = ["mha_to_sha.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        "//litert/vendors/qualcomm/core:op_code",
+        "//litert/vendors/qualcomm/core/builders:concatenation_op_builder",
+        "//litert/vendors/qualcomm/core/builders:op_builder",
+        "//litert/vendors/qualcomm/core/builders:reshape_op_builder",
+        "//litert/vendors/qualcomm/core/builders:split_op_builder",
+        "//litert/vendors/qualcomm/core/utils:log",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core:tensor_pool",
     ],
 )

--- a/litert/vendors/qualcomm/core/transformation/README.md
+++ b/litert/vendors/qualcomm/core/transformation/README.md
@@ -1,0 +1,149 @@
+# Graph-to-graph Transformation
+## Matmul-convert Fusion
+Original graph:
+```mermaid
+graph TB
+  In1 --> MatMul1["MatMul"]
+  In2 --> MatMul2["MatMul"]
+  MatMul1 --> Convert["Convert"]
+  Convert --> |"Quant Params"| Concat["Concat"]
+  MatMul2["MatMul"] --> Concat --> Out
+  In1@{ shape: sm-circ}
+  In2@{ shape: sm-circ}
+  Out@{ shape: sm-circ}
+```
+The updated computational graph after the transformation is shown below.
+```mermaid
+graph TB
+  In1 --> MatMul1["MatMul"]
+  In2 --> MatMul2["MatMul"]
+  MatMul1 --> |"Quant Params"| Concat["Concat"]
+  MatMul2["MatMul"] --> Concat --> Out
+  In1@{ shape: sm-circ}
+  In2@{ shape: sm-circ}
+  Out@{ shape: sm-circ}
+```
+## Multi-head Attention Optimization
+| Dimension	 | Description	   | Example (Gemma3 1B)           |
+|:-----------|----------------:|------------------------------:|
+| B          | Batch size      | 1                             |
+| T          | Sequence length | 128 for prefill/ 1 for decode |
+| N          | Number of heads | 4                             |
+| K          | Number KV heads | 1                             |
+| H          | Head size       | 256                           |
+| KV_LEN     | KV Cache Length | 1280                          |
+* Notation reference: [AI Edge Torch](https://github.com/google-ai-edge/ai-edge-torch)
+
+Original MHA (Multi-head Attention) in Gemma3 prefill graph
+```mermaid
+graph TB
+  RopeOut --> |"[B, T, N, H]"| Mul["Mul"]
+  Mul --> |"[B, T, N, H]"| Transpose["Transpose"]
+  Transpose --> |"[B, N, T, H]"| Reshape1["Reshape"]
+  Reshape1 --> |"[B, 1, N*T, H]"| MatMul1["MatMul"] & MatMul2["MatMul"]
+  MatMul1 --> |"[B, 1, N\*T, K*KV_LEN]"| Concat2
+  MatMul2 --> |"[B, 1, N\*T, K*T]"| Concat2
+  Concat2[Concat] --> |"[B, 1, N*T, K\*KV_LEN+K\*T]"| Reshape2["Reshape"] 
+  Reshape2 --> |"[B, N, T, K\*KV_LEN+K\*T]"| Add["Add"]
+  Mask["Mask"] --> |"[B, 1, T, K\*KV_LEN+K\*T]"| Add
+  Add --> |"[B, N, T, K\*KV_LEN+K\*T]"| Reshape3["Reshape"] 
+  Reshape3--> |"[B, 1, N*T, K\*KV_LEN+K\*T]"| Softmax["Softmax"] 
+  Softmax --> |"[B, 1, N*T, K\*KV_LEN+K\*T]"| StridedSlice1["StridedSlice"] & StridedSlice2["StridedSlice"]
+  StridedSlice1 --> |"[B, 1, N*T, K\*KV_LEN]"| MatMul3["MatMul"]
+  StridedSlice2 --> |"[B, 1, N*T, K\*T]"| MatMul4["MatMul"]
+  MatMul3 & MatMul4 --> |"[B, 1, N*T, H]"| Add2["Add"]
+  Add2--> |"[B, 1, N*T, H]"| Reshape4["Reshape"]
+  Reshape4 --> |"[B, N, T, H]"| Transpose1["Transpose"]
+  Transpose1 --> |"[B, T, N, H]"| Reshape5["Reshape"]
+  Reshape5 --> |"[B, T, N*H]"| FCIn
+
+  KCache["K Cache"] --> |"[B, 1, K*KV_LEN, H]"| MatMul1
+  KSlice["K Slice"] --> |"[B, K*T, 1, H]"| ReshapeKSlice["Reshape"]
+  ReshapeKSlice --> |"[B, 1, K*T, H]"| MatMul2
+  ReshapeKSlice --> |"[B, 1, K*T, H]"| KSliceOut["K Slice"]
+
+  VCache["V Cache"] --> |"[B, 1, H, K*KV_LEN]"| MatMul3
+  VSlice["V Slice"] --> |"[B, K*T, 1, H]"| TransposeVSlice[Transpose]
+  TransposeVSlice --> |"[B, 1, H, K*T]"| MatMul4
+  TransposeVSlice --> |"[B, 1, H, K*T]"| VSliceOut["V Slice"]
+
+  KCache@{shape: text}
+  KSlice@{shape: text}
+  KSliceOut@{shape: text}
+  Mask@{shape: text}
+  VCache@{shape: text}
+  VSlice@{shape: text}
+  VSliceOut@{shape: text}
+  FCIn@{shape: sm-circ}
+  RopeOut@{shape: sm-circ}
+```
+The updated computational graph after the transformation is shown below.
+```mermaid
+graph TB
+  RopeOut --> |"[B, T, N, H]"| Transpose["Transpose"]
+  Transpose --> |"[B, N, T, H]"| Reshape1
+  Reshape1["Reshape"] --> |"[B, 1, N*T, H]"| Split
+  Split["Split
+  (N=4)"] --> |"[B, 1, T, H]"| SHA1["SHA"] & SHA2["SHA"] & SHA3["SHA"] & SHA4["SHA"]
+  SHA1 & SHA2 & SHA3 & SHA4 --> |"[B, 1, T, H]"| Concat2["Concat 
+  (N=4)"]
+  Concat2 --> |"[B, 1, T, N*H]"| Reshape2[Reshape]
+  Reshape2 --> |"[B, T, N*H]"| FCIn
+  SHAInputs["SHA Inputs"] --> SHA1 & SHA2 & SHA3 & SHA4
+  KSlice["K Slice"] --> ReshapeKSlice[Reshape]
+  ReshapeKSlice --> SHAInputs
+  ReshapeKSlice --> KSliceOut["K Slice"]
+  VSlice["V Slice"] --> TransposeVSlice[Transpose]
+  TransposeVSlice --> VSliceOut["V Slice"]
+  TransposeVSlice --> SHAInputs
+
+  KCache["K Cache"] --> SHAInputs
+  Mask["Mask"] --> SHAInputs
+  VCache["V Cache"] --> SHAInputs
+
+  KCache@{shape: text}
+  KSlice@{shape: text}
+  Mask@{shape: text}
+  VCache@{shape: text}
+
+  SHAInputs@{shape: text}
+  KSliceOut@{shape: text}
+  VSliceOut@{shape: text}
+  KSlice@{shape: text}
+  VSlice@{shape: text}
+  FCIn@{shape: sm-circ}
+  RopeOut@{shape: sm-circ}
+```
+with the following four SHA (Single-head Attention), based on the number of heads in MHA.
+```mermaid
+graph TB
+  SHAIn --> |"[B, 1, T, H]"| Mul1
+  Mul1["Mul"] --> |"[B, 1, T, H]"| MatMul1["MatMul"] & MatMul2["MatMul"]
+  MatMul1 --> |"[B, 1, T, K*KV_LEN]"| Concat["Concat"]
+  MatMul2 --> |"[B, 1, T, K*T]"| Concat["Concat"]
+  Concat --> |"[B, 1, T, K*KV_LEN+K\*T]"| Add["Add"]
+  Add --> |"[B, 1, T, K*KV_LEN+K\*T]"| SoftMax["Softmax"] 
+  SoftMax --> |"[B, 1, T, K*KV_LEN+K\*T]"| StridedSlice1["StridedSlice"] & StridedSlice2["StridedSlice"]
+  StridedSlice1 --> |"[B, 1, T, K*KV_LEN]"| MatMul3["MatMul"]
+  StridedSlice2 --> |"[B, 1, T, K\*T]"| MatMul4["MatMul"]
+  KCache["K Cache"] --> |"[B, 1, K*KV_LEN, H]"| MatMul1
+  KSlice["K Slice"] --> |"[B, K*T, 1, H]"| ReshapeKSlice[Reshape]
+  ReshapeKSlice --> |"[B, 1, K*T, H]"| MatMul2
+  ReshapeKSlice --> |"[B, 1, K*T, H]"| KSliceOut["K Slice"]
+  Mask["Mask"] --> |"[B, 1, T, K*KV_LEN+K\*T]"| Add
+  VCache["V Cache"] --> |"[B, 1, H, K*KV_LEN]"| MatMul3
+  VSlice["V Slice"] --> |"[B, K*T, 1, H]"| TransposeVSlice[Transpose]
+  TransposeVSlice --> |"[B, 1, H, K*T]"| MatMul4
+  TransposeVSlice --> |"[B, 1, H, K*T]"| VSliceOut["V Slice"]
+  MatMul3 & MatMul4 --> |"[B, 1, T, H]"| Add2["Add"]
+  Add2 --> |"[B, 1, T, H]"| SHAOut
+  SHAIn@{shape: sm-circ}
+  SHAOut@{shape: sm-circ}
+  KCache@{shape: text}
+  Mask@{shape: text}
+  VCache@{shape: text}
+  KSlice@{shape: text}
+  VSlice@{shape: text}
+  KSliceOut@{shape: text}
+  VSliceOut@{shape: text}
+```

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
@@ -1,39 +1,161 @@
 // Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstring>
+#include "litert/vendors/qualcomm/core/transformation/graph_to_graph.h"
+
+#include <array>
+#include <functional>
 #include <vector>
 
 #include "litert/vendors/qualcomm/core/op_code.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/transformation/matmul_convert.h"
+#include "litert/vendors/qualcomm/core/transformation/mha_to_sha.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "QnnCommon.h"  // from @qairt
+#include "QnnInterface.h"  // from @qairt
 
 namespace qnn {
 
 namespace {
-constexpr size_t kMatMulConvertRange = 2;
-void FuseMatMulConvert(std::vector<OpWrapper>& ops, size_t start_id,
-                       size_t end_id) {
-  if (!ops[start_id].IsOpCode(QnnOpCode::kMatMul)) {
-    return;
+
+constexpr size_t kQnnOpCodeSize = static_cast<size_t>(QnnOpCode::kUnknown);
+
+std::vector<size_t> CreateBadMatchTable(
+    const std::vector<QnnOpCode>& pattern_ops) {
+  std::vector<size_t> table(kQnnOpCodeSize, pattern_ops.size());
+  for (size_t i = 0; i < pattern_ops.size() - 1; ++i) {
+    table[static_cast<size_t>(pattern_ops[i])] = pattern_ops.size() - i - 1;
   }
-  for (size_t convert_id = start_id + 1; convert_id <= end_id; ++convert_id) {
-    if (convert_id >= ops.size()) {
-      break;
+  return table;
+}
+
+// Returns the start index of the matched operator pattern beginning at
+// start_index; returns -1 if no match is found in the graph.
+int GetPatternStartIndex(size_t start_index, const std::vector<OpWrapper>& ops,
+                         const std::vector<QnnOpCode>& pattern_ops,
+                         const std::vector<size_t>& bad_match_table) {
+  size_t end_index = start_index + (pattern_ops.size() - 1);
+  while (end_index < ops.size()) {
+    bool found_pattern = true;
+    for (size_t i = 0; i < pattern_ops.size(); ++i) {
+      if (!ops[end_index - i].IsOpCode(
+              pattern_ops[pattern_ops.size() - i - 1])) {
+        found_pattern = false;
+        break;
+      }
     }
-    if (ops[convert_id].IsOpCode(QnnOpCode::kConvert) &&
-        ops[convert_id].GetInputTensor(0) == ops[start_id].GetOutputTensor(0)) {
-      ops[start_id].StealOutputs(ops[convert_id]);
-      ops.erase(ops.begin() + convert_id);
-      return;
+    if (found_pattern) {
+      return end_index - (pattern_ops.size() - 1);
+    } else {
+      end_index +=
+          bad_match_table[static_cast<size_t>(ops[end_index].GetOpCode())];
+    }
+  }
+  return -1;
+}
+
+// Returns the number of indices to skip for the next pattern match.
+// This function attempts to transform a specific pattern into optimized one
+// and returns the size of the skippable indices for the next index check.
+typedef size_t (*G2GTransform)(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size);
+void Transform(std::function<bool(OpWrapper&)> validate_op_config,
+               std::vector<OpWrapper>& ops, TensorPool& tensor_pool,
+               const std::vector<QnnOpCode>& pattern_ops,
+               G2GTransform custom_transform) {
+  auto bad_match_table = CreateBadMatchTable(pattern_ops);
+  size_t start_index = 0;
+  while ((start_index + (pattern_ops.size() - 1)) < ops.size()) {
+    if (auto pattern_start_index = GetPatternStartIndex(
+            start_index, ops, pattern_ops, bad_match_table);
+        pattern_start_index != -1) {
+      start_index =
+          pattern_start_index +
+          custom_transform(validate_op_config, ops, pattern_start_index,
+                           tensor_pool, pattern_ops.size());
+    } else {
+      break;
     }
   }
 }
+
 }  // namespace
 
 // TODO (jiunkaiy): Add more G2G transformation.
-void GraphToGraphTransform(std::vector<OpWrapper>& ops) {
-  for (size_t op_id = 0; op_id < ops.size(); ++op_id) {
-    FuseMatMulConvert(ops, op_id, op_id + kMatMulConvertRange);
+void GraphToGraphTransform(const G2GConfig g2g_option,
+                           std::vector<OpWrapper>& ops, TensorPool& tensor_pool,
+                           std::function<bool(OpWrapper&)> validate_op_config) {
+  if (g2g_option == G2GConfig::kOff) {
+    return;
+  }
+
+  // MatMul-convert Fusion
+  if (g2g_option == G2GConfig::kMatMulConvert ||
+      g2g_option == G2GConfig::kMHAOptPrefill ||
+      g2g_option == G2GConfig::kMHAOpt) {
+    const std::vector<QnnOpCode> matmul_convert_decode = {
+        QnnOpCode::kMatMul,
+        QnnOpCode::kConvert,
+    };
+    Transform(validate_op_config, ops, tensor_pool, matmul_convert_decode,
+              FuseMatMulConvertDecode);
+    const std::vector<QnnOpCode> matmul_convert_prefill = {
+        QnnOpCode::kMatMul,
+        QnnOpCode::kMatMul,
+        QnnOpCode::kConvert,
+    };
+    Transform(validate_op_config, ops, tensor_pool, matmul_convert_prefill,
+              FuseMatMulConvertPrefill);
+  }
+  // MHA Optimization
+  if (g2g_option == G2GConfig::kMHAOpt) {
+    const std::vector<QnnOpCode> gemma3_mha_decode = {
+        QnnOpCode::kElementWiseMultiply,
+        QnnOpCode::kMatMul,
+        QnnOpCode::kMatMul,
+        QnnOpCode::kConcat,
+        QnnOpCode::kReshape,
+        QnnOpCode::kElementWiseAdd,
+        QnnOpCode::kReshape,
+        QnnOpCode::kSoftmax,
+        QnnOpCode::kStridedSlice,
+        QnnOpCode::kStridedSlice,
+        QnnOpCode::kMatMul,
+        QnnOpCode::kMatMul,
+        QnnOpCode::kElementWiseAdd,
+        QnnOpCode::kReshape,
+    };
+    Transform(validate_op_config, ops, tensor_pool, gemma3_mha_decode,
+              OptimizeMHADecode);
+  }
+  if (g2g_option == G2GConfig::kMHAOptPrefill ||
+      g2g_option == G2GConfig::kMHAOpt) {
+    const std::vector<QnnOpCode> gemma3_mha_prefill = {
+        QnnOpCode::kElementWiseMultiply,
+        QnnOpCode::kTranspose,
+        QnnOpCode::kReshape,
+        QnnOpCode::kMatMul,
+        QnnOpCode::kMatMul,
+        QnnOpCode::kConcat,
+        QnnOpCode::kReshape,
+        QnnOpCode::kElementWiseAdd,
+        QnnOpCode::kReshape,
+        QnnOpCode::kSoftmax,
+        QnnOpCode::kStridedSlice,
+        QnnOpCode::kStridedSlice,
+        QnnOpCode::kMatMul,
+        QnnOpCode::kMatMul,
+        QnnOpCode::kElementWiseAdd,
+        QnnOpCode::kReshape,
+        QnnOpCode::kTranspose,
+        QnnOpCode::kReshape,
+    };
+    Transform(validate_op_config, ops, tensor_pool, gemma3_mha_prefill,
+              OptimizeMHAPrefill);
   }
 }
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph.h
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph.h
@@ -6,10 +6,26 @@
 
 #include <vector>
 
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "QnnInterface.h"  // from @qairt
 
 namespace qnn {
-void GraphToGraphTransform(std::vector<OpWrapper>& ops);
+
+enum class G2GConfig {
+  // Disable G2G.
+  kOff,
+  // Enable G2G MatMul-convert fusion.
+  kMatMulConvert,
+  // Enable G2G MHA optimization for prefill only.
+  kMHAOptPrefill,
+  // Enable G2G MHA optimization for both decode and prefill.
+  kMHAOpt,
+};
+
+void GraphToGraphTransform(const G2GConfig g2g_option,
+                           std::vector<OpWrapper>& ops, TensorPool& tensor_pool,
+                           std::function<bool(OpWrapper&)> validate_op_config);
 }  // namespace qnn
 
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_GRAPH_TO_GRAPH_H_

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
@@ -4,12 +4,17 @@
 #include "litert/vendors/qualcomm/core/transformation/graph_to_graph.h"
 
 #include <algorithm>
-#include <iterator>
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "litert/vendors/qualcomm/core/builders/concatenation_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/elementwise_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/matmul_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/quantize_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/reshape_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/slice_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/softmax_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/transpose_op_builder.h"
 #include "litert/vendors/qualcomm/core/op_code.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
@@ -96,7 +101,9 @@ TEST(MatMulConvertTest, Gemma3Prefill) {
 
   ASSERT_EQ(op_wrappers.size(), 3);
 
-  GraphToGraphTransform(op_wrappers);
+  const ::qnn::G2GConfig g2g_option = ::qnn::G2GConfig::kMatMulConvert;
+  GraphToGraphTransform(g2g_option, op_wrappers, tensor_pool,
+                        [](OpWrapper& op) { return true; });
 
   ASSERT_EQ(op_wrappers.size(), 2);
   ASSERT_EQ(op_wrappers[0].IsOpCode(QnnOpCode::kMatMul), true);
@@ -165,10 +172,518 @@ TEST(MatMulConvertTest, Gemma3Decode) {
 
   ASSERT_EQ(op_wrappers.size(), 2);
 
-  GraphToGraphTransform(op_wrappers);
+  const ::qnn::G2GConfig g2g_option = ::qnn::G2GConfig::kMatMulConvert;
+  GraphToGraphTransform(g2g_option, op_wrappers, tensor_pool,
+                        [](OpWrapper& op) { return true; });
 
   ASSERT_EQ(op_wrappers.size(), 1);
   ASSERT_EQ(op_wrappers[0].IsOpCode(QnnOpCode::kMatMul), true);
 }
+
+TEST(MHAConvertTest, Gemma3Prefill) {
+  // G2G Test case: MHA -> SHA
+  //
+  // ---------------- Before ---------------------
+  //                   In0
+  //                    |
+  //                   Mul
+  //                    |
+  //                Transpose0
+  //                    |
+  //                 Reshape0
+  //      kv_cache_k  /   \  kv_slice_k
+  //              \  /     \  /
+  //           MatMulK0   MatMulK1
+  //                 \     /
+  //                  Concat
+  //                    |
+  //                 Reshape1
+  //                    |
+  //               mask |
+  //                  \ |
+  //                   Add0
+  //                    |
+  //                 Reshape2
+  //                    |
+  //                 Softmax
+  //                  /   \
+  //                 /     \
+  // kv_cache_v  Slice0   Slice1  kv_slice_v
+  //      \        /         \        /
+  //       \      /           \      /
+  //       MatMulV0           MatMulV1
+  //              \           /
+  //               \         /
+  //                \       /
+  //                 \     /
+  //                   Add1
+  //                    |
+  //                 Reshape3
+  //                    |
+  //                Transpose1
+  //                    |
+  //                 Reshape4
+  //                    |
+  //                   Out0
+  //
+  // ---------------- After ---------------------
+  //                   In0
+  //                    |
+  //                Transpose
+  //                    |
+  //                 Reshape
+  //                    |
+  //                  Split
+  //                    | \\\
+  //                    |  \\\
+  //                    |   ...
+  //                   Mul
+  //      kv_cache_k  /   \  kv_slice_k
+  //              \  /     \  /
+  //              MatMul  MatMul
+  //                 \     /
+  //                  Concat
+  //                    |
+  //                   Add
+  //                    |
+  //                 Softmax
+  //                  /   \
+  //                 /     \
+  // kv_cache_v  Slice0   Slice1  kv_slice_v
+  //      \        /         \        /
+  //       \      /           \      /
+  //        MatMul             MatMul
+  //              \           /
+  //               \         /
+  //                \       /
+  //                 \     /
+  //                   Add    ...
+  //                    |    ///
+  //                    |   ///
+  //                    Concat
+  //                      |
+  //                   Reshape
+  //                      |
+  //                     Out0
+  //
+  TensorPool tensor_pool;
+  QuantizeParamsWrapperVariant quant_param;
+  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  std::vector<OpWrapper> op_wrappers;
+  // Mul
+  auto& input0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_16,
+                                                quant_param, {1, 128, 4, 256});
+  std::array<int16_t, 1> mul_val = {32767};
+  auto& mul_const = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {mul_val.size()},
+      mul_val.size() * sizeof(mul_val[0]), mul_val.data());
+  auto& mul_output =
+      tensor_pool.CloneNativeTensorFrom(input0, {1, 128, 4, 256});
+  auto mul =
+      BuildElementwiseMulOp(tensor_pool, {input0, mul_const}, {mul_output});
+  std::move(mul.begin(), mul.end(), std::back_inserter(op_wrappers));
+  // Transpose0
+  std::array<int32_t, 4> transpose_val = {0, 2, 1, 3};
+  auto& transpose_perm = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, quant_param, {transpose_val.size()},
+      transpose_val.size() * sizeof(transpose_val[0]), transpose_val.data());
+  auto& transpose0_output =
+      tensor_pool.CloneNativeTensorFrom(mul_output, {1, 4, 128, 256});
+  auto transpose0 = BuildTransposeOp(tensor_pool, {mul_output, transpose_perm},
+                                     {transpose0_output});
+  std::move(transpose0.begin(), transpose0.end(),
+            std::back_inserter(op_wrappers));
+
+  // Reshape0
+  auto& reshape0_output =
+      tensor_pool.CloneNativeTensorFrom(transpose0_output, {1, 1, 512, 256});
+  auto reshape0 =
+      BuildReshapeOp(tensor_pool, {transpose0_output}, {reshape0_output});
+  std::move(reshape0.begin(), reshape0.end(), std::back_inserter(op_wrappers));
+
+  // MatMulK0
+  auto& kv_cache_k = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 1280, 256});
+  auto& matmulk0_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 512, 1280});
+  auto matmulk0 = BuildMatmulOp(tensor_pool, {reshape0_output, kv_cache_k},
+                                {matmulk0_output}, false, true);
+  std::move(matmulk0.begin(), matmulk0.end(), std::back_inserter(op_wrappers));
+  // MatMulK1
+  auto& kv_slice_k = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 128, 256});
+  auto& matmulk1_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 512, 128});
+  auto matmulk1 = BuildMatmulOp(tensor_pool, {reshape0_output, kv_slice_k},
+                                {matmulk1_output}, false, true);
+  std::move(matmulk1.begin(), matmulk1.end(), std::back_inserter(op_wrappers));
+  // Concat
+  auto& concat_output =
+      tensor_pool.CloneNativeTensorFrom(matmulk0_output, {1, 1, 512, 1408});
+  auto concat = BuildConcatenationOp(
+      tensor_pool, {matmulk0_output, matmulk1_output}, {concat_output}, 3);
+  std::move(concat.begin(), concat.end(), std::back_inserter(op_wrappers));
+  // Reshape1
+  auto& reshape1_output =
+      tensor_pool.CloneNativeTensorFrom(concat_output, {1, 4, 128, 1408});
+  auto reshape1 =
+      BuildReshapeOp(tensor_pool, {concat_output}, {reshape1_output});
+  std::move(reshape1.begin(), reshape1.end(), std::back_inserter(op_wrappers));
+  // Add
+  auto& add0_output = tensor_pool.CloneNativeTensorFrom(reshape1_output);
+  auto& mask = tensor_pool.CloneNativeTensorFrom(reshape1_output);
+  auto add0 = BuildElementwiseAddOp(tensor_pool, {reshape1_output, mask},
+                                    {add0_output});
+  std::move(add0.begin(), add0.end(), std::back_inserter(op_wrappers));
+  // Reshape2
+  auto& reshape2_output =
+      tensor_pool.CloneNativeTensorFrom(add0_output, {1, 1, 512, 1408});
+  auto reshape2 = BuildReshapeOp(tensor_pool, {add0_output}, {reshape2_output});
+  std::move(reshape2.begin(), reshape2.end(), std::back_inserter(op_wrappers));
+  // Softmax
+  auto& softmax_output = tensor_pool.CloneNativeTensorFrom(reshape2_output);
+  auto softmax =
+      BuildSoftmaxOp(tensor_pool, {reshape2_output}, {softmax_output}, 1.0f);
+  std::move(softmax.begin(), softmax.end(), std::back_inserter(op_wrappers));
+  // Slice0
+  const std::array<int32_t, 4> slice0_begin_data{0, 0, 0, 0};
+  auto& slice0_begin = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {slice0_begin_data.size()},
+      slice0_begin_data.size() * sizeof(slice0_begin_data[0]),
+      slice0_begin_data.data());
+  const std::array<int32_t, 4> slice0_size_data{1, 1, 512, 1280};
+  auto& slice0_size = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {slice0_size_data.size()},
+      slice0_size_data.size() * sizeof(slice0_size_data[0]),
+      slice0_size_data.data());
+  auto& slice0_output =
+      tensor_pool.CloneNativeTensorFrom(reshape2_output, {1, 1, 512, 1280});
+  auto slice0 =
+      BuildSliceOp(tensor_pool, {softmax_output, slice0_begin, slice0_size},
+                   {slice0_output});
+  std::move(slice0.begin(), slice0.end(), std::back_inserter(op_wrappers));
+  // Slice1
+  const std::array<int32_t, 4> slice1_begin_data{0, 0, 0, 1280};
+  auto& slice1_begin = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {slice1_begin_data.size()},
+      slice1_begin_data.size() * sizeof(slice1_begin_data[0]),
+      slice1_begin_data.data());
+  ;
+  const std::array<int32_t, 4> slice1_size_data{1, 1, 512, 128};
+  auto& slice1_size = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {slice1_size_data.size()},
+      slice1_size_data.size() * sizeof(slice1_size_data[0]),
+      slice1_size_data.data());
+  auto& slice1_output =
+      tensor_pool.CloneNativeTensorFrom(reshape2_output, {1, 1, 512, 128});
+  auto slice1 =
+      BuildSliceOp(tensor_pool, {softmax_output, slice1_begin, slice1_size},
+                   {slice1_output});
+  std::move(slice1.begin(), slice1.end(), std::back_inserter(op_wrappers));
+  // MatMulV0
+  auto& kv_cache_v = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 256, 1280});
+  auto& matmulv0_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 512, 256});
+  auto matmulv0 = BuildMatmulOp(tensor_pool, {slice0_output, kv_cache_v},
+                                {matmulv0_output}, false, true);
+  std::move(matmulv0.begin(), matmulv0.end(), std::back_inserter(op_wrappers));
+  // MatMulV1
+  auto& kv_slice_v = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 256, 128});
+  auto& matmulv1_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 512, 256});
+  auto matmulv1 = BuildMatmulOp(tensor_pool, {slice1_output, kv_slice_v},
+                                {matmulv1_output}, false, true);
+  std::move(matmulv1.begin(), matmulv1.end(), std::back_inserter(op_wrappers));
+  // Add1
+  auto& add1_output = tensor_pool.CloneNativeTensorFrom(matmulv0_output);
+  auto add1 = BuildElementwiseAddOp(
+      tensor_pool, {matmulv0_output, matmulv1_output}, {add1_output});
+  std::move(add1.begin(), add1.end(), std::back_inserter(op_wrappers));
+  // Reshape3
+  auto& reshape3_output =
+      tensor_pool.CloneNativeTensorFrom(add1_output, {1, 4, 128, 256});
+  auto reshape3 = BuildReshapeOp(tensor_pool, {add1_output}, {reshape3_output});
+  std::move(reshape3.begin(), reshape3.end(), std::back_inserter(op_wrappers));
+  // Transpose
+  auto& transpose1_output =
+      tensor_pool.CloneNativeTensorFrom(reshape3_output, {1, 128, 4, 256});
+  auto transpose1 = BuildTransposeOp(
+      tensor_pool, {reshape3_output, transpose_perm}, {transpose1_output});
+  std::move(transpose1.begin(), transpose1.end(),
+            std::back_inserter(op_wrappers));
+  // Reshape4
+  auto& reshape4_output =
+      tensor_pool.CloneNativeTensorFrom(transpose1_output, {1, 128, 1024});
+  auto reshape4 =
+      BuildReshapeOp(tensor_pool, {transpose1_output}, {reshape4_output});
+  std::move(reshape4.begin(), reshape4.end(), std::back_inserter(op_wrappers));
+
+  ASSERT_EQ(op_wrappers.size(), 18);
+
+  const ::qnn::G2GConfig g2g_option = ::qnn::G2GConfig::kMHAOptPrefill;
+  GraphToGraphTransform(g2g_option, op_wrappers, tensor_pool,
+                        [](OpWrapper& op) { return true; });
+
+  ASSERT_EQ(op_wrappers.size(), 49);
+
+  ASSERT_EQ(op_wrappers[0].IsOpCode(QnnOpCode::kTranspose), true);
+  ASSERT_EQ(op_wrappers[1].IsOpCode(QnnOpCode::kReshape), true);
+  ASSERT_EQ(op_wrappers[2].IsOpCode(QnnOpCode::kSplit), true);
+  const size_t sha_size = 11;
+  const size_t num_head = 4;
+  for (int i = 0; i < num_head; ++i) {
+    ASSERT_EQ(op_wrappers[3 + sha_size * i].GetOpCode(),
+              QnnOpCode::kElementWiseMultiply);
+    ASSERT_EQ(op_wrappers[4 + sha_size * i].GetOpCode(), QnnOpCode::kMatMul);
+    ASSERT_EQ(op_wrappers[5 + sha_size * i].GetOpCode(), QnnOpCode::kMatMul);
+    ASSERT_EQ(op_wrappers[6 + sha_size * i].GetOpCode(), QnnOpCode::kConcat);
+    ASSERT_EQ(op_wrappers[7 + sha_size * i].GetOpCode(),
+              QnnOpCode::kElementWiseAdd);
+    ASSERT_EQ(op_wrappers[8 + sha_size * i].GetOpCode(), QnnOpCode::kSoftmax);
+    ASSERT_EQ(op_wrappers[9 + sha_size * i].GetOpCode(),
+              QnnOpCode::kStridedSlice);
+    ASSERT_EQ(op_wrappers[10 + sha_size * i].GetOpCode(), QnnOpCode::kMatMul);
+    ASSERT_EQ(op_wrappers[11 + sha_size * i].GetOpCode(),
+              QnnOpCode::kStridedSlice);
+    ASSERT_EQ(op_wrappers[12 + sha_size * i].GetOpCode(), QnnOpCode::kMatMul);
+    ASSERT_EQ(op_wrappers[13 + sha_size * i].GetOpCode(),
+              QnnOpCode::kElementWiseAdd);
+  }
+  ASSERT_EQ(op_wrappers[47].GetOpCode(), QnnOpCode::kConcat);
+  ASSERT_EQ(op_wrappers[48].GetOpCode(), QnnOpCode::kReshape);
+}
+
+TEST(MHAConvertTest, Gemma3Decode) {
+  // G2G Test case: MHA -> SHA
+  //
+  // ---------------- Before ---------------------
+  //                   In0
+  //                    |
+  //                   Mul
+  //      kv_cache_k  /   \  kv_slice_k
+  //              \  /     \  /
+  //           MatMulK0   MatMulK1
+  //                 \     /
+  //                  Concat
+  //                    |
+  //                 Reshape0
+  //                    |
+  //               mask |
+  //                  \ |
+  //                   Add0
+  //                    |
+  //                 Reshape1
+  //                    |
+  //                 Softmax
+  //                  /   \
+  //                 /     \
+  // kv_cache_v  Slice0   Slice1  kv_slice_v
+  //      \        /         \        /
+  //       \      /           \      /
+  //       MatMulV0           MatMulV1
+  //              \           /
+  //               \         /
+  //                \       /
+  //                 \     /
+  //                   Add1
+  //                    |
+  //                 Reshape2
+  //                    |
+  //                   Out0
+  //
+  // ---------------- After ---------------------
+  //                   In0
+  //                    |
+  //                  Split
+  //                    | \\\
+  //                    |  \\\
+  //                    |   ...
+  //                   Mul
+  //      kv_cache_k  /   \  kv_slice_k
+  //              \  /     \  /
+  //              MatMul  MatMul
+  //                 \     /
+  //                  Concat
+  //                    |
+  //                   Add
+  //                    |
+  //                 Softmax
+  //                  /   \
+  //                 /     \
+  // kv_cache_v  Slice0   Slice1  kv_slice_v
+  //      \        /         \        /
+  //       \      /           \      /
+  //        MatMul             MatMul
+  //              \           /
+  //               \         /
+  //                \       /
+  //                 \     /
+  //                   Add    ...
+  //                    |    ///
+  //                    |   ///
+  //                    Concat
+  //                      |
+  //                   Reshape
+  //                      |
+  //                     Out0
+  //
+  TensorPool tensor_pool;
+  QuantizeParamsWrapperVariant quant_param;
+  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  std::vector<OpWrapper> op_wrappers;
+  // Mul
+  auto& input0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_16,
+                                                quant_param, {1, 1, 4, 256});
+  std::array<int16_t, 1> mul_val = {32767};
+  auto& mul_const = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {mul_val.size()},
+      mul_val.size() * sizeof(mul_val[0]), mul_val.data());
+  auto& mul_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 4, 256});
+  auto mul =
+      BuildElementwiseMulOp(tensor_pool, {input0, mul_const}, {mul_output});
+  std::move(mul.begin(), mul.end(), std::back_inserter(op_wrappers));
+
+  // MatMulK0
+  auto& kv_cache_k = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 1280, 256});
+  auto& matmulk0_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 4, 1280});
+  auto matmulk0 = BuildMatmulOp(tensor_pool, {mul_output, kv_cache_k},
+                                {matmulk0_output}, false, true);
+  std::move(matmulk0.begin(), matmulk0.end(), std::back_inserter(op_wrappers));
+  // MatMulK1
+  auto& kv_slice_k = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 1, 256});
+  auto& matmulk1_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 4, 1});
+  auto matmulk1 = BuildMatmulOp(tensor_pool, {mul_output, kv_slice_k},
+                                {matmulk1_output}, false, true);
+  std::move(matmulk1.begin(), matmulk1.end(), std::back_inserter(op_wrappers));
+  // Concat
+  auto& concat_output =
+      tensor_pool.CloneNativeTensorFrom(matmulk0_output, {1, 1, 4, 1281});
+  auto concat = BuildConcatenationOp(
+      tensor_pool, {matmulk0_output, matmulk1_output}, {concat_output}, 3);
+  std::move(concat.begin(), concat.end(), std::back_inserter(op_wrappers));
+  // Reshape0
+  auto& reshape0_output =
+      tensor_pool.CloneNativeTensorFrom(concat_output, {1, 4, 1, 1281});
+  auto reshape0 =
+      BuildReshapeOp(tensor_pool, {concat_output}, {reshape0_output});
+  std::move(reshape0.begin(), reshape0.end(), std::back_inserter(op_wrappers));
+  // Add
+  auto& add0_output = tensor_pool.CloneNativeTensorFrom(reshape0_output);
+  auto& mask = tensor_pool.CloneNativeTensorFrom(reshape0_output);
+  auto add0 = BuildElementwiseAddOp(tensor_pool, {reshape0_output, mask},
+                                    {add0_output});
+  std::move(add0.begin(), add0.end(), std::back_inserter(op_wrappers));
+  // Reshape1
+  auto& reshape1_output =
+      tensor_pool.CloneNativeTensorFrom(add0_output, {1, 1, 4, 1281});
+  auto reshape1 = BuildReshapeOp(tensor_pool, {add0_output}, {reshape1_output});
+  std::move(reshape1.begin(), reshape1.end(), std::back_inserter(op_wrappers));
+  // Softmax
+  auto& softmax_output = tensor_pool.CloneNativeTensorFrom(reshape1_output);
+  auto softmax =
+      BuildSoftmaxOp(tensor_pool, {reshape1_output}, {softmax_output}, 1.0f);
+  std::move(softmax.begin(), softmax.end(), std::back_inserter(op_wrappers));
+  // Slice0
+  const std::array<int32_t, 4> slice0_begin_data{0, 0, 0, 0};
+  auto& slice0_begin = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {slice0_begin_data.size()},
+      slice0_begin_data.size() * sizeof(slice0_begin_data[0]),
+      slice0_begin_data.data());
+  const std::array<int32_t, 4> slice0_size_data{1, 1, 4, 1280};
+  auto& slice0_size = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {slice0_size_data.size()},
+      slice0_size_data.size() * sizeof(slice0_size_data[0]),
+      slice0_size_data.data());
+  auto& slice0_output =
+      tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 1, 4, 1280});
+  auto slice0 =
+      BuildSliceOp(tensor_pool, {softmax_output, slice0_begin, slice0_size},
+                   {slice0_output});
+  std::move(slice0.begin(), slice0.end(), std::back_inserter(op_wrappers));
+  // Slice1
+  const std::array<int32_t, 4> slice1_begin_data{0, 0, 0, 1280};
+  auto& slice1_begin = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {slice1_begin_data.size()},
+      slice1_begin_data.size() * sizeof(slice1_begin_data[0]),
+      slice1_begin_data.data());
+  ;
+  const std::array<int32_t, 4> slice1_size_data{1, 1, 4, 1};
+  auto& slice1_size = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {slice1_size_data.size()},
+      slice1_size_data.size() * sizeof(slice1_size_data[0]),
+      slice1_size_data.data());
+  auto& slice1_output =
+      tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 1, 4, 256});
+  auto slice1 =
+      BuildSliceOp(tensor_pool, {softmax_output, slice1_begin, slice1_size},
+                   {slice1_output});
+  std::move(slice1.begin(), slice1.end(), std::back_inserter(op_wrappers));
+  // MatMulV0
+  auto& kv_cache_v = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 256, 1280});
+  auto& matmulv0_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 4, 256});
+  auto matmulv0 = BuildMatmulOp(tensor_pool, {slice0_output, kv_cache_v},
+                                {matmulv0_output}, false, true);
+  std::move(matmulv0.begin(), matmulv0.end(), std::back_inserter(op_wrappers));
+  // MatMulV1
+  auto& kv_slice_v = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 256, 1});
+  auto& matmulv1_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 4, 256});
+  auto matmulv1 = BuildMatmulOp(tensor_pool, {slice1_output, kv_slice_v},
+                                {matmulv1_output}, false, true);
+  std::move(matmulv1.begin(), matmulv1.end(), std::back_inserter(op_wrappers));
+  // Add1
+  auto& add1_output = tensor_pool.CloneNativeTensorFrom(matmulv0_output);
+  auto add1 = BuildElementwiseAddOp(
+      tensor_pool, {matmulv0_output, matmulv1_output}, {add1_output});
+  std::move(add1.begin(), add1.end(), std::back_inserter(op_wrappers));
+  // Reshape2
+  auto& reshape2_output =
+      tensor_pool.CloneNativeTensorFrom(add1_output, {1, 1, 1024});
+  auto reshape2 = BuildReshapeOp(tensor_pool, {add1_output}, {reshape2_output});
+  std::move(reshape2.begin(), reshape2.end(), std::back_inserter(op_wrappers));
+
+  ASSERT_EQ(op_wrappers.size(), 14);
+
+  const ::qnn::G2GConfig g2g_option = ::qnn::G2GConfig::kMHAOpt;
+  GraphToGraphTransform(g2g_option, op_wrappers, tensor_pool,
+                        [](OpWrapper& op) { return true; });
+
+  ASSERT_EQ(op_wrappers.size(), 47);
+
+  ASSERT_EQ(op_wrappers[0].IsOpCode(QnnOpCode::kSplit), true);
+  const size_t sha_size = 11;
+  const size_t num_head = 4;
+  for (int i = 0; i < num_head; ++i) {
+    ASSERT_EQ(op_wrappers[1 + sha_size * i].GetOpCode(),
+              QnnOpCode::kElementWiseMultiply);
+    ASSERT_EQ(op_wrappers[2 + sha_size * i].GetOpCode(), QnnOpCode::kMatMul);
+    ASSERT_EQ(op_wrappers[3 + sha_size * i].GetOpCode(), QnnOpCode::kMatMul);
+    ASSERT_EQ(op_wrappers[4 + sha_size * i].GetOpCode(), QnnOpCode::kConcat);
+    ASSERT_EQ(op_wrappers[5 + sha_size * i].GetOpCode(),
+              QnnOpCode::kElementWiseAdd);
+    ASSERT_EQ(op_wrappers[6 + sha_size * i].GetOpCode(), QnnOpCode::kSoftmax);
+    ASSERT_EQ(op_wrappers[7 + sha_size * i].GetOpCode(),
+              QnnOpCode::kStridedSlice);
+    ASSERT_EQ(op_wrappers[8 + sha_size * i].GetOpCode(), QnnOpCode::kMatMul);
+    ASSERT_EQ(op_wrappers[9 + sha_size * i].GetOpCode(),
+              QnnOpCode::kStridedSlice);
+    ASSERT_EQ(op_wrappers[10 + sha_size * i].GetOpCode(), QnnOpCode::kMatMul);
+    ASSERT_EQ(op_wrappers[11 + sha_size * i].GetOpCode(),
+              QnnOpCode::kElementWiseAdd);
+  }
+  ASSERT_EQ(op_wrappers[45].GetOpCode(), QnnOpCode::kConcat);
+  ASSERT_EQ(op_wrappers[46].GetOpCode(), QnnOpCode::kReshape);
+}
+
 }  // namespace
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/matmul_convert.cc
+++ b/litert/vendors/qualcomm/core/transformation/matmul_convert.cc
@@ -1,0 +1,61 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/transformation/matmul_convert.h"
+
+#include <array>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/op_code.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "QnnInterface.h"  // from @qairt
+
+namespace qnn {
+
+size_t FuseMatMulConvertDecode(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size) {
+  // Connection check
+  if (ops[start_index].GetOutputTensor(0) !=
+      ops[start_index + 1].GetInputTensor(0)) {
+    return 1;
+  }
+  // Graph transform
+  QNN_LOG_INFO("[G2G] MatMul-convert fusion (Decode)");
+  ops[start_index].SwapOutputs(ops[start_index + 1]);
+  if (validate_op_config(ops[start_index])) {
+    ops.erase(ops.begin() + start_index + 1);
+  } else {
+    QNN_LOG_WARNING(
+        "[G2G] Validation failed. Rolling back to the original graph.");
+    ops[start_index].SwapOutputs(ops[start_index + 1]);
+  }
+  return 1;
+}
+
+size_t FuseMatMulConvertPrefill(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size) {
+  // Connection check
+  if (ops[start_index].GetOutputTensor(0) !=
+      ops[start_index + 2].GetInputTensor(0)) {
+    return 1;
+  }
+  // Graph transform
+  QNN_LOG_INFO("[G2G] MatMul-convert fusion (Prefill)");
+  ops[start_index].SwapOutputs(ops[start_index + 2]);
+  if (validate_op_config(ops[start_index])) {
+    ops.erase(ops.begin() + start_index + 2);
+  } else {
+    QNN_LOG_WARNING(
+        "[G2G] Validation failed. Rolling back to the original graph.");
+    ops[start_index].SwapOutputs(ops[start_index + 1]);
+  }
+  return 1;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/matmul_convert.h
+++ b/litert/vendors/qualcomm/core/transformation/matmul_convert.h
@@ -1,0 +1,28 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_MATMUL_CONVERT_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_MATMUL_CONVERT_H_
+
+#include <functional>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/op_code.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "QnnInterface.h"  // from @qairt
+
+namespace qnn {
+
+size_t FuseMatMulConvertDecode(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size);
+
+size_t FuseMatMulConvertPrefill(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size);
+
+}  // namespace qnn
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_MATMUL_CONVERT_H_

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
@@ -1,0 +1,380 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/transformation/mha_to_sha.h"
+
+#include <array>
+#include <functional>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/builders/concatenation_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/reshape_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/split_op_builder.h"
+#include "litert/vendors/qualcomm/core/op_code.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "QnnInterface.h"  // from @qairt
+#include "QnnOpDef.h"  // from @qairt
+
+namespace qnn {
+namespace {
+
+// Returns a boolean indicating whether the output tensor of op1 at out_index is
+// connected to the input tensor of op2 at in_index.
+#define IS_CONNECTED(op1, out_index, op2, in_index)     \
+  (ops[start_index + op1].GetOutputTensor(out_index) == \
+   ops[start_index + op2].GetInputTensor(in_index))
+
+constexpr size_t kMulIndex = 0;
+constexpr size_t kTransposePrefillIndex = 1;
+constexpr size_t kReshapePrefillIndex = 2;
+constexpr size_t kMatMulK1Index = 1;
+constexpr size_t kMatMulK2Index = 2;
+constexpr size_t kConcatIndex = 3;
+constexpr size_t kReshape0Index = 4;
+constexpr size_t kAddIndex = 5;
+constexpr size_t kReshape1Index = 6;
+constexpr size_t kSoftmaxIndex = 7;
+constexpr size_t kSlice1Index = 8;
+constexpr size_t kSlice2Index = 9;
+constexpr size_t kMatMulV1Index = 10;
+constexpr size_t kMatMulV2Index = 11;
+constexpr size_t kAdd2Index = 12;
+constexpr size_t kReshape2Index = 13;
+constexpr size_t kTranspose2Index = 14;
+constexpr size_t kReshape3Index = 15;
+
+// QNN Slice Param ranges in the form (begin, end, stride) for each axis. To
+// set the 3rd axis "end" value, we need to access ranges[3 * 2 + 2 - 1 = 7].
+constexpr size_t kSlice3rdAxisEndIndex = 7;
+
+// Emplaces the operator with updated inputs/outputs into new_ops.
+// This function copies the source_op and updates the tensors according to
+// inputs and outputs. The std::nullopt input/output element indicates that the
+// tensor will not be updated.
+void EmplaceOpWithIO(
+    std::vector<OpWrapper>& new_ops, const OpWrapper& source_op,
+    const std::vector<std::optional<qnn::TensorWrapperRef>>& inputs,
+    const std::vector<std::optional<qnn::TensorWrapperRef>>& outputs) {
+  OpWrapper ret = source_op;
+  ret.UpdateTensors(inputs, outputs);
+  new_ops.emplace_back(ret);
+}
+
+TensorWrapper& BuildSingleSHA(std::vector<OpWrapper>& ops, size_t start_index,
+                              std::vector<OpWrapper>& new_ops,
+                              TensorPool& tensor_pool,
+                              qnn::TensorWrapper& sha_input,
+                              const ::qnn::OpWrapper& scaling_mul,
+                              size_t num_heads) {
+  // Mul
+  auto& mul_output = tensor_pool.CloneNativeTensorFrom(
+      scaling_mul.GetOutputTensor(0), sha_input.GetDims());
+  EmplaceOpWithIO(new_ops, scaling_mul, {sha_input, std::nullopt},
+                  {mul_output});
+  // MatMul 1
+  const auto& matmulk_cache_output =
+      ops[start_index + kMatMulK1Index].GetOutputTensor(0);
+  std::vector<uint32_t> matmul1_output_dim = matmulk_cache_output.GetDims();
+  matmul1_output_dim[2] /= num_heads;
+  auto& matmul1_output = tensor_pool.CloneNativeTensorFrom(matmulk_cache_output,
+                                                           matmul1_output_dim);
+  EmplaceOpWithIO(new_ops, ops[start_index + kMatMulK1Index],
+                  {mul_output, std::nullopt}, {matmul1_output});
+  // MatMul 2
+  const auto& matmulk_slice_output =
+      ops[start_index + kMatMulK2Index].GetOutputTensor(0);
+  std::vector<uint32_t> matmul2_output_dim = matmulk_slice_output.GetDims();
+  matmul2_output_dim[2] = matmul2_output_dim[2] / num_heads;
+  auto& matmul2_output = tensor_pool.CloneNativeTensorFrom(matmulk_slice_output,
+                                                           matmul2_output_dim);
+  EmplaceOpWithIO(new_ops, ops[start_index + kMatMulK2Index],
+                  {mul_output, std::nullopt}, {matmul2_output});
+  // Concat
+  std::vector<uint32_t> concat_output_dim = matmul1_output.GetDims();
+  concat_output_dim[3] += matmul2_output.GetDim(3);
+  auto& concat_output = tensor_pool.CloneNativeTensorFrom(
+      ops[start_index + kConcatIndex].GetOutputTensor(0), concat_output_dim);
+  EmplaceOpWithIO(new_ops, ops[start_index + kConcatIndex],
+                  {matmul1_output, matmul2_output}, {concat_output});
+  // Add
+  auto& add_output = tensor_pool.CloneNativeTensorFrom(
+      ops[start_index + kAddIndex].GetOutputTensor(0), concat_output.GetDims());
+  EmplaceOpWithIO(new_ops, ops[start_index + kAddIndex],
+                  {concat_output, std::nullopt}, {add_output});
+  // Softmax
+  auto& softmax_output = tensor_pool.CloneNativeTensorFrom(
+      ops[start_index + kSoftmaxIndex].GetOutputTensor(0),
+      add_output.GetDims());
+  EmplaceOpWithIO(new_ops, ops[start_index + kSoftmaxIndex], {add_output},
+                  {softmax_output});
+  // Slice 1
+  // Create StridedSlice param ranges.
+  auto mha_slice1_param =
+      ops[start_index + kSlice1Index].GetTensorPararm(0).GetTensor();
+  auto mha_slice1_param_data = mha_slice1_param.GetStaticTensorData<int32_t>();
+  std::vector<int32_t> slice1_ranges(mha_slice1_param_data.value().begin(),
+                                     mha_slice1_param_data.value().end());
+  slice1_ranges[kSlice3rdAxisEndIndex] /= num_heads;
+  auto& slice1_param_tensor = tensor_pool.CreateStaticTensor(
+      mha_slice1_param.GetDataType(), mha_slice1_param.GetQuantParams(),
+      mha_slice1_param.GetDims(), mha_slice1_param.GetTensorBytes(),
+      slice1_ranges.data());
+  // Create StridedSlice op.
+  auto slice1_output_dims =
+      ops[start_index + kSlice1Index].GetOutputTensor(0).GetDims();
+  slice1_output_dims[2] /= num_heads;
+  auto& slice1_output = tensor_pool.CloneNativeTensorFrom(
+      ops[start_index + kSlice1Index].GetOutputTensor(0), slice1_output_dims);
+  EmplaceOpWithIO(new_ops, ops[start_index + kSlice1Index], {softmax_output},
+                  {slice1_output});
+  new_ops.back().ClearTensorParams();
+  new_ops.back().AddTensorParam(QNN_OP_STRIDED_SLICE_PARAM_RANGES,
+                                slice1_param_tensor);
+  // MatMul 1
+  const auto& matmulv_cache_output =
+      ops[start_index + kMatMulV1Index].GetOutputTensor(0);
+
+  std::vector<uint32_t> matmul1_v_output_dim = matmulv_cache_output.GetDims();
+  matmul1_v_output_dim[2] = matmul1_v_output_dim[2] / num_heads;
+  auto& matmul1_v_output = tensor_pool.CloneNativeTensorFrom(
+      matmulv_cache_output, matmul1_v_output_dim);
+  EmplaceOpWithIO(new_ops, ops[start_index + kMatMulV1Index],
+                  {slice1_output, std::nullopt}, {matmul1_v_output});
+  // Slice 2
+  // Create StridedSlice param ranges.
+  auto mha_slice2_param =
+      ops[start_index + kSlice2Index].GetTensorPararm(0).GetTensor();
+  auto mha_slice2_param_data = mha_slice2_param.GetStaticTensorData<int32_t>();
+  std::vector<int32_t> slice2_ranges(mha_slice2_param_data.value().begin(),
+                                     mha_slice2_param_data.value().end());
+  slice2_ranges[kSlice3rdAxisEndIndex] /= num_heads;
+  auto& slice2_param_tensor = tensor_pool.CreateStaticTensor(
+      mha_slice2_param.GetDataType(), mha_slice2_param.GetQuantParams(),
+      mha_slice2_param.GetDims(), mha_slice2_param.GetTensorBytes(),
+      slice2_ranges.data());
+  // Create StridedSlice op.
+  auto slice2_output_dims =
+      ops[start_index + kSlice2Index].GetOutputTensor(0).GetDims();
+  slice2_output_dims[2] /= num_heads;
+  auto& slice2_output = tensor_pool.CloneNativeTensorFrom(
+      ops[start_index + kSlice2Index].GetOutputTensor(0), slice2_output_dims);
+  EmplaceOpWithIO(new_ops, ops[start_index + kSlice2Index], {softmax_output},
+                  {slice2_output});
+  new_ops.back().ClearTensorParams();
+  new_ops.back().AddTensorParam(QNN_OP_STRIDED_SLICE_PARAM_RANGES,
+                                slice2_param_tensor);
+  // MatMul 2
+  const auto& matmulv_slice_output =
+      ops[start_index + kMatMulV2Index].GetOutputTensor(0);
+  std::vector<uint32_t> matmul2_v_output_dim = matmulv_slice_output.GetDims();
+  matmul2_v_output_dim[2] = matmul2_v_output_dim[2] / num_heads;
+  auto& matmul2_v_output = tensor_pool.CloneNativeTensorFrom(
+      matmulv_slice_output, matmul2_v_output_dim);
+  EmplaceOpWithIO(new_ops, ops[start_index + kMatMulV2Index],
+                  {slice2_output, std::nullopt}, {matmul2_v_output});
+  // Add
+  auto& add_final_output = tensor_pool.CloneNativeTensorFrom(
+      ops[start_index + kAdd2Index].GetOutputTensor(0),
+      matmul1_v_output.GetDims());
+  EmplaceOpWithIO(new_ops, ops[start_index + kAdd2Index],
+                  {matmul1_v_output, matmul2_v_output}, {add_final_output});
+  return add_final_output;
+}
+
+std::vector<OpWrapper> TransformToSHA(
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    const qnn::TensorWrapper& mha_input, const qnn::TensorWrapper& mha_output,
+    const ::qnn::OpWrapper& scaling_mul, size_t num_heads) {
+  std::vector<OpWrapper> new_ops;
+
+  // Prepare inputs for num_heads SHAs.
+  std::vector<::qnn::TensorWrapperRef> sha_inputs;
+  sha_inputs.reserve(num_heads);
+  for (int i = 0; i < num_heads; ++i) {
+    auto head_input_dims = ops[start_index].GetOutputTensor(0).GetDims();
+    head_input_dims[2] /= num_heads;
+    auto& split_output =
+        tensor_pool.CloneNativeTensorFrom(mha_input, head_input_dims);
+    sha_inputs.emplace_back(split_output);
+  }
+  // Split
+  const std::array<int32_t, 1> split_axis_data{2};
+  auto& split_axis = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {split_axis_data.size()},
+      split_axis_data.size() * sizeof(split_axis_data[0]),
+      split_axis_data.data());
+  auto split = BuildSplitOp(
+      tensor_pool, {split_axis, const_cast<::qnn::TensorWrapper&>(mha_input)},
+      sha_inputs, num_heads);
+  std::move(split.begin(), split.end(), std::back_inserter(new_ops));
+  // Prepare outputs for num_heads SHAs.
+  std::vector<::qnn::TensorWrapperRef> sha_outputs;
+  sha_outputs.reserve(num_heads);
+  // Create num_heads SHA.
+  for (int i = 0; i < num_heads; ++i) {
+    sha_outputs.emplace_back(
+        BuildSingleSHA(ops, start_index, new_ops, tensor_pool,
+                       const_cast<TensorWrapper&>(sha_inputs[i].get()),
+                       scaling_mul, num_heads));
+  }
+  // Concat
+  auto concat_dims = mha_output.GetDims();
+  concat_dims.insert(concat_dims.begin(), 1);
+  auto& concat_output =
+      tensor_pool.CloneNativeTensorFrom(mha_output, concat_dims);
+  auto concat_final =
+      BuildConcatenationOp(tensor_pool, sha_outputs, {concat_output}, 3);
+  std::move(concat_final.begin(), concat_final.end(),
+            std::back_inserter(new_ops));
+  // Reshape
+  auto reshape =
+      BuildReshapeOp(tensor_pool, {concat_output},
+                     {const_cast<::qnn::TensorWrapper&>(mha_output)});
+  std::move(reshape.begin(), reshape.end(), std::back_inserter(new_ops));
+  return new_ops;
+}
+
+}  // namespace
+
+size_t OptimizeMHAPrefill(std::function<bool(OpWrapper&)> validate_op_config,
+                          std::vector<OpWrapper>& ops, size_t start_index,
+                          TensorPool& tensor_pool, size_t pattern_size) {
+  // Connection check
+  if (!(IS_CONNECTED(kMulIndex, 0, kTransposePrefillIndex, 0) &&
+        IS_CONNECTED(kTransposePrefillIndex, 0, kReshapePrefillIndex, 0) &&
+        IS_CONNECTED(kReshapePrefillIndex, 0, kMatMulK1Index + 2, 0) &&
+        IS_CONNECTED(kReshapePrefillIndex, 0, kMatMulK2Index + 2, 0) &&
+        IS_CONNECTED(kMatMulK1Index + 2, 0, kConcatIndex + 2, 0) &&
+        IS_CONNECTED(kMatMulK2Index + 2, 0, kConcatIndex + 2, 1) &&
+        IS_CONNECTED(kConcatIndex + 2, 0, kReshape0Index + 2, 0) &&
+        IS_CONNECTED(kReshape0Index + 2, 0, kAddIndex + 2, 0) &&
+        IS_CONNECTED(kAddIndex + 2, 0, kReshape1Index + 2, 0) &&
+        IS_CONNECTED(kReshape1Index + 2, 0, kSoftmaxIndex + 2, 0) &&
+        IS_CONNECTED(kSoftmaxIndex + 2, 0, kSlice1Index + 2, 0) &&
+        IS_CONNECTED(kSoftmaxIndex + 2, 0, kSlice2Index + 2, 0) &&
+        IS_CONNECTED(kSlice1Index + 2, 0, kMatMulV1Index + 2, 0) &&
+        IS_CONNECTED(kSlice2Index + 2, 0, kMatMulV2Index + 2, 0) &&
+        IS_CONNECTED(kMatMulV1Index + 2, 0, kAdd2Index + 2, 0) &&
+        IS_CONNECTED(kMatMulV2Index + 2, 0, kAdd2Index + 2, 1) &&
+        IS_CONNECTED(kAdd2Index + 2, 0, kReshape2Index + 2, 0) &&
+        IS_CONNECTED(kReshape2Index + 2, 0, kTranspose2Index + 2, 0) &&
+        IS_CONNECTED(kTranspose2Index + 2, 0, kReshape3Index + 2, 0))) {
+    return 1;
+  }
+  // Graph transform
+  QNN_LOG_INFO("[G2G] MHA optimization (Prefill)");
+  std::vector<OpWrapper> new_ops;
+  const auto& scaling_mul = ops[start_index + kMulIndex];
+  const auto& pattern_input = scaling_mul.GetInputTensor(0);
+  const auto& pattern_output =
+      ops[start_index + pattern_size - 1].GetOutputTensor(0);
+
+  // Transpose
+  auto transpose_output_dims =
+      ops[start_index + kTransposePrefillIndex].GetOutputTensor(0).GetDims();
+  auto& transpose_output =
+      tensor_pool.CloneNativeTensorFrom(pattern_input, transpose_output_dims);
+  EmplaceOpWithIO(new_ops, ops[start_index + kTransposePrefillIndex],
+                  {const_cast<::qnn::TensorWrapper&>(pattern_input)},
+                  {transpose_output});
+
+  // Reshape
+  auto& reshape_output = tensor_pool.CloneNativeTensorFrom(
+      pattern_input, {transpose_output_dims[0], 1,
+                      transpose_output_dims[1] * transpose_output_dims[2],
+                      transpose_output_dims[3]});
+  EmplaceOpWithIO(new_ops, ops[start_index + kReshapePrefillIndex],
+                  {transpose_output}, {reshape_output});
+
+  // Process MHA to SHA transformation.
+  const int num_heads = pattern_input.GetDim(2);
+  const auto& mha_input = new_ops.back().GetOutputTensor(0);
+  auto sha_ops =
+      TransformToSHA(ops, start_index + new_ops.size(), tensor_pool, mha_input,
+                     pattern_output, scaling_mul, num_heads);
+  std::move(sha_ops.begin(), sha_ops.end(), std::back_inserter(new_ops));
+
+  // Validate new graph.
+  // TODO(jiunkaiy): Disable bypassing Split int16 op validator.
+  const bool is_valid =
+      std::all_of(new_ops.begin(), new_ops.end(),
+                  [validate_op_config](::qnn::OpWrapper& op_wrapper) -> bool {
+                    return op_wrapper.IsOpCode(QnnOpCode::kSplit) ||
+                           validate_op_config(op_wrapper);
+                  });
+  if (is_valid) {
+    // Replace the matched pattern with a newly generated subgraph.
+    size_t step_size = new_ops.size();
+    ops.insert(ops.begin() + start_index + pattern_size,
+               std::make_move_iterator(new_ops.begin()),
+               std::make_move_iterator(new_ops.end()));
+    ops.erase(ops.begin() + start_index,
+              ops.begin() + start_index + pattern_size);
+    return step_size;
+  }
+  QNN_LOG_WARNING(
+      "[G2G] Validation failed. Rolling back to the original graph.");
+  return 1;
+}
+
+size_t OptimizeMHADecode(std::function<bool(OpWrapper&)> validate_op_config,
+                         std::vector<OpWrapper>& ops, size_t start_index,
+                         TensorPool& tensor_pool, size_t pattern_size) {
+  // Connection check
+  if (!(IS_CONNECTED(kMulIndex, 0, kMatMulK1Index, 0) &&
+        IS_CONNECTED(kMulIndex, 0, kMatMulK2Index, 0) &&
+        IS_CONNECTED(kMatMulK1Index, 0, kConcatIndex, 0) &&
+        IS_CONNECTED(kMatMulK2Index, 0, kConcatIndex, 1) &&
+        IS_CONNECTED(kConcatIndex, 0, kReshape0Index, 0) &&
+        IS_CONNECTED(kReshape0Index, 0, kAddIndex, 0) &&
+        IS_CONNECTED(kAddIndex, 0, kReshape1Index, 0) &&
+        IS_CONNECTED(kReshape1Index, 0, kSoftmaxIndex, 0) &&
+        IS_CONNECTED(kSoftmaxIndex, 0, kSlice1Index, 0) &&
+        IS_CONNECTED(kSoftmaxIndex, 0, kSlice2Index, 0) &&
+        IS_CONNECTED(kSlice1Index, 0, kMatMulV1Index, 0) &&
+        IS_CONNECTED(kSlice2Index, 0, kMatMulV2Index, 0) &&
+        IS_CONNECTED(kMatMulV1Index, 0, kAdd2Index, 0) &&
+        IS_CONNECTED(kMatMulV2Index, 0, kAdd2Index, 1) &&
+        IS_CONNECTED(kAdd2Index, 0, kReshape2Index, 0))) {
+    return 1;
+  }
+  // Graph transform
+  QNN_LOG_INFO("[G2G] MHA optimization (Decode)");
+  std::vector<OpWrapper> new_ops;
+  const auto& scaling_mul = ops[start_index + kMulIndex];
+  const auto& pattern_input = scaling_mul.GetInputTensor(0);
+  const auto& pattern_output =
+      ops[start_index + pattern_size - 1].GetOutputTensor(0);
+
+  // Process MHA to SHA transformation.
+  const int num_heads = pattern_input.GetDim(2);
+  auto sha_ops =
+      TransformToSHA(ops, start_index + new_ops.size(), tensor_pool,
+                     pattern_input, pattern_output, scaling_mul, num_heads);
+  std::move(sha_ops.begin(), sha_ops.end(), std::back_inserter(new_ops));
+
+  // Validate new graph.
+  // TODO(jiunkaiy): Disable bypassing Split int16 op validator.
+  const bool is_valid =
+      std::all_of(new_ops.begin(), new_ops.end(),
+                  [validate_op_config](::qnn::OpWrapper& op_wrapper) -> bool {
+                    return op_wrapper.IsOpCode(QnnOpCode::kSplit) ||
+                           validate_op_config(op_wrapper);
+                  });
+  if (is_valid) {
+    // Replace the matched pattern with a newly generated subgraph.
+    size_t step_size = new_ops.size();
+    ops.insert(ops.begin() + start_index + pattern_size,
+               std::make_move_iterator(new_ops.begin()),
+               std::make_move_iterator(new_ops.end()));
+    ops.erase(ops.begin() + start_index,
+              ops.begin() + start_index + pattern_size);
+    return step_size;
+  }
+  QNN_LOG_WARNING(
+      "[G2G] Validation failed. Rolling back to the original graph.");
+  return 1;
+}
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.h
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.h
@@ -1,0 +1,28 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_MHA_TO_SHA_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_MHA_TO_SHA_H_
+
+#include <functional>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/op_code.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "QnnInterface.h"  // from @qairt
+
+namespace qnn {
+
+size_t OptimizeMHAPrefill(std::function<bool(OpWrapper&)> validate_op_config,
+                          std::vector<OpWrapper>& ops, size_t start_index,
+                          TensorPool& tensor_pool, size_t pattern_size);
+
+size_t OptimizeMHADecode(std::function<bool(OpWrapper&)> validate_op_config,
+                         std::vector<OpWrapper>& ops, size_t start_index,
+                         TensorPool& tensor_pool, size_t pattern_size);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_MHA_TO_SHA_H_

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -20,7 +20,10 @@ OpWrapper::OpWrapper(std::string name, const char* op_type, QnnOpCode op_code)
 OpWrapper::OpWrapper(const OpWrapper& other) = default;
 
 OpWrapper& OpWrapper::operator=(const OpWrapper& other) {
-  new (this) OpWrapper(other);
+  if (this != &other) {
+    this->~OpWrapper();
+    new (this) OpWrapper(other);
+  }
   return *this;
 }
 
@@ -89,6 +92,8 @@ Qnn_OpConfig_t OpWrapper::GetOpConfig() {
   return qnn_op;
 }
 
+QnnOpCode OpWrapper::GetOpCode() const { return op_code_; }
+
 bool OpWrapper::IsOpCode(QnnOpCode op_code) const {
   return op_code_ == op_code;
 }
@@ -101,8 +106,48 @@ const qnn::TensorWrapper& OpWrapper::GetOutputTensor(size_t i) const {
   return output_tensors_[i].get();
 }
 
-void OpWrapper::StealOutputs(const OpWrapper& other) {
-  this->output_tensors_ = other.output_tensors_;
+const qnn::TensorParamWrapper& OpWrapper::GetTensorPararm(size_t i) const {
+  return tensor_params_[i];
 }
+
+void OpWrapper::SwapOutputs(OpWrapper& other) {
+  this->output_tensors_.swap(other.output_tensors_);
+}
+
+void OpWrapper::ClearTensorParams() { tensor_params_.clear(); }
+
+void OpWrapper::UpdateTensors(
+    const std::vector<std::optional<qnn::TensorWrapperRef>>& inputs,
+    const std::vector<std::optional<qnn::TensorWrapperRef>>& outputs) {
+  if (inputs.size() != input_tensors_.size() ||
+      outputs.size() != output_tensors_.size()) {
+    QNN_LOG_WARNING("UpdateTensors skipped due to incorrect tensor count.");
+    return;
+  }
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    if (inputs[i].has_value()) {
+      input_tensors_[i] = inputs[i].value();
+    }
+  }
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    if (outputs[i].has_value()) {
+      output_tensors_[i] = outputs[i].value();
+    }
+  }
+}
+
+std::vector<std::reference_wrapper<TensorWrapper>> OpWrapper::GetAllTensors() {
+  std::vector<std::reference_wrapper<TensorWrapper>> ret;
+  for (auto& tensor_ref : input_tensors_) {
+    ret.emplace_back(const_cast<TensorWrapper&>(tensor_ref.get()));
+  }
+  for (auto& tensor_ref : output_tensors_) {
+    ret.emplace_back(const_cast<TensorWrapper&>(tensor_ref.get()));
+  }
+  for (const auto& param : tensor_params_) {
+    ret.emplace_back(const_cast<TensorWrapper&>(param.GetTensor()));
+  }
+  return ret;
+};
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -42,13 +42,25 @@ class OpWrapper final {
 
   Qnn_OpConfig_t GetOpConfig();
 
+  QnnOpCode GetOpCode() const;
+
   bool IsOpCode(QnnOpCode op_code) const;
 
   const qnn::TensorWrapper& GetInputTensor(size_t i) const;
 
   const qnn::TensorWrapper& GetOutputTensor(size_t i) const;
 
-  void StealOutputs(const OpWrapper& other);
+  const qnn::TensorParamWrapper& GetTensorPararm(size_t i) const;
+
+  std::vector<std::reference_wrapper<TensorWrapper>> GetAllTensors();
+
+  void SwapOutputs(OpWrapper& other);
+
+  void UpdateTensors(
+      const std::vector<std::optional<qnn::TensorWrapperRef>>& inputs,
+      const std::vector<std::optional<qnn::TensorWrapperRef>>& outputs);
+
+  void ClearTensorParams();
 
  private:
   const char* type_name_{nullptr};

--- a/litert/vendors/qualcomm/core/wrappers/param_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/param_wrapper.cc
@@ -24,4 +24,6 @@ void TensorParamWrapper::CloneTo(Qnn_Param_t& dst) const {
   tensor_.CloneTo(dst.tensorParam);
 }
 
+const TensorWrapper& TensorParamWrapper::GetTensor() const { return tensor_; }
+
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/param_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/param_wrapper.h
@@ -68,6 +68,8 @@ class TensorParamWrapper {
 
   void CloneTo(Qnn_Param_t& dst) const;
 
+  const TensorWrapper& GetTensor() const; 
+
  private:
   const char* name_ = nullptr;
   const TensorWrapper& tensor_;

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -112,6 +112,8 @@ class TensorWrapper final {
 
   bool operator==(const TensorWrapper& other) const { return this == &other; }
 
+  bool operator!=(const TensorWrapper& other) const { return this != &other; }
+
   void CloneTo(Qnn_Tensor_t& dst) const;
 
   Qnn_Tensor_t& GetQnnTensor() { return qnn_tensor_; }

--- a/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
@@ -178,7 +178,7 @@ TEST(OpWrapperTest, GetInputOutputTensorTest) {
   EXPECT_EQ(op_wrapper.GetOutputTensor(0), tensor_wrapper_output);
 }
 
-TEST(OpWrapperTest, StealOutputsTest) {
+TEST(OpWrapperTest, SwapOutputsTest) {
   TensorWrapper input_1{};
   TensorWrapper output_1{};
   OpWrapper op_wrapper_1{"name", "OP_TYPE", QnnOpCode::kUnknown};
@@ -192,8 +192,10 @@ TEST(OpWrapperTest, StealOutputsTest) {
   op_wrapper_2.AddOutputTensor(output_2);
 
   EXPECT_EQ(op_wrapper_1.GetOutputTensor(0), output_1);
-  op_wrapper_1.StealOutputs(op_wrapper_2);
+  op_wrapper_1.SwapOutputs(op_wrapper_2);
   EXPECT_EQ(op_wrapper_1.GetOutputTensor(0), output_2);
+  op_wrapper_1.SwapOutputs(op_wrapper_2);
+  EXPECT_EQ(op_wrapper_1.GetOutputTensor(0), output_1);
 }
 
 }  // namespace


### PR DESCRIPTION
Summary:
- Apply the Boyer–Moore–Horspool algorithm for pattern matching.
- Transform MHA into multiple SHAs.
- Refactor the MatMul-convert funsion.
- Add Qnn Tensors only if they are utilized.

Target //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
```
[----------] Global test environment tear-down
[==========] 4 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 4 tests.
```
* New test: `MHAConvertTest.Gemma3Prefill` and `MHAConvertTest.Gemma3Decode`

Target //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
```
[----------] Global test environment tear-down
[==========] 172 tests from 4 test suites ran. (19090 ms total)
[  PASSED  ] 172 tests.
```
Target //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
```
[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (479 ms total)
[  PASSED  ] 4 tests.
```
Target //litert/runtime/dispatch:_dispatch_delegate_qualcomm_test
```
[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (526 ms total)
[  PASSED  ] 5 tests.
```
Target //litert/vendors/qualcomm/core/utils:utils_test
```
[----------] Global test environment tear-down
[==========] 11 tests from 3 test suites ran. (9 ms total)
[  PASSED  ] 11 tests.
```
Target //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
```
[----------] Global test environment tear-down
[==========] 15 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 15 tests.
```
Target //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
```
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.
```
Target //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
```
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.
```
Target //litert/vendors/qualcomm/core:tensor_pool_test
```
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.
```
Target //litert/vendors/qualcomm:qnn_manager_test
```
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (49 ms total)
[  PASSED  ] 2 tests.
```
Target //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
```
[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 6 tests.
```