### PR TITLE
Qualcomm AI Engine Direct - Fix Conv2D Options.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -608,7 +608,7 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
           LiteRtGetConv2dDilationWOption(litert_op.Get(), &dilation_w_factor));
       int32_t dilation_h_factor;
       LITERT_RETURN_IF_ERROR(
-          LiteRtGetConv2dDilationWOption(litert_op.Get(), &dilation_h_factor));
+          LiteRtGetConv2dDilationHOption(litert_op.Get(), &dilation_h_factor));
       uint32_t fused_activation;
       LITERT_RETURN_IF_ERROR(LiteRtGetConv2dFusedActivationOption(
           litert_op.Get(), &fused_activation));


### PR DESCRIPTION
```
//litert/vendors/qualcomm/core/utils:utils_test
[----------] Global test environment tear-down
[==========] 12 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 6 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (22 ms total)
[  PASSED  ] 2 tests.

//litert/c/options:litert_qualcomm_options_test
[----------] Global test environment tear-down
[==========] 10 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 10 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[----------] Global test environment tear-down
[==========] 7 tests from 4 test suites ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[----------] Global test environment tear-down
[==========] 172 tests from 4 test suites ran. (11393 ms total)
[  PASSED  ] 172 tests.
```