### PR TITLE
Qualcomm AI Engine Direct - Transform Quantize Op in Gemma3 Mask

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -36,6 +36,7 @@
 #include "litert/c/litert_logging.h"
 #include "litert/c/litert_model.h"
 #include "litert/c/options/litert_qualcomm_options.h"  // IWYU pragma: keep
+#include "litert/cc/litert_element_type.h"
 #include "litert/cc/litert_environment_options.h"
 #include "litert/cc/litert_expected.h"
 #include "litert/cc/litert_macros.h"
@@ -106,6 +107,27 @@ LiteRtStatus InitQnnOptions(
   qnn_options.SetDumpTensorIds(qualcomm_options.GetDumpTensorIds());
   LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
   return kLiteRtStatusOk;
+}
+
+bool SkipValidationOfQuantizeOp(const litert::Op& op) {
+  const auto op_input_0 = op.Inputs()[0].RankedTensorType();
+  if (!op_input_0) {
+    LITERT_LOG(LITERT_ERROR, "%s", op_input_0.Error().Message().data());
+    return false;
+  }
+  const auto op_output_0 = op.Outputs()[0].RankedTensorType();
+  if (!op_output_0) {
+    LITERT_LOG(LITERT_ERROR, "%s", op_output_0.Error().Message().data());
+    return false;
+  }
+
+  if (op_input_0->ElementType() == litert::ElementType::Float32 &&
+      op_output_0->ElementType() == litert::ElementType::Int16 &&
+      op.Code() == kLiteRtOpCodeTflQuantize) {
+    LITERT_LOG(LITERT_INFO, "[G2G] Skip validation of quant op in Gemma3 mask");
+    return true;
+  }
+  return false;
 }
 
 }  // namespace
@@ -317,7 +339,8 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
     if (op_wrappers.empty()) {
       continue;
     }
