### PR TITLE
Qualcomm AI Engine Direct - Correct bias quant params for Conv2D.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -189,7 +189,13 @@ LiteRtStatus ConvertTensor(const litert::Tensor& litert_tensor,
   } else {
     dimentions.resize(litert_layout.Rank());
     for (size_t i = 0; i < dimentions.size(); ++i) {
-      dimentions[i] = litert_layout.Dimensions()[i];
+      // TODO(jiunkaiy): Integrate QNN dynamic dimension.
+      // If any dimension sizes are unknown, they are indicated with -1.
+      if (litert_layout.Dimensions()[i] == -1) {
+        dimentions[i] = 1;
+      } else {
+        dimentions[i] = litert_layout.Dimensions()[i];
+      }
     }
   }
 

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -293,20 +293,20 @@ class TensorWrapper final {
   template <typename T>
   std::optional<absl::Span<const T>> GetStaticTensorData() const;
 
-  void ConvertAxisScaleOffsetToScaleOffset() {
-    if (!std::holds_alternative<AxisScaleOffsetQuantizeParamsWrapper>(
-            quantize_params_)) {
-      return;
-    }
-
-    quantize_params_.emplace<ScaleOffsetQuantizeParamsWrapper>(0.0, 0);
-  }
+  void ConvertAxisScaleOffsetToScaleOffset();
 
   size_t GetTensorBytes() const;
 
   void ConvertQint16ToQuint16();
 
  private:
+  void UpdateQnnQuantParams() {
+    std::visit(
+        [this](auto&& quantize_params) -> void {
+          quantize_params.CloneTo(qnn_tensor_.v2.quantizeParams);
+        },
+        quantize_params_);
+  }
   Qnn_TensorType_t GetTensorType() const;
 
   void SetDataType(Qnn_DataType_t data_type) {


### PR DESCRIPTION
# WHAT
Summary:
- Update bias QNN quant params in ConvertAxisScaleOffsetToScaleOffset().
- Integrate the use of std::visit for QNN tensor quantization parameters within UpdateQnnQuantParams().
- Set unknown dimension from -1 to 1.

# TEST
`qint8_Conv2d_DepthConv2d.tflite` can be fully delegated.

Target //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
```
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.
```
Target //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
```
[----------] Global test environment tear-down
[==========] 172 tests from 4 test suites ran. (19524 ms total)
[  PASSED  ] 172 tests.
```
Target //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
```
[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (521 ms total)
[  PASSED  ] 4 tests.
```
Target //litert/runtime/dispatch:_dispatch_delegate_qualcomm_test
```
[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (589 ms total)
[  PASSED  ] 5 tests.
```
Target //litert/vendors/qualcomm/core/utils:utils_test
```
[----------] Global test environment tear-down
[==========] 11 tests from 3 test suites ran. (9 ms total)
[  PASSED  ] 11 tests.
```
Target //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
```
[----------] Global test environment tear-down
[==========] 15 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 15 tests.
```
Target //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
```
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.
```
Target //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
```
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.
```
Target //litert/vendors/qualcomm/core:tensor_pool_test
```
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.
```
Target //litert/vendors/qualcomm:qnn_manager_test
```
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (48 ms total)
[  PASSED  ] 2 tests.
```
Target //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
```
[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 6 tests.
```
