### PR TITLE
[NeuroPilot] Fix fully-connected bias issue

### DIFF
--- a/litert/vendors/mediatek/compiler/compiler_plugin.cc
+++ b/litert/vendors/mediatek/compiler/compiler_plugin.cc
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include "absl/strings/str_format.h"  // from @com_google_absl
+#include "absl/strings/str_format.h"   // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_logging.h"

--- a/litert/vendors/mediatek/compiler/legalizations/legalize_helper.h
+++ b/litert/vendors/mediatek/compiler/legalizations/legalize_helper.h
@@ -59,10 +59,16 @@ inline Expected<uint32_t> AddZeroBiasForConvBase(const Tensor& input_tensor,
                               ? NEURON_TENSOR_FLOAT32
                               : NEURON_TENSOR_INT32;
   auto bias_data_size =
-      (input_type == ElementType::Float32) ? sizeof(float) : sizeof(int32_t);
-  std::vector<uint8_t> bias_data(num_element * bias_data_size, 0);
-  return operand_map.AddTensorByType(bias_neuron_type, bias_shape,
-                                     bias_data.data(), bias_data.size());
+      num_element *
+      ((input_type == ElementType::Float32) ? sizeof(float) : sizeof(int32_t));
+
+  int32_t bias_extra_data_idx = -1;
+  LITERT_ASSIGN_OR_RETURN(bias_extra_data_idx,
+                          operand_map.RegisterExtraData(bias_data_size));
+  memset(operand_map.GetExtraData(bias_extra_data_idx), 0, bias_data_size);
+  return operand_map.AddTensorByType(
+      bias_neuron_type, bias_shape,
+      operand_map.GetExtraData(bias_extra_data_idx), bias_data_size);
 }
 
 //==============================================================================
