### PR TITLE
Qualcomm AI Engine Direct - Parse Qnn Option in Dispatch.

### DIFF
--- a/litert/vendors/qualcomm/BUILD
+++ b/litert/vendors/qualcomm/BUILD
@@ -31,6 +31,8 @@ cc_library(
     deps = [
         "//litert/c:litert_common",
         "//litert/cc:litert_element_type",
+        "//litert/cc/options:litert_qualcomm_options",
+        "//litert/vendors/qualcomm/core:common",
         "@qairt//:qnn_lib_headers",
     ],
 )

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -15,12 +15,14 @@
 #ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_COMMON_H_
 #define ODML_LITERT_LITERT_VENDORS_QUALCOMM_COMMON_H_
 
-#include "litert/c/litert_common.h"
-#include "litert/cc/litert_element_type.h"
 #include "QnnCommon.h"  // from @qairt
 #include "QnnInterface.h"  // from @qairt
 #include "QnnTypes.h"  // from @qairt
 #include "System/QnnSystemInterface.h"  // from @qairt
+#include "litert/c/litert_common.h"
+#include "litert/cc/litert_element_type.h"
+#include "litert/cc/options/litert_qualcomm_options.h"
+#include "litert/vendors/qualcomm/core/common.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -98,5 +100,22 @@ inline LiteRtStatus LegalizeElementType(litert::ElementType litert_type,
 #ifdef __cplusplus
 }
 #endif  // __cplusplus
+
+inline LiteRtStatus InitQnnOptions(
+    ::qnn::Options& qnn_options,
+    litert::qualcomm::QualcommOptions& qualcomm_options) {
+  qnn_options.SetLogLevel(
+      static_cast<::qnn::LogLevel>(qualcomm_options.GetLogLevel()));
+  qnn_options.SetProfiling(
+      static_cast<::qnn::Profiling>(qualcomm_options.GetProfiling()));
+  qnn_options.SetUseHtpPreference(qualcomm_options.GetUseHtpPreference());
+  qnn_options.SetUseQint16AsQuint16(qualcomm_options.GetUseQint16AsQuint16());
+  qnn_options.SetEnableWeightSharing(qualcomm_options.GetEnableWeightSharing());
+  qnn_options.SetHtpPerformanceMode(static_cast<::qnn::HtpPerformanceMode>(
+      qualcomm_options.GetHtpPerformanceMode()));
+  qnn_options.SetDumpTensorIds(qualcomm_options.GetDumpTensorIds());
+  LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
+  return kLiteRtStatusOk;
+}
 
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_COMMON_H_

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -47,6 +47,7 @@
 #include "litert/cc/options/litert_qualcomm_options.h"
 #include "litert/vendors/c/litert_compiler_plugin.h"
 #include "litert/vendors/cc/options_helper.h"
+#include "litert/vendors/qualcomm/common.h"
 #include "litert/vendors/qualcomm/compiler/qnn_compose_graph.h"
 #include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/core/schema/soc_table.h"
