### PR TITLE
Qualcomm AI Engine Direct - Support INT32 Broadcast_to.

### DIFF
--- a/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.cc
@@ -92,47 +92,47 @@ std::vector<OpWrapper> BuildBroadcastToOp(
 
   auto& broadcast_op = CreateOpWrapper(res, qnn_op);
   broadcast_op.AddInputTensor(inputs[0]);
-
-  switch (inputs[0].get().GetDataType()) {
+  auto data_type = inputs[0].get().GetDataType();
+  switch (data_type) {
     case QNN_DATATYPE_BOOL_8: {
       TensorWrapper& static_tensor = CreateStaticTensor<std::uint8_t>(
-          tensor_pool, inputs[0].get().GetDataType(), inputs[0], outputs[0],
-          false);
+          tensor_pool, data_type, inputs[0], outputs[0], false);
       broadcast_op.AddInputTensor(static_tensor);
       break;
     }
     case QNN_DATATYPE_UFIXED_POINT_8: {
       TensorWrapper& static_tensor = CreateStaticTensor<std::uint8_t>(
-          tensor_pool, inputs[0].get().GetDataType(), inputs[0], outputs[0],
-          true);
+          tensor_pool, data_type, inputs[0], outputs[0], true);
       broadcast_op.AddInputTensor(static_tensor);
       break;
     }
     case QNN_DATATYPE_SFIXED_POINT_8: {
       TensorWrapper& static_tensor = CreateStaticTensor<std::int8_t>(
-          tensor_pool, inputs[0].get().GetDataType(), inputs[0], outputs[0],
-          true);
+          tensor_pool, data_type, inputs[0], outputs[0], true);
       broadcast_op.AddInputTensor(static_tensor);
       break;
     }
     case QNN_DATATYPE_UFIXED_POINT_16: {
       TensorWrapper& static_tensor = CreateStaticTensor<std::uint16_t>(
-          tensor_pool, inputs[0].get().GetDataType(), inputs[0], outputs[0],
-          true);
+          tensor_pool, data_type, inputs[0], outputs[0], true);
       broadcast_op.AddInputTensor(static_tensor);
       break;
     }
     case QNN_DATATYPE_SFIXED_POINT_16: {
       TensorWrapper& static_tensor = CreateStaticTensor<std::int16_t>(
-          tensor_pool, inputs[0].get().GetDataType(), inputs[0], outputs[0],
-          true);
+          tensor_pool, data_type, inputs[0], outputs[0], true);
       broadcast_op.AddInputTensor(static_tensor);
       break;
     }
     case QNN_DATATYPE_FLOAT_32: {
-      TensorWrapper& static_tensor =
-          CreateStaticTensor<float>(tensor_pool, inputs[0].get().GetDataType(),
-                                    inputs[0], outputs[0], false);
+      TensorWrapper& static_tensor = CreateStaticTensor<float>(
+          tensor_pool, data_type, inputs[0], outputs[0], false);
+      broadcast_op.AddInputTensor(static_tensor);
+      break;
+    }
+    case QNN_DATATYPE_INT_32: {
+      TensorWrapper& static_tensor = CreateStaticTensor<std::int32_t>(
+          tensor_pool, data_type, inputs[0], outputs[0], false);
       broadcast_op.AddInputTensor(static_tensor);
       break;
     }


### PR DESCRIPTION
//litert/vendors/qualcomm/core/utils:utils_test
[----------] Global test environment tear-down
[==========] 12 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 12 tests.

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 6 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (56 ms total)
[  PASSED  ] 2 tests.

//litert/c/options:litert_qualcomm_options_test
[----------] Global test environment tear-down
[==========] 10 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 10 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[----------] Global test environment tear-down
[==========] 7 tests from 4 test suites ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[----------] Global test environment tear-down
[==========] 172 tests from 4 test suites ran. (14099 ms total)
[  PASSED  ] 172 tests.