### PR TITLE
Qualcomm AI Engine Direct - Remove workaround for RMSNorm validation.

### DIFF
--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -268,11 +268,6 @@ LiteRtStatus QnnManager::GenerateContextBinary(
 }
 
 LiteRtStatus QnnManager::ValidateOp(const Qnn_OpConfig_t& op_config) {
-  // TODO: Unblock QNN validation for RMSNorm
-  if (std::string(op_config.v1.name).find("RmsNorm") != std::string::npos) {
-    return kLiteRtStatusOk;
-  }
-
   if (Qnn_ErrorHandle_t error =
           Api()->backendValidateOpConfig(BackendHandle(), op_config);
       QNN_SUCCESS != error) {


### PR DESCRIPTION
Summary:
- 16bit RMSNorm validation supported on QNN 2.35, remove the workaround.