### PR TITLE
Qualcomm AI Engine Direct - Refactor Fuse Activation.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -312,12 +312,12 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       LITERT_RETURN_IF_ERROR(LiteRtGetConcatenationFusedActivationOption(
           litert_op.Get(), &fused_activation));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       op_wrappers = ::qnn::BuildConcatenationOp(tensor_pool, input_tensors,
-                                                output_tensors, axis);
+                                                {activation_input}, axis);
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflAdd: {
@@ -325,12 +325,12 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       LITERT_RETURN_IF_ERROR(LiteRtGetAddFusedActivationOption(
           litert_op.Get(), &fused_activation));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       op_wrappers = ::qnn::BuildElementwiseAddOp(tensor_pool, input_tensors,
-                                                 output_tensors);
+                                                 {activation_input});
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflLogicalAnd: {
@@ -353,12 +353,12 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       LITERT_RETURN_IF_ERROR(LiteRtGetDivFusedActivationOption(
           litert_op.Get(), &fused_activation));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       op_wrappers = ::qnn::BuildElementwiseDivOp(tensor_pool, input_tensors,
-                                                 output_tensors);
+                                                 {activation_input});
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflGreater: {
@@ -376,12 +376,12 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       LITERT_RETURN_IF_ERROR(LiteRtGetMulFusedActivationOption(
           litert_op.Get(), &fused_activation));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       op_wrappers = ::qnn::BuildElementwiseMulOp(tensor_pool, input_tensors,
-                                                 output_tensors);
+                                                 {activation_input});
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflRsqrt: {
@@ -414,12 +414,12 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       LITERT_RETURN_IF_ERROR(LiteRtGetSubFusedActivationOption(
           litert_op.Get(), &fused_activation));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       op_wrappers = ::qnn::BuildElementwiseSubOp(tensor_pool, input_tensors,
-                                                 output_tensors);
+                                                 {activation_input});
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflMinimum: {
@@ -455,18 +455,18 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       LITERT_RETURN_IF_ERROR(LiteRtGetFullyConnectedKeepNumDimsOption(
           litert_op.Get(), &keep_num_dims));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       if (use_htp_preferences) {
         op_wrappers = ::qnn::BuildFullyConnectedOpHtp(
-            tensor_pool, input_tensors, output_tensors, keep_num_dims);
+            tensor_pool, input_tensors, {activation_input}, keep_num_dims);
       }
       if (op_wrappers.empty()) {
         op_wrappers = ::qnn::BuildFullyConnectedOp(
-            tensor_pool, input_tensors, output_tensors, keep_num_dims);
+            tensor_pool, input_tensors, {activation_input}, keep_num_dims);
       }
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflGather: {
@@ -641,13 +641,13 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       ::qnn::PaddingType qnn_padding;
       LITERT_RETURN_IF_ERROR(ConvertPaddingType(padding, qnn_padding));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       op_wrappers = ::qnn::BuildConv2dOp(
-          tensor_pool, input_tensors, output_tensors, stride_h, stride_w,
+          tensor_pool, input_tensors, {activation_input}, stride_h, stride_w,
           dilation_h_factor, dilation_w_factor, qnn_padding);
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflConv3d: {
@@ -679,14 +679,14 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       ::qnn::PaddingType qnn_padding;
       LITERT_RETURN_IF_ERROR(ConvertPaddingType(padding, qnn_padding));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       op_wrappers = ::qnn::BuildConv3dOp(
-          tensor_pool, input_tensors, output_tensors, stride_d, stride_h,
+          tensor_pool, input_tensors, {activation_input}, stride_d, stride_h,
           stride_w, dilation_d_factor, dilation_h_factor, dilation_w_factor,
           qnn_padding);
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflTransposeConv: {
@@ -706,13 +706,13 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       ::qnn::PaddingType qnn_padding;
       LITERT_RETURN_IF_ERROR(ConvertPaddingType(padding, qnn_padding));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       op_wrappers = ::qnn::BuildTransposeConvOp(tensor_pool, input_tensors,
-                                                output_tensors, stride_h,
+                                                {activation_input}, stride_h,
                                                 stride_w, qnn_padding);
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflDepthwiseConv2d: {
@@ -738,13 +738,13 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       ::qnn::PaddingType qnn_padding;
       LITERT_RETURN_IF_ERROR(ConvertPaddingType(padding, qnn_padding));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       op_wrappers = ::qnn::BuildDepthwiseConv2dOp(
-          tensor_pool, input_tensors, output_tensors, stride_h, stride_w,
+          tensor_pool, input_tensors, {activation_input}, stride_h, stride_w,
           dilation_h_factor, dilation_w_factor, qnn_padding);
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflAveragePool2d: {
@@ -770,13 +770,13 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       ::qnn::PaddingType qnn_padding;
       LITERT_RETURN_IF_ERROR(ConvertPaddingType(padding, qnn_padding));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       op_wrappers = ::qnn::BuildAveragePoolOp(
-          tensor_pool, input_tensors, output_tensors, stride_h, stride_w,
+          tensor_pool, input_tensors, {activation_input}, stride_h, stride_w,
           filter_height, filter_width, qnn_padding);
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflMaxPool2d: {
@@ -802,13 +802,13 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
       ::qnn::PaddingType qnn_padding;
       LITERT_RETURN_IF_ERROR(ConvertPaddingType(padding, qnn_padding));
 
-      auto& activation_output = ::qnn::ReplaceOutputTensorForFusedActivation(
+      auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
           tensor_pool, fused_activation, output_tensors);
       op_wrappers = ::qnn::BuildMaxPoolOp(
-          tensor_pool, input_tensors, output_tensors, stride_h, stride_w,
+          tensor_pool, input_tensors, {activation_input}, stride_h, stride_w,
           filter_height, filter_width, qnn_padding);
       ::qnn::AddFusedActivationNode(op_wrappers, fused_activation,
-                                    output_tensors[0], activation_output);
+                                    activation_input, output_tensors[0]);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflDepthToSpace: {

--- a/litert/vendors/qualcomm/core/builders/op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/op_builder.cc
@@ -231,7 +231,7 @@ OpWrapper& CreateSimpleActivationOp(std::vector<OpWrapper>& ops,
   return ret;
 }
 
-TensorWrapper& ReplaceOutputTensorForFusedActivation(
+TensorWrapper& CreateFusedActivationInputTensor(
     TensorPool& tensor_pool, const uint32_t fused_activation_function,
     std::vector<TensorWrapperRef>& output_tensors) {
   if (fused_activation_function == FusedActivationNone) {
@@ -245,11 +245,7 @@ TensorWrapper& ReplaceOutputTensorForFusedActivation(
         fused_activation_function);
   }
 
-  TensorWrapper& activation_input =
-      tensor_pool.CloneNativeTensorFrom(output_tensors[0]);
-  TensorWrapper& activation_output = output_tensors[0].get();
-  output_tensors[0] = TensorWrapperRef(activation_input);
-  return activation_output;
+  return tensor_pool.CloneNativeTensorFrom(output_tensors[0]);
 }
 
 void AddFusedActivationNode(std::vector<OpWrapper>& res,

--- a/litert/vendors/qualcomm/core/builders/op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/op_builder.h
@@ -48,7 +48,7 @@ OpWrapper& CreateSimpleActivationOp(std::vector<OpWrapper>& ops,
   The replaced output tensor will be returned and can be used in fused
   activation node.
 */
-TensorWrapper& ReplaceOutputTensorForFusedActivation(
+TensorWrapper& CreateFusedActivationInputTensor(
     TensorPool& tensor_pool, const uint32_t fused_activation_function,
     std::vector<TensorWrapperRef>& output_tensors);
 


### PR DESCRIPTION
# What

- Original method modifies the Op output tensor, will impact future feature development
- Change to create a new tensor but not modify the output tensor vector


# Test
```
//litert/vendors/qualcomm/core/utils:utils_test
[----------] Global test environment tear-down
[==========] 11 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 11 tests.
 
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 6 tests.
 
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.
 
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.
 
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.
 
//litert/vendors/qualcomm/core:tensor_pool_test
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.
 
//litert/vendors/qualcomm:qnn_manager_test
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (150 ms total)
[  PASSED  ] 2 tests.
 
//litert/c/options:litert_qualcomm_options_test
[----------] Global test environment tear-down
[==========] 10 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 10 tests.
 
//litert/c:litert_op_options_test
[----------] Global test environment tear-down
[==========] 32 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 32 tests.
 
//litert/tools/flags/vendors:qualcomm_flags_test
[----------] Global test environment tear-down
[==========] 7 tests from 4 test suites ran. (0 ms total)
[  PASSED  ] 7 tests.
 
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[----------] Global test environment tear-down
[==========] 198 tests from 4 test suites ran. (37666 ms total)
[  PASSED  ] 198 tests.
```