### PR TITLE
Qualcomm AI Engine Direct - Dump QNN IR JSON graph.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <string>
 
 #include "absl/strings/string_view.h"  // from @com_google_absl
 #include "litert/c/litert_common.h"
@@ -35,6 +36,7 @@ struct LiteRtQualcommOptionsT {
   LiteRtQualcommOptionsHtpPerformanceMode htp_performance_mode =
       kLiteRtQualcommHtpPerformanceModeDefault;
   std::vector<std::int32_t> dump_tensor_ids;
+  std::string ir_json_dir;
 };
 
 LiteRtStatus LiteRtQualcommOptionsCreate(LiteRtOpaqueOptions* options) {
@@ -241,6 +243,28 @@ LiteRtStatus LiteRtQualcommOptionsGetProfiling(
   }
 
   *profiling = options->profiling;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetIrJsonDir(LiteRtQualcommOptions options,
+                                               const char* ir_json_dir) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->ir_json_dir = ir_json_dir;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetIrJsonDir(LiteRtQualcommOptions options,
+                                               const char** ir_json_dir) {
+  if (options == nullptr || ir_json_dir == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *ir_json_dir = options->ir_json_dir.data();
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -156,6 +156,12 @@ LiteRtStatus LiteRtQualcommOptionsSetProfiling(
 LiteRtStatus LiteRtQualcommOptionsGetProfiling(
     LiteRtQualcommOptions options, LiteRtQualcommOptionsProfiling* profiling);
 
+LiteRtStatus LiteRtQualcommOptionsSetIrJsonDir(LiteRtQualcommOptions options,
+                                               const char* ir_json_dir);
+
+LiteRtStatus LiteRtQualcommOptionsGetIrJsonDir(LiteRtQualcommOptions options,
+                                               const char** ir_json_dir);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -153,6 +153,23 @@ TEST(LiteRtQualcommOptionsTest, Profiling) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
+TEST(LiteRtQualcommOptionsTest, IrJsonDir) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetIrJsonDir(qualcomm_options, "tmp/"));
+
+  const char* ir_json_dir;
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsGetIrJsonDir(qualcomm_options, &ir_json_dir));
+  EXPECT_STREQ(ir_json_dir, "tmp/");
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
 TEST(LiteRtQualcommOptionsTest, DumpTensorIds) {
   LiteRtOpaqueOptions options;
   LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
@@ -213,6 +230,10 @@ TEST(QualcommOptionsTest, CppApi) {
   for (size_t i = 0; i < kDumpTensorIds.size(); i++) {
     EXPECT_EQ(ids[i], kDumpTensorIds[i]);
   }
+
+  EXPECT_EQ(options->GetIrJsonDir(), "");
+  options->SetIrJsonDir("tmp");
+  EXPECT_EQ(options->GetIrJsonDir(), "tmp");
 }
 
 TEST(QualcommOptionsTest, FindFromChain) {

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -136,6 +136,17 @@ std::vector<std::int32_t> QualcommOptions::GetDumpTensorIds() {
   return dump_ids;
 }
 
+void QualcommOptions::SetIrJsonDir(const std::string& ir_json_dir) {
+  internal::AssertOk(LiteRtQualcommOptionsSetIrJsonDir, Data(),
+                     ir_json_dir.c_str());
+}
+
+absl::string_view QualcommOptions::GetIrJsonDir() {
+  const char* ir_json_dir;
+  internal::AssertOk(LiteRtQualcommOptionsGetIrJsonDir, Data(), &ir_json_dir);
+  return absl::string_view(ir_json_dir);
+}
+
 Expected<QualcommOptions> QualcommOptions::Create(OpaqueOptions& options) {
   const auto id = options.GetIdentifier();
   if (!id || *id != Discriminator()) {

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -23,6 +23,7 @@
 #include "litert/c/options/litert_qualcomm_options.h"
 #include "litert/cc/litert_expected.h"
 #include "litert/cc/litert_opaque_options.h"
+#include "absl/strings/string_view.h"  // from @com_google_absl
 
 namespace litert::qualcomm {
 
@@ -60,6 +61,9 @@ class QualcommOptions : public OpaqueOptions {
 
   void SetDumpTensorIds(const std::vector<std::int32_t>& ids);
   std::vector<std::int32_t> GetDumpTensorIds();
+
+  void SetIrJsonDir(const std::string& profiling);
+  absl::string_view GetIrJsonDir();
 
  private:
   LiteRtQualcommOptions Data() const;

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -92,8 +92,8 @@ ABSL_FLAG(bool, qualcomm_use_qint16_as_quint16, false,
           "quantized uin16 model.");
 
 ABSL_FLAG(LiteRtQualcommOptionsHtpPerformanceMode,
-          qualcomm_htp_performance_mode,
-          kLiteRtQualcommHtpPerformanceModeBurst, "HTP performance mode.");
+          qualcomm_htp_performance_mode, kLiteRtQualcommHtpPerformanceModeBurst,
+          "HTP performance mode.");
 
 ABSL_FLAG(std::vector<std::string>, qualcomm_dump_tensor_ids, {},
           "Debug Feature. Ids to dump as outputs. Comma-separated list of "
@@ -209,6 +209,12 @@ std::string AbslUnparseFlag(LiteRtQualcommOptionsProfiling options) {
       return "linting";
   }
 }
+
+ABSL_FLAG(
+    std::string, qualcomm_ir_json_dir, "",
+    "Qnn IR JSON directory. If provided, you can obtain Qnn IR in Qnn JSON "
+    "format.");
+
 // NOLINTEND(*alien-types*)
 
 namespace litert::qualcomm {
@@ -244,6 +250,9 @@ Expected<QualcommOptions> QualcommOptionsFromFlags() {
                   int32_ids.push_back(std::stoi(id));
                 });
   opts.SetDumpTensorIds(int32_ids);
+
+  const auto ir_json_dir = absl::GetFlag(FLAGS_qualcomm_ir_json_dir);
+  opts.SetIrJsonDir(ir_json_dir);
 
   return opts;
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -48,6 +48,8 @@ ABSL_DECLARE_FLAG(bool, qualcomm_use_qint16_as_quint16);
 
 ABSL_DECLARE_FLAG(std::vector<std::string>, qualcomm_dump_tensor_ids);
 
+ABSL_DECLARE_FLAG(std::string, qualcomm_ir_json_dir);
+
 #endif
 
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -115,6 +115,7 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetHtpPerformanceMode(static_cast<::qnn::HtpPerformanceMode>(
       qualcomm_options.GetHtpPerformanceMode()));
   qnn_options.SetDumpTensorIds(qualcomm_options.GetDumpTensorIds());
+  qnn_options.SetIrJsonDir(qualcomm_options.GetIrJsonDir());
   LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
   return kLiteRtStatusOk;
 }

--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -202,6 +202,7 @@ litert_lib(
         "//litert/vendors/qualcomm/core/builders:transpose_conv_op_builder",
         "//litert/vendors/qualcomm/core/builders:transpose_op_builder",
         "//litert/vendors/qualcomm/core/builders:unpack_op_builder",
+        "//litert/vendors/qualcomm/core/dump:dump_graph",
         "//litert/vendors/qualcomm/core/transformation:graph_to_graph",
         "//litert/vendors/qualcomm/core/utils:miscs",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -26,6 +26,7 @@
 
 #include "absl/container/flat_hash_map.h"  // from @com_google_absl
 #include "absl/container/flat_hash_set.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
 #include "absl/types/span.h"  // from @com_google_absl
 #include "litert/c/litert_common.h"
@@ -85,6 +86,7 @@
 #include "litert/vendors/qualcomm/core/builders/prelu_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/unpack_op_builder.h"
 #include "litert/vendors/qualcomm/core/common.h"
+#include "litert/vendors/qualcomm/core/dump/dump_graph.h"
 #include "litert/vendors/qualcomm/core/transformation/graph_to_graph.h"
 #include "litert/vendors/qualcomm/core/utils/miscs.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
@@ -1091,6 +1093,18 @@ LiteRtStatus MapGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
     LITERT_RETURN_IF_ERROR(ConvertOp(options.GetUseHtpPreference(), op,
                                      tensor_pool, input_tensors, output_tensors,
                                      op_wrappers));
+
+    if (!op.Outputs().empty()) {
+      // Add op namespace based on the first output tensor name.
+      if (size_t pos = op.Outputs()[0].Name().find(";");
+          pos != std::string_view::npos) {
+        auto op_namespace = op.Outputs()[0].Name().substr(0, pos);
+        for (auto& op_wrapper : op_wrappers) {
+          op_wrapper.AddPrefixToName(absl::StrCat(op_namespace, "/"));
+        }
+      }
+    }
+    // Move op_wrappers to graph_op_wrappers.
     std::move(op_wrappers.begin(), op_wrappers.end(),
               std::back_inserter(graph_op_wrappers));
   }
@@ -1129,6 +1143,12 @@ LiteRtStatus MapGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
           error);
     }
     return kLiteRtStatusErrorRuntimeFailure;
+  }
+
+  // Dump IR Json to understand Qnn graph.
+  if (!options.GetIrJsonDir().empty()) {
+    ::qnn::DumpIrJson(created_tensors, graph_op_wrappers,
+                      options.GetIrJsonDir(), qnn_graph_name);
   }
 
   LITERT_RETURN_STATUS_IF_QNN_NOT_OK(graph_mapper.Finalize());

--- a/litert/vendors/qualcomm/core/builders/op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/op_builder.cc
@@ -214,9 +214,9 @@ OpWrapper& CreateOpWrapper(std::vector<OpWrapper>& ops, const char* op_type) {
           {QNN_OP_UN_PACK, QnnOpCode::kUnPack},
       };
 
-  const auto op_count = ops.size();
-  const auto name = "op_type_" + std::string(op_type) + "_op_count_" +
-                    std::to_string(op_count);
+  // TODO(jiunkaiy): Remove the static op_index to ensure each op has a unique name.
+  static uint32_t op_index = 0;
+  const auto name = std::string(op_type) + "_" + std::to_string(op_index++);
 
   return ops.emplace_back(std::move(name), op_type, code_type_map->at(op_type));
 }

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -58,6 +58,12 @@ std::vector<std::int32_t> Options::GetDumpTensorIds() const {
   return dump_tensor_ids_;
 }
 
+absl::string_view Options::GetIrJsonDir() const { return ir_json_dir_; }
+
+void Options::SetIrJsonDir(absl::string_view ir_json_dir) {
+  ir_json_dir_ = ir_json_dir;
+}
+
 std::string Options::Dump() const {
   static constexpr absl::string_view kQnnOptionsDumpFormat =
       "\
@@ -68,14 +74,15 @@ UseHtpPreference: %v\n\
 UseQint16AsQuint16: %v\n\
 EnableWeightSharing: %v\n\
 HtpPerformanceMode: %d\n\
-DumpTensorIds: %s\n";  // NOLINT
+DumpTensorIds: %s\n\
+IrJsonDir: %s\n";  // NOLINT
 
   std::string dump_tensor_ids = absl::StrJoin(dump_tensor_ids_, ",");
 
   return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, profiling_,
                          use_htp_preference_, use_qint16_as_quint16_,
                          enable_weight_sharing_, htp_performance_mode_,
-                         dump_tensor_ids);
+                         dump_tensor_ids, ir_json_dir_);
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -8,6 +8,8 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/string_view.h"  // from @com_google_absl
+
 // c++ enum and wrapper without dependency.
 namespace qnn {
 
@@ -61,6 +63,9 @@ class Options {
   void SetDumpTensorIds(const std::vector<std::int32_t>& ids);
   std::vector<std::int32_t> GetDumpTensorIds() const;
 
+  absl::string_view GetIrJsonDir() const;
+  void SetIrJsonDir(absl::string_view ir_json_dir);
+
   std::string Dump() const;
 
  private:
@@ -71,6 +76,7 @@ class Options {
   bool enable_weight_sharing_ = false;
   HtpPerformanceMode htp_performance_mode_ = HtpPerformanceMode::kDefault;
   std::vector<std::int32_t> dump_tensor_ids_;
+  std::string ir_json_dir_;
 };
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -110,6 +110,15 @@ TEST(QnnOptionTest, EnableWeightSharing) {
   EXPECT_EQ(options.GetEnableWeightSharing(), false);
 }
 
+TEST(QnnOptionTest, SetIrJsonDir) {
+  Options options;
+  options.SetIrJsonDir("tmp/");
+  EXPECT_FALSE(options.GetIrJsonDir().empty());
+  EXPECT_EQ(options.GetIrJsonDir(), "tmp/");
+  options.SetIrJsonDir("");
+  EXPECT_TRUE(options.GetIrJsonDir().empty());
+}
+
 TEST(QnnOptionTest, Default) {
   Options options;
   EXPECT_EQ(options.GetLogLevel(), LogLevel::kInfo);
@@ -118,6 +127,7 @@ TEST(QnnOptionTest, Default) {
   EXPECT_FALSE(options.GetUseQint16AsQuint16());
   EXPECT_FALSE(options.GetEnableWeightSharing());
   EXPECT_EQ(options.GetHtpPerformanceMode(), HtpPerformanceMode::kDefault);
+  EXPECT_TRUE(options.GetIrJsonDir().empty());
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/core/dump/BUILD
+++ b/litert/vendors/qualcomm/core/dump/BUILD
@@ -1,0 +1,45 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    default_visibility = ["//litert/vendors/qualcomm:__subpackages__"],
+)
+
+cc_library(
+    name = "dump_graph",
+    srcs = ["dump_graph.cc"],
+    hdrs = ["dump_graph.h"],
+    deps = [
+        "//litert/vendors/qualcomm/core/utils:log",
+        "//litert/vendors/qualcomm/core/utils:miscs",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@com_github_nlohmann_json//:json",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/types:span",
+        "@qairt//:qnn_lib_headers",
+    ]
+)
+
+cc_test(
+    name = "dump_graph_test",
+    srcs = [
+        "dump_graph_test.cc",
+    ],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        ":dump_graph",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:matmul_op_builder",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@com_github_nlohmann_json//:json",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_googletest//:gtest_main",
+    ]
+)

--- a/litert/vendors/qualcomm/core/dump/dump_graph.cc
+++ b/litert/vendors/qualcomm/core/dump/dump_graph.cc
@@ -1,0 +1,316 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+
+#include "absl/container/flat_hash_set.h"  // from @com_google_absl
+#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/vendors/qualcomm/core/utils/log.h"
+#include "litert/vendors/qualcomm/core/utils/miscs.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "nlohmann/json.hpp"
+#include "QnnTypes.h"  // from @qairt
+
+namespace qnn {
+
+namespace {
+template <typename T>
+nlohmann::json ReshapeDataRecursive(uint32_t& cur_index, T* data,
+                                    uint32_t num_elements,
+                                    absl::Span<uint32_t> dims) {
+  if (dims.empty()) {
+    return nlohmann::json();
+  }
+
+  uint32_t size = dims[0];
+  nlohmann::json nested_array = nlohmann::json::array();
+  if (dims.size() == 1) {
+    for (uint32_t i = 0; i < size; ++i) {
+      if (cur_index < num_elements) {
+        nested_array.emplace_back(data[cur_index++]);
+      } else {
+        QNN_LOG_ERROR("The data size for tensor_params does not match.");
+        // Fill with 0 if array is smaller than the specified dimensions.
+        nested_array.emplace_back(0);
+      }
+    }
+  } else {
+    absl::Span<uint32_t> sub_dims = dims.subspan(1);
+    for (uint32_t i = 0; i < size; ++i) {
+      nested_array.emplace_back(
+          ReshapeDataRecursive<T>(cur_index, data, num_elements, sub_dims));
+    }
+  }
+  return nested_array;
+}
+
+template <typename T>
+nlohmann::json ReshapeData(void* buffer_data, uint32_t buffer_size,
+                           absl::Span<uint32_t> dims) {
+  T* data = static_cast<T*>(buffer_data);
+  uint32_t ind = 0;
+  return ReshapeDataRecursive<T>(ind, data, buffer_size / sizeof(T), dims);
+}
+}  // namespace
+
+nlohmann::json SerializeQuantParamToJson(
+    const Qnn_QuantizeParams_t& quant_params) {
+  nlohmann::json qnn_quant_params = {
+      {"definition", quant_params.encodingDefinition},
+      {"encoding", quant_params.quantizationEncoding}};
+  // TODO (jiunkaiy): Support more quant encoding.
+  if (quant_params.quantizationEncoding ==
+      QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+    qnn_quant_params["scale_offset"] = {
+        {"scale", quant_params.scaleOffsetEncoding.scale},
+        {"offset", quant_params.scaleOffsetEncoding.offset}};
+  } else if (quant_params.quantizationEncoding ==
+             QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+    qnn_quant_params["scale_offset"] = {
+        {"bitwidth", quant_params.bwScaleOffsetEncoding.bitwidth},
+        {"scale", quant_params.bwScaleOffsetEncoding.scale},
+        {"offset", quant_params.bwScaleOffsetEncoding.offset}};
+  } else if (quant_params.quantizationEncoding ==
+             QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
+    std::vector<nlohmann::json> scale_offsets;
+    uint32_t num_scale_offsets =
+        quant_params.axisScaleOffsetEncoding.numScaleOffsets;
+    scale_offsets.reserve(num_scale_offsets);
+    for (int i = 0; i < num_scale_offsets; ++i) {
+      scale_offsets.emplace_back(nlohmann::json{
+          {"scale", quant_params.axisScaleOffsetEncoding.scaleOffset[i].scale},
+          {"offset",
+           quant_params.axisScaleOffsetEncoding.scaleOffset[i].offset}});
+    }
+    qnn_quant_params["axis_scale_offset"] = {
+        {"axis", quant_params.axisScaleOffsetEncoding.axis},
+        {"num_scale_offsets", num_scale_offsets},
+        {"scale_offsets", scale_offsets},
+    };
+  } else if (quant_params.quantizationEncoding ==
+             QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET) {
+    std::vector<nlohmann::json> scale_offsets;
+    uint32_t num_elements = quant_params.bwAxisScaleOffsetEncoding.numElements;
+    scale_offsets.reserve(num_elements);
+    for (int i = 0; i < num_elements; ++i) {
+      scale_offsets.emplace_back(nlohmann::json{
+          {"scale", quant_params.bwAxisScaleOffsetEncoding.scales[i]},
+          {"offset", quant_params.bwAxisScaleOffsetEncoding.offsets[i]}});
+    }
+    qnn_quant_params["axis_scale_offset"] = {
+        {"bitwidth", quant_params.bwAxisScaleOffsetEncoding.bitwidth},
+        {"axis", quant_params.bwAxisScaleOffsetEncoding.axis},
+        {"num_scale_offsets", num_elements},
+        {"scale_offsets", scale_offsets},
+    };
+  } else {
+    QNN_LOG_WARNING(
+        "Quantization encoding: %u is not supported in Qnn "
+        "Json dump",
+        quant_params.quantizationEncoding);
+  }
+  return qnn_quant_params;
+}
+
+nlohmann::json SerializeTensorToJson(const Qnn_TensorV1_t& qnn_tensor) {
+  nlohmann::json qnn_tensor_json;
+  qnn_tensor_json["id"] = qnn_tensor.id;
+  qnn_tensor_json["type"] = qnn_tensor.type;
+  qnn_tensor_json["dataFormat"] = qnn_tensor.dataFormat;
+  qnn_tensor_json["data_type"] = qnn_tensor.dataType;
+  qnn_tensor_json["dims"] =
+      absl::Span<uint32_t>(qnn_tensor.dimensions, qnn_tensor.rank);
+
+  const Qnn_QuantizeParams_t& quant_params = qnn_tensor.quantizeParams;
+  if (quant_params.encodingDefinition != QNN_DEFINITION_DEFINED) {
+    return qnn_tensor_json;
+  }
+  // Add basic key-value pairs for quant_params.
+  qnn_tensor_json["quant_params"] = SerializeQuantParamToJson(quant_params);
+  return qnn_tensor_json;
+}
+
+nlohmann::json SerializeScalarParamToJson(const Qnn_Scalar_t& scalar) {
+  Qnn_DataType_t datatype = scalar.dataType;
+  switch (datatype) {
+    case QNN_DATATYPE_INT_8:
+    case QNN_DATATYPE_SFIXED_POINT_8:
+      return nlohmann::json{{std::to_string(datatype), scalar.int8Value}};
+    case QNN_DATATYPE_INT_16:
+    case QNN_DATATYPE_SFIXED_POINT_16:
+      return nlohmann::json{{std::to_string(datatype), scalar.int16Value}};
+    case QNN_DATATYPE_INT_32:
+    case QNN_DATATYPE_SFIXED_POINT_32:
+      return nlohmann::json{{std::to_string(datatype), scalar.int32Value}};
+    case QNN_DATATYPE_INT_64:
+      return nlohmann::json{{std::to_string(datatype), scalar.int64Value}};
+    case QNN_DATATYPE_BOOL_8:
+    case QNN_DATATYPE_UINT_8:
+    case QNN_DATATYPE_UFIXED_POINT_8:
+      return nlohmann::json{{std::to_string(datatype), scalar.uint8Value}};
+    case QNN_DATATYPE_UINT_16:
+    case QNN_DATATYPE_UFIXED_POINT_16:
+      return nlohmann::json{{std::to_string(datatype), scalar.uint16Value}};
+    case QNN_DATATYPE_UINT_32:
+    case QNN_DATATYPE_UFIXED_POINT_32:
+      return nlohmann::json{{std::to_string(datatype), scalar.uint32Value}};
+    case QNN_DATATYPE_UINT_64:
+      return nlohmann::json{{std::to_string(datatype), scalar.uint64Value}};
+    case QNN_DATATYPE_FLOAT_32:
+      return nlohmann::json{{std::to_string(datatype), scalar.floatValue}};
+    case QNN_DATATYPE_FLOAT_64:
+      return nlohmann::json{{std::to_string(datatype), scalar.doubleValue}};
+    case QNN_DATATYPE_STRING:
+      return nlohmann::json{{std::to_string(datatype), scalar.stringValue}};
+    default:
+      QNN_LOG_WARNING(
+          "Datatype: %u is not supported for scalar_params in Qnn Json dump",
+          datatype)
+      break;
+  }
+  return nlohmann::json::object();
+}
+
+nlohmann::json SerializeTensorParamToJson(const Qnn_TensorV1_t& qnn_tensor) {
+  void* data = qnn_tensor.clientBuf.data;
+  uint32_t size = qnn_tensor.clientBuf.dataSize;
+  absl::Span dims =
+      absl::Span<uint32_t>(qnn_tensor.dimensions, qnn_tensor.rank);
+  switch (qnn_tensor.dataType) {
+    case QNN_DATATYPE_INT_8:
+    case QNN_DATATYPE_SFIXED_POINT_8:
+      return ReshapeData<int8_t>(data, size, dims);
+    case QNN_DATATYPE_BOOL_8:
+    case QNN_DATATYPE_UINT_8:
+    case QNN_DATATYPE_UFIXED_POINT_8:
+      return ReshapeData<uint8_t>(data, size, dims);
+    case QNN_DATATYPE_INT_16:
+    case QNN_DATATYPE_SFIXED_POINT_16:
+      return ReshapeData<int16_t>(data, size, dims);
+    case QNN_DATATYPE_UINT_16:
+    case QNN_DATATYPE_UFIXED_POINT_16:
+      return ReshapeData<uint16_t>(data, size, dims);
+    case QNN_DATATYPE_INT_32:
+    case QNN_DATATYPE_SFIXED_POINT_32:
+      return ReshapeData<int32_t>(data, size, dims);
+    case QNN_DATATYPE_UINT_32:
+    case QNN_DATATYPE_UFIXED_POINT_32:
+      return ReshapeData<uint32_t>(data, size, dims);
+    case QNN_DATATYPE_FLOAT_32:
+      return ReshapeData<float>(data, size, dims);
+    case QNN_DATATYPE_FLOAT_64:
+      return ReshapeData<double>(data, size, dims);
+    case QNN_DATATYPE_INT_64:
+      return ReshapeData<int64_t>(data, size, dims);
+    case QNN_DATATYPE_UINT_64:
+      return ReshapeData<uint64_t>(data, size, dims);
+    default:
+      QNN_LOG_ERROR(
+          "Datatype: %u is not supported for tensor_params in Qnn Json dump",
+          qnn_tensor.dataType);
+      break;
+  }
+  return nlohmann::json();
+}
+
+nlohmann::json SerializeOpToJson(const Qnn_OpConfig_t& op_config) {
+  nlohmann::json qnn_node_json;
+  // Create input_names and output_names.
+  qnn_node_json["input_names"] = nlohmann::json::array();
+  for (uint32_t i = 0; i < op_config.v1.numOfInputs; ++i) {
+    qnn_node_json["input_names"].emplace_back(
+        op_config.v1.inputTensors[i].v1.name);
+  }
+  qnn_node_json["output_names"] = nlohmann::json::array();
+  for (uint32_t i = 0; i < op_config.v1.numOfOutputs; ++i) {
+    qnn_node_json["output_names"].emplace_back(
+        op_config.v1.outputTensors[i].v1.name);
+  }
+  // Create macs_per_inferences and op type.
+  qnn_node_json["macs_per_inference"] = "";
+  qnn_node_json["type"] = op_config.v1.typeName;
+  // Create scalar_params and tensor_params.
+  qnn_node_json["scalar_params"] = nlohmann::json::object();
+  qnn_node_json["tensor_params"] = nlohmann::json::object();
+  for (uint32_t i = 0; i < op_config.v1.numOfParams; ++i) {
+    if (op_config.v1.params[i].paramType == QNN_PARAMTYPE_SCALAR) {
+      qnn_node_json["scalar_params"][op_config.v1.params[i].name] =
+          SerializeScalarParamToJson(op_config.v1.params[i].scalarParam);
+    } else if (op_config.v1.params[i].paramType == QNN_PARAMTYPE_TENSOR) {
+      const Qnn_TensorV1_t& qnn_tensor = op_config.v1.params[i].tensorParam.v1;
+      nlohmann::json qnn_tensor_json = SerializeTensorToJson(qnn_tensor);
+      qnn_tensor_json["data"] = SerializeTensorParamToJson(qnn_tensor);
+      qnn_node_json["tensor_params"][op_config.v1.params[i].name]
+                   [qnn_tensor.name] = qnn_tensor_json;
+    }
+  }
+  return qnn_node_json;
+}
+
+void DumpIrJson(
+    const absl::flat_hash_set<const TensorWrapper*>& tensor_wrappers,
+    std::vector<OpWrapper>& graph_op_wrappers, std::string_view json_dir,
+    std::string_view graph_name) {
+  CreateDirectoryRecursive(json_dir);
+
+  std::filesystem::path ir_json_path = json_dir;
+  ir_json_path /= std::string(graph_name) + ".json";
+  QNN_LOG_INFO("Qnn Json Path: %s", ir_json_path.c_str());
+
+  nlohmann::json ir_json = {
+      {"model.cpp", "N/A"},
+      {"model.bin", "N/A"},
+      {"converter_command", ""},
+      {"copyright_str",
+       "Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved."},
+      {"op_types", nlohmann::json::array()},
+      {"Total parameters", ""},
+      {"Total MACs per inference", ""},
+      {"graph",
+       {{"tensors", nlohmann::json::object()},
+        {"nodes", nlohmann::json::object()}}}};
+
+  // Dump Qnn Ops.
+  // Note that only the static data of tensorParam is stored in QNN Json.
+  absl::flat_hash_set<uint32_t> param_tensor_ids;
+  absl::flat_hash_set<std::string> op_types;
+  for (auto& op : graph_op_wrappers) {
+    const Qnn_OpConfig_t op_config = op.GetOpConfig();
+    ir_json["graph"]["nodes"][op_config.v1.name] = SerializeOpToJson(op_config);
+    // Record seen op type in a set.
+    op_types.emplace(op_config.v1.typeName);
+    // Record tensor param IDs to avoid adding them to graph tensors.
+    for (uint32_t i = 0; i < op_config.v1.numOfParams; ++i) {
+      if (op_config.v1.params[i].paramType == QNN_PARAMTYPE_TENSOR) {
+        param_tensor_ids.emplace(op_config.v1.params[i].tensorParam.v1.id);
+      }
+    }
+  }
+  // Dump Qnn Tensors.
+  for (const TensorWrapper* tensor : tensor_wrappers) {
+    // Skip tensor params.
+    if (param_tensor_ids.count(tensor->GetId()) > 0) {
+      continue;
+    }
+    // Create tensors.
+    nlohmann::json qnn_tensor_json =
+        SerializeTensorToJson(tensor->GetQnnTensor().v1);
+    ir_json["graph"]["tensors"][tensor->GetName()] = qnn_tensor_json;
+  }
+  // Dumpe Qnn op types.
+  ir_json["op_types"] = op_types;
+  // Write the JSON string to a file.
+  std::ofstream outFile(ir_json_path);
+  if (outFile.is_open()) {
+    outFile << ir_json.dump(4);
+    outFile.close();
+  } else {
+    QNN_LOG_ERROR("Unable to open qnn_litert.json for writing.");
+  }
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/dump/dump_graph.h
+++ b/litert/vendors/qualcomm/core/dump/dump_graph.h
@@ -1,0 +1,27 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_DUMP_DUMP_GRAPH_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_DUMP_DUMP_GRAPH_H_
+#include <string_view>
+
+#include "absl/container/flat_hash_set.h"  // from @com_google_absl
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "nlohmann/json.hpp"
+#include "QnnTypes.h"  // from @qairt
+
+namespace qnn {
+nlohmann::json SerializeTensorToJson(const Qnn_TensorV1_t& qnn_tensor);
+nlohmann::json SerializeQuantParamToJson(
+    const Qnn_QuantizeParams_t& quant_params);
+nlohmann::json SerializeScalarParamToJson(const Qnn_Scalar_t& scalar);
+nlohmann::json SerializeTensorParamToJson(const Qnn_TensorV1_t& qnn_tensor);
+nlohmann::json SerializeOpToJson(const Qnn_OpConfig_t& op_config);
+
+void DumpIrJson(const absl::flat_hash_set<const TensorWrapper*>& tensors,
+                std::vector<OpWrapper>& graph_op_wrappers,
+                std::string_view json_dir, std::string_view graph_name);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_DUMP_DUMP_GRAPH_H_

--- a/litert/vendors/qualcomm/core/dump/dump_graph_test.cc
+++ b/litert/vendors/qualcomm/core/dump/dump_graph_test.cc
@@ -1,0 +1,220 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/dump/dump_graph.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <fstream>
+#include <iostream>
+
+#include "absl/container/flat_hash_set.h"  // from @com_google_absl
+#include "litert/vendors/qualcomm/core/builders/matmul_op_builder.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "nlohmann/json.hpp"
+
+namespace qnn {
+namespace {
+
+TEST(IrJsonDump, SerializeOpToJson) {
+  TensorPool tensor_pool;
+  std::vector<OpWrapper> graph_op_wrappers;
+  QuantizeParamsWrapperVariant quant_param;
+  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(0.001, 0);
+
+  auto& input0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_16,
+                                                quant_param, {1, 1, 512, 256});
+  auto& input1 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_16,
+                                                quant_param, {1, 1, 1280, 256});
+  auto& output0 = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 512, 1280});
+  auto matmul0 =
+      BuildMatmulOp(tensor_pool, {input0, input1}, {output0}, false, true);
+  nlohmann::json qnn_op = SerializeOpToJson(matmul0[0].GetOpConfig());
+
+  ASSERT_TRUE(qnn_op.contains("input_names"));
+  EXPECT_EQ(qnn_op["input_names"][0], "0_qnn");
+  EXPECT_EQ(qnn_op["input_names"][1], "1_qnn");
+  ASSERT_TRUE(qnn_op.contains("output_names"));
+  EXPECT_EQ(qnn_op["output_names"][0], "2_qnn");
+  ASSERT_TRUE(qnn_op.contains("scalar_params"));
+  ASSERT_TRUE(qnn_op["scalar_params"].contains("transpose_in0"));
+  ASSERT_TRUE(qnn_op["scalar_params"].contains("transpose_in1"));
+  ASSERT_TRUE(qnn_op.contains("tensor_params"));
+  ASSERT_TRUE(qnn_op.contains("type"));
+  EXPECT_EQ(qnn_op["type"], "MatMul");
+}
+
+TEST(IrJsonDump, SerializeQuantParamToJson) {
+  const Qnn_QuantizeParams_t quant_params = {
+      QNN_DEFINITION_DEFINED,                 /*encodingDefinition*/
+      QNN_QUANTIZATION_ENCODING_SCALE_OFFSET, /*quantizationEncoding*/
+      {{
+          0.003f, /*scale*/
+          0       /*offset*/
+      }}};
+  nlohmann::json quant_info = SerializeQuantParamToJson(quant_params);
+  ASSERT_TRUE(quant_info.contains("definition"));
+  ASSERT_TRUE(quant_info.contains("encoding"));
+  ASSERT_TRUE(quant_info.contains("scale_offset"));
+  ASSERT_TRUE(quant_info["scale_offset"].contains("scale"));
+  ASSERT_TRUE(quant_info["scale_offset"].contains("offset"));
+  EXPECT_EQ(quant_info["scale_offset"]["scale"], 0.003f);
+  EXPECT_EQ(quant_info["scale_offset"]["offset"], 0);
+}
+
+TEST(IrJsonDump, SerializeScalarParamToJson) {
+  const Qnn_Scalar_t qnn_scalar = {QNN_DATATYPE_FLOAT_32, /*dataType*/
+                                   {
+                                       1e-6f /*floatValue*/
+                                   }};
+  nlohmann::json tensor_info = SerializeScalarParamToJson(qnn_scalar);
+  ASSERT_TRUE(tensor_info.contains(std::to_string(qnn_scalar.dataType)));
+  EXPECT_EQ(tensor_info[std::to_string(qnn_scalar.dataType)], 1e-6f);
+}
+
+TEST(IrJsonDump, SerializeTensorAndParamToJson) {
+  std::array<uint32_t, 1> axes = {3};
+  std::array<uint32_t, 1> dims = {1};
+  const Qnn_TensorV1_t qnn_tensor = {
+      79u,                                /*id*/
+      "83_qnn",                           /*name*/
+      QNN_TENSOR_TYPE_STATIC,             /*type*/
+      QNN_TENSOR_DATA_FORMAT_FLAT_BUFFER, /*dataFormat*/
+      QNN_DATATYPE_UINT_32,               /*dataType*/
+      QNN_QUANTIZE_PARAMS_INIT,           /*quantizeParams*/
+      1u,                                 /*rank*/
+      dims.data(),                        /*dimensions*/
+      QNN_TENSORMEMTYPE_RAW,              /*memType*/
+      {{
+          axes.data(),                  /*data*/
+          axes.size() * sizeof(axes[0]) /*dataSize*/
+      }}};
+  nlohmann::json tensor_info = SerializeTensorToJson(qnn_tensor);
+  EXPECT_EQ(tensor_info["dataFormat"], qnn_tensor.dataFormat);
+  EXPECT_EQ(tensor_info["data_type"], qnn_tensor.dataType);
+  EXPECT_EQ(tensor_info["id"], qnn_tensor.id);
+  EXPECT_EQ(tensor_info["type"], qnn_tensor.type);
+  ASSERT_EQ(tensor_info["dims"].size(), dims.size());
+  EXPECT_EQ(tensor_info["dims"][0], dims[0]);
+
+  nlohmann::json data = SerializeTensorParamToJson(qnn_tensor);
+  ASSERT_EQ(data.size(), axes.size());
+  EXPECT_EQ(data[0], axes[0]);
+}
+
+TEST(IrJsonDump, MatMul) {
+  TensorPool tensor_pool;
+  std::vector<OpWrapper> graph_op_wrappers;
+  QuantizeParamsWrapperVariant quant_param;
+  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(0.001, 0);
+
+  auto& input0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_16,
+                                                quant_param, {1, 1, 512, 256});
+  auto& input1 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_16,
+                                                quant_param, {1, 1, 1280, 256});
+  auto& output0 = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, {1, 1, 512, 1280});
+  auto matmul0 =
+      BuildMatmulOp(tensor_pool, {input0, input1}, {output0}, false, true);
+  std::move(matmul0.begin(), matmul0.end(),
+            std::back_inserter(graph_op_wrappers));
+  absl::flat_hash_set<const ::qnn::TensorWrapper*> created_tensors;
+  for (auto& op_wrapper : graph_op_wrappers) {
+    for (const auto& tensor_wrapper_ref : op_wrapper.GetAllTensors()) {
+      created_tensors.emplace(&tensor_wrapper_ref.get());
+    }
+  }
+  const char* filename = "/tmp/qnn_graph.json";
+  DumpIrJson(created_tensors, graph_op_wrappers, "/tmp/", "qnn_graph");
+
+  // Retrieve Qnn JSON file.
+  std::ifstream input_file(filename);
+
+  // Parse the JSON data.
+  nlohmann::json qnn_ir;
+  input_file >> qnn_ir;
+  input_file.close();
+  // Check op_types.
+  ASSERT_TRUE(qnn_ir.contains("op_types"));
+  ASSERT_EQ(qnn_ir["op_types"].size(), 1);
+  EXPECT_EQ(qnn_ir["op_types"][0], "MatMul");
+  // Check tensors.
+  ASSERT_TRUE(qnn_ir.contains("graph"));
+  ASSERT_TRUE(qnn_ir["graph"].contains("tensors"));
+  ASSERT_EQ(qnn_ir["graph"]["tensors"].size(), 3);
+  const auto& tensor = qnn_ir["graph"]["tensors"];
+  for (const auto& op_name : {"0_qnn", "1_qnn", "2_qnn"}) {
+    ASSERT_TRUE(tensor.contains(op_name));
+    // Check dataFormat.
+    ASSERT_TRUE(tensor[op_name].contains("dataFormat"));
+    EXPECT_EQ(tensor[op_name]["dataFormat"], 0);
+    // Check data_type.
+    ASSERT_TRUE(tensor[op_name].contains("data_type"));
+    EXPECT_EQ(tensor[op_name]["data_type"], 790);
+    // Check dims.
+    ASSERT_TRUE(tensor[op_name].contains("dims"));
+    ASSERT_EQ(tensor[op_name]["dims"].size(), 4);
+    EXPECT_EQ(tensor[op_name]["dims"][0], 1);
+    EXPECT_EQ(tensor[op_name]["dims"][1], 1);
+    if (op_name == "0_qnn") {
+      EXPECT_EQ(tensor[op_name]["dims"][2], 512);
+      EXPECT_EQ(tensor[op_name]["dims"][3], 256);
+    } else if (op_name == "1_qnn") {
+      EXPECT_EQ(tensor[op_name]["dims"][2], 1280);
+      EXPECT_EQ(tensor[op_name]["dims"][3], 256);
+    } else {
+      EXPECT_EQ(tensor[op_name]["dims"][2], 512);
+      EXPECT_EQ(tensor[op_name]["dims"][3], 1280);
+    }
+    // Check quant_params.
+    ASSERT_TRUE(tensor[op_name].contains("quant_params"));
+    const auto& quant_params = tensor[op_name]["quant_params"];
+    ASSERT_TRUE(quant_params.contains("definition"));
+    EXPECT_EQ(quant_params["definition"], 1);
+    ASSERT_TRUE(quant_params.contains("encoding"));
+    EXPECT_EQ(quant_params["encoding"], 0);
+    ASSERT_TRUE(quant_params.contains("scale_offset"));
+    double scale = quant_params["scale_offset"]["scale"].get<double>();
+    EXPECT_EQ(std::abs(scale - 1e-3) < 1e-4, true);
+    EXPECT_EQ(quant_params["scale_offset"]["offset"], 0);
+    // Check type.
+    ASSERT_TRUE(tensor[op_name].contains("type"));
+    EXPECT_EQ(tensor[op_name]["type"], 3);
+  }
+  // Check nodes.
+  ASSERT_TRUE(qnn_ir["graph"].contains("nodes"));
+  ASSERT_EQ(qnn_ir["graph"]["nodes"].size(), 1);
+  auto it = qnn_ir["graph"]["nodes"].begin();
+  const auto& node = it.value();
+  // Check input_names.
+  ASSERT_TRUE(node.contains("input_names"));
+  EXPECT_EQ(node["input_names"][0], "0_qnn");
+  EXPECT_EQ(node["input_names"][1], "1_qnn");
+  // Check output_names.
+  ASSERT_TRUE(node.contains("output_names"));
+  EXPECT_EQ(node["output_names"][0], "2_qnn");
+  // Check macs_per_inference.
+  ASSERT_TRUE(node.contains("macs_per_inference"));
+  // Check scalar_params.
+  ASSERT_TRUE(node.contains("scalar_params"));
+  ASSERT_TRUE(node["scalar_params"].contains("transpose_in0"));
+  ASSERT_TRUE(node["scalar_params"]["transpose_in0"].contains("1288"));
+  EXPECT_EQ(node["scalar_params"]["transpose_in0"]["1288"], 0);
+  ASSERT_TRUE(node["scalar_params"].contains("transpose_in1"));
+  ASSERT_TRUE(node["scalar_params"]["transpose_in1"].contains("1288"));
+  EXPECT_EQ(node["scalar_params"]["transpose_in1"]["1288"], 1);
+  // Check tensor_params.
+  ASSERT_TRUE(node.contains("tensor_params"));
+  // Check type.
+  ASSERT_TRUE(node.contains("type"));
+  EXPECT_EQ(node["type"], "MatMul");
+
+  ASSERT_EQ(std::remove(filename), 0);
+}
+}  // namespace
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/BUILD
+++ b/litert/vendors/qualcomm/core/wrappers/BUILD
@@ -51,6 +51,8 @@ cc_library(
         ":tensor_wrapper",
         "//litert/vendors/qualcomm/core:op_code",
         "//litert/vendors/qualcomm/core/utils:log",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
         "@qairt//:qnn_lib_headers",
     ],
 )

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -10,6 +10,8 @@
 #include <utility>
 #include <vector>
 
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "absl/strings/string_view.h"  // from @com_google_absl
 #include "litert/vendors/qualcomm/core/op_code.h"
 #include "litert/vendors/qualcomm/core/utils/log.h"
 #include "litert/vendors/qualcomm/core/wrappers/param_wrapper.h"
