### PR TITLE
Qualcomm AI Engine Direct - Support V69 Devices

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
@@ -131,6 +131,7 @@ const auto kSupportedSocModels = Values(
     "SA8255",
     "SM8350",
     "SM8450",
+    "SM8475",
     "SM8550",
     "SM8650",
     "SM8750"
@@ -145,7 +146,7 @@ TEST(TestQnnPlugin, GetConfigInfo) {
   LiteRtParamIndex num_supported_soc_models;
   LITERT_ASSERT_OK(LiteRtGetNumCompilerPluginSupportedSocModels(
       plugin.get(), &num_supported_soc_models));
-  ASSERT_EQ(num_supported_soc_models, 8);
+  ASSERT_EQ(num_supported_soc_models, 9);
 
   const char* config_id;
   LITERT_ASSERT_OK(

--- a/litert/vendors/qualcomm/core/schema/soc_table.cc
+++ b/litert/vendors/qualcomm/core/schema/soc_table.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "litert/vendors/qualcomm/core/schema/soc_table.h"
+
 #include <cstdint>
 namespace qnn {
 constexpr SocInfo kSocInfos[] = {
@@ -18,6 +19,9 @@ constexpr SocInfo kSocInfos[] = {
              4  // vtcm_size_in_mb
              )},
     {SocInfo("SM8450", SnapdragonModel::SM8450, DspArch::V69,
+             8  // vtcm_size_in_mb
+             )},
+    {SocInfo("SM8475", SnapdragonModel::SM8475, DspArch::V69,
              8  // vtcm_size_in_mb
              )},
     {SocInfo("SM8550", SnapdragonModel::SM8550, DspArch::V73,

--- a/litert/vendors/qualcomm/core/schema/soc_table.h
+++ b/litert/vendors/qualcomm/core/schema/soc_table.h
@@ -11,6 +11,7 @@ enum class SnapdragonModel {
   SA8295 = 39,
   SM8350 = 30,
   SM8450 = 36,
+  SM8475 = 42,
   SM8550 = 43,
   SA8255 = 52,
   SM8650 = 57,


### PR DESCRIPTION
`qnn_compiler_plugin_test`
```[----------] Global test environment tear-down
[==========] 175 tests from 5 test suites ran. (12814 ms total)
[  PASSED  ] 175 tests.```