### PR TITLE
[NeuroPilot] Fix incorrect parameters for legalize

### DIFF
--- a/litert/vendors/mediatek/compiler/legalizations/transpose_conv_op_legalization.cc
+++ b/litert/vendors/mediatek/compiler/legalizations/transpose_conv_op_legalization.cc
@@ -86,8 +86,10 @@ Expected<void> LegalizeTransposeConvOp(
       status != kLiteRtStatusOk) {
     return Error(status, "Failed to get padding");
   }
-  auto padding_operand_index =
-      operand_map.AddScalarInt32(static_cast<int32_t>(padding));
+  NeuronAdapterPaddingCode neuron_padding = NEURON_PADDING_SAME;
+  CHECK_RT_STATUS(ConvertPaddingType(padding, neuron_padding),
+                  "Fails to convert padding");
+  auto padding_operand_index = operand_map.AddScalarInt32(neuron_padding);
   CHECK_OP_IDX_AND_RETURN_ERROR(padding_operand_index);
   input_indices.push_back(*padding_operand_index);
 


### PR DESCRIPTION
1. Fix the incorrect padding for `conv2d `& `depthwiseConv2d `& `transposeConv`