### PR TITLE
Qualcomm AI Engine Direct - run_model support the iteration argument.

### DIFF
--- a/litert/tools/BUILD
+++ b/litert/tools/BUILD
@@ -305,7 +305,6 @@ cc_binary(
         # "//litert/runtime/accelerators/gpu:ml_drift_cl_accelerator",  # buildcleaner: keep
         # copybara:uncomment_end
         "//litert/c:litert_common",
-        "//litert/c:litert_logging",
         "//litert/cc/internal:litert_compiled_model",
         "//litert/cc:litert_element_type",
         "//litert/cc/internal:litert_environment",


### PR DESCRIPTION
# WHAT
1. Support the iteration argument to execute the graph multiple times.
2. Record the run time and calculate the statistics.
3. Use ABSL_LOG and remove LITERT_LOG.

# TEST
```
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1689520440.064678   15029 run_model.cc:150] Model: /data/local/tmp/weilhuan/torchvision_efficientnet_b0_compiled.tflite
...
VERBOSE: Replacing 1 out of 1 node(s) with delegate (DispatchDelegate) node, yielding 1 partitions for subgraph 0.
INFO: [litert/vendors/qualcomm/context_binary_info.cc:110] Found qnn graph: qnn_partition_0
INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
I0000 00:00:1689520440.503551   15029 run_model.cc:179] Signature index: 0
I0000 00:00:1689520440.503730   15029 run_model.cc:181] Prepare input buffers
I0000 00:00:1689520440.504463   15029 run_model.cc:197] Prepare output buffers
I0000 00:00:1689520440.504714   15029 run_model.cc:208] Run model for 50 times
I0000 00:00:1689520440.561801   15029 run_model.cc:217] First run took 2719 microseconds
I0000 00:00:1689520440.562003   15029 run_model.cc:218] Slowest run took 2719 microseconds
I0000 00:00:1689520440.562056   15029 run_model.cc:221] Fastest run took 1075 microseconds
I0000 00:00:1689520440.562121   15029 run_model.cc:224] All runs took average 1139 microseconds
I0000 00:00:1689520440.562155   15029 run_model.cc:237] Model run completed
FORTIFY: pthread_mutex_lock called on a destroyed mutex (0xb400007961a4ea30)
```
