### PR TITLE
remove gitmodules. workpsace by default is using http_archive

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "third_party/tensorflow"]
-	path = third_party/tensorflow
-	url = https://github.com/tensorflow/tensorflow
-	branch = master


### PR DESCRIPTION
remove gitmodules. workpsace by default is using http_archive pointing to master
through source_repo.