@@ -155,5 +157,13 @@ std::vector<std::reference_wrapper<TensorWrapper>> OpWrapper::GetAllTensors() {
   }
   return ret;
 };
+
+void OpWrapper::AddPrefixToName(absl::string_view prefix) {
+  name_ = absl::StrCat(prefix, name_);
+}
+
+void OpWrapper::AddSuffixToName(absl::string_view suffix) {
+  name_ = absl::StrCat(name_, suffix);
+}
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/string_view.h"  // from @com_google_absl
 #include "litert/vendors/qualcomm/core/op_code.h"
 #include "litert/vendors/qualcomm/core/wrappers/param_wrapper.h"
 #include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
@@ -62,6 +63,10 @@ class OpWrapper final {
       const std::vector<std::optional<qnn::TensorWrapperRef>>& outputs);
 
   void ClearTensorParams();
+
+  void AddPrefixToName(absl::string_view prefix);
+
+  void AddSuffixToName(absl::string_view suffix);
 
  private:
   const char* type_name_{nullptr};

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -120,6 +120,12 @@ class TensorWrapper final {
 
   Qnn_Tensor_t& GetQnnTensor() { return qnn_tensor_; }
 
+  uint32_t GetId() const { return qnn_tensor_.v1.id; }
+
+  const Qnn_Tensor_t& GetQnnTensor() const { return qnn_tensor_; }
+
+  std::string GetName() const { return qnn_tensor_.v1.name; }
+
   std::uint32_t GetRank() const;
 
   std::uint32_t GetDim(size_t index) const;
@@ -315,8 +321,6 @@ class TensorWrapper final {
     return absl::EndsWith(name_, kDumpSuffix) &&
            qnn_tensor_.v2.type == QNN_TENSOR_TYPE_APP_READ;
   }
-
-  std::string GetName() const { return name_; }
 
  private:
   void UpdateQnnQuantParams() {

--- a/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
@@ -198,5 +198,14 @@ TEST(OpWrapperTest, SwapOutputsTest) {
   EXPECT_EQ(op_wrapper_1.GetOutputTensor(0), output_1);
 }
 
+TEST(OpWrapperTest, ChangeOpName) {
+  OpWrapper op_wrapper_1{"name", "OP_TYPE", QnnOpCode::kUnknown};
+  EXPECT_STREQ(op_wrapper_1.GetOpConfig().v1.name, "name");
+  op_wrapper_1.AddPrefixToName("namespace/");
+  EXPECT_STREQ(op_wrapper_1.GetOpConfig().v1.name, "namespace/name");
+  op_wrapper_1.AddSuffixToName("_new");
+  EXPECT_STREQ(op_wrapper_1.GetOpConfig().v1.name, "namespace/name_new");
+}
+
 }  // namespace
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -327,7 +327,7 @@ TEST(TensorWrapperTest, QnnTensorPerTensorQuantConstructTest) {
                                {1, 1, 3}};
   const auto& qnn_tensor = tensor_wrapper.GetQnnTensor();
   TensorWrapper tensor_wrapper_1(qnn_tensor);
-  Qnn_Tensor_t& ref = tensor_wrapper.GetQnnTensor();
+  Qnn_Tensor_t& ref = tensor_wrapper_1.GetQnnTensor();
 
   EXPECT_EQ(ref.version, qnn_tensor.version);
   EXPECT_EQ(ref.v2.id, qnn_tensor.v2.id);
@@ -407,6 +407,53 @@ TEST(TensorWrapperTest, SameTensorWrapperTest) {
   EXPECT_EQ(tensor_wrapper_1, tensor_wrapper_1);
   TensorWrapper& tensor_wrapper_ref = tensor_wrapper_1;
   EXPECT_EQ(tensor_wrapper_1, tensor_wrapper_ref);
+}
+
+TEST(TensorWrapperTest, QnnTensorIdAndName) {
+  ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
+  TensorWrapper tensor_wrapper{"tensor_name",
+                               QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_UFIXED_POINT_8,
+                               q_param,
+                               {1, 1, 3}};
+  const uint32_t id = tensor_wrapper.GetId();
+  EXPECT_EQ(id, 0);
+  std::string tensor_name = tensor_wrapper.GetName();
+  EXPECT_EQ(tensor_name, "tensor_name");
+}
+
+TEST(TensorWrapperTest, ConstQnnTensorPerTensorQuantConstructTest) {
+  ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
+  TensorWrapper tensor_wrapper{"",
+                               QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_UFIXED_POINT_8,
+                               q_param,
+                               {1, 1, 3}};
+  const auto& qnn_tensor = tensor_wrapper.GetQnnTensor();
+  const TensorWrapper tensor_wrapper_1(qnn_tensor);
+  const Qnn_Tensor_t& ref = tensor_wrapper_1.GetQnnTensor();
+
+  EXPECT_EQ(ref.version, qnn_tensor.version);
+  EXPECT_EQ(ref.v2.id, qnn_tensor.v2.id);
+  EXPECT_STREQ(ref.v2.name, qnn_tensor.v2.name);
+  EXPECT_EQ(ref.v2.type, qnn_tensor.v2.type);
+  EXPECT_EQ(ref.v2.dataFormat, qnn_tensor.v2.dataFormat);
+  EXPECT_EQ(ref.v2.dataType, qnn_tensor.v2.dataType);
+  EXPECT_EQ(ref.v2.rank, qnn_tensor.v2.rank);
+  EXPECT_EQ(std::vector(ref.v2.dimensions, ref.v2.dimensions + ref.v2.rank),
+            std::vector(qnn_tensor.v2.dimensions,
+                        qnn_tensor.v2.dimensions + qnn_tensor.v2.rank));
+  EXPECT_EQ(ref.v2.quantizeParams.encodingDefinition,
+            qnn_tensor.v2.quantizeParams.encodingDefinition);
+  EXPECT_EQ(ref.v2.quantizeParams.quantizationEncoding,
+            qnn_tensor.v2.quantizeParams.quantizationEncoding);
+  EXPECT_FLOAT_EQ(ref.v2.quantizeParams.scaleOffsetEncoding.scale,
+                  qnn_tensor.v2.quantizeParams.scaleOffsetEncoding.scale);
+  EXPECT_EQ(ref.v2.quantizeParams.scaleOffsetEncoding.offset,
+            qnn_tensor.v2.quantizeParams.scaleOffsetEncoding.offset);
+  EXPECT_EQ(ref.v2.memType, qnn_tensor.v2.memType);
+  EXPECT_EQ(ref.v2.clientBuf.dataSize, qnn_tensor.v2.clientBuf.dataSize);
+  EXPECT_EQ(ref.v2.clientBuf.data, qnn_tensor.v2.clientBuf.data);
 }
 }  // namespace
 }  // namespace qnn


### PR DESCRIPTION
Summary:
- Implement the option to dump Qnn IR JSON.
- Ensure compatibility with the Qnn converter and ORT Qnn IR JSON format.
- Use the output tensor name as the namespace.

<img width="490" alt="image" src="https://github.com/user-attachments/assets/423246e0-a563-4edf-83cf-54ab8b636e28" />

Original quic account PR:
* https://github.com/google-ai-edge/LiteRT/pull/2446