@@ -90,24 +91,6 @@ bool IsWeightSharingSupported(::qnn::DspArch dsp_arch) {
 #else
   return dsp_arch >= ::qnn::DspArch::V73;
 #endif
-}
-
-// TODO(Alen): share this utility with dispatch_api
-LiteRtStatus InitQnnOptions(
-    ::qnn::Options& qnn_options,
-    litert::qualcomm::QualcommOptions& qualcomm_options) {
-  qnn_options.SetLogLevel(
-      static_cast<::qnn::LogLevel>(qualcomm_options.GetLogLevel()));
-  qnn_options.SetProfiling(
-      static_cast<::qnn::Profiling>(qualcomm_options.GetProfiling()));
-  qnn_options.SetUseHtpPreference(qualcomm_options.GetUseHtpPreference());
-  qnn_options.SetUseQint16AsQuint16(qualcomm_options.GetUseQint16AsQuint16());
-  qnn_options.SetEnableWeightSharing(qualcomm_options.GetEnableWeightSharing());
-  qnn_options.SetHtpPerformanceMode(static_cast<::qnn::HtpPerformanceMode>(
-      qualcomm_options.GetHtpPerformanceMode()));
-  qnn_options.SetDumpTensorIds(qualcomm_options.GetDumpTensorIds());
-  LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
-  return kLiteRtStatusOk;
 }
 
 bool SkipValidationOfQuantizeOp(const litert::Op& op) {

--- a/litert/vendors/qualcomm/dispatch/BUILD
+++ b/litert/vendors/qualcomm/dispatch/BUILD
@@ -60,11 +60,11 @@ litert_dynamic_lib(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "//litert/c:litert_runtime_c_api_shared_lib",
-        "//litert/c:litert_options",
+        "//litert/cc/options:litert_qualcomm_options",
+        "//litert/vendors/cc:options_helper",
         "//litert/cc:litert_expected",
         "//litert/cc:litert_macros",
         "//litert/cc:litert_element_type",
-        "//litert/cc:litert_environment_options",
         # TODO: Remove this dependency.
         "//litert/core/util:tensor_type_util",
         "//litert/vendors/c:litert_dispatch_c_api",

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -491,12 +491,18 @@ LiteRtStatus QnnManager::Init(absl::Span<const QnnBackend_Config_t*> configs,
   if (options.GetHtpPerformanceMode() != ::qnn::HtpPerformanceMode::kDefault) {
     LITERT_LOG(LITERT_INFO, "Set HTP performance mode: %d",
                options.GetHtpPerformanceMode());
-    perf_control_ =
-        std::make_unique<PerfControl>(Api(), options.GetHtpPerformanceMode());
-    QnnHtpDevice_Arch_t local_arch =
-        device_platform_info_->v1.hwDevices->v1.deviceInfoExtension
-            ->onChipDevice.arch;
-    if (auto status = perf_control_->Init(local_arch); !status) {
+    if (device_platform_info_) {
+      perf_control_ =
+          std::make_unique<PerfControl>(Api(), options.GetHtpPerformanceMode());
+      QnnHtpDevice_Arch_t local_arch =
+          device_platform_info_->v1.hwDevices->v1.deviceInfoExtension
+              ->onChipDevice.arch;
+      if (auto status = perf_control_->Init(local_arch); !status) {
+        return kLiteRtStatusErrorRuntimeFailure;
+      }
+    } else {
+      LITERT_LOG(LITERT_ERROR,
+                 "Cannot set HTP performance mode since no platforminfo found");
       return kLiteRtStatusErrorRuntimeFailure;
     }
   }


### PR DESCRIPTION
# What

- Move `InitQnnOptions` to [litert/vendors/qualcomm/common.h](https://github.com/google-ai-edge/LiteRT/compare/main...chuntl-qti:LiteRT:dev/chunhsue/qc_option_dispatch?expand=1#diff-278355b93b2341d7d258102af66e202f7f70505475681df2e7dc9f217f473005)
- Parse qnn option in [litert/vendors/qualcomm/dispatch/dispatch_api.cc](https://github.com/google-ai-edge/LiteRT/compare/main...chuntl-qti:LiteRT:dev/chunhsue/qc_option_dispatch?expand=1#diff-b246474468abb6f80f3476e9d277640887ebeed2c09a8ec845e2202045cc9a6e)
# Test
Tried `run_model` with `--qualcomm_log_level verbose` and `--qualcomm_htp_performance_mode sustained_high_performance`

Seeing verbose log
<img width="1020" height="167" alt="image" src="https://github.com/user-attachments/assets/503c817c-e59a-4244-989b-e3c302db3d30" />
And option dump
<img width="477" height="213" alt="image" src="https://github.com/user-attachments/assets/413f6502-b344-45ae-b499-3b7ca9e49b87" />


```
//litert/vendors/qualcomm/core/utils:utils_test
[----------] Global test environment tear-down
[==========] 11 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 11 tests.

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 6 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (48 ms total)
[  PASSED  ] 2 tests.

//litert/c/options:litert_qualcomm_options_test
[----------] Global test environment tear-down
[==========] 10 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 10 tests.

//litert/c:litert_op_options_test
[----------] Global test environment tear-down
[==========] 32 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 32 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[----------] Global test environment tear-down
[==========] 7 tests from 4 test suites ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[----------] Global test environment tear-down
[==========] 198 tests from 4 test suites ran. (36543 ms total)
[  PASSED  ] 198 tests.
```
