### PR TITLE
Exclude linux header files for non-AHWB supported builds

### DIFF
--- a/litert/vendors/intel_openvino/dispatch/device_context.cc
+++ b/litert/vendors/intel_openvino/dispatch/device_context.cc
@@ -19,8 +19,10 @@
 #endif  // __ANDROID__
 
 #include <string.h>
+#if LITERT_HAS_AHWB_SUPPORT
 #include <sys/socket.h>
 #include <unistd.h>
+#endif  // LITERT_HAS_AHWB_SUPPORT
 
 #include <openvino/runtime/intel_npu/level_zero/level_zero.hpp>
 #include <openvino/runtime/remote_context.hpp>


### PR DESCRIPTION
Disable the include of unistd.h and sys/socket.h linux header files for enabling Windows builds