### PR TITLE
[NeuroPilot] Support Int4/Int64 for legalizations

### DIFF
--- a/litert/vendors/mediatek/compiler/compiler_plugin.cc
+++ b/litert/vendors/mediatek/compiler/compiler_plugin.cc
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include "absl/strings/str_format.h"  // from @com_google_absl
+#include "absl/strings/str_format.h"   // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_logging.h"
@@ -38,6 +38,7 @@
 #include "litert/vendors/mediatek/compiler/compile_model.h"
 #include "litert/vendors/mediatek/compiler/create_model.h"
 #include "litert/vendors/mediatek/compiler/legalizations/common_op_legalization.h"
+#include "litert/vendors/mediatek/compiler/legalizations/operand_map.h"
 #include "litert/vendors/mediatek/neuron_adapter_api.h"
 #include "litert/vendors/mediatek/schema/neuron_schema_generated.h"
 #include "litert/vendors/mediatek/schema/schema_resolver.h"
@@ -51,6 +52,7 @@ using litert::Expected;
 using litert::mediatek::NeuronAdapterApi;
 using litert::mediatek::NeuronCompilationPtr;
 using litert::mediatek::NeuronModelPtr;
+using litert::mediatek::OperandMap;
 
 namespace {
 
@@ -98,6 +100,8 @@ constexpr LiteRtOpCode kSupportedOps[] = {
     kLiteRtOpCodeTflResizeNearestNeighbor,
     kLiteRtOpCodeTflTransposeConv,
     kLiteRtOpCodeTflMaxPool2d,
+    kLiteRtOpCodeTflDequantize,
+    kLiteRtOpCodeTflPadv2,
     kLiteRtOpCodeTflHardSwish
 };
 // clang-format on
@@ -309,10 +313,13 @@ namespace {
 Expected<std::vector<uint8_t>> CompilePartition(
     NeuronAdapterApi& neuron_adapter_api, const litert::Subgraph& partition,
     const std::string& graph_name, std::optional<std::string> soc_model) {
-  auto model = CreateModel(neuron_adapter_api, partition, graph_name);
+  auto model = neuron_adapter_api.CreateModel();
   if (!model) {
     return model.Error();
   }
+  OperandMap operand_map(neuron_adapter_api, model->get());
+  LITERT_RETURN_IF_ERROR(CreateModel(neuron_adapter_api, partition, graph_name,
+                                     model->get(), &operand_map));
 
   auto compilation = CompileModel(neuron_adapter_api, model->get(), soc_model);
   if (!compilation) {

--- a/litert/vendors/mediatek/compiler/create_model.cc
+++ b/litert/vendors/mediatek/compiler/create_model.cc
@@ -19,9 +19,9 @@
 #include <tuple>
 #include <vector>
 
-#include "neuron/api/NeuronAdapter.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_op_code.h"
+#include "litert/c/litert_options.h"
 #include "litert/cc/litert_expected.h"
 #include "litert/cc/litert_model.h"
 #include "litert/vendors/mediatek/compiler/legalizations/add_op_legalization.h"
@@ -33,7 +33,6 @@
 #include "litert/vendors/mediatek/compiler/legalizations/legalize_helper.h"
 #include "litert/vendors/mediatek/compiler/legalizations/mean_op_legalization.h"
 #include "litert/vendors/mediatek/compiler/legalizations/mul_op_legalization.h"
-#include "litert/vendors/mediatek/compiler/legalizations/operand_map.h"
 #include "litert/vendors/mediatek/compiler/legalizations/reshape_op_legalization.h"
 #include "litert/vendors/mediatek/compiler/legalizations/resize_bilinear_op_legalization.h"
 #include "litert/vendors/mediatek/compiler/legalizations/resize_nearest_neighbor_op_legalization.h"
@@ -45,27 +44,22 @@
 #include "litert/vendors/mediatek/compiler/legalizations/transpose_op_legalization.h"
 #include "litert/vendors/mediatek/neuron_adapter_api.h"
 #include "litert/vendors/mediatek/schema/schema_resolver.h"
+#include "neuron/api/NeuronAdapter.h"
 
 namespace litert::mediatek {
 
-Expected<NeuronModelPtr> CreateModel(const NeuronAdapterApi& neuron_adapter_api,
-                                     const litert::Subgraph& partition,
-                                     const std::string& model_name) {
-  auto model = neuron_adapter_api.CreateModel();
-  if (!model) {
-    return model.Error();
-  }
-
-  if (neuron_adapter_api.api().model_set_name(
-          model->get(), model_name.c_str()) != NEURON_NO_ERROR) {
+Expected<void> CreateModel(const NeuronAdapterApi& neuron_adapter_api,
+                           const litert::Subgraph& partition,
+                           const std::string& model_name, NeuronModel* model,
+                           OperandMap* operand_map) {
+  if (neuron_adapter_api.api().model_set_name(model, model_name.c_str()) !=
+      NEURON_NO_ERROR) {
     return Error(kLiteRtStatusErrorRuntimeFailure, "Failed to set model name");
   }
 
-  OperandMap operand_map(neuron_adapter_api, model->get());
-
   std::vector<uint32_t> input_indices;
   for (const auto& input : partition.Inputs()) {
-    auto operand_index = operand_map.GetOperandIndex(input);
+    auto operand_index = operand_map->GetOperandIndex(input);
     if (!operand_index) {
       return operand_index.Error();
     }
@@ -74,7 +68,7 @@ Expected<NeuronModelPtr> CreateModel(const NeuronAdapterApi& neuron_adapter_api,
 
   std::vector<uint32_t> output_indices;
   for (const auto& output : partition.Outputs()) {
-    auto operand_index = operand_map.GetOperandIndex(output);
+    auto operand_index = operand_map->GetOperandIndex(output);
     if (!operand_index) {
       return operand_index.Error();
     }
@@ -82,7 +76,7 @@ Expected<NeuronModelPtr> CreateModel(const NeuronAdapterApi& neuron_adapter_api,
   }
 
   if (neuron_adapter_api.api().model_identify_inputs_and_outputs(
-          model->get(), input_indices.size(), input_indices.data(),
+          model, input_indices.size(), input_indices.data(),
           output_indices.size(), output_indices.data()) != NEURON_NO_ERROR) {
     return Error(kLiteRtStatusErrorRuntimeFailure,
                  "Failed to identify model I/Os");
@@ -93,67 +87,67 @@ Expected<NeuronModelPtr> CreateModel(const NeuronAdapterApi& neuron_adapter_api,
     switch (op.Code()) {
       case kLiteRtOpCodeTflAdd:
         status =
-            LegalizeAddOp(neuron_adapter_api, model->get(), operand_map, op);
+            LegalizeAddOp(neuron_adapter_api, model, *operand_map, op);
         break;
       case kLiteRtOpCodeTflMul:
         status =
-            LegalizeMulOp(neuron_adapter_api, model->get(), operand_map, op);
+            LegalizeMulOp(neuron_adapter_api, model, *operand_map, op);
         break;
       case kLiteRtOpCodeTflBatchMatmul:
-        status = LegalizeBatchMatMulOp(neuron_adapter_api, model->get(),
-                                       operand_map, op);
+        status = LegalizeBatchMatMulOp(neuron_adapter_api, model,
+                                       *operand_map, op);
         break;
       case kLiteRtOpCodeTflFullyConnected:
-        status = LegalizeFullyConnectedOp(neuron_adapter_api, model->get(),
-                                          operand_map, op);
+        status = LegalizeFullyConnectedOp(neuron_adapter_api, model,
+                                          *operand_map, op);
         break;
       case kLiteRtOpCodeTflReshape:
-        status = LegalizeReshapeOp(neuron_adapter_api, model->get(),
-                                   operand_map, op);
+        status = LegalizeReshapeOp(neuron_adapter_api, model,
+                                   *operand_map, op);
         break;
       case kLiteRtOpCodeTflTranspose:
-        status = LegalizeTransposeOp(neuron_adapter_api, model->get(),
-                                     operand_map, op);
+        status = LegalizeTransposeOp(neuron_adapter_api, model,
+                                     *operand_map, op);
         break;
       case kLiteRtOpCodeTflRsqrt:
         status =
-            LegalizeRsqrtOp(neuron_adapter_api, model->get(), operand_map, op);
+            LegalizeRsqrtOp(neuron_adapter_api, model, *operand_map, op);
         break;
       case kLiteRtOpCodeTflConcatenation:
         status =
-            LegalizeConcatOp(neuron_adapter_api, model->get(), operand_map, op);
+            LegalizeConcatOp(neuron_adapter_api, model, *operand_map, op);
         break;
       case kLiteRtOpCodeTflQuantize:
-        status = LegalizeCommonOp(neuron_adapter_api, model->get(), operand_map,
+        status = LegalizeCommonOp(neuron_adapter_api, model, *operand_map,
                                   op, NEURON_QUANTIZE);
         break;
       case kLiteRtOpCodeTflSlice:
-        status = LegalizeCommonOp(neuron_adapter_api, model->get(), operand_map,
+        status = LegalizeCommonOp(neuron_adapter_api, model, *operand_map,
                                   op, NEURON_SLICE);
         break;
       case kLiteRtOpCodeTflTanh:
-        status = LegalizeCommonOp(neuron_adapter_api, model->get(), operand_map,
+        status = LegalizeCommonOp(neuron_adapter_api, model, *operand_map,
                                   op, NEURON_TANH);
         break;
       case kLiteRtOpCodeTflSub:
         status =
-            LegalizeSubOp(neuron_adapter_api, model->get(), operand_map, op);
+            LegalizeSubOp(neuron_adapter_api, model, *operand_map, op);
         break;
       case kLiteRtOpCodeTflSoftmax:
-        status = LegalizeSoftmaxOp(neuron_adapter_api, model->get(),
-                                   operand_map, op);
+        status = LegalizeSoftmaxOp(neuron_adapter_api, model,
+                                   *operand_map, op);
         break;
       case kLiteRtOpCodeTflMean:
         status =
-            LegalizeMeanOp(neuron_adapter_api, model->get(), operand_map, op);
+            LegalizeMeanOp(neuron_adapter_api, model, *operand_map, op);
         break;
       case kLiteRtOpCodeTflGelu:
         status =
-            LegalizeGeluOp(neuron_adapter_api, model->get(), operand_map, op);
+            LegalizeGeluOp(neuron_adapter_api, model, *operand_map, op);
         break;
       case kLiteRtOpCodeTflMaxPool2d:
         status = LegalizeOp(
-            neuron_adapter_api, model->get(), operand_map, op,
+            neuron_adapter_api, model, *operand_map, op,
             NEURON_MAX_POOL_2D,
             std::make_tuple(
                 AddMaxPool2dPaddingOption,           // padding
@@ -168,21 +162,21 @@ Expected<NeuronModelPtr> CreateModel(const NeuronAdapterApi& neuron_adapter_api,
                                   op, NEURON_HARD_SWISH);
         break;
       case kLiteRtOpCodeTflPad:
-        status = LegalizeCommonOp(neuron_adapter_api, model->get(), operand_map,
+        status = LegalizeCommonOp(neuron_adapter_api, model, *operand_map,
                                   op, NEURON_PAD);
         break;
       case kLiteRtOpCodeTflLogistic:
-        status = LegalizeCommonOp(neuron_adapter_api, model->get(), operand_map,
+        status = LegalizeCommonOp(neuron_adapter_api, model, *operand_map,
                                   op, NEURON_LOGISTIC);
         break;
       case kLiteRtOpCodeTflSum:
-        status = LegalizeOp(neuron_adapter_api, model->get(), operand_map, op,
+        status = LegalizeOp(neuron_adapter_api, model, *operand_map, op,
                             NEURON_REDUCE_SUM,
                             std::make_tuple(AddSumKeepDimsOption));
         break;
       case kLiteRtOpCodeTflConv2d:
         status = LegalizeOp(
-            neuron_adapter_api, model->get(), operand_map, op, NEURON_CONV_2D,
+            neuron_adapter_api, model, *operand_map, op, NEURON_CONV_2D,
             std::make_tuple(AddConv2dPaddingOption,         // padding
                             AddConv2dStrideWOption,         // stride_w
                             AddConv2dStrideHOption,         // stride_h
@@ -193,7 +187,7 @@ Expected<NeuronModelPtr> CreateModel(const NeuronAdapterApi& neuron_adapter_api,
         break;
       case kLiteRtOpCodeTflDepthwiseConv2d:
         status = LegalizeOp(
-            neuron_adapter_api, model->get(), operand_map, op,
+            neuron_adapter_api, model, *operand_map, op,
             NEURON_DEPTHWISE_CONV_2D,
             std::make_tuple(
                 AddDepthwiseConv2dPaddingOption,  // padding
@@ -206,20 +200,28 @@ Expected<NeuronModelPtr> CreateModel(const NeuronAdapterApi& neuron_adapter_api,
                 AddDepthwiseConv2dDilationHOption));     // dilation_h
         break;
       case kLiteRtOpCodeTflSquaredDifference:
-        status = LegalizeSquaredDifferenceOp(neuron_adapter_api, model->get(),
-                                             operand_map, op);
+        status = LegalizeSquaredDifferenceOp(neuron_adapter_api, model,
+                                             *operand_map, op);
         break;
       case kLiteRtOpCodeTflResizeBilinear:
-        status = LegalizeResizeBilinearOp(neuron_adapter_api, model->get(),
-                                          operand_map, op);
+        status = LegalizeResizeBilinearOp(neuron_adapter_api, model,
+                                          *operand_map, op);
         break;
       case kLiteRtOpCodeTflResizeNearestNeighbor:
         status = LegalizeResizeNearestNeighborOp(neuron_adapter_api,
-                                                 model->get(), operand_map, op);
+                                                 model, *operand_map, op);
         break;
       case kLiteRtOpCodeTflTransposeConv:
-        status = LegalizeTransposeConvOp(neuron_adapter_api, model->get(),
-                                         operand_map, op);
+        status = LegalizeTransposeConvOp(neuron_adapter_api, model,
+                                         *operand_map, op);
+        break;
+      case kLiteRtOpCodeTflDequantize:
+        status = LegalizeCommonOp(neuron_adapter_api, model, *operand_map, op,
+                                  NEURON_DEQUANTIZE);
+        break;
+      case kLiteRtOpCodeTflPadv2:
+        status = LegalizeCommonOp(neuron_adapter_api, model, *operand_map, op,
+                                  NEURON_PAD_V2);
         break;
       default:
         return Error(kLiteRtStatusErrorRuntimeFailure, "Unsupported op");
@@ -230,11 +232,11 @@ Expected<NeuronModelPtr> CreateModel(const NeuronAdapterApi& neuron_adapter_api,
     }
   }
 
-  if (neuron_adapter_api.api().model_finish(model->get()) != NEURON_NO_ERROR) {
+  if (neuron_adapter_api.api().model_finish(model) != NEURON_NO_ERROR) {
     return Error(kLiteRtStatusErrorRuntimeFailure, "Failed to finish model");
   }
 
-  return model;
+  return {};
 }
 
 }  // namespace litert::mediatek

--- a/litert/vendors/mediatek/compiler/create_model.h
+++ b/litert/vendors/mediatek/compiler/create_model.h
@@ -20,14 +20,16 @@
 #include "litert/c/litert_common.h"
 #include "litert/cc/litert_expected.h"
 #include "litert/cc/litert_model.h"
+#include "litert/vendors/mediatek/compiler/legalizations/operand_map.h"
 #include "litert/vendors/mediatek/neuron_adapter_api.h"
 
 namespace litert::mediatek {
 
 // Create a new NeuronModel Graph from given LiteRt Graph.
-Expected<NeuronModelPtr> CreateModel(const NeuronAdapterApi& neuron_adapter_api,
-                                     const Subgraph& partition,
-                                     const std::string& model_name);
+Expected<void> CreateModel(const NeuronAdapterApi& neuron_adapter_api,
+                           const Subgraph& partition,
+                           const std::string& model_name, NeuronModel* model,
+                           OperandMap* operand_map);
 
 }  // namespace litert::mediatek
 

--- a/litert/vendors/mediatek/compiler/legalizations/BUILD
+++ b/litert/vendors/mediatek/compiler/legalizations/BUILD
@@ -20,7 +20,10 @@ package(
 cc_library(
     name = "operand_map",
     srcs = ["operand_map.cc"],
-    hdrs = ["operand_map.h"],
+    hdrs = [
+        "operand_map.h",
+        "extra_data_mgr.h",
+    ],
     tags = [
         # Don't build/test in OS until MediaTek SDK is available.
         "nobuilder",

--- a/litert/vendors/mediatek/compiler/legalizations/extra_data_mgr.h
+++ b/litert/vendors/mediatek/compiler/legalizations/extra_data_mgr.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 MediaTek Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ODML_LITERT_LITERT_VENDORS_MEDIATEK_COMPILER_LEGALIZATIONS_EXTRA_DATA_MGR_H_
+#define ODML_LITERT_LITERT_VENDORS_MEDIATEK_COMPILER_LEGALIZATIONS_EXTRA_DATA_MGR_H_
+
+#include <cstdint>
+#include <map>
+#include <numeric>
+#include <vector>
+
+#include "litert/c/litert_common.h"
+#include "litert/c/litert_logging.h"
+#include "litert/cc/litert_expected.h"
+#include "litert/cc/litert_model.h"
+
+namespace litert::mediatek {
+
+class ExtraDataMgr {
+ public:
+  Expected<size_t> Register(size_t bytes) {
+    if (bytes <= 0) {
+      return Error(kLiteRtStatusErrorRuntimeFailure,
+                   "Bytes must be greater than 0");
+    }
+    extra_data_vec_.emplace_back(std::make_unique<uint8_t[]>(bytes));
+    return extra_data_vec_.size() - 1;
+  }
+
+  uint8_t* Get(size_t index) {
+    if (index < 0 || index >= extra_data_vec_.size()) {
+      LITERT_LOG(LITERT_ERROR, "Index out of bound.");
+      return nullptr;
+    }
+    return extra_data_vec_[index].get();
+  }
+
+ private:
+  std::vector<std::unique_ptr<uint8_t[]>> extra_data_vec_;
+};
+
+}  // namespace litert::mediatek
+
+#endif  // ODML_LITERT_LITERT_VENDORS_MEDIATEK_COMPILER_LEGALIZATIONS_EXTRA_DATA_MGR_H_

--- a/litert/vendors/mediatek/compiler/legalizations/fully_connected_op_legalization.cc
+++ b/litert/vendors/mediatek/compiler/legalizations/fully_connected_op_legalization.cc
@@ -120,13 +120,12 @@ Expected<void> LegalizeFullyConnectedOp(
       return output_operand.Error();
     }
 
-    LITERT_ASSIGN_OR_RETURN(auto tensor_type,
-                            op.Outputs()[0].RankedTensorType());
-    auto dimension = tensor_type.Layout().Dimensions();
+    auto dimension = GetDimensions(op.Outputs()[0]);
     std::vector<uint32_t> new_shape(dimension.begin(), dimension.end());
     std::vector<uint32_t> tensor_shape = {(uint32_t)new_shape.size()};
-    auto new_shape_operand_index = operand_map.AddTensorInt32(
-        tensor_shape, new_shape.data(), new_shape.size() * sizeof(int32_t));
+    auto new_shape_operand_index = operand_map.AddTensorByType(
+        NEURON_TENSOR_INT32, tensor_shape, new_shape.data(),
+        new_shape.size() * sizeof(int32_t));
     if (!new_shape_operand_index) {
       return new_shape_operand_index.Error();
     }

--- a/litert/vendors/mediatek/compiler/legalizations/neuron_utils.cc
+++ b/litert/vendors/mediatek/compiler/legalizations/neuron_utils.cc
@@ -57,6 +57,20 @@ Expected<NeuronTensorType> GetNeuronTensorType(const Tensor& t,
                      "Int8 is not supported.");
       }
       break;
+    case ElementType::Int4:
+      if (t.QTypeId() == kLiteRtQuantizationPerTensor) {
+        mtk_type = NEURON_EXT_TENSOR_QUANT4_SYMM;
+      } else if (t.QTypeId() == kLiteRtQuantizationPerChannel) {
+        mtk_type = NEURON_EXT_TENSOR_QUANT4_SYMM_PER_CHANNEL;
+      } else {
+        return Error(kLiteRtStatusErrorRuntimeFailure,
+                     "Int4 is not supported.");
+      }
+      break;
+    case ElementType::Int64:
+      mtk_type = NEURON_TENSOR_INT32;
+      LITERT_LOG(LITERT_WARNING, "Currently force casting int64 to int32.");
+      break;
     default:
       return Error(kLiteRtStatusErrorRuntimeFailure,
                    absl::StrFormat("Unsupported element type: %d",
@@ -172,6 +186,47 @@ size_t PackOemScalarString(const char* str, uint8_t** out_buffer) {
   free(operand_value.data);
 
   return out_len;
+}
+
+Expected<void> UnpackDenseInt4IntoInt8(const int8_t* src_buffer,
+                                       int num_elements, int8_t* dst_buffer) {
+  // num_elements means the number of elements regardless of packed or
+  // For example, 3 elements means both
+  //   1) Packed: 3 int4's = 12 bit -> 16 bits (padded) = 2 bytes.
+  //      stored in src_buffer[0] and src_buffer[1] (i = 0..1)
+  //   2) Unpacked: 3 int8's = 3 bytes.
+  //.     stored in dst_buffer[0], dst_buffer[1] and dst_buffer[2] (j =
+  for (int i = 0; i < num_elements / 2; i++) {
+    int8_t byte = src_buffer[i];
+    // Shift left first so that sign is properly extended when shifted
+    int8_t lower = static_cast<int8_t>(byte << 4) >> 4;
+    int8_t higher = byte >> 4;
+    dst_buffer[2 * i] = lower;
+    dst_buffer[2 * i + 1] = higher;
+  }
+
+  // If the buffer size is odd, extract the final lower nibble.
+  if (num_elements % 2 != 0) {
+    dst_buffer[num_elements - 1] =
+        static_cast<int8_t>(src_buffer[num_elements / 2] << 4) >> 4;
+  }
+  return {};
+}
+
+Expected<void> CastInt64IntoInt32(const int64_t* src_buffer, int num_elements,
+                                  int32_t* dst_buffer) {
+  for (int i = 0; i < num_elements; ++i) {
+    int64_t value = src_buffer[i];
+    //Check if the value exceeds the int32_t range
+    if (value > std::numeric_limits<int32_t>::max() ||
+        value < std::numeric_limits<int32_t>::min()) {
+      return Error(kLiteRtStatusErrorRuntimeFailure,
+                   "CastInt64IntoInt32: value out of int32_t range.");
+    } else {
+      dst_buffer[i] = static_cast<int32_t>(value);
+    }
+  }
+  return {};
 }
 
 }  // namespace litert::mediatek

--- a/litert/vendors/mediatek/compiler/legalizations/neuron_utils.h
+++ b/litert/vendors/mediatek/compiler/legalizations/neuron_utils.h
@@ -56,6 +56,14 @@ NeuronReturnCode ModelAddOperation(const NeuronAdapterApi& api,
 
 size_t PackOemScalarString(const char* str, uint8_t** out_buffer);
 
+// Unpack or inflate `src_buffer` by taking each element and splitting it as
+// two elements into `dst_buffer`.
+Expected<void> UnpackDenseInt4IntoInt8(const int8_t* src_buffer,
+                                       int num_elements, int8_t* dst_buffer);
+
+Expected<void> CastInt64IntoInt32(const int64_t* src_buffer, int num_elements,
+                                  int32_t* dst_buffer);
+
 }  // namespace litert::mediatek
 
 #endif  // ODML_LITERT_LITERT_VENDORS_MEDIATEK_COMPILER_LEGALIZATIONS_NEURON_UTILS_H_

--- a/litert/vendors/mediatek/compiler/legalizations/transpose_conv_op_legalization.cc
+++ b/litert/vendors/mediatek/compiler/legalizations/transpose_conv_op_legalization.cc
@@ -91,7 +91,6 @@ Expected<void> LegalizeTransposeConvOp(
       << "Fails to convert padding";
   auto padding_operand_index = operand_map.AddScalarInt32(neuron_padding);
   CHECK_OP_IDX_AND_RETURN_ERROR(padding_operand_index);
-
   input_indices.push_back(*padding_operand_index);
 
   int32_t stride_width;


### PR DESCRIPTION
- Support new data types: int4 & int64 Notice that we currently force cast int64 to int32
- Introduce an extra data manager to manage additional tensor data
- Add new legalizations for Padv2 and Dequantize