-    if (std::all_of(
+    if (SkipValidationOfQuantizeOp(op) ||
+        std::all_of(
             op_wrappers.begin(), op_wrappers.end(),
             [&qnn_manager](::qnn::OpWrapper& op_wrapper) -> bool {
               return kLiteRtStatusOk ==

--- a/litert/vendors/qualcomm/core/transformation/BUILD
+++ b/litert/vendors/qualcomm/core/transformation/BUILD
@@ -19,6 +19,7 @@ cc_test(
         ":graph_to_graph",
         "//litert/vendors/qualcomm/core:op_code",
         "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:cast_op_builder",
         "//litert/vendors/qualcomm/core/builders:concatenation_op_builder",
         "//litert/vendors/qualcomm/core/builders:elementwise_op_builder",
         "//litert/vendors/qualcomm/core/builders:matmul_op_builder",
@@ -46,6 +47,7 @@ cc_library(
         "nobuilder",
     ],
     deps = [
+        ":mask",
         ":matmul_convert",
         ":mha_to_sha",
         "//litert/vendors/qualcomm/core:op_code",
@@ -86,6 +88,23 @@ cc_library(
         "//litert/vendors/qualcomm/core/builders:reshape_op_builder",
         "//litert/vendors/qualcomm/core/builders:split_op_builder",
         "//litert/vendors/qualcomm/core/utils:log",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+cc_library(
+    name = "mask",
+    srcs = ["mask.cc"],
+    hdrs = ["mask.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:select_op_builder",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
         "@qairt//:qnn_lib_headers",

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
@@ -9,6 +9,7 @@
 
 #include "litert/vendors/qualcomm/core/op_code.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/transformation/mask.h"
 #include "litert/vendors/qualcomm/core/transformation/matmul_convert.h"
 #include "litert/vendors/qualcomm/core/transformation/mha_to_sha.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
@@ -154,5 +155,13 @@ void GraphToGraphTransform(const G2GConfig g2g_option,
     Transform(validate_op_config, ops, tensor_pool, gemma3_mha_prefill,
               OptimizeMHAPrefill);
   }
+  const std::vector<QnnOpCode> gemma3_mask = {
+      QnnOpCode::kElementWiseNot,
+      QnnOpCode::kCast,
+      QnnOpCode::kQuantize,
+      QnnOpCode::kElementWiseMultiply,
+  };
+  Transform(validate_op_config, ops, tensor_pool, gemma3_mask,
+            TransformQuantizeInMask);
 }
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/mask.cc
+++ b/litert/vendors/qualcomm/core/transformation/mask.cc
@@ -1,0 +1,97 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/transformation/mask.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include "QnnTypes.h"  // from @qairt
+#include "litert/vendors/qualcomm/core/builders/select_op_builder.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> TransformToSelectOp(
+    const std::vector<OpWrapper>& original_ops, size_t start_index,
+    TensorPool& tensor_pool, size_t pattern_size) {
+  // const_cast for BuildSelectOp, can be removed if builders are refined
+  auto& pattern_input =
+      const_cast<TensorWrapper&>(original_ops[start_index].GetInputTensor(0));
+  auto& pattern_output = const_cast<TensorWrapper&>(
+      original_ops[start_index + pattern_size - 1].GetOutputTensor(0));
+  const auto& quant_param = pattern_output.GetQuantParams();
+  const auto& tensor_dims = pattern_input.GetDims();
+  const std::uint32_t num_element = pattern_input.GetTensorNumElements();
+
+  std::vector<std::int16_t> all_zero_data(num_element, 0);
+  auto& input_1 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, tensor_dims,
+      all_zero_data.size() * sizeof(all_zero_data[0]), all_zero_data.data());
+
+  auto& mul_static_tensor =
+      original_ops[start_index + pattern_size - 1].GetInputTensor(1);
+  auto static_tensor_data =
+      mul_static_tensor.GetStaticTensorData<std::int16_t>();
+  if (!static_tensor_data) {
+    QNN_LOG_ERROR("[G2G] Get tensor data failed when transforming mask model.");
+    return {};
+  }
+  std::vector<std::int16_t> mask_data(num_element,
+                                      static_tensor_data.value()[0]);
+  auto& input_2 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, tensor_dims,
+      mask_data.size() * sizeof(mask_data[0]), mask_data.data());
+
+  return BuildSelectOp(tensor_pool, {pattern_input, input_1, input_2},
+                       {pattern_output});
+}
+
+size_t TransformQuantizeInMask(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size) {
+  // Connection check
+  bool is_connected = ops[start_index + 0].GetOutputTensor(0) ==
+                          ops[start_index + 1].GetInputTensor(0) &&
+                      ops[start_index + 1].GetOutputTensor(0) ==
+                          ops[start_index + 2].GetInputTensor(0);
+  if (!is_connected) {
+    return 1;
+  }
+  // Graph transform
+  QNN_LOG_INFO("[G2G] Transform quant ops in Gemma3 mask models");
+  // Construct the new subgraph
+  auto new_ops =
+      TransformToSelectOp(ops, start_index, tensor_pool, pattern_size);
+  if (new_ops.empty()) {
+    QNN_LOG_WARNING(
+        "[G2G] Transformation failed. Rolling back to the original graph.");
+    return 1;
+  }
+  // Validate new graph.
+  bool is_valid =
+      std::all_of(new_ops.begin(), new_ops.end(),
+                  [validate_op_config](::qnn::OpWrapper& op_wrapper) -> bool {
+                    return validate_op_config(op_wrapper);
+                  });
+  if (is_valid) {
+    // Replace the matched pattern with a newly generated subgraph.
+    size_t step_size = new_ops.size();
+    ops.insert(ops.begin() + start_index + pattern_size,
+               std::make_move_iterator(new_ops.begin()),
+               std::make_move_iterator(new_ops.end()));
+    ops.erase(ops.begin() + start_index,
+              ops.begin() + start_index + pattern_size);
+    return step_size;
+  }
+  QNN_LOG_WARNING(
+      "[G2G] Validation failed. Rolling back to the original graph.");
+  return 1;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/mask.h
+++ b/litert/vendors/qualcomm/core/transformation/mask.h
@@ -1,0 +1,20 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_MASK_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_MASK_H_
+
+#include <cstddef>
+#include <functional>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+
+namespace qnn {
+size_t TransformQuantizeInMask(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size);
+}  // namespace qnn
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_MASK_H_


### PR DESCRIPTION
# What
- QNN does not support Quant Op with float32 inputs and int16 outputs
- Transform [logic not] -> [cast] -> [quant] -> [mul] into a [e-wise select].
# Tests
```
======================== Test Summary ========================
//litert/vendors/qualcomm/core/utils:utils_test
[----------] Global test environment tear-down
[==========] 12 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 6 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (49 ms total)
[  PASSED  ] 2 tests.

//litert/c/options:litert_qualcomm_options_test
[----------] Global test environment tear-down
[==========] 10 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 10 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[----------] Global test environment tear-down
[==========] 7 tests from 4 test suites ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[----------] Global test environment tear-down
[==========] 172 tests from 4 test suites ran. (14813 ms total)
[  PASSED  ] 172 tests.
```