### PR TITLE
Qualcomm AI Engine Direct - Import Custom Op Package

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -31,6 +31,9 @@ struct LiteRtQualcommOptionsT {
   bool enable_weight_sharing = false;
   LiteRtQualcommOptionsHtpPerformanceMode htp_performance_mode =
       kLiteRtQualcommHtpPerformanceModeDefault;
+  std::string custom_op_package_path = "";
+  std::string custom_op_package_target = "";
+  std::string custom_op_package_interface_provider = "";
 };
 
 LiteRtStatus LiteRtQualcommOptionsCreate(LiteRtOpaqueOptions* options) {
@@ -215,5 +218,74 @@ LiteRtStatus LiteRtQualcommOptionsGetProfiling(
 
   *profiling = options->profiling;
 
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetCustomOpPackagePath(
+    LiteRtQualcommOptions options, const char* custom_op_package_path,
+    uint32_t length) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+  options->custom_op_package_path = std::string(custom_op_package_path, length);
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetCustomOpPackagePath(
+    LiteRtQualcommOptions options, const char** custom_op_package_path,
+    uint32_t* length) {
+  if (options == nullptr || custom_op_package_path == nullptr ||
+      length == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+  *custom_op_package_path = options->custom_op_package_path.data();
+  *length = options->custom_op_package_path.size();
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetCustomOpPackageTarget(
+    LiteRtQualcommOptions options, const char* custom_op_package_target,
+    uint32_t length) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+  options->custom_op_package_target =
+      std::string(custom_op_package_target, length);
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetCustomOpPackageTarget(
+    LiteRtQualcommOptions options, const char** custom_op_package_target,
+    uint32_t* length) {
+  if (options == nullptr || custom_op_package_target == nullptr ||
+      length == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+  *custom_op_package_target = options->custom_op_package_target.data();
+  *length = options->custom_op_package_target.size();
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetCustomOpPackageInterfaceProvider(
+    LiteRtQualcommOptions options,
+    const char* custom_op_package_interface_provider, uint32_t length) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+  options->custom_op_package_interface_provider =
+      std::string(custom_op_package_interface_provider, length);
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetCustomOpPackageInterfaceProvider(
+    LiteRtQualcommOptions options,
+    const char** custom_op_package_interface_provider, uint32_t* length) {
+  if (options == nullptr || custom_op_package_interface_provider == nullptr ||
+      length == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+  *custom_op_package_interface_provider =
+      options->custom_op_package_interface_provider.data();
+  *length = options->custom_op_package_interface_provider.size();
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -17,6 +17,8 @@
 #ifndef THIRD_PARTY_ODML_LITERT_LITERT_C_OPTIONS_LITERT_QUALCOMM_OPTIONS_H_
 #define THIRD_PARTY_ODML_LITERT_LITERT_C_OPTIONS_LITERT_QUALCOMM_OPTIONS_H_
 
+#include <stdint.h>
+
 #include "litert/c/litert_common.h"
 
 // User-facing options for Qualcomm. This is not built as part of
@@ -147,6 +149,30 @@ LiteRtStatus LiteRtQualcommOptionsSetProfiling(
 
 LiteRtStatus LiteRtQualcommOptionsGetProfiling(
     LiteRtQualcommOptions options, LiteRtQualcommOptionsProfiling* profiling);
+
+LiteRtStatus LiteRtQualcommOptionsSetCustomOpPackagePath(
+    LiteRtQualcommOptions options, const char* custom_op_package_path,
+    uint32_t length);
+
+LiteRtStatus LiteRtQualcommOptionsGetCustomOpPackagePath(
+    LiteRtQualcommOptions options, const char** custom_op_package_path,
+    uint32_t* length);
+
+LiteRtStatus LiteRtQualcommOptionsSetCustomOpPackageTarget(
+    LiteRtQualcommOptions options, const char* custom_op_package_target,
+    uint32_t length);
+
+LiteRtStatus LiteRtQualcommOptionsGetCustomOpPackageTarget(
+    LiteRtQualcommOptions options, const char** custom_op_package_target,
+    uint32_t* length);
+
+LiteRtStatus LiteRtQualcommOptionsSetCustomOpPackageInterfaceProvider(
+    LiteRtQualcommOptions options,
+    const char* custom_op_package_interface_provider, uint32_t length);
+
+LiteRtStatus LiteRtQualcommOptionsGetCustomOpPackageInterfaceProvider(
+    LiteRtQualcommOptions options,
+    const char** custom_op_package_interface_provider, uint32_t* length);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -151,6 +151,57 @@ TEST(LiteRtQualcommOptionsTest, Profiling) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
+TEST(LiteRtQualcommOptionsTest, CustomOpPackage) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  const std::string custom_op_package_path = "path";
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetCustomOpPackagePath(
+      qualcomm_options, custom_op_package_path.data(),
+      custom_op_package_path.size()));
+
+  const char* custom_op_package_path_ptr = nullptr;
+  uint32_t custom_op_package_path_length = 0;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetCustomOpPackagePath(
+      qualcomm_options, &custom_op_package_path_ptr,
+      &custom_op_package_path_length));
+  EXPECT_EQ(custom_op_package_path, std::string(custom_op_package_path_ptr,
+                                                custom_op_package_path_length));
+
+  const std::string custom_op_package_target = "target";
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetCustomOpPackageTarget(
+      qualcomm_options, custom_op_package_target.data(),
+      custom_op_package_target.size()));
+
+  const char* custom_op_package_target_ptr = nullptr;
+  uint32_t custom_op_package_target_length = 0;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetCustomOpPackageTarget(
+      qualcomm_options, &custom_op_package_target_ptr,
+      &custom_op_package_target_length));
+  EXPECT_EQ(custom_op_package_target,
+            std::string(custom_op_package_target_ptr,
+                        custom_op_package_target_length));
+
+  const std::string custom_op_package_interface_provider = "interface_provider";
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetCustomOpPackageInterfaceProvider(
+      qualcomm_options, custom_op_package_interface_provider.data(),
+      custom_op_package_interface_provider.size()));
+
+  const char* custom_op_package_interface_provider_ptr = nullptr;
+  uint32_t custom_op_package_interface_provider_length = 0;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetCustomOpPackageInterfaceProvider(
+      qualcomm_options, &custom_op_package_interface_provider_ptr,
+      &custom_op_package_interface_provider_length));
+  EXPECT_EQ(custom_op_package_interface_provider,
+            std::string(custom_op_package_interface_provider_ptr,
+                        custom_op_package_interface_provider_length));
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
 TEST(QualcommOptionsTest, CppApi) {
   auto options = QualcommOptions::Create();
   ASSERT_TRUE(options);
@@ -180,6 +231,19 @@ TEST(QualcommOptionsTest, CppApi) {
   EXPECT_EQ(options->GetProfiling(), kLiteRtQualcommProfilingOff);
   options->SetProfiling(kLiteRtQualcommProfilingDetailed);
   EXPECT_EQ(options->GetProfiling(), kLiteRtQualcommProfilingDetailed);
+
+  EXPECT_EQ(options->GetCustomOpPackagePath(), "");
+  options->SetCustomOpPackagePath("path");
+  EXPECT_EQ(options->GetCustomOpPackagePath(), "path");
+
+  EXPECT_EQ(options->GetCustomOpPackageTarget(), "");
+  options->SetCustomOpPackageTarget("target");
+  EXPECT_EQ(options->GetCustomOpPackageTarget(), "target");
+
+  EXPECT_EQ(options->GetCustomOpPackageInterfaceProvider(), "");
+  options->SetCustomOpPackageInterfaceProvider("interface_provider");
+  EXPECT_EQ(options->GetCustomOpPackageInterfaceProvider(),
+            "interface_provider");
 }
 
 TEST(QualcommOptionsTest, FindFromChain) {

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -111,7 +111,48 @@ LiteRtQualcommOptionsProfiling QualcommOptions::GetProfiling() {
   return profiling;
 }
 
-Expected<QualcommOptions> QualcommOptions::Create(OpaqueOptions& options) {
+void QualcommOptions::SetCustomOpPackagePath(std::string_view path) {
+  internal::AssertOk(LiteRtQualcommOptionsSetCustomOpPackagePath, Data(),
+                     path.data(), path.size());
+}
+
+std::string_view QualcommOptions::GetCustomOpPackagePath() {
+  const char *path = nullptr;
+  uint32_t length = 0;
+  internal::AssertOk(LiteRtQualcommOptionsGetCustomOpPackagePath, Data(), &path,
+                     &length);
+  return std::string_view(path, length);
+}
+
+void QualcommOptions::SetCustomOpPackageTarget(std::string_view target) {
+  internal::AssertOk(LiteRtQualcommOptionsSetCustomOpPackageTarget, Data(),
+                     target.data(), target.size());
+}
+
+std::string_view QualcommOptions::GetCustomOpPackageTarget() {
+  const char *target = nullptr;
+  uint32_t length = 0;
+  internal::AssertOk(LiteRtQualcommOptionsGetCustomOpPackageTarget, Data(),
+                     &target, &length);
+  return std::string_view(target, length);
+}
+
+void QualcommOptions::SetCustomOpPackageInterfaceProvider(
+    std::string_view interface_provider) {
+  internal::AssertOk(LiteRtQualcommOptionsSetCustomOpPackageInterfaceProvider,
+                     Data(), interface_provider.data(),
+                     interface_provider.size());
+}
+
+std::string_view QualcommOptions::GetCustomOpPackageInterfaceProvider() {
+  const char *interface_provider = nullptr;
+  uint32_t length = 0;
+  internal::AssertOk(LiteRtQualcommOptionsGetCustomOpPackageInterfaceProvider,
+                     Data(), &interface_provider, &length);
+  return std::string_view(interface_provider, length);
+}
+
+Expected<QualcommOptions> QualcommOptions::Create(OpaqueOptions &options) {
   const auto id = options.GetIdentifier();
   if (!id || *id != Discriminator()) {
     return Error(kLiteRtStatusErrorInvalidArgument);

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -17,6 +17,8 @@
 #ifndef THIRD_PARTY_ODML_LITERT_LITERT_CC_OPTIONS_LITERT_QUALCOMM_OPTIONS_H_
 #define THIRD_PARTY_ODML_LITERT_LITERT_CC_OPTIONS_LITERT_QUALCOMM_OPTIONS_H_
 
+#include <string_view>
+
 #include "litert/c/options/litert_qualcomm_options.h"
 #include "litert/cc/litert_expected.h"
 #include "litert/cc/litert_opaque_options.h"
@@ -54,6 +56,15 @@ class QualcommOptions : public OpaqueOptions {
 
   void SetProfiling(LiteRtQualcommOptionsProfiling profiling);
   LiteRtQualcommOptionsProfiling GetProfiling();
+
+  void SetCustomOpPackagePath(std::string_view path);
+  std::string_view GetCustomOpPackagePath();
+
+  void SetCustomOpPackageTarget(std::string_view target);
+  std::string_view GetCustomOpPackageTarget();
+
+  void SetCustomOpPackageInterfaceProvider(std::string_view interface_provider);
+  std::string_view GetCustomOpPackageInterfaceProvider();
 
  private:
   LiteRtQualcommOptions Data() const;

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -77,6 +77,18 @@ std::string AbslUnparseFlag(LiteRtQualcommOptionsLogLevel options) {
   }
 }
 
+ABSL_FLAG(
+    std::string, qualcomm_custom_op_package_path, "",
+    "Path to the custom op package, e.g. libQnnLiteRtQualcommOpPackage.so");
+
+ABSL_FLAG(std::string, qualcomm_custom_op_package_target, "",
+          "The target platform on which the backend register the op package.");
+
+ABSL_FLAG(
+    std::string, qualcomm_custom_op_package_interface_provider, "",
+    "Symbol name of the interface provider in the custom op package, e.g. "
+    "LiteRtQualcommOpPackageInterfaceProvider");
+
 ABSL_FLAG(bool, qualcomm_enable_weight_sharing, false,
           "Whether to enable weight sharing, this is unsupported on mobile "
           "platforms.");
@@ -229,6 +241,20 @@ Expected<QualcommOptions> QualcommOptionsFromFlags() {
 
   const auto profiling = absl::GetFlag(FLAGS_qualcomm_profiling);
   opts.SetProfiling(profiling);
+
+  const auto custom_op_package_path =
+      absl::GetFlag(FLAGS_qualcomm_custom_op_package_path);
+  opts.SetCustomOpPackagePath(std::string_view(custom_op_package_path.data(),
+                                               custom_op_package_path.size()));
+  const auto custom_op_package_target =
+      absl::GetFlag(FLAGS_qualcomm_custom_op_package_target);
+  opts.SetCustomOpPackageTarget(std::string_view(
+      custom_op_package_target.data(), custom_op_package_target.size()));
+  const auto custom_op_package_interface_provider =
+      absl::GetFlag(FLAGS_qualcomm_custom_op_package_interface_provider);
+  opts.SetCustomOpPackageInterfaceProvider(
+      std::string_view(custom_op_package_interface_provider.data(),
+                       custom_op_package_interface_provider.size()));
 
   return opts;
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -33,6 +33,12 @@ std::string AbslUnparseFlag(LiteRtQualcommOptionsLogLevel options);
 bool AbslParseFlag(absl::string_view text,
                    LiteRtQualcommOptionsLogLevel* options, std::string* error);
 
+ABSL_DECLARE_FLAG(std::string, qualcomm_custom_op_package_path);
+
+ABSL_DECLARE_FLAG(std::string, qualcomm_custom_op_package_target);
+
+ABSL_DECLARE_FLAG(std::string, qualcomm_custom_op_package_interface_provider);
+
 #endif
 
 // COMPILATION OPTIONS /////////////////////////////////////////////////////////

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -251,6 +251,10 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   EXPECT_FALSE(options.Value().GetEnableWeightSharing());
   EXPECT_EQ(options.Value().GetHtpPerformanceMode(),
             kLiteRtQualcommHtpPerformanceModeBurst);
+
+  EXPECT_EQ(options.Value().GetCustomOpPackagePath(), "");
+  EXPECT_EQ(options.Value().GetCustomOpPackageTarget(), "");
+  EXPECT_EQ(options.Value().GetCustomOpPackageInterfaceProvider(), "");
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -103,6 +103,10 @@ LiteRtStatus InitQnnOptions(
   qnn_options.SetEnableWeightSharing(qualcomm_options.GetEnableWeightSharing());
   qnn_options.SetHtpPerformanceMode(static_cast<::qnn::HtpPerformanceMode>(
       qualcomm_options.GetHtpPerformanceMode()));
+  qnn_options.SetCustomOpPackage(
+      qualcomm_options.GetCustomOpPackagePath(),
+      qualcomm_options.GetCustomOpPackageTarget(),
+      qualcomm_options.GetCustomOpPackageInterfaceProvider());
   LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
   return kLiteRtStatusOk;
 }

--- a/litert/vendors/qualcomm/core/builders/elementwise_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/elementwise_op_builder.cc
@@ -19,7 +19,10 @@ std::vector<OpWrapper> BuildElementwiseAddOp(
     const std::vector<TensorWrapperRef>& outputs) {
   std::vector<OpWrapper> res;
 
-  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_ADD);
+  // TODO(Alen): should not merge, it is only for test.
+  auto& elementwise_op =
+      res.emplace_back("custom_add", "LiteRtQualcommOpPackage",
+                       "ElementWiseAdd", QnnOpCode::kElementWiseAdd);
   for (const auto& input : inputs) {
     elementwise_op.AddInputTensor(input);
   }

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -46,6 +46,17 @@ HtpPerformanceMode Options::GetHtpPerformanceMode() const {
   return htp_performance_mode_;
 }
 
+void Options::SetCustomOpPackage(std::string_view path, std::string_view target,
+                                 std::string_view interface_provider) {
+  custom_op_package_.path = path;
+  custom_op_package_.target = target;
+  custom_op_package_.interface_provider = interface_provider;
+}
+
+const CustomOpPackage &Options::GetCustomOpPackage() const {
+  return custom_op_package_;
+}
+
 std::string Options::Dump() const {
   static constexpr absl::string_view kQnnOptionsDumpFormat =
       "\
@@ -55,11 +66,19 @@ Profiling: %d\n\
 UseHtpPreference: %v\n\
 UseQint16AsQuint16: %v\n\
 EnableWeightSharing: %v\n\
-HtpPerformanceMode: %d\n";
+HtpPerformanceMode: %d\n\
+CustomOpPackage: {\n\
+  path: %s\n\
+  target: %s\n\
+  interface_provider: %s\n\
+}\n\
+";
 
   return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, profiling_,
                          use_htp_preference_, use_qint16_as_quint16_,
-                         enable_weight_sharing_, htp_performance_mode_);
+                         enable_weight_sharing_, htp_performance_mode_,
+                         custom_op_package_.path, custom_op_package_.target,
+                         custom_op_package_.interface_provider);
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -5,6 +5,7 @@
 #define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_COMMON_H_
 
 #include <string>
+#include <string_view>
 
 // c++ enum and wrapper without dependency.
 namespace qnn {
@@ -33,6 +34,12 @@ enum class HtpPerformanceMode {
   kExtremePowerSaver = 9,
 };
 
+struct CustomOpPackage {
+  std::string path = "";
+  std::string target = "";
+  std::string interface_provider = "";
+};
+
 class Options {
  public:
   Options() = default;
@@ -55,6 +62,10 @@ class Options {
   void SetHtpPerformanceMode(const HtpPerformanceMode htp_performance_mode);
   HtpPerformanceMode GetHtpPerformanceMode() const;
 
+  void SetCustomOpPackage(std::string_view path, std::string_view target,
+                          std::string_view interface_provider);
+  const CustomOpPackage &GetCustomOpPackage() const;
+
   std::string Dump() const;
 
  private:
@@ -64,6 +75,7 @@ class Options {
   bool use_qint16_as_quint16_ = false;
   bool enable_weight_sharing_ = false;
   HtpPerformanceMode htp_performance_mode_ = HtpPerformanceMode::kDefault;
+  CustomOpPackage custom_op_package_;
 };
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -110,6 +110,15 @@ TEST(QnnOptionTest, EnableWeightSharing) {
   EXPECT_EQ(options.GetEnableWeightSharing(), false);
 }
 
+TEST(QnnOptionTest, CustomOpPackage) {
+  Options options;
+  options.SetCustomOpPackage("path", "target", "interface_provider");
+  const auto custom_op_package = options.GetCustomOpPackage();
+  EXPECT_EQ(custom_op_package.path, "path");
+  EXPECT_EQ(custom_op_package.target, "target");
+  EXPECT_EQ(custom_op_package.interface_provider, "interface_provider");
+}
+
 TEST(QnnOptionTest, Default) {
   Options options;
   EXPECT_EQ(options.GetLogLevel(), LogLevel::kInfo);
@@ -118,6 +127,10 @@ TEST(QnnOptionTest, Default) {
   EXPECT_FALSE(options.GetUseQint16AsQuint16());
   EXPECT_FALSE(options.GetEnableWeightSharing());
   EXPECT_EQ(options.GetHtpPerformanceMode(), HtpPerformanceMode::kDefault);
+  const auto custom_op_package = options.GetCustomOpPackage();
+  EXPECT_EQ(custom_op_package.path, "");
+  EXPECT_EQ(custom_op_package.target, "");
+  EXPECT_EQ(custom_op_package.interface_provider, "");
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/core/custom_op_package/LiteRtQualcommOpPackage/Makefile
+++ b/litert/vendors/qualcomm/core/custom_op_package/LiteRtQualcommOpPackage/Makefile
@@ -1,0 +1,381 @@
+# check all setup prerequisites if the command goal is not clean
+ifneq ($(MAKECMDGOALS),clean)
+ifndef QNN_INCLUDE
+$(info "INFO: Qnn include not explicitly defined, attempting to use QNN_SDK_ROOT if it is valid")
+QNN_INCLUDE := $(QNN_SDK_ROOT)/include/QNN
+endif
+ifeq ($(wildcard $(QNN_INCLUDE)),)
+$(error "ERROR: QNN_INCLUDE path is not set. QNN include paths must be set to obtain BE headers necessary to compile the package")
+endif
+ifndef QNN_TARGET_LIB
+$(info "INFO: Qnn target not explicitly defined, attempting to use QNN_SDK_ROOT if it is valid")
+QNN_TARGET_LIB := $(QNN_SDK_ROOT)/lib/aarch64-android
+endif
+ifeq ($(wildcard $(QNN_TARGET_LIB)),)
+ifeq ($(MAKECMDGOALS),htp_aarch64)
+$(error "ERROR: QNN_TARGET_LIB is needed to compile package for aarch64")
+else ifeq ($(MAKECMDGOALS),all)
+$(info "WARNING:QNN_TARGET_LIB may need to be defined to compile packages")
+endif
+endif
+
+ifndef HEXAGON_SDK_ROOT
+$(error "ERROR: HEXAGON_SDK_ROOT is not set. Hexagon-SDK path must be set to the latest hexagon-sdk-x.y.z")
+endif
+
+ifeq ($(wildcard $(HEXAGON_SDK_ROOT)),)
+$(error "ERROR: HEXAGON_SDK_ROOT is not set correctly. Please set HEXAGON_SDK_ROOT to latest hexagon-sdk-X.Y.Z path")
+endif
+
+HEXAGON_SDK_BASE := $(dir $(HEXAGON_SDK_ROOT))
+
+$(info "HEXAGON_SDK_ROOT is [${HEXAGON_SDK_ROOT}]")
+# Users should note that the tools version may change between hexagon sdk versions
+# Following combination of SDK and Tool version is supported
+HEXAGON_SDK_ROOT_V68 := $(HEXAGON_SDK_BASE)/hexagon-sdk-4.2.0
+HEXAGON_SDK_ROOT_V69 := $(HEXAGON_SDK_BASE)/hexagon-sdk-4.3.0
+HEXAGON_SDK_ROOT_V73 := $(HEXAGON_SDK_BASE)/hexagon-sdk-5.4.0
+HEXAGON_SDK_ROOT_V75 := $(HEXAGON_SDK_BASE)/hexagon-sdk-5.4.0
+HEXAGON_SDK_ROOT_V79 := $(HEXAGON_SDK_BASE)/hexagon-sdk-6.0.0
+HEXAGON_SDK_ROOT_V81 := $(HEXAGON_SDK_BASE)/hexagon-sdk-6.2.0
+#Updated to point to latest sdk to match with libQnnHtp.so
+HEXAGON_SDK_ROOT_X86 := $(HEXAGON_SDK_ROOT_V81)
+HEXAGON_TOOLS_VERSION_V68 := 8.4.09
+HEXAGON_TOOLS_VERSION_V69 := 8.5.03
+HEXAGON_TOOLS_VERSION_V73 := 8.6.02
+HEXAGON_TOOLS_VERSION_V75 := 8.7.03
+HEXAGON_TOOLS_VERSION_V79 := 8.8.02
+HEXAGON_TOOLS_VERSION_V81 := 19.0.01
+#Updated to point to latest sdk to match with libQnnHtp.so
+HEXAGON_TOOLS_VERSION_X86 := 19.0.01
+
+ifndef ANDROID_NDK_ROOT
+ifeq ($(MAKECMDGOALS),htp_aarch64)
+$(error "ERROR: ANDROID_NDK_ROOT is not set. Android NDK path must be set to compile package for aarch64")
+else ifeq ($(MAKECMDGOALS),all)
+$(info "WARNING: ANDROID_NDK_ROOT is not set. Android NDK path must be set to compile package for aarch64")
+endif
+endif
+
+ifndef PACKAGE_NAME
+export
+PACKAGE_NAME := $(notdir $(shell pwd))
+$(info "INFO: No package name defined. Using current directory name: $(PACKAGE_NAME) as the package name")
+endif
+
+WORK := build
+SRC_DIR := src
+OP_SRC_DIR := src/ops
+OP_INCLUDE_DIR := ./include
+OP_INCLUDES =  #$(wildcard $(OP_INCLUDE_DIR)/*.h) user defined if any op specific headers are needed, add -I to common flags
+LIBRARY_NAME := libQnn$(PACKAGE_NAME).so
+SUPPORTED_TARGETS = x86_64-linux-clang hexagon-v68 hexagon-v69 hexagon-v73 hexagon-v75 hexagon-v79 hexagon-v81 aarch64-android
+
+
+COMMON_CXX_FLAGS = -std=c++17 -I$(QNN_INCLUDE) -fPIC -Wall -Wreorder -Wno-missing-braces -Wno-unused-function
+COMMON_CXX_FLAGS += -Werror -Wno-format -Wno-unused-command-line-argument -fvisibility=default -stdlib=libc++
+COMMON_CXX_FLAGS += -DQNN_API="__attribute__((visibility(\"default\")))"  -D__QAIC_HEADER_EXPORT="__attribute__((visibility(\"default\")))"
+
+X86_LIBNATIVE_RELEASE_DIR := $(HEXAGON_SDK_ROOT_X86)/tools/HEXAGON_Tools/$(HEXAGON_TOOLS_VERSION_X86)/Tools
+
+# Ensure hexagon sdk tool version can be retrieved
+ifeq ($(wildcard $(X86_LIBNATIVE_RELEASE_DIR)/.),)
+$(error "Cannot retrieve hexagon tools from: $(X86_LIBNATIVE_RELEASE_DIR).  \
+         \
+         Please check that hexagon tools version is correct. Expected: $(HEXAGON_TOOLS_VERSION_X86)")
+endif
+
+#Check tools for hexagon_v79 are present.
+ifeq ($(MAKECMDGOALS),htp_v79)
+ifeq ($(wildcard $(HEXAGON_SDK_ROOT_V79)),)
+$(error "ERROR: HEXAGON_SDK_ROOT_V79 is set incorrectly. Cannot retrieve $(HEXAGON_SDK_ROOT_V79)")
+endif
+endif
+
+#Check tools for hexagon_v75 are present.
+ifeq ($(MAKECMDGOALS),htp_v75)
+ifeq ($(wildcard $(HEXAGON_SDK_ROOT_V75)),)
+$(error "ERROR: HEXAGON_SDK_ROOT_V75 is set incorrectly. Cannot retrieve $(HEXAGON_SDK_ROOT_V75)")
+endif
+endif
+
+#Check tools for hexagon_v68 are present.
+ifeq ($(MAKECMDGOALS),htp_v68)
+ifeq ($(wildcard $(HEXAGON_SDK_ROOT_V68)),)
+$(error "ERROR: HEXAGON_SDK_ROOT_V68 is set incorrectly. Cannot retrieve $(HEXAGON_SDK_ROOT_V68)")
+endif
+endif
+
+ifeq ($(MAKECMDGOALS),htp_v69)
+ifeq ($(wildcard $(HEXAGON_SDK_ROOT_V69)),)
+$(error "ERROR: HEXAGON_SDK_ROOT_V69 is set incorrectly. Cannot retrieve $(HEXAGON_SDK_ROOT_V69)")
+endif
+endif
+
+ifeq ($(MAKECMDGOALS),htp_v73)
+ifeq ($(wildcard $(HEXAGON_SDK_ROOT_V73)),)
+$(error "ERROR: HEXAGON_SDK_ROOT_V73 is set incorrectly. Cannot retrieve $(HEXAGON_SDK_ROOT_V73)")
+endif
+endif
+
+#Check tools for hexagon_v81 are present.
+ifeq ($(MAKECMDGOALS),htp_v81)
+ifeq ($(wildcard $(HEXAGON_SDK_ROOT_V81)),)
+$(error "ERROR: HEXAGON_SDK_ROOT_V81 is set incorrectly. Cannot retrieve $(HEXAGON_SDK_ROOT_V81)")
+endif
+endif
+
+
+endif
+OP_SOURCES = $(wildcard $(OP_SRC_DIR)/*.cpp)
+OTHER_SOURCES = $(wildcard $(SRC_DIR)/*.cpp)
+HFILES = $(wildcard $(QNN_INCLUDE)/*.h)
+HFILES += $(wildcard $(QNN_INCLUDE)/HTP/*.h)
+HFILES += $(wildcard $(QNN_INCLUDE)/HTP/core/*.h)
+OP_OBJS = $(patsubst $(SRC_DIR)/%,%,$(patsubst %.cpp,%.o,$(OP_SOURCES)))
+OTHER_OBJS =  $(patsubst $(SRC_DIR)/%,%,$(patsubst %.cpp,%.o,$(OTHER_SOURCES)))
+
+#======= Assembly ========
+OP_SOURCES_ASM_X86 += $(wildcard $(OP_SRC_DIR)/x86_asm/*.S)
+OP_OBJS_ASM_X86 += $(subst /x86_asm/,/,$(patsubst $(SRC_DIR)/%,%,$(patsubst %.S,%.o,$(OP_SOURCES_ASM_X86))))
+OP_SOURCES_ASM_V68 += $(wildcard $(OP_SRC_DIR)/v68_asm/*.S)
+OP_OBJS_ASM_V68 += $(subst /v68_asm/,/,$(patsubst $(SRC_DIR)/%,%,$(patsubst %.S,%.o,$(OP_SOURCES_ASM_V68))))
+OP_SOURCES_ASM_V69 += $(wildcard $(OP_SRC_DIR)/v69_asm/*.S)
+OP_OBJS_ASM_V69 += $(subst /v69_asm/,/,$(patsubst $(SRC_DIR)/%,%,$(patsubst %.S,%.o,$(OP_SOURCES_ASM_V69))))
+OP_SOURCES_ASM_V73 += $(wildcard $(OP_SRC_DIR)/v73_asm/*.S)
+OP_OBJS_ASM_V73 += $(subst /v73_asm/,/,$(patsubst $(SRC_DIR)/%,%,$(patsubst %.S,%.o,$(OP_SOURCES_ASM_V73))))
+OP_SOURCES_ASM_V75 += $(wildcard $(OP_SRC_DIR)/v75_asm/*.S)
+OP_OBJS_ASM_V75 += $(subst /v75_asm/,/,$(patsubst $(SRC_DIR)/%,%,$(patsubst %.S,%.o,$(OP_SOURCES_ASM_V75))))
+OP_SOURCES_ASM_V79 += $(wildcard $(OP_SRC_DIR)/v79_asm/*.S)
+OP_OBJS_ASM_V79 += $(subst /v79_asm/,/,$(patsubst $(SRC_DIR)/%,%,$(patsubst %.S,%.o,$(OP_SOURCES_ASM_V79))))
+OP_SOURCES_ASM_V81 += $(wildcard $(OP_SRC_DIR)/v81_asm/*.S)
+OP_OBJS_ASM_V81 += $(subst /v81_asm/,/,$(patsubst $(SRC_DIR)/%,%,$(patsubst %.S,%.o,$(OP_SOURCES_ASM_V81))))
+
+OP_SOURCES_ASM_ANDROID += $(wildcard $(OP_SRC_DIR)/android_asm/*.S)
+OP_OBJS_ASM_ANDROID += $(subst /android_asm/,/,$(patsubst $(SRC_DIR)/%,%,$(patsubst %.S,%.o,$(OP_SOURCES_ASM_ANDROID))))
+
+all: htp_v68 htp_x86 htp_aarch64
+
+#============================================================================================================
+# Setup compiler, compiler instructions and linker for x86
+X86_CXX ?= clang++-9
+# Checking if clang++-9 is present. If not switch to clang++
+ifeq ($(shell $(X86_CXX) -v 2>&1 | grep -c "clang version"), 0)
+  X86_CXX := clang++
+endif
+X86_TARGET_LIB := $(QNN_SDK_ROOT)/lib/x86_64-linux-clang
+X86_LDFLAGS:= -Wl,--whole-archive -L$(X86_LIBNATIVE_RELEASE_DIR)/libnative/lib -lnative -Wl,--no-whole-archive -lpthread -L$(X86_TARGET_LIB) -lQnnHtp
+X86_C_FLAGS := -D__HVXDBL__ -I$(X86_LIBNATIVE_RELEASE_DIR)/libnative/include -ffast-math -DUSE_OS_LINUX
+X86_CXX_FLAGS = $(COMMON_CXX_FLAGS) $(X86_C_FLAGS) -fomit-frame-pointer -Wno-invalid-offsetof
+linux_objs =
+#============================================================================================================
+# Setup compiler, compiler instructions and linker for hexagon
+HEXAGON_CXX_FLAGS := $(COMMON_CXX_FLAGS) -mhvx -mhvx-length=128B -mhmx -DUSE_OS_QURT -O2 -Wno-reorder -DPREPARE_DISABLED
+
+HEXAGON_CXX_FLAGS_V68 := $(HEXAGON_CXX_FLAGS) -mv68 -I$(HEXAGON_SDK_ROOT_V68)/rtos/qurt/computev68/include/qurt -I$(HEXAGON_SDK_ROOT_V68)/rtos/qurt/computev68/include/posix -I$(HEXAGON_SDK_ROOT_V68)/incs -I$(HEXAGON_SDK_ROOT_V68)/incs/stddef
+HEXAGON_CXX_FLAGS_V69 := $(HEXAGON_CXX_FLAGS) -mv69 -I$(HEXAGON_SDK_ROOT_V69)/rtos/qurt/computev69/include/qurt -I$(HEXAGON_SDK_ROOT_V69)/rtos/qurt/computev69/include/posix -I$(HEXAGON_SDK_ROOT_V69)/incs -I$(HEXAGON_SDK_ROOT_V69)/incs/stddef
+HEXAGON_CXX_FLAGS_V73 := $(HEXAGON_CXX_FLAGS) -mv73 -I$(HEXAGON_SDK_ROOT_V73)/rtos/qurt/computev73/include/qurt -I$(HEXAGON_SDK_ROOT_V73)/rtos/qurt/computev73/include/posix -I$(HEXAGON_SDK_ROOT_V73)/incs -I$(HEXAGON_SDK_ROOT_V73)/incs/stddef
+HEXAGON_CXX_FLAGS_V75 := $(HEXAGON_CXX_FLAGS) -mv75 -I$(HEXAGON_SDK_ROOT_V75)/rtos/qurt/computev75/include/qurt -I$(HEXAGON_SDK_ROOT_V75)/rtos/qurt/computev75/include/posix -I$(HEXAGON_SDK_ROOT_V75)/incs -I$(HEXAGON_SDK_ROOT_V75)/incs/stddef
+HEXAGON_CXX_FLAGS_V79 := $(HEXAGON_CXX_FLAGS) -mv79 -I$(HEXAGON_SDK_ROOT_V79)/rtos/qurt/computev79/include/qurt -I$(HEXAGON_SDK_ROOT_V79)/rtos/qurt/computev79/include/posix -I$(HEXAGON_SDK_ROOT_V79)/incs -I$(HEXAGON_SDK_ROOT_V79)/incs/stddef
+HEXAGON_CXX_FLAGS_V81 := $(HEXAGON_CXX_FLAGS) -mv81 -I$(HEXAGON_SDK_ROOT_V81)/rtos/qurt/computev81/include/qurt -I$(HEXAGON_SDK_ROOT_V81)/rtos/qurt/computev81/include/posix -I$(HEXAGON_SDK_ROOT_V81)/incs -I$(HEXAGON_SDK_ROOT_V81)/incs/stddef
+
+HEXAGON_CXX_V68 := $(HEXAGON_SDK_ROOT_V68)/tools/HEXAGON_Tools/$(HEXAGON_TOOLS_VERSION_V68)/Tools/bin/hexagon-clang++
+HEXAGON_CXX_V69 := $(HEXAGON_SDK_ROOT_V69)/tools/HEXAGON_Tools/$(HEXAGON_TOOLS_VERSION_V69)/Tools/bin/hexagon-clang++
+HEXAGON_CXX_V73 := $(HEXAGON_SDK_ROOT_V73)/tools/HEXAGON_Tools/$(HEXAGON_TOOLS_VERSION_V73)/Tools/bin/hexagon-clang++
+HEXAGON_CXX_V75 := $(HEXAGON_SDK_ROOT_V75)/tools/HEXAGON_Tools/$(HEXAGON_TOOLS_VERSION_V75)/Tools/bin/hexagon-clang++
+HEXAGON_CXX_V79 := $(HEXAGON_SDK_ROOT_V79)/tools/HEXAGON_Tools/$(HEXAGON_TOOLS_VERSION_V79)/Tools/bin/hexagon-clang++
+HEXAGON_CXX_V81 := $(HEXAGON_SDK_ROOT_V81)/tools/HEXAGON_Tools/$(HEXAGON_TOOLS_VERSION_V81)/Tools/bin/hexagon-clang++
+
+HEX_LDFLAGS =
+hexagon_objs =
+#============================================================================================================
+# Setup compiler, compiler instructions and linker for aarch64
+AARCH64_C__FLAGS = -D__HVXDBL__ -I$(X86_LIBNATIVE_RELEASE_DIR)/libnative/include -ffast-math -DUSE_OS_LINUX -DANDROID
+AARCH64_CXX_FLAGS = $(COMMON_CXX_FLAGS) $(AARCH64_C__FLAGS) -fomit-frame-pointer -Wno-invalid-offsetof  -Wno-unused-variable -Wno-unused-parameter -Wno-missing-braces -Wno-sign-compare -Wno-unused-private-field -Wno-unused-variable -Wno-ignored-qualifiers -Wno-missing-field-initializers
+ARM_CLANG_OPTS =--target=aarch64-none-linux-android21 --sysroot=$(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/linux-x86_64/sysroot -stdlib=libc++ -static-libstdc++
+AARCH64_CXX = $(ANDROID_NDK_ROOT)/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ $(ARM_CLANG_OPTS)
+AARCH64_LDFLAGS = -L$(QNN_TARGET_LIB) -lQnnHtp -lQnnHtpPrepare
+aarch64_objs =
+#============================================================================================================
+# Setup targets and goals
+
+htp_x86: X86_BUILD
+
+htp_v68: HEXAGON_BUILD_V68
+
+htp_v69: HEXAGON_BUILD_V69
+
+htp_v73: HEXAGON_BUILD_V73
+
+htp_v75: HEXAGON_BUILD_V75
+
+htp_v79: HEXAGON_BUILD_V79
+
+htp_v81: HEXAGON_BUILD_V81
+
+htp_aarch64: AARCH64_BUILD
+
+AARCH64_BUILD: $(WORK)/aarch64-android/$(LIBRARY_NAME)
+
+HEXAGON_BUILD_V68:  $(WORK)/hexagon-v68/$(LIBRARY_NAME)
+
+HEXAGON_BUILD_V69:  $(WORK)/hexagon-v69/$(LIBRARY_NAME)
+
+HEXAGON_BUILD_V73:  $(WORK)/hexagon-v73/$(LIBRARY_NAME)
+
+HEXAGON_BUILD_V75:  $(WORK)/hexagon-v75/$(LIBRARY_NAME)
+
+HEXAGON_BUILD_V79:  $(WORK)/hexagon-v79/$(LIBRARY_NAME)
+
+HEXAGON_BUILD_V81:  $(WORK)/hexagon-v81/$(LIBRARY_NAME)
+
+X86_BUILD: $(WORK)/x86_64-linux-clang/$(LIBRARY_NAME)
+
+
+define build_objs =
+ifneq ($(filter $(2),$(SUPPORTED_TARGETS)),)
+$(2)_objs += $(foreach x,$(1),$(WORK)/$(2)/$(x))
+else
+$$(error "Unknown target option provided: $(2): Supported targets are: $(SUPPORTED_TARGETS)")
+endif
+endef
+
+$(eval $(call build_objs,$(OTHER_OBJS),x86_64-linux-clang))
+$(eval $(call build_objs,$(OP_OBJS),x86_64-linux-clang))
+$(eval $(call build_objs,$(OP_OBJS_ASM_X86),x86_64-linux-clang))
+$(eval $(call build_objs,$(OTHER_OBJS),hexagon-v68))
+$(eval $(call build_objs,$(OP_OBJS),hexagon-v68))
+$(eval $(call build_objs,$(OP_OBJS_ASM_V68),hexagon-v68))
+$(eval $(call build_objs,$(OTHER_OBJS),hexagon-v69))
+$(eval $(call build_objs,$(OP_OBJS),hexagon-v69))
+$(eval $(call build_objs,$(OP_OBJS_ASM_V69),hexagon-v69))
+$(eval $(call build_objs,$(OTHER_OBJS),hexagon-v73))
+$(eval $(call build_objs,$(OP_OBJS),hexagon-v73))
+$(eval $(call build_objs,$(OP_OBJS_ASM_V73),hexagon-v73))
+$(eval $(call build_objs,$(OTHER_OBJS),hexagon-v75))
+$(eval $(call build_objs,$(OP_OBJS),hexagon-v75))
+$(eval $(call build_objs,$(OP_OBJS_ASM_V75),hexagon-v75))
+$(eval $(call build_objs,$(OTHER_OBJS),hexagon-v79))
+$(eval $(call build_objs,$(OP_OBJS),hexagon-v79))
+$(eval $(call build_objs,$(OP_OBJS_ASM_V75),hexagon-v79))
+$(eval $(call build_objs,$(OTHER_OBJS),hexagon-v81))
+$(eval $(call build_objs,$(OP_OBJS),hexagon-v81))
+$(eval $(call build_objs,$(OP_OBJS_ASM_V81),hexagon-v81))
+
+
+$(eval $(call build_objs,$(OTHER_OBJS),aarch64-android))
+$(eval $(call build_objs,$(OP_OBJS),aarch64-android))
+$(eval $(call build_objs,$(OP_OBJS_ASM_ANDROID),aarch64-android))
+
+# x86
+$(WORK)/x86_64-linux-clang $(WORK)/hexagon-v68 $(WORK)/hexagon-v69 $(WORK)/hexagon-v73 $(WORK)/hexagon-v75 $(WORK)/hexagon-v79 $(WORK)/hexagon-v81 $(WORK)/aarch64-android:
+	@mkdir -p $@/ops
+
+$(WORK)/x86_64-linux-clang/%.o: $(SRC_DIR)/%.cpp | $(WORK)/x86_64-linux-clang
+	$(X86_CXX) $(X86_CXX_FLAGS) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/x86_64-linux-clang/ops/%.o: $(OP_SRC_DIR)/%.cpp | $(WORK)/x86_64-linux-clang
+	$(X86_CXX) $(X86_CXX_FLAGS) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/x86_64-linux-clang/ops/%.o: $(OP_SRC_DIR)/x86_asm/%.S | $(WORK)/x86_64-linux-clang
+	$(X86_CXX) $(X86_CXX_FLAGS) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/x86_64-linux-clang/$(LIBRARY_NAME): $(x86_64-linux-clang_objs) | $(HFILES)
+	$(X86_CXX) -fPIC -std=c++17 -g -shared -o $@ $^ $(X86_LDFLAGS)
+
+# v68
+$(WORK)/hexagon-v68/%.o: $(SRC_DIR)/%.cpp | $(WORK)/hexagon-v68
+	$(HEXAGON_CXX_V68) $(HEXAGON_CXX_FLAGS_V68) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v68/ops/%.o: $(OP_SRC_DIR)/%.cpp | $(WORK)/hexagon-v68
+	$(HEXAGON_CXX_V68) $(HEXAGON_CXX_FLAGS_V68) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v68/ops/%.o: $(OP_SRC_DIR)/v68_asm/%.S | $(WORK)/hexagon-v68
+	$(HEXAGON_CXX_V68) $(HEXAGON_CXX_FLAGS_V68) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v68/$(LIBRARY_NAME): $(hexagon-v68_objs) | $(HFILES)
+	$(HEXAGON_CXX_V68) -fPIC -std=c++17 -g -shared -o $@ $^ $(HEX_LDFLAGS)
+
+# v69
+$(WORK)/hexagon-v69/%.o: $(SRC_DIR)/%.cpp | $(WORK)/hexagon-v69
+	$(HEXAGON_CXX_V69) $(HEXAGON_CXX_FLAGS_V69) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v69/ops/%.o: $(OP_SRC_DIR)/%.cpp | $(WORK)/hexagon-v69
+	$(HEXAGON_CXX_V69) $(HEXAGON_CXX_FLAGS_V69) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v69/ops/%.o: $(OP_SRC_DIR)/v69_asm/%.S | $(WORK)/hexagon-v69
+	$(HEXAGON_CXX_V69) $(HEXAGON_CXX_FLAGS_V69) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v69/$(LIBRARY_NAME): $(hexagon-v69_objs) | $(HFILES)
+	$(HEXAGON_CXX_V69) -fPIC -std=c++17 -g -shared -o $@ $^ $(HEX_LDFLAGS)
+
+# v73
+$(WORK)/hexagon-v73/%.o: $(SRC_DIR)/%.cpp | $(WORK)/hexagon-v73
+	$(HEXAGON_CXX_V73) $(HEXAGON_CXX_FLAGS_V73) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v73/ops/%.o: $(OP_SRC_DIR)/%.cpp | $(WORK)/hexagon-v73
+	$(HEXAGON_CXX_V73) $(HEXAGON_CXX_FLAGS_V73) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v73/ops/%.o: $(OP_SRC_DIR)/v73_asm/%.S | $(WORK)/hexagon-v73
+	$(HEXAGON_CXX_V73) $(HEXAGON_CXX_FLAGS_V73) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v73/$(LIBRARY_NAME): $(hexagon-v73_objs) | $(HFILES)
+	$(HEXAGON_CXX_V73) -fPIC -std=c++17 -g -shared -o $@ $^ $(HEX_LDFLAGS)
+
+#v75
+$(WORK)/hexagon-v75/%.o: $(SRC_DIR)/%.cpp | $(WORK)/hexagon-v75
+	$(HEXAGON_CXX_V75) $(HEXAGON_CXX_FLAGS_V75) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v75/ops/%.o: $(OP_SRC_DIR)/%.cpp | $(WORK)/hexagon-v75
+	$(HEXAGON_CXX_V75) $(HEXAGON_CXX_FLAGS_V75) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v75/ops/%.o: $(OP_SRC_DIR)/v75_asm/%.S | $(WORK)/hexagon-v75
+	$(HEXAGON_CXX_V75) $(HEXAGON_CXX_FLAGS_V75) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v75/$(LIBRARY_NAME): $(hexagon-v75_objs) | $(HFILES)
+	$(HEXAGON_CXX_V75) -fPIC -std=c++17 -g -shared -o $@ $^ $(HEX_LDFLAGS)
+
+#v79
+$(WORK)/hexagon-v79/%.o: $(SRC_DIR)/%.cpp | $(WORK)/hexagon-v79
+	$(HEXAGON_CXX_V79) $(HEXAGON_CXX_FLAGS_V79) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v79/ops/%.o: $(OP_SRC_DIR)/%.cpp | $(WORK)/hexagon-v79
+	$(HEXAGON_CXX_V79) $(HEXAGON_CXX_FLAGS_V79) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v79/ops/%.o: $(OP_SRC_DIR)/v79_asm/%.S | $(WORK)/hexagon-v79
+	$(HEXAGON_CXX_V79) $(HEXAGON_CXX_FLAGS_V79) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v79/$(LIBRARY_NAME): $(hexagon-v79_objs) | $(HFILES)
+	$(HEXAGON_CXX_V79) -fPIC -std=c++17 -g -shared -o $@ $^ $(HEX_LDFLAGS)
+
+# v81
+$(WORK)/hexagon-v81/%.o: $(SRC_DIR)/%.cpp | $(WORK)/hexagon-v81
+	$(HEXAGON_CXX_V81) $(HEXAGON_CXX_FLAGS_V81) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v81/ops/%.o: $(OP_SRC_DIR)/%.cpp | $(WORK)/hexagon-v81
+	$(HEXAGON_CXX_V81) $(HEXAGON_CXX_FLAGS_V81) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v81/ops/%.o: $(OP_SRC_DIR)/v81_asm/%.S | $(WORK)/hexagon-v81
+	$(HEXAGON_CXX_V81) $(HEXAGON_CXX_FLAGS_V81) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/hexagon-v81/$(LIBRARY_NAME): $(hexagon-v81_objs) | $(HFILES)
+	$(HEXAGON_CXX_V81) -fPIC -std=c++17 -g -shared -o $@ $^ $(HEX_LDFLAGS)
+
+
+# aarch64
+$(WORK)/aarch64-android/%.o: $(SRC_DIR)/%.cpp | $(WORK)/aarch64-android
+	$(AARCH64_CXX) $(AARCH64_CXX_FLAGS) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/aarch64-android/ops/%.o: $(OP_SRC_DIR)/%.cpp | $(WORK)/aarch64-android
+	$(AARCH64_CXX) $(AARCH64_CXX_FLAGS) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/aarch64-android/ops/%.o: $(OP_SRC_DIR)/android_asm/%.S | $(WORK)/aarch64-android
+	$(AARCH64_CXX) $(AARCH64_CXX_FLAGS) -DTHIS_PKG_NAME=$(PACKAGE_NAME) -MMD -c $< -o $@
+
+$(WORK)/aarch64-android/$(LIBRARY_NAME): $(aarch64-android_objs) | $(HFILES)
+	$(AARCH64_CXX) -fPIC -std=c++17 -g -shared -o $@ $^ $(AARCH64_LDFLAGS)
+
+clean:
+	-rm -rf $(WORK)
+
+.PHONY: all clean

--- a/litert/vendors/qualcomm/core/custom_op_package/LiteRtQualcommOpPackage/config/CustomOpPackageHtp.xml
+++ b/litert/vendors/qualcomm/core/custom_op_package/LiteRtQualcommOpPackage/config/CustomOpPackageHtp.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2020 Qualcomm Technologies, Inc.
+All Rights Reserved.
+Confidential and Proprietary - Qualcomm Technologies, Inc.
+-->
+<OpDefCollection
+        PackageName="LiteRtQualcommOpPackage"
+        Domain="custom"
+        Version="1.0"
+>
+    <OpDefList>
+        <!--Example Op Package which shows how a package can be defined using supplemental info-->
+        <OpDef>
+            <Name>ElementWiseAdd</Name>
+            <Description>
+                <Content>
+                    Adds two tensors element-wise. The output is the sum of input tensors.
+                </Content>
+                <Code>out[0] = in[0] + in[1]</Code>
+                <Content>
+                    Refer to ElementWiseAdd backend definitions for supported data type
+                    and layouts for each backend.
+                </Content>
+            </Description>
+
+            <Reference Source="Android NDK NeuralNetworks"
+                   Url="ANEURALNETWORKS_ADD &lt;https://developer.android.com/ndk/reference/group/neural-networks#group___neural_networks_1ggaabbe492c60331b13038e39d4207940e0ad681988001e5f8ab73230a311f4ab034&gt;"></Reference>
+    
+            <Input>
+                <Name>in[0]</Name>
+                <Mandatory>true</Mandatory>
+                <Datatype>BACKEND_SPECIFIC</Datatype>
+                <Shape>
+                    <Rank>ND</Rank>
+                    <Text>A tensor of rank N</Text>
+                </Shape>
+            </Input>
+
+            <Input>
+                <Name>in[1]</Name>
+                <Mandatory>true</Mandatory>
+                <Datatype>BACKEND_SPECIFIC</Datatype>
+                <Shape>
+                    <Rank>ND</Rank>
+                    <Text>A tensor of rank M</Text>
+                </Shape>
+            </Input>
+
+            <Output>
+                <Name>out[0]</Name>
+                <Mandatory>true</Mandatory>
+                <Datatype>BACKEND_SPECIFIC</Datatype>
+                <Shape>
+                    <Rank>ND</Rank>
+                    <Text>a tensor of rank = max(N,M)</Text>
+                </Shape>
+            </Output>
+
+            <!--This Op is implemented on these Backends-->
+            <SupportedBackend>HTP</SupportedBackend>
+        </OpDef>
+
+    </OpDefList>
+
+    <SupplementalOpDefList Backend="HTP">
+        <SupportedOps>
+            <OpName>ElementWiseAdd</OpName>
+        </SupportedOps>
+
+        <!--ElementWiseAdd-->
+        <SupplementalOpDef>
+            <Name>ElementWiseAdd</Name>
+
+            <Input>
+                <Name>in[0]</Name>
+                <Datatype>QNN_DATATYPE_FLOAT_32</Datatype>
+                <Datatype>QNN_DATATYPE_SFIXED_POINT_8</Datatype>
+                <Datatype>QNN_DATATYPE_UFIXED_POINT_8</Datatype>
+                <Datatype>QNN_DATATYPE_SFIXED_POINT_16</Datatype>
+                <Datatype>QNN_DATATYPE_UFIXED_POINT_16</Datatype>
+            </Input>
+
+            <Input>
+                <Name>in[1]</Name>
+                <Datatype>QNN_DATATYPE_FLOAT_32</Datatype>
+                <Datatype>QNN_DATATYPE_SFIXED_POINT_8</Datatype>
+                <Datatype>QNN_DATATYPE_UFIXED_POINT_8</Datatype>
+                <Datatype>QNN_DATATYPE_SFIXED_POINT_16</Datatype>
+                <Datatype>QNN_DATATYPE_UFIXED_POINT_16</Datatype>
+            </Input>
+
+            <Output>
+                <Name>out[0]</Name>
+                <Datatype>QNN_DATATYPE_FLOAT_32</Datatype>
+                <Datatype>QNN_DATATYPE_SFIXED_POINT_8</Datatype>
+                <Datatype>QNN_DATATYPE_UFIXED_POINT_8</Datatype>
+                <Datatype>QNN_DATATYPE_SFIXED_POINT_16</Datatype>
+                <Datatype>QNN_DATATYPE_UFIXED_POINT_16</Datatype>
+            </Output>
+        </SupplementalOpDef>
+
+    </SupplementalOpDefList>
+
+</OpDefCollection>
+

--- a/litert/vendors/qualcomm/core/custom_op_package/LiteRtQualcommOpPackage/src/LiteRtQualcommOpPackageInterface.cpp
+++ b/litert/vendors/qualcomm/core/custom_op_package/LiteRtQualcommOpPackage/src/LiteRtQualcommOpPackageInterface.cpp
@@ -1,0 +1,274 @@
+//==============================================================================
+// Auto Generated Code for LiteRtQualcommOpPackage
+//==============================================================================
+
+#include "HTP/QnnHtpCommon.h"
+#include "HTP/core/constraints.h"
+#include "HTP/core/op_package_feature_support.h"
+#include "HTP/core/op_register_ext.h"
+#include "HTP/core/optimize.h"
+#include "HTP/core/simple_reg.h"
+#include "HTP/core/unique_types.h"
+#include "QnnOpPackage.h"
+#include "QnnSdkBuildId.h"
+
+DEFINE_UNIQ_TY()
+BEGIN_PKG_OPS_OPTS_LIST()
+
+/** Note that the order of declarations given here defines the order in which ops and graph optimizations are
+ *  registered to the HTP Core.
+ *  Append the latest OpName at the bottom
+ */
+DECLARE_PKG_OPS_OPTS_LIST(PKG_ElementWiseAdd)
+
+END_PKG_OPS_OPTS_LIST()
+
+// op package info
+static constexpr auto sg_packageName = THIS_PKG_NAME_STR;  // package name passed in as compile flag
+
+static std::array<const char*, 1> sg_opNames{{"ElementWiseAdd"}};
+
+static Qnn_ApiVersion_t sg_sdkApiVersion  = QNN_HTP_API_VERSION_INIT;
+static QnnOpPackage_Info_t sg_packageInfo = QNN_OP_PACKAGE_INFO_INIT;
+
+// global data
+static QnnOpPackage_GlobalInfrastructure_t sg_globalInfra =
+nullptr;  // global infrastructure not in use for now
+static bool sg_packageInitialized = false;
+
+/*
+ * user provided logging call back function
+ * currently only supported on linux x86-64 and nonrpc versions
+ * typedef void (*QnnLog_Callback_t)(const char* fmt,
+ *                                   QnnLog_Level_t level,
+ *                                   uint64_t timestamp,
+ *                                   va_list args);
+ * usage: if(sg_logInitialized && level <= sg_maxLogLevel)
+ *            sg_logCallback(fmt, level, timestamp, args);
+ *
+ * for cross rpc versions, skel side user provided logging call back function
+ * can be defined as part of op packages. maximal log level sg_maxLogLevel
+ * can be set by Qnn_ErrorHandle_t LiteRtQualcommOpPackageLogSetLevel(QnnLog_Level_t maxLogLevel)
+ */
+/*
+ * for alternative logging method provided by HTP core, please refer to log.h
+ */
+static QnnLog_Callback_t sg_logCallback =
+    nullptr;  // user provided call back function pointer for logging
+static QnnLog_Level_t sg_maxLogLevel =
+    (QnnLog_Level_t)0;  // maximal log level used in user provided logging
+static bool sg_logInitialized =
+    false;  // tracks whether user provided logging method has been initialized
+
+
+/*
+* op initialization
+* needs to be global in the package
+* one initialization per package before any op definitions
+* syntax: INIT_PACKAGE_OP_DEF()
+*/
+INIT_PACKAGE_OP_DEF()
+
+/*
+* optimization initialization
+* needs to be global in the package
+* one initialization per package before any optimization definitions
+* syntax: INIT_PACKAGE_OPTIMIZATION_DEF()
+*/
+INIT_PACKAGE_OPTIMIZATION_DEF()
+
+/*
+ * op parameter order initialization
+ * needs to be global in the package
+ * one initialization per package before any op parameter order definitions
+ * syntax: INIT_PACKAGE_PARAM_ORDER_DEF()
+ */
+INIT_PACKAGE_PARAM_ORDER_DEF()
+
+/*
+ * axis parameter name list
+ * optional
+ * needs to be global in the package
+ * one list per package
+ * for listing axis parameter names passed into Qnn_AddNode API
+ * HTP backend auto-adjusts values in axis parameters based on HTP backfilling
+ * note: HTP backend backfills tensor dimensions to 4 dimensions
+ * syntax: LIST_PACKAGE_AXIS_PARAMS(...)
+ * e.g. LIST_PACKAGE_AXIS_PARAMS("Axis", "AXIS", "axis")
+ */
+// LIST_PACKAGE_AXIS_PARAMS()
+
+/*
+ * per-channel quantized op name list
+ * optional
+ * needs to be global in the package
+ * one list per package
+ * for listing op names which support per-channel quantization
+ * per-axis quantization info of an op is embeded in axisScaleOffsetEncoding
+ *   inside Qnn_Tensor_t types
+ * HTP backend only supports per-channel scale ops
+ *   i.e. along last dimension, offset is always zero
+ * if an op name is marked as having per-channel scale support, and in
+ *   QNN_AddNode, at least one input, parameter, or output has
+ *   QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET type:
+ * then:
+ *   HTP backend will pass to op implementation function the following:
+ *     output(s), input(s), parameter(s),
+ *     outputPerChannelScale(s), inputPerChannelScale(s), paramPerChannelScale(s)
+ *
+ * optimization rules can be used to remove extra perChannelScale tensors
+ *
+ * syntax: LIST_PACKAGE_PER_CHANNEL_QUANTIZED_OPS(...)
+ * e.g. LIST_PACKAGE_PER_CHANNEL_QUANTIZED_OPS(sg_op1Name, sg_op2Name)
+ */
+
+// LIST_PACKAGE_PER_CHANNEL_QUANTIZED_OPS()
+
+/*
+* Declare and define the special intialize function for HTP Backend to load
+*/
+INIT_PKG_CORE_INIT_FUNC()
+
+/* op package API's */
+
+Qnn_ErrorHandle_t LiteRtQualcommOpPackageInit(QnnOpPackage_GlobalInfrastructure_t infrastructure) {
+    if (sg_packageInitialized) return QNN_OP_PACKAGE_ERROR_LIBRARY_ALREADY_INITIALIZED;
+
+    /*
+    * op parameter order registration
+    * registers all defined op parameter orders in the package
+    * syntax: REGISTER_PACKAGE_PARAM_ORDERS()
+    */
+    REGISTER_PACKAGE_PARAM_ORDERS()
+
+    /*
+    * op axis parameter name registration
+    * registers all axis parameter names in the package
+    * used with LIST_PACKAGE_AXIS_PARAMS(...)
+    * syntax: REGISTER_PACKAGE_AXIS_PARAMS()
+    */
+    REGISTER_PACKAGE_AXIS_PARAMS()
+
+    /*
+    * per-channel scale op name registration
+    * registers all per-channel scale op names in the package
+    * used with LIST_PACKAGE_PER_CHANNEL_QUANTIZED_OPS(...)
+    * syntax: REGISTER_PACKAGE_PER_CHANNEL_QUANTIZED_OPS()
+    */
+    REGISTER_PACKAGE_PER_CHANNEL_QUANTIZED_OPS()
+
+    sg_globalInfra        = infrastructure;
+    sg_packageInitialized = true;
+    return QNN_SUCCESS;
+}
+
+Qnn_ErrorHandle_t LiteRtQualcommOpPackageGetInfo(const QnnOpPackage_Info_t** info) {
+    if (!sg_packageInitialized) return QNN_OP_PACKAGE_ERROR_LIBRARY_NOT_INITIALIZED;
+    if (!info) return QNN_OP_PACKAGE_ERROR_INVALID_INFO;
+
+    sg_packageInfo                = QNN_OP_PACKAGE_INFO_INIT;
+    sg_packageInfo.packageName    = sg_packageName;
+    sg_packageInfo.operationNames = sg_opNames.data();
+    sg_packageInfo.numOperations  = sg_opNames.size();
+    sg_packageInfo.sdkBuildId     = QNN_SDK_BUILD_ID;
+    sg_packageInfo.sdkApiVersion  = &sg_sdkApiVersion;
+
+    *info = &sg_packageInfo;
+    return QNN_SUCCESS;
+}
+
+Qnn_ErrorHandle_t LiteRtQualcommOpPackageLogInitialize(QnnLog_Callback_t callback, QnnLog_Level_t maxLogLevel) {
+    if (sg_logInitialized) return QNN_OP_PACKAGE_ERROR_LIBRARY_ALREADY_INITIALIZED;
+    if (!callback) return QNN_LOG_ERROR_INVALID_ARGUMENT;
+    if (maxLogLevel < QNN_LOG_LEVEL_ERROR) return QNN_LOG_ERROR_INVALID_ARGUMENT;
+    sg_logCallback    = callback;
+    sg_maxLogLevel    = maxLogLevel;
+    sg_logInitialized = true;
+    return QNN_SUCCESS;
+}
+
+Qnn_ErrorHandle_t LiteRtQualcommOpPackageLogSetLevel(QnnLog_Level_t maxLogLevel) {
+    if (maxLogLevel < QNN_LOG_LEVEL_ERROR) return QNN_LOG_ERROR_INVALID_ARGUMENT;
+    sg_maxLogLevel = maxLogLevel;
+    return QNN_SUCCESS;
+}
+
+Qnn_ErrorHandle_t LiteRtQualcommOpPackageLogTerminate() {
+    if (!sg_logInitialized) return QNN_OP_PACKAGE_ERROR_LIBRARY_NOT_INITIALIZED;
+    sg_logCallback    = nullptr;
+    sg_maxLogLevel    = (QnnLog_Level_t)0;
+    sg_logInitialized = false;
+    return QNN_SUCCESS;
+}
+
+Qnn_ErrorHandle_t LiteRtQualcommOpPackageValidateOpConfig (Qnn_OpConfig_t opConfig){
+    if (std::string(sg_packageName) != opConfig.v1.packageName) {
+        return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+    }
+
+    /* auto-generated validation code below
+     * Check if op config type matches any registered ops
+     * If a match is found, check number of inputs, outputs and params
+     */
+    if (std::string(opConfig.v1.typeName) == "ElementWiseAdd"){
+        if (opConfig.v1.numOfParams != 0 || opConfig.v1.numOfInputs != 2 || opConfig.v1.numOfOutputs != 1){
+          return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+        }
+    }
+    else{
+        return QNN_OP_PACKAGE_ERROR_VALIDATION_FAILURE;
+    }
+
+    /*
+    * additional validation code here
+    * */
+
+    return QNN_SUCCESS;
+}
+
+/* The following three functions in this comment are not called by HTP backend for now,
+ * no auto-generated implementations are created. Users should see example for full function signatures.
+ * (version 1.3.0) Qnn_ErrorHandle_t LiteRtQualcommOpPackageCreateKernels (QnnOpPackage_GraphInfrastructure_t
+ * graphInfrastructure, QnnOpPackage_Node_t node, QnnOpPackage_Kernel_t** kernels, uint32_t*
+ * numKernels)
+ * (version 1.3.0) Qnn_ErrorHandle_t LiteRtQualcommOpPackageFreeKernels (QnnOpPackage_Kernel_t* kernels)
+ *
+ * (version 1.4.0) Qnn_ErrorHandle_t LiteRtQualcommOpPackageCreateOpImpl (QnnOpPackage_GraphInfrastructure_t
+ * graphInfrastructure, QnnOpPackage_Node_t node, QnnOpPackage_OpImpl_t* opImpl)
+ *(version 1.4.0) Qnn_ErrorHandle_t LiteRtQualcommOpPackageFreeOpImpl (QnnOpPackage_OpImpl_t opImpl)
+ */
+
+Qnn_ErrorHandle_t LiteRtQualcommOpPackageTerminate() {
+if (!sg_packageInitialized) return QNN_OP_PACKAGE_ERROR_LIBRARY_NOT_INITIALIZED;
+
+sg_globalInfra        = nullptr;
+sg_packageInitialized = false;
+return QNN_SUCCESS;
+}
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* latest version */
+Qnn_ErrorHandle_t LiteRtQualcommOpPackageInterfaceProvider(QnnOpPackage_Interface_t* interface) {
+  if (!interface) return QNN_OP_PACKAGE_ERROR_INVALID_ARGUMENT;
+  interface->interfaceVersion      = {1, 4, 0};
+  interface->v1_4.init             = LiteRtQualcommOpPackageInit;
+  interface->v1_4.terminate        = LiteRtQualcommOpPackageTerminate;
+  interface->v1_4.getInfo          = LiteRtQualcommOpPackageGetInfo;
+  interface->v1_4.validateOpConfig = LiteRtQualcommOpPackageValidateOpConfig;
+  interface->v1_4.createOpImpl     = nullptr;
+  interface->v1_4.freeOpImpl       = nullptr;
+  interface->v1_4.logInitialize    = LiteRtQualcommOpPackageLogInitialize;
+  interface->v1_4.logSetLevel      = LiteRtQualcommOpPackageLogSetLevel;
+  interface->v1_4.logTerminate     = LiteRtQualcommOpPackageLogTerminate;
+  return QNN_SUCCESS;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+

--- a/litert/vendors/qualcomm/core/custom_op_package/LiteRtQualcommOpPackage/src/ops/ElementWiseAdd.cpp
+++ b/litert/vendors/qualcomm/core/custom_op_package/LiteRtQualcommOpPackage/src/ops/ElementWiseAdd.cpp
@@ -1,0 +1,181 @@
+//==============================================================================
+// Auto Generated Code for LiteRtQualcommOpPackage
+//==============================================================================
+
+#include "HTP/core/constraints.h"
+#include "HTP/core/op_package_feature_support.h"
+#include "HTP/core/op_register_ext.h"
+#include "HTP/core/optimize.h"
+#include "HTP/core/simple_reg.h"
+#include "QnnOpPackage.h"
+
+BEGIN_PKG_OP_DEFINITION(PKG_ElementWiseAdd);
+
+// op execute function declarations
+template <typename TensorType>
+GraphStatus elementwiseaddImpl(TensorType& out_0, const TensorType& in_0,
+                               const TensorType& in_1);
+
+// forward declaration of sample cost function
+static float elementwiseaddCostFunc(const Op* op);
+
+/*
+ * method 1 for defining op, using default cost value (i.e. GLACIAL) and default
+ * flag (Flags::RESOURCE_HVX) syntax: DEF_PACKAGE_OP(F,OP) e.g.
+ * DEF_PACKAGE_OP((elementwiseaddImpl<Tensor>), "ElementWiseAdd")
+ */
+DEF_PACKAGE_OP((elementwiseaddImpl<Tensor>), "ElementWiseAdd")
+
+/*
+ * method 2 for defining op with specified cost value (one of GLACIAL, SNAIL,
+ * FAST, FREE) and provided flags syntax:
+ * DEF_PACKAGE_OP_AND_COST_AND_FLAGS(F,OP,COST,...) can use zero or more flags,
+ * FLAG options are IS_CONST, INHIBIT_CONST_PROP, RESOURCE_HVX, RESOURCE_HMX(not
+ * supported in external op packages) e.g.
+ * DEF_PACKAGE_OP_AND_COST_AND_FLAGS((elementwiseaddImpl<PlainFloatTensor>),
+ * "ElementWiseAdd", SNAIL)
+ */
+
+/*
+ * method 3 for defining op with cost function pointer and provided flags
+ * cost function pointer type: typedef float (*cost_function) (const Op * op);
+ * syntax: DEF_PACKAGE_OP_AND_COST_F_AND_FLAGS(F,OP,COST_F,...)
+ * e.g.
+ * DEF_PACKAGE_OP_AND_COST_F_AND_FLAGS((elementwiseaddImpl<PlainFloatTensor>),
+ * "ElementWiseAdd", elementwiseaddCostFunc, Flags::RESOURCE_HVX)
+ */
+
+/*
+ * optimization definitions
+ * need to be global in the package
+ * one definition per optimization
+ * syntax:
+ * DEF_PACKAGE_OPTIMIZATION(PRIORITY,MATCHCODE,CONSTRAINTCODE,REPLACECODE)
+ * PRIORITY predefined values include EARLY(2000), MIDDLE(3000), LATE(4000)
+ * HTP core provides some replacement functions for op package to use
+ * for more information about optimization rules, please refer to HTP core
+ * documentations
+ */
+
+/*
+ * op parameter order definitions
+ * need to be global in the package
+ * one definition per op, and this is optional
+ * syntax:
+ * DEF_PACKAGE_PARAM_ORDER(OP,PARAM1,MANDATORY1,DEFAULT1,PARAM2,MANDATORY2,DEFAULT2...)
+ * one or more parameters can be specified for each op
+ * order of parameters listed determines the order of parameters passed into op
+ * execution functions if an op does not have a parameter order definition,
+ * parameter order passed into Qnn_addNode will be passed into op execution
+ * functions if an op has a parameter order definition, any parameter passed
+ * into Qnn_addNode with unlisted name will be abandoned if two or more op
+ * packages with the same package name will be registered, they cannot list
+ *   conflicting parameter orders
+ * PARAM refers to parameter name as a string literal
+ * MANDATORY refers to whether this parameter is required to be provided at
+ * Qnn_addNode DEFAULT is used when MANDATORY is false if provided as
+ * Qnn_Param_t*, DEFAULT will be used for graph construction when this parameter
+ * is not provided at Qnn_addNode if provided as nullptr, graph construction
+ * will skip this parameter when this parameter is not provided at Qnn_addNode
+ */
+
+/* execute functions for ops */
+
+namespace {
+template <typename TensorType, typename DataType>
+void elementwiseAdd(const size_t num_elements, TensorType& output_0,
+                    const TensorType& input_0, const TensorType& input_1) {
+  const auto* input_data_0 =
+      static_cast<const DataType*>(input_0.raw_data_const());
+  const auto* input_data_1 =
+      static_cast<const DataType*>(input_1.raw_data_const());
+  auto* output_data_0 = static_cast<DataType*>(output_0.raw_data());
+  for (size_t i = 0; i < num_elements; ++i) {
+    output_data_0[i] = input_data_0[i] + input_data_1[i];
+  }
+}
+
+}  // namespace
+
+template <typename TensorType>
+GraphStatus elementwiseaddImpl(TensorType& output_0, const TensorType& input_0,
+                               const TensorType& input_1) {
+  /*
+   * add code here
+   * */
+  /*
+   * To have good performance and stability, it is required to avoid heap memory
+   * allocation in this function. The heap memory allocation includes but not
+   * limited to calling malloc, operator new, constructing STL container objects
+   * like std::vector with default allocator, and adding items like calling
+   * std::vector::push_back to STL container objects with default allocator.
+   *
+   * Please check in SDK documentation for more information.
+   */
+
+  const size_t input_num_elements_0 = input_0.total_storage_elements();
+  const size_t input_num_elements_1 = input_1.total_storage_elements();
+  const size_t output_num_elements_0 = output_0.total_storage_elements();
+  if (input_num_elements_0 != input_num_elements_1 ||
+      input_num_elements_0 != output_num_elements_0) {
+    return GraphStatus::ErrorBadInput;
+  }
+
+  const DTypeScaleOff input_dtype_0 = input_0.get_dtype_intfc();
+  const DTypeScaleOff input_dtype_1 = input_1.get_dtype_intfc();
+  const DTypeScaleOff output_dtype_0 = output_0.get_dtype_intfc();
+  if (input_dtype_0.dtype != input_dtype_1.dtype ||
+      input_dtype_0.dtype != output_dtype_0.dtype) {
+    return GraphStatus::ErrorBadInput;
+  }
+
+  // Handle float types.
+  if (input_dtype_0.dtype == DType::Float32) {
+    elementwiseAdd<TensorType, float>(input_num_elements_0, output_0, input_0,
+                                      input_1);
+    return GraphStatus::Success;
+  }
+
+  // Currently we only support quantized types with the same offset and scale.
+  if (input_dtype_0.scale != input_dtype_1.scale ||
+      input_dtype_0.scale != output_dtype_0.scale) {
+    return GraphStatus::ErrorBadInput;
+  }
+  if (input_dtype_0.offset != input_dtype_1.offset ||
+      input_dtype_0.offset != output_dtype_0.offset) {
+    return GraphStatus::ErrorBadInput;
+  }
+
+  // Handle quantized types.
+  if (input_dtype_0.dtype == DType::QInt8) {
+    elementwiseAdd<TensorType, std::int8_t>(input_num_elements_0, output_0,
+                                            input_0, input_1);
+  } else if (input_dtype_0.dtype == DType::QUInt8) {
+    elementwiseAdd<TensorType, std::uint8_t>(input_num_elements_0, output_0,
+                                             input_0, input_1);
+  } else if (input_dtype_0.dtype == DType::QInt16) {
+    elementwiseAdd<TensorType, std::int16_t>(input_num_elements_0, output_0,
+                                             input_0, input_1);
+  } else if (input_dtype_0.dtype == DType::QUInt16) {
+    elementwiseAdd<TensorType, std::uint16_t>(input_num_elements_0, output_0,
+                                              input_0, input_1);
+  } else {
+    return GraphStatus::ErrorBadInput;
+  }
+
+  return GraphStatus::Success;
+}
+
+__attribute__((unused)) static float elementwiseaddCostFunc(const Op* op) {
+  /*
+   * add code here
+   * */
+
+  float cost = 0.0;  // add cost computation here
+  return cost;
+}
+
+/* At the bottom of the op file, call END_PKG_OP_DEFINITION(<name>),
+   where <name> is as BEGIN_PKG_OP_DEFINITION
+*/
+END_PKG_OP_DEFINITION(PKG_ElementWiseAdd);

--- a/litert/vendors/qualcomm/core/custom_op_package/README.md
+++ b/litert/vendors/qualcomm/core/custom_op_package/README.md
@@ -1,0 +1,69 @@
+
+# Environment Setting
+- QNN_SDK_ROOT
+- HEXAGON_SDK_ROOT
+- ANDROID_NDK_ROOT
+- OP_PACKAGE_XML
+- GENERATE_FOLDER
+
+# Code Generation
+```sh
+export PYTHONPATH=${QNN_SDK_ROOT}/lib/python/
+${QNN_SDK_ROOT}/bin/x86_64-linux-clang/qnn-op-package-generator -p ${OP_PACKAGE_XML} -o ${GENERATE_FOLDER}
+```
+
+# File Structure
+- op package source code will be generated in ${GENERATE_FOLDER} like:
+```log
+${GENERATE_FOLDER}
+├── LiteRtQualcommOpPackage
+│   ├── Makefile
+│   ├── config
+│   │   └── CustomOpPackageHtp.xml
+│   ├── include
+│   └── src
+│       ├── LiteRtQualcommOpPackageInterface.cpp
+│       └── ops
+│           └── ElementWiseAdd.cpp
+└── README.md
+```
+
+# Makefile patch
+- Please modify Makefile with this patch to fix the undefined symbol error in x86, we need to link libQnnHtp.
+```
+X86_TARGET_LIB := $(QNN_SDK_ROOT)/lib/x86_64-linux-clang
+X86_LDFLAGS:= -Wl,--whole-archive -L$(X86_LIBNATIVE_RELEASE_DIR)/libnative/lib -lnative -Wl,--no-whole-archive -lpthread -L$(X86_TARGET_LIB) -lQnnHtp
+```
+
+# Op Implemnetation
+- Implement op in ${GENERATE_FOLDER}/LiteRtQualcommOpPackage/src/ops/.
+
+
+# Build
+- Make sure clang++ can be found in your environment.
+```sh
+export QNN_SDK_ROOT=<Your QNN Root>
+export HEXAGON_SDK_ROOT=<Your HEXAGON SDK Root>
+export ANDROID_NDK_ROOT=<Your Android NDK Root>
+cd ${GENERATE_FOLDER}/LiteRtQualcommOpPackage
+make htp_x86
+make htp_aarch64
+make htp_v75
+```
+
+
+# Register Op Package in Qnn backend
+```cpp
+- build/x86_64-linux-clang/libQnnLiteRtQualcommOpPackage.so
+- - Interface provider: ExamplePackageInterfaceProvider
+- - Target: CPU
+
+- build/hexagon-v75/libQnnLiteRtQualcommOpPackage.so
+- - Interface provider: ExamplePackageInterfaceProvider
+- - Target: HTP
+
+- build/aarch64-android/libQnnLiteRtQualcommOpPackage.so
+- - Interface provider: ExamplePackageInterfaceProvider
+- - Target: HTP
+
+```

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -20,7 +20,15 @@
 namespace qnn {
 
 OpWrapper::OpWrapper(std::string name, const char* op_type, QnnOpCode op_code)
-    : type_name_{op_type}, name_{std::move(name)}, op_code_{op_code} {}
+    : OpWrapper(std::move(name), QNN_OP_PACKAGE_NAME_QTI_AISW, op_type,
+                op_code) {}
+
+OpWrapper::OpWrapper(std::string name, const char* package_name,
+                     const char* op_type, QnnOpCode op_code)
+    : package_name_{package_name},
+      type_name_{op_type},
+      name_{std::move(name)},
+      op_code_{op_code} {}
 
 OpWrapper::OpWrapper(const OpWrapper& other) = default;
 
@@ -33,7 +41,8 @@ OpWrapper& OpWrapper::operator=(const OpWrapper& other) {
 }
 
 OpWrapper::OpWrapper(OpWrapper&& other)
-    : type_name_{other.type_name_},
+    : package_name_{other.package_name_},
+      type_name_{other.type_name_},
       name_{std::move(other.name_)},
       input_tensors_{std::move(other.input_tensors_)},
       output_tensors_{std::move(other.output_tensors_)},
@@ -60,7 +69,7 @@ void OpWrapper::AddTensorParam(const char* name, const TensorWrapper& tensor) {
 
 Qnn_OpConfig_t OpWrapper::GetOpConfig() {
   Qnn_OpConfig_t qnn_op = QNN_OPCONFIG_INIT;
-  qnn_op.v1.packageName = QNN_OP_PACKAGE_NAME_QTI_AISW;
+  qnn_op.v1.packageName = package_name_;
   qnn_op.v1.typeName = type_name_;
   qnn_op.v1.name = name_.data();
   // input tensors

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -21,6 +21,8 @@ class OpWrapper final {
  public:
   explicit OpWrapper(std::string name, const char* op_type, QnnOpCode op_code);
 
+  explicit OpWrapper(std::string name, const char* package_name, const char* op_type, QnnOpCode op_code);
+
   OpWrapper(const OpWrapper& other);
 
   OpWrapper& operator=(const OpWrapper& other);
@@ -64,6 +66,7 @@ class OpWrapper final {
   void ClearTensorParams();
 
  private:
+  const char* package_name_{nullptr};
   const char* type_name_{nullptr};
   std::string name_{};  // human readable name
   std::vector<std::reference_wrapper<const TensorWrapper>> input_tensors_{};

--- a/litert/vendors/qualcomm/dispatch/dispatch_api.cc
+++ b/litert/vendors/qualcomm/dispatch/dispatch_api.cc
@@ -80,6 +80,9 @@ LiteRtStatus Initialize(LiteRtEnvironmentOptions environment_options,
   ::qnn::Options qnn_options;
   qnn_options.SetHtpPerformanceMode(::qnn::HtpPerformanceMode::kBurst);
   qnn_options.SetLogLevel(::qnn::LogLevel::kOff);
+  // TODO(Alen): should not merge, it is only for test.
+  qnn_options.SetCustomOpPackage("libQnnLiteRtQualcommOpPackage.so", "HTP",
+                                 "LiteRtQualcommOpPackageInterfaceProvider");
   if (auto qnn_manager = QnnManager::Create(
           /*configs=*/configs,
           /*options=*/qnn_options,

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -408,6 +408,21 @@ LiteRtStatus QnnManager::Init(absl::Span<const QnnBackend_Config_t*> configs,
       return kLiteRtStatusErrorRuntimeFailure;
     }
   }
+
+  if (const auto& custom_op_package = options.GetCustomOpPackage();
+      !custom_op_package.path.empty()) {
+    if (auto status = Api()->backendRegisterOpPackage(
+            BackendHandle(), custom_op_package.path.data(),
+            custom_op_package.interface_provider.data(),
+            custom_op_package.target.data());
+        status != QNN_SUCCESS) {
+      LITERT_LOG(LITERT_ERROR, "Failed to register op package. Error code: %d",
+                 status);
+    } else {
+      LITERT_LOG(LITERT_INFO, "Op package loaded successfully.");
+    }
+  }
+
   return kLiteRtStatusOk;
 }
 
@@ -492,5 +507,4 @@ QnnManager::WeightSharingContextConfigs() {
   static const QnnContext_Config_t* configs[2] = {&contextConfig, nullptr};
   return absl::MakeSpan(configs);
 }
-
 };  // namespace litert::qnn


### PR DESCRIPTION
Summary:
1. Support custom op package path, target, interface provider in options.
2. Implement an custom add op which replace the native qnn op. (Should not merge).
3. Support package name in OpWrapper.
4. Add README for custom op.