@@ -316,13 +322,12 @@ inline Expected<uint32_t> AddAveragePool2dFilterHOption(
 //==============================================================================
 // kLiteRtOpCodeTflMaxPool2d
 //==============================================================================
-inline Expected<uint32_t> AddMaxPool2dPaddingOption(
-    const litert::Op& op, OperandMap& operand_map) {
+inline Expected<uint32_t> AddMaxPool2dPaddingOption(const litert::Op& op,
+                                                    OperandMap& operand_map) {
   // Note that return type should be same as the NEURON parameters needs for
   // NEURON_MAX_POOL_2D.
   uint32_t padding = 0;
-  LITERT_RETURN_IF_ERROR(
-      LiteRtGetMaxPool2dPaddingOption(op.Get(), &padding))
+  LITERT_RETURN_IF_ERROR(LiteRtGetMaxPool2dPaddingOption(op.Get(), &padding))
       << "Fails to get MaxPool2dPadding";
   NeuronAdapterPaddingCode neuron_padding = NEURON_PADDING_SAME;
   LITERT_RETURN_IF_ERROR(ConvertPaddingType(padding, neuron_padding))
@@ -330,30 +335,28 @@ inline Expected<uint32_t> AddMaxPool2dPaddingOption(
   return operand_map.AddScalarInt32(neuron_padding);
 }
 
-inline Expected<uint32_t> AddMaxPool2dStrideWOption(
-    const litert::Op& op, OperandMap& operand_map) {
+inline Expected<uint32_t> AddMaxPool2dStrideWOption(const litert::Op& op,
+                                                    OperandMap& operand_map) {
   // Note that return type should be same as the NEURON parameters needs for
   // NEURON_MAX_POOL_2D.
   int32_t stride_w = 0;
-  LITERT_RETURN_IF_ERROR(
-      LiteRtGetMaxPool2dStrideWOption(op.Get(), &stride_w))
+  LITERT_RETURN_IF_ERROR(LiteRtGetMaxPool2dStrideWOption(op.Get(), &stride_w))
       << "Fails to get MaxPool2dStrideW";
   return operand_map.AddScalarInt32(stride_w);
 }
 
-inline Expected<uint32_t> AddMaxPool2dStrideHOption(
-    const litert::Op& op, OperandMap& operand_map) {
+inline Expected<uint32_t> AddMaxPool2dStrideHOption(const litert::Op& op,
+                                                    OperandMap& operand_map) {
   // Note that return type should be same as the NEURON parameters needs for
   // NEURON_MAX_POOL_2D.
   int32_t stride_h = 0;
-  LITERT_RETURN_IF_ERROR(
-      LiteRtGetMaxPool2dStrideHOption(op.Get(), &stride_h))
+  LITERT_RETURN_IF_ERROR(LiteRtGetMaxPool2dStrideHOption(op.Get(), &stride_h))
       << "Fails to get MaxPool2dStrideH";
   return operand_map.AddScalarInt32(stride_h);
 }
 
-inline Expected<uint32_t> AddMaxPool2dFilterWOption(
-    const litert::Op& op, OperandMap& operand_map) {
+inline Expected<uint32_t> AddMaxPool2dFilterWOption(const litert::Op& op,
+                                                    OperandMap& operand_map) {
   // Note that return type should be same as the NEURON parameters needs for
   // NEURON_MAX_POOL_2D.
   int32_t filter_w = 0;
@@ -363,8 +366,8 @@ inline Expected<uint32_t> AddMaxPool2dFilterWOption(
   return operand_map.AddScalarInt32(filter_w);
 }
 
-inline Expected<uint32_t> AddMaxPool2dFilterHOption(
-    const litert::Op& op, OperandMap& operand_map) {
+inline Expected<uint32_t> AddMaxPool2dFilterHOption(const litert::Op& op,
+                                                    OperandMap& operand_map) {
   // Note that return type should be same as the NEURON parameters needs for
   // NEURON_MAX_POOL_2D.
   int32_t filter_h = 0;

--- a/litert/vendors/mediatek/compiler/legalizations/operand_map.cc
+++ b/litert/vendors/mediatek/compiler/legalizations/operand_map.cc
@@ -78,30 +78,28 @@ Expected<uint32_t> OperandMap::Register(const Tensor& t, int32_t tensor_flags) {
       if (tensor_type.ElementType() == ElementType::Int4) {
         // Unpack Int4 into Int8
         new_bytes = num_element * sizeof(int8_t);
-        LITERT_ASSIGN_OR_RETURN(extra_data_idx,
-                                extra_data_mgr_.Register(new_bytes))
+        LITERT_ASSIGN_OR_RETURN(extra_data_idx, RegisterExtraData(new_bytes))
         LITERT_LOG(LITERT_INFO, "\nUnpack Int4 into Int8, new bytes: %d",
                    new_bytes);
         LITERT_RETURN_IF_ERROR(UnpackDenseInt4IntoInt8(
             reinterpret_cast<const int8_t*>(weights.data()), num_element,
-            reinterpret_cast<int8_t*>(extra_data_mgr_.Get(extra_data_idx))));
+            reinterpret_cast<int8_t*>(GetExtraData(extra_data_idx))));
       } else if (tensor_type.ElementType() == ElementType::Int64) {
         // Cast Int64 into Int32
         new_bytes = num_element * sizeof(int32_t);
-        LITERT_ASSIGN_OR_RETURN(extra_data_idx,
-                                extra_data_mgr_.Register(new_bytes))
+        LITERT_ASSIGN_OR_RETURN(extra_data_idx, RegisterExtraData(new_bytes))
         LITERT_LOG(LITERT_INFO, "\nCast Int64 into Int32, new bytes: %d",
                    new_bytes);
         LITERT_RETURN_IF_ERROR(CastInt64IntoInt32(
             reinterpret_cast<const int64_t*>(weights.data()), num_element,
-            reinterpret_cast<int32_t*>(extra_data_mgr_.Get(extra_data_idx))));
+            reinterpret_cast<int32_t*>(GetExtraData(extra_data_idx))));
       } else {
         return Error(kLiteRtStatusErrorRuntimeFailure,
                      "Failed to set value for some tensor type.");
       }
 
       if (neuron_adapter_api_.api().model_set_operand_value(
-              model_, *operand_index, extra_data_mgr_.Get(extra_data_idx),
+              model_, *operand_index, GetExtraData(extra_data_idx),
               new_bytes) != NEURON_NO_ERROR) {
         return Error(kLiteRtStatusErrorRuntimeFailure,
                      "Failed to set value of tensor weights for special case: "

--- a/litert/vendors/mediatek/compiler/legalizations/operand_map.h
+++ b/litert/vendors/mediatek/compiler/legalizations/operand_map.h
@@ -263,6 +263,12 @@ class OperandMap {
     }
   }
 
+  Expected<size_t> RegisterExtraData(size_t bytes) {
+    return extra_data_mgr_.Register(bytes);
+  }
+
+  uint8_t* GetExtraData(size_t index) { return extra_data_mgr_.Get(index); }
+
  private:
   Expected<uint32_t> Register(const Tensor& t, int32_t tensor_flags = 0);
   Expected<uint32_t> Register(const NeuronOperandType& operand_type);


### PR DESCRIPTION
1. allocate extra memory for the zero bias to prevent the data from being released before call compilation.