### PR TITLE
Qualcomm AI Engine Direct - Refine QNN Library Version Check.

### DIFF
--- a/litert/vendors/qualcomm/BUILD
+++ b/litert/vendors/qualcomm/BUILD
@@ -86,7 +86,6 @@ litert_cc_lib_with_qnn(
         "//litert/vendors/qualcomm/core/backends:htp_perf_control",
         "//litert/vendors/qualcomm/core/schema:soc_table",
         "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@qairt//:qnn_lib_headers",


### PR DESCRIPTION
# What
- Align QNN library version check with QNN TFLiteDelegate

# Test
```
//litert/vendors/qualcomm/core/utils:utils_test
[----------] Global test environment tear-down
[==========] 12 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 6 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (43 ms total)
[  PASSED  ] 2 tests.

//litert/c/options:litert_qualcomm_options_test
[----------] Global test environment tear-down
[==========] 10 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 10 tests.

//litert/c:litert_op_options_test
[----------] Global test environment tear-down
[==========] 31 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 31 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[----------] Global test environment tear-down
[==========] 7 tests from 4 test suites ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[----------] Global test environment tear-down
[==========] 186 tests from 4 test suites ran. (36883 ms total)
[  PASSED  ] 186 tests.
```