### PR TITLE
Qualcomm AI Engine Direct - Add Accuracy Test Utils.

### DIFF
--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -68,6 +68,7 @@ litert_dynamic_lib(
         "//litert/vendors/qualcomm:common",
         "//litert/vendors/qualcomm:qnn_manager",
         "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core/utils:miscs",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/dump:dump_graph",
         "//litert/vendors/qualcomm/core/schema:soc_table",

--- a/litert/vendors/qualcomm/core/builders/arg_min_max_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/arg_min_max_op_builder.cc
@@ -23,7 +23,7 @@ constexpr size_t kOutputIndex = 0;
 bool GetAxis(std::uint32_t& axis, const TensorWrapper& axis_tensor,
              const std::uint32_t input_rank) {
   if (const auto opt_axis_data =
-          axis_tensor.GetStaticTensorData<std::int32_t>();
+          axis_tensor.GetTensorData<std::int32_t>();
       opt_axis_data.has_value()) {
     const auto axis_data = opt_axis_data.value();
     axis = axis_data[0] >= 0 ? axis_data[0] : axis_data[0] + input_rank;
@@ -31,7 +31,7 @@ bool GetAxis(std::uint32_t& axis, const TensorWrapper& axis_tensor,
   }
 
   if (const auto opt_axis_data =
-          axis_tensor.GetStaticTensorData<std::int64_t>();
+          axis_tensor.GetTensorData<std::int64_t>();
       opt_axis_data.has_value()) {
     const auto axis_data = opt_axis_data.value();
     const auto axis_value = static_cast<std::int32_t>(axis_data[0]);

--- a/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
@@ -58,7 +58,7 @@ std::vector<OpWrapper> BuildConv2dOp(
   if (filter_tensor.IsTensorStatic() &&
       filter_tensor.GetDataType() ==
           Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_8) {
-    auto filter_data = filter_tensor.GetStaticTensorData<std::int8_t>();
+    auto filter_data = filter_tensor.GetTensorData<std::int8_t>();
     std::vector<int8_t> transpose_weight_int8;
     TransposeFromOHWIToHWIO(filter_data.value(), filters_dims,
                             transpose_weight_int8);
@@ -68,7 +68,7 @@ std::vector<OpWrapper> BuildConv2dOp(
   } else if (filter_tensor.IsTensorStatic() &&
              filter_tensor.GetDataType() ==
                  Qnn_DataType_t::QNN_DATATYPE_UFIXED_POINT_8) {
-    auto filter_data = filter_tensor.GetStaticTensorData<std::uint8_t>();
+    auto filter_data = filter_tensor.GetTensorData<std::uint8_t>();
     std::vector<uint8_t> transpose_weight_uint8;
     TransposeFromOHWIToHWIO(filter_data.value(), filters_dims,
                             transpose_weight_uint8);

--- a/litert/vendors/qualcomm/core/builders/cumsum_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/cumsum_op_builder.cc
@@ -34,7 +34,7 @@ std::vector<OpWrapper> BuildCumsumOp(
     return res;
   }
 
-  const auto axis_data = axis_tensor.GetStaticTensorData<std::int32_t>();
+  const auto axis_data = axis_tensor.GetTensorData<std::int32_t>();
   if (!axis_data.has_value()) {
     QNN_LOG_ERROR("Failed to get static axis tensor data.");
     return res;

--- a/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
@@ -38,7 +38,7 @@ std::vector<OpWrapper> BuildEmbeddingLookupOp(
         "is int16. Int8 table will be cast to int16.");
     std::vector<std::int16_t> int16_data;
     size_t data_len = table_tensor.GetTensorNumElements();
-    auto int8_data = table_tensor.GetStaticTensorData<std::int8_t>();
+    auto int8_data = table_tensor.GetTensorData<std::int8_t>();
     if (!int8_data.has_value()) {
       QNN_LOG_ERROR("Embedding lookup get int8 table failed.");
       return res;

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
@@ -37,7 +37,7 @@ std::vector<OpWrapper> BuildFullyConnectedOp(
     TensorWrapper& bias_tensor = inputs[kBiasIdx];
     if (bias_tensor.IsTensorStatic() &&
         bias_tensor.GetDataType() == QNN_DATATYPE_INT_64) {
-      const auto original_data = bias_tensor.GetStaticTensorData<int64_t>();
+      const auto original_data = bias_tensor.GetTensorData<int64_t>();
       if (!original_data.has_value()) {
         QNN_LOG_ERROR(
             "Failed to get static tensor data when convert bias tensor from "

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder_htp.cc
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder_htp.cc
@@ -72,28 +72,28 @@ std::vector<OpWrapper> BuildFullyConnectedOpHtp(
   TensorWrapper* weight;
   if (weight_tensor.GetDataType() == QNN_DATATYPE_SFIXED_POINT_8) {
     std::vector<std::int8_t> conv_weight;
-    auto fc_weight = weight_tensor.GetStaticTensorData<std::int8_t>();
+    auto fc_weight = weight_tensor.GetTensorData<std::int8_t>();
     TransposeFromOHWIToHWIO(fc_weight.value(), transpose_dim, conv_weight);
     weight = &(tensor_pool.CreateStaticTensor(
         weight_tensor.GetDataType(), quant_params, weight_dims, weight_bytes,
         conv_weight.data()));
   } else if (weight_tensor.GetDataType() == QNN_DATATYPE_SFIXED_POINT_16) {
     std::vector<std::int16_t> conv_weight;
-    auto fc_weight = weight_tensor.GetStaticTensorData<std::int16_t>();
+    auto fc_weight = weight_tensor.GetTensorData<std::int16_t>();
     TransposeFromOHWIToHWIO(fc_weight.value(), transpose_dim, conv_weight);
     weight = &(tensor_pool.CreateStaticTensor(
         weight_tensor.GetDataType(), quant_params, weight_dims, weight_bytes,
         conv_weight.data()));
   } else if (weight_tensor.GetDataType() == QNN_DATATYPE_UFIXED_POINT_16) {
     std::vector<std::uint16_t> conv_weight;
-    auto fc_weight = weight_tensor.GetStaticTensorData<std::uint16_t>();
+    auto fc_weight = weight_tensor.GetTensorData<std::uint16_t>();
     TransposeFromOHWIToHWIO(fc_weight.value(), transpose_dim, conv_weight);
     weight = &(tensor_pool.CreateStaticTensor(
         weight_tensor.GetDataType(), quant_params, weight_dims, weight_bytes,
         conv_weight.data()));
   } else if (weight_tensor.GetDataType() == QNN_DATATYPE_FLOAT_32) {
     std::vector<float> conv_weight;
-    auto fc_weight = weight_tensor.GetStaticTensorData<float>();
+    auto fc_weight = weight_tensor.GetTensorData<float>();
     TransposeFromOHWIToHWIO(fc_weight.value(), transpose_dim, conv_weight);
     weight = &(tensor_pool.CreateStaticTensor(
         weight_tensor.GetDataType(), quant_params, weight_dims, weight_bytes,

--- a/litert/vendors/qualcomm/core/builders/mean_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/mean_op_builder.cc
@@ -34,7 +34,7 @@ std::vector<OpWrapper> BuildMeanOp(TensorPool& tensor_pool,
 
   TensorWrapper& input_tensor = inputs[0];
 
-  auto axis_data = axis_tensor.GetStaticTensorData<std::int32_t>();
+  auto axis_data = axis_tensor.GetTensorData<std::int32_t>();
   if (!axis_data.has_value()) {
     QNN_LOG_ERROR("Get axis_data failed.");
     return res;

--- a/litert/vendors/qualcomm/core/builders/pad_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/pad_op_builder.cc
@@ -58,7 +58,7 @@ std::vector<OpWrapper> BuildPadOp(
     std::int32_t pad_const_value = 0;
     if (inputs.size() >= kPadConstValueIndex + 1) {
       const auto pad_const_data =
-          inputs[kPadConstValueIndex].get().GetStaticTensorData<std::int32_t>();
+          inputs[kPadConstValueIndex].get().GetTensorData<std::int32_t>();
       if (!pad_const_data.has_value()) {
         QNN_LOG_ERROR("Failed to get pad const value data.");
         return {};
@@ -84,7 +84,7 @@ std::vector<OpWrapper> BuildPadOp(
     float pad_const_value = 0;
     if (inputs.size() >= kPadConstValueIndex + 1) {
       const auto pad_const_data =
-          inputs[kPadConstValueIndex].get().GetStaticTensorData<float>();
+          inputs[kPadConstValueIndex].get().GetTensorData<float>();
       if (!pad_const_data.has_value()) {
         QNN_LOG_ERROR("Failed to get pad const value data.");
         return {};

--- a/litert/vendors/qualcomm/core/builders/reduce_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/reduce_op_builder.cc
@@ -34,7 +34,7 @@ std::vector<OpWrapper> BuildReduceOp(
 
   TensorWrapper& input_tensor = inputs[0];
 
-  auto axis_data = axis_tensor.GetStaticTensorData<std::int32_t>();
+  auto axis_data = axis_tensor.GetTensorData<std::int32_t>();
   if (!axis_data.has_value()) {
     QNN_LOG_ERROR("Get axis_data failed.");
     return {};

--- a/litert/vendors/qualcomm/core/builders/reverse_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/reverse_op_builder.cc
@@ -46,7 +46,7 @@ std::vector<OpWrapper> BuildReverseOp(
     return {};
   }
 
-  auto axis_values = axis_tensor.GetStaticTensorData<std::int32_t>();
+  auto axis_values = axis_tensor.GetTensorData<std::int32_t>();
   if (!axis_values) {
     QNN_LOG_ERROR("ReverseV2 axis tensor not contain static tensor.");
     return {};

--- a/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
@@ -38,12 +38,12 @@ std::vector<OpWrapper> BuildSliceOp(
   }
 
   const auto input_rank = input_tensor.GetRank();
-  auto begin_data = begin_tensor.GetStaticTensorData<int32_t>();
+  auto begin_data = begin_tensor.GetTensorData<int32_t>();
   if (!begin_data.has_value()) {
     QNN_LOG_ERROR("Get begin_data failed.");
     return res;
   }
-  auto size_data = size_tensor.GetStaticTensorData<int32_t>();
+  auto size_data = size_tensor.GetTensorData<int32_t>();
   if (!size_data.has_value()) {
     QNN_LOG_ERROR("Get size_data failed.");
     return res;

--- a/litert/vendors/qualcomm/core/builders/split_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/split_op_builder.cc
@@ -33,7 +33,7 @@ std::vector<OpWrapper> BuildSplitOp(
   }
 
   const TensorWrapper& input_tensor = inputs[kInputIndex];
-  auto axis_data = axis_tensor.GetStaticTensorData<int32_t>();
+  auto axis_data = axis_tensor.GetTensorData<int32_t>();
   if (!axis_data.has_value()) {
     QNN_LOG_ERROR("Get axis_data failed.");
     return res;

--- a/litert/vendors/qualcomm/core/builders/strided_slice_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/strided_slice_op_builder.cc
@@ -47,10 +47,10 @@ std::vector<OpWrapper> BuildStridedSliceOp(
     return {};
   }
 
-  const auto opt_begin_data = begin_tensor.GetStaticTensorData<std::int32_t>();
-  const auto opt_end_data = end_tensor.GetStaticTensorData<std::int32_t>();
+  const auto opt_begin_data = begin_tensor.GetTensorData<std::int32_t>();
+  const auto opt_end_data = end_tensor.GetTensorData<std::int32_t>();
   const auto opt_strides_data =
-      strides_tensor.GetStaticTensorData<std::int32_t>();
+      strides_tensor.GetTensorData<std::int32_t>();
   if (!opt_begin_data.has_value() || !opt_end_data.has_value() ||
       !opt_strides_data.has_value()) {
     QNN_LOG_ERROR(

--- a/litert/vendors/qualcomm/core/builders/tile_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/tile_op_builder.cc
@@ -35,7 +35,7 @@ std::vector<OpWrapper> BuildTileOp(
     QNN_LOG_WARNING("Convert multiples param of Tile OP from INT64 to UINT32.");
     std::vector<std::uint32_t> uint32_data;
     size_t data_len = multiples_tensor.GetTensorNumElements();
-    auto int64_data = multiples_tensor.GetStaticTensorData<std::int64_t>();
+    auto int64_data = multiples_tensor.GetTensorData<std::int64_t>();
     if (!int64_data.has_value()) {
       QNN_LOG_ERROR("Tile OP get int64 multiples param failed.");
       return {};

--- a/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.cc
@@ -57,7 +57,7 @@ std::vector<OpWrapper> BuildTransposeConvOp(
   if (filter_tensor.IsTensorStatic() &&
       filter_tensor.GetDataType() ==
           Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_8) {
-    auto filter_data = filter_tensor.GetStaticTensorData<std::int8_t>();
+    auto filter_data = filter_tensor.GetTensorData<std::int8_t>();
     std::vector<int8_t> transpose_weight_int8;
     TransposeFromOHWIToHWIO(filter_data.value(), filters_dims,
                             transpose_weight_int8);
@@ -67,7 +67,7 @@ std::vector<OpWrapper> BuildTransposeConvOp(
   } else if (filter_tensor.IsTensorStatic() &&
              filter_tensor.GetDataType() ==
                  Qnn_DataType_t::QNN_DATATYPE_UFIXED_POINT_8) {
-    auto filter_data = filter_tensor.GetStaticTensorData<std::uint8_t>();
+    auto filter_data = filter_tensor.GetTensorData<std::uint8_t>();
     std::vector<uint8_t> transpose_weight_uint8;
     TransposeFromOHWIToHWIO(filter_data.value(), filters_dims,
                             transpose_weight_uint8);

--- a/litert/vendors/qualcomm/core/tensor_pool.h
+++ b/litert/vendors/qualcomm/core/tensor_pool.h
@@ -87,7 +87,7 @@ namespace {
 
 template <typename Src, typename Dst>
 bool FillData(const TensorWrapper& src_tensor, std::vector<Dst>& dst_data) {
-  const auto src_data = src_tensor.GetStaticTensorData<Src>();
+  const auto src_data = src_tensor.GetTensorData<Src>();
   if (!src_data.has_value()) {
     QNN_LOG_ERROR("Failed to get static tensor data when filling data.");
     return false;

--- a/litert/vendors/qualcomm/core/tensor_pool_test.cc
+++ b/litert/vendors/qualcomm/core/tensor_pool_test.cc
@@ -58,7 +58,7 @@ TEST(TensorPoolConvertStaticTensorTest, SameTypeConversionFloat32) {
   auto* res = tensor_pool.ConvertStaticTensorFrom<float>(tensor_wrapper);
   ASSERT_NE(res, nullptr);
 
-  auto converted_data = res->GetStaticTensorData<float>();
+  auto converted_data = res->GetTensorData<float>();
   ASSERT_TRUE(converted_data.has_value());
 
   ASSERT_EQ(tensor_data.size(), converted_data->size());
@@ -79,7 +79,7 @@ TEST(TensorPoolConvertStaticTensorTest, SameTypeConversionInt32) {
   auto* res = tensor_pool.ConvertStaticTensorFrom<std::int32_t>(tensor_wrapper);
   ASSERT_NE(res, nullptr);
 
-  auto converted_data = res->GetStaticTensorData<std::int32_t>();
+  auto converted_data = res->GetTensorData<std::int32_t>();
   ASSERT_TRUE(converted_data.has_value());
 
   ASSERT_EQ(tensor_data.size(), converted_data->size());
@@ -100,7 +100,7 @@ TEST(TensorPoolConvertStaticTensorTest, ExpandTypeConversionFloat32) {
   auto* res = tensor_pool.ConvertStaticTensorFrom<double>(tensor_wrapper);
   ASSERT_NE(res, nullptr);
 
-  auto converted_data = res->GetStaticTensorData<double>();
+  auto converted_data = res->GetTensorData<double>();
   ASSERT_TRUE(converted_data.has_value());
 
   ASSERT_EQ(tensor_data.size(), converted_data->size());
@@ -121,7 +121,7 @@ TEST(TensorPoolConvertStaticTensorTest, ExpandTypeConversionInt32) {
   auto* res = tensor_pool.ConvertStaticTensorFrom<std::int64_t>(tensor_wrapper);
   ASSERT_NE(res, nullptr);
 
-  auto converted_data = res->GetStaticTensorData<std::int64_t>();
+  auto converted_data = res->GetTensorData<std::int64_t>();
   ASSERT_TRUE(converted_data.has_value());
 
   ASSERT_EQ(tensor_data.size(), converted_data->size());
@@ -142,7 +142,7 @@ TEST(TensorPoolConvertStaticTensorTest, NarrowTypeConversionFloat32) {
   auto* res = tensor_pool.ConvertStaticTensorFrom<float>(tensor_wrapper);
   ASSERT_NE(res, nullptr);
 
-  auto converted_data = res->GetStaticTensorData<float>();
+  auto converted_data = res->GetTensorData<float>();
   ASSERT_TRUE(converted_data.has_value());
 
   ASSERT_EQ(tensor_data.size(), converted_data->size());
@@ -163,7 +163,7 @@ TEST(TensorPoolConvertStaticTensorTest, NarrowTypeConversionInt32) {
   auto* res = tensor_pool.ConvertStaticTensorFrom<std::int32_t>(tensor_wrapper);
   ASSERT_NE(res, nullptr);
 
-  auto converted_data = res->GetStaticTensorData<std::int32_t>();
+  auto converted_data = res->GetTensorData<std::int32_t>();
   ASSERT_TRUE(converted_data.has_value());
 
   ASSERT_EQ(tensor_data.size(), converted_data->size());

--- a/litert/vendors/qualcomm/core/transformation/mask.cc
+++ b/litert/vendors/qualcomm/core/transformation/mask.cc
@@ -36,7 +36,7 @@ std::vector<OpWrapper> TransformToSelectOp(
   auto& mul_static_tensor =
       original_ops[start_index + pattern_size - 1].GetInputTensor(1);
   auto static_tensor_data =
-      mul_static_tensor.GetStaticTensorData<std::int16_t>();
+      mul_static_tensor.GetTensorData<std::int16_t>();
   if (!static_tensor_data) {
     QNN_LOG_ERROR("[G2G] Get tensor data failed when transforming mask model.");
     return {};

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
@@ -121,7 +121,7 @@ TensorWrapper& BuildSingleSHA(std::vector<OpWrapper>& ops, size_t start_index,
   // Create StridedSlice param ranges.
   auto mha_slice1_param =
       ops[start_index + kSlice1Index].GetTensorPararm(0).GetTensor();
-  auto mha_slice1_param_data = mha_slice1_param.GetStaticTensorData<int32_t>();
+  auto mha_slice1_param_data = mha_slice1_param.GetTensorData<int32_t>();
   std::vector<int32_t> slice1_ranges(mha_slice1_param_data.value().begin(),
                                      mha_slice1_param_data.value().end());
   slice1_ranges[kSlice3rdAxisEndIndex] /= num_heads;
@@ -154,7 +154,7 @@ TensorWrapper& BuildSingleSHA(std::vector<OpWrapper>& ops, size_t start_index,
   // Create StridedSlice param ranges.
   auto mha_slice2_param =
       ops[start_index + kSlice2Index].GetTensorPararm(0).GetTensor();
-  auto mha_slice2_param_data = mha_slice2_param.GetStaticTensorData<int32_t>();
+  auto mha_slice2_param_data = mha_slice2_param.GetTensorData<int32_t>();
   std::vector<int32_t> slice2_ranges(mha_slice2_param_data.value().begin(),
                                      mha_slice2_param_data.value().end());
   slice2_ranges[kSlice3rdAxisEndIndex] /= num_heads;

--- a/litert/vendors/qualcomm/core/utils/BUILD
+++ b/litert/vendors/qualcomm/core/utils/BUILD
@@ -32,6 +32,7 @@ cc_library(
     hdrs = ["miscs.h"],
     deps = [
         ":log",
+        "//litert/vendors/qualcomm/core/schema:soc_table",
         "@com_google_absl//absl/types:span",
         "@qairt//:qnn_lib_headers",
     ],
@@ -56,4 +57,18 @@ litert_device_exec(
     name = "utils_device_test",
     backend_id = "qualcomm",
     target = ":utils_test",
+)
+
+cc_library(
+    name = "qnn_model",
+    srcs = ["qnn_model.cc"],
+    hdrs = ["qnn_model.h"],
+    deps = [
+        ":log",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/types:span",
+        "@qairt//:qnn_lib_headers",
+    ],
 )

--- a/litert/vendors/qualcomm/core/utils/miscs.cc
+++ b/litert/vendors/qualcomm/core/utils/miscs.cc
@@ -7,11 +7,15 @@
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
+#include <optional>
+#include <string_view>
 #include <system_error>
 #include <vector>
 
 #include "absl/types/span.h"  // from @com_google_absl
 #include "litert/vendors/qualcomm/core/utils/log.h"
+#include "litert/vendors/qualcomm/core/schema/soc_table.h"
+
 #include "QnnCommon.h"  // from @qairt
 #include "QnnInterface.h"  // from @qairt
 #include "QnnTypes.h"  // from @qairt
@@ -155,4 +159,14 @@ const QNN_INTERFACE_VER_TYPE* ResolveQnnApi(
   return &providers[0]->QNN_INTERFACE_VER_NAME;
 }
 
+std::optional<::qnn::SocInfo> FindSocModel(std::string_view soc_model_name) {
+  std::optional<::qnn::SocInfo> soc_model;
+  for (auto i = 0; i < ::qnn::kNumSocInfos; ++i) {
+    if (soc_model_name == ::qnn::kSocInfos[i].soc_name) {
+      soc_model = ::qnn::kSocInfos[i];
+      break;
+    }
+  }
+  return soc_model;
+}
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/utils/miscs.h
+++ b/litert/vendors/qualcomm/core/utils/miscs.h
@@ -10,11 +10,14 @@
 #include <cstdint>
 #include <filesystem>
 #include <limits>
+#include <optional>
+#include <string_view>
 #include <memory>
 #include <type_traits>
 #include <vector>
 
 #include "absl/types/span.h"  // from @com_google_absl
+#include "litert/vendors/qualcomm/core/schema/soc_table.h"
 #include "QnnInterface.h"  // from @qairt
 #include "QnnTypes.h"  // from @qairt
 namespace qnn {
@@ -59,5 +62,6 @@ DLHandle CreateDLHandle(const char* path);
 const QNN_INTERFACE_VER_TYPE* ResolveQnnApi(void* handle,
                                             Qnn_Version_t expected_qnn_version);
 
+std::optional<::qnn::SocInfo> FindSocModel(std::string_view soc_model_name);
 }  // namespace qnn
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_UTILS_MISCS_H_

--- a/litert/vendors/qualcomm/core/utils/qnn_model.cc
+++ b/litert/vendors/qualcomm/core/utils/qnn_model.cc
@@ -1,0 +1,105 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/utils/qnn_model.h"
+
+#include "HTP/QnnHtpGraph.h"               // from @qairt
+#include "QnnGraph.h"                      // from @qairt
+#include "absl/container/flat_hash_set.h"  // from @com_google_absl
+#include "absl/types/span.h"               // from @com_google_absl
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
+
+namespace qnn {
+namespace {
+#define QNN_RETURN_STATUS_IF_NOT_OK(expr) \
+  if (QNN_SUCCESS != (expr)) {            \
+    return false;                         \
+  }
+
+inline absl::Span<const QnnGraph_Config_t*> DefaultGraphConfigs() {
+  static std::array<QnnHtpGraph_CustomConfig_t, 3> graph_custom_configs;
+  // Default use O3 for now.
+  graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+  graph_custom_configs[0].option = QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+  graph_custom_configs[0].optimizationOption.type =
+      QNN_HTP_GRAPH_OPTIMIZATION_TYPE_FINALIZE_OPTIMIZATION_FLAG;
+  // Change to 2 if you want to use O2 (default).
+  graph_custom_configs[0].optimizationOption.floatValue = 3;
+  // VTCM
+  graph_custom_configs[1] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+  graph_custom_configs[1].option = QNN_HTP_GRAPH_CONFIG_OPTION_VTCM_SIZE;
+  graph_custom_configs[1].vtcmSizeInMB = QNN_HTP_GRAPH_CONFIG_OPTION_MAX;
+  // FoldRelu Off
+  graph_custom_configs[2] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+  graph_custom_configs[2].option =
+      QNN_HTP_GRAPH_CONFIG_OPTION_FOLD_RELU_ACTIVATION_INTO_CONV_OFF;
+  graph_custom_configs[2].foldReluActivationIntoConvOff = true;
+
+  static std::array<QnnGraph_Config_t, 3> graph_configs;
+  graph_configs[0] = QNN_GRAPH_CONFIG_INIT;
+  graph_configs[0].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+  graph_configs[0].customConfig = &graph_custom_configs[0];
+
+  graph_configs[1] = QNN_GRAPH_CONFIG_INIT;
+  graph_configs[1].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+  graph_configs[1].customConfig = &graph_custom_configs[1];
+
+  graph_configs[2] = QNN_GRAPH_CONFIG_INIT;
+  graph_configs[2].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+  graph_configs[2].customConfig = &graph_custom_configs[2];
+
+  static std::array<const QnnGraph_Config_t*, 4> result = {
+      &graph_configs[0], &graph_configs[1], &graph_configs[2], nullptr};
+
+  return absl::MakeSpan(result.data(), result.size());
+}
+}  // namespace
+bool QnnModel::ValidateOpConfig() {
+  return std::all_of(op_wrappers_.begin(), op_wrappers_.end(),
+                     [this](OpWrapper& op_wrapper) -> bool {
+                       return QNN_SUCCESS ==
+                              api_->backendValidateOpConfig(
+                                  backend_handle_, op_wrapper.GetOpConfig());
+                     });
+}
+
+bool QnnModel::Finalize() {
+  absl::flat_hash_set<const ::qnn::TensorWrapper*> created_tensors;
+  QNN_RETURN_STATUS_IF_NOT_OK(api_->graphCreate(
+      context_handle_, "test", DefaultGraphConfigs().data(), &graph_handle_));
+  for (auto& op_wrapper : op_wrappers_) {
+    for (const auto& tensor_wrapper_ref : op_wrapper.GetAllTensors()) {
+      if (!created_tensors.count(&(tensor_wrapper_ref.get()))) {
+        QNN_RETURN_STATUS_IF_NOT_OK(api_->tensorCreateGraphTensor(
+            graph_handle_, &(tensor_wrapper_ref.get().GetQnnTensor())));
+        created_tensors.emplace(&(tensor_wrapper_ref.get()));
+      }
+    }
+    api_->graphAddNode(graph_handle_, op_wrapper.GetOpConfig());
+  }
+  QNN_RETURN_STATUS_IF_NOT_OK(
+      api_->graphFinalize(graph_handle_, nullptr, nullptr));
+  return true;
+}
+
+bool QnnModel::Execute() {
+  if (graph_handle_ == nullptr) {
+    QNN_LOG_ERROR("Finalize() should be called before Execute()")
+    return false;
+  }
+  std::vector<Qnn_Tensor_t> input_tensors;
+  std::vector<Qnn_Tensor_t> output_tensors;
+  for (auto* tensor_wrapper : input_tensors_) {
+    input_tensors.emplace_back(tensor_wrapper->GetQnnTensor());
+  }
+  for (auto* tensor_wrapper : output_tensors_) {
+    tensor_wrapper->AllocateOutputTensorBuffer();
+    output_tensors.emplace_back(tensor_wrapper->GetQnnTensor());
+  }
+  QNN_RETURN_STATUS_IF_NOT_OK(api_->graphExecute(
+      graph_handle_, input_tensors.data(), input_tensors.size(),
+      output_tensors.data(), output_tensors.size(), nullptr, nullptr));
+  return true;
+}
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/utils/qnn_model.h
+++ b/litert/vendors/qualcomm/core/utils/qnn_model.h
@@ -1,0 +1,82 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_UTILS_QNN_MODEL_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_UTILS_QNN_MODEL_H_
+
+#include <cstddef>
+#include <vector>
+
+#include "QnnCommon.h"
+#include "QnnInterface.h"
+#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+class QnnModel {
+ public:
+  QnnModel(const Qnn_BackendHandle_t backend_handle,
+           const QNN_INTERFACE_VER_TYPE* api,
+           const Qnn_ContextHandle_t context_handle)
+      : backend_handle_(backend_handle),
+        api_(api),
+        context_handle_(context_handle){};
+
+  QnnModel() = default;
+  ~QnnModel() = default;
+
+  template <typename T>
+  bool SetInputData(size_t idx, absl::Span<const T> data) {
+    if (idx >= input_tensors_.size()) {
+      return false;
+    }
+    return input_tensors_[idx]->SetTensorData(data);
+  }
+
+  // TODO (chunhsue-qti): Add another SetInputData which gets input in float and
+  // quantize.
+
+  size_t AddInputTensor(TensorWrapper& tensor) {
+    input_tensors_.emplace_back(&tensor);
+    return input_tensors_.size() - 1;
+  }
+
+  template <typename T>
+  std::optional<absl::Span<const T>> GetOutputData(size_t idx) {
+    if (idx >= output_tensors_.size()) {
+      return std::nullopt;
+    }
+    return output_tensors_[idx]->GetTensorData<T>();
+  }
+
+  size_t AddOutputTensor(TensorWrapper& tensor) {
+    output_tensors_.emplace_back(&tensor);
+    return output_tensors_.size() - 1;
+  }
+
+  bool ValidateOpConfig();
+
+  bool Finalize();
+
+  bool Execute();
+
+  void MoveOpsToGraph(std::vector<::qnn::OpWrapper>&& ops) {
+    std::move(ops.begin(), ops.end(), std::back_inserter(op_wrappers_));
+  }
+
+ private:
+  Qnn_BackendHandle_t backend_handle_ = nullptr;
+  const QNN_INTERFACE_VER_TYPE* api_{nullptr};
+  Qnn_ContextHandle_t context_handle_ = nullptr;
+  Qnn_GraphHandle_t graph_handle_ = nullptr;
+
+  std::vector<OpWrapper> op_wrappers_;
+
+  std::vector<TensorWrapper*> input_tensors_;
+  std::vector<TensorWrapper*> output_tensors_;
+};
+
+}  // namespace qnn
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_UTILS_QNN_MODEL_H_

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -228,11 +228,11 @@ void TensorWrapper::ConvertQint16ToQuint16() {
 
   // adjust static data
   if (IsTensorStatic()) {
-    auto int16_data = GetStaticTensorData<std::int16_t>();
+    auto int16_data = GetTensorData<std::int16_t>();
     if (!int16_data.has_value()) {
       QNN_LOG_ERROR(
           "Cannot convert static QInt16 data to QUint16 data failed since "
-          "GetStaticTensorData failed.");
+          "GetTensorData failed.");
       return;
     }
     QNN_LOG_DEBUG("Converting static tensor data from QInt16 to QUint16...");
@@ -268,7 +268,7 @@ void TensorWrapper::ConvertQint16ToQuint16() {
 
   UpdateQnnQuantParams();
 
-  // change data type here since GetStaticTensorData checks data type
+  // change data type here since GetTensorData checks data type
   qnn_tensor_.v2.dataType = QNN_DATATYPE_UFIXED_POINT_16;
   QNN_LOG_DEBUG(
       "QNN does not fully support QInt16 now, converting to QUint16 for better "

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -301,7 +301,7 @@ class TensorWrapper final {
   }
 
   template <typename T>
-  std::optional<absl::Span<const T>> GetStaticTensorData() const;
+  std::optional<absl::Span<const T>> GetTensorData() const;
 
   void ConvertAxisScaleOffsetToScaleOffset();
 
@@ -358,16 +358,16 @@ class TensorWrapper final {
 using TensorWrapperRef = std::reference_wrapper<TensorWrapper>;
 
 template <typename T>
-std::optional<absl::Span<const T>> TensorWrapper::GetStaticTensorData() const {
-  if (!IsTensorStatic()) {
+std::optional<absl::Span<const T>> TensorWrapper::GetTensorData() const {
+  if (!IsTensorStatic() && !IsSubgraphOutput()) {
     QNN_LOG_ERROR(
-        "Cannot GetStaticTensorData() on a non-static tensor, tensor type %d.",
+        "Cannot GetTensorData() on a non-static tensor, tensor type %d.",
         GetTensorType());
     return std::nullopt;
   }
 
   if (GetDataType() != GetQnnDataType<T>(IsQuant())) {
-    QNN_LOG_ERROR("GetStaticTensorData() with incorrect template type.");
+    QNN_LOG_ERROR("GetTensorData() with incorrect template type.");
     return std::nullopt;
   }
 

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -35,12 +35,12 @@ TEST(TensorWrapperTest, SanityTest) {
   EXPECT_FALSE(tensor_wrapper.IsSubgraphInput());
   EXPECT_FALSE(tensor_wrapper.IsSubgraphOutput());
   EXPECT_FALSE(tensor_wrapper.IsTensorStatic());
-  EXPECT_EQ(tensor_wrapper.GetStaticTensorData<std::uint8_t>(), std::nullopt);
+  EXPECT_EQ(tensor_wrapper.GetTensorData<std::uint8_t>(), std::nullopt);
   std::vector<std::uint8_t> data = {1, 2, 3};
   // expect no use, since tensor type not correct
   tensor_wrapper.SetTensorData<std::uint8_t>(
       absl::MakeSpan(data.data(), data.size()));
-  EXPECT_EQ(tensor_wrapper.GetStaticTensorData<std::uint8_t>(), std::nullopt);
+  EXPECT_EQ(tensor_wrapper.GetTensorData<std::uint8_t>(), std::nullopt);
 }
 
 TEST(TensorWrapperTest, CopyTensorTest) {
@@ -62,10 +62,10 @@ TEST(TensorWrapperTest, CopyTensorTest) {
   EXPECT_FALSE(copied.IsSubgraphInput());
   EXPECT_FALSE(copied.IsSubgraphOutput());
   EXPECT_TRUE(copied.IsTensorStatic());
-  EXPECT_EQ(copied.GetStaticTensorData<std::uint8_t>(), std::nullopt);
+  EXPECT_EQ(copied.GetTensorData<std::uint8_t>(), std::nullopt);
   std::vector<std::uint8_t> data = {1, 2, 3};
   copied.SetTensorData<std::uint8_t>(absl::MakeSpan(data.data(), data.size()));
-  const auto tensor_data = copied.GetStaticTensorData<std::uint8_t>();
+  const auto tensor_data = copied.GetTensorData<std::uint8_t>();
   EXPECT_TRUE(tensor_data.has_value());
   for (size_t i = 0; i < data.size(); i++) {
     EXPECT_EQ((*tensor_data)[i], data[i]);
@@ -98,7 +98,7 @@ TEST(TensorWrapperTest, MoveTensorTest) {
   EXPECT_FALSE(moved.IsSubgraphInput());
   EXPECT_FALSE(moved.IsSubgraphOutput());
   EXPECT_TRUE(moved.IsTensorStatic());
-  const auto tensor_data = moved.GetStaticTensorData<std::uint8_t>();
+  const auto tensor_data = moved.GetTensorData<std::uint8_t>();
   EXPECT_TRUE(tensor_data.has_value());
   for (size_t i = 0; i < data.size(); i++) {
     EXPECT_EQ(tensor_data.value()[i], data[i]);
@@ -244,30 +244,30 @@ TEST(TensorWrapperTest, DumpTensorTest) {
   EXPECT_TRUE(tensor_wrapper.IsMarkedDump());
 }
 
-TEST(TensorWrapperTest, GetStaticTensorDataNonStaticTest) {
+TEST(TensorWrapperTest, GetTensorDataNonStaticTest) {
   std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
   ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
   TensorWrapper tensor_wrapper{"", QNN_TENSOR_TYPE_APP_WRITE,
                                QNN_DATATYPE_UFIXED_POINT_8, q_param,
                                dummy_dims};
-  EXPECT_FALSE(tensor_wrapper.GetStaticTensorData<std::uint8_t>().has_value());
+  EXPECT_FALSE(tensor_wrapper.GetTensorData<std::uint8_t>().has_value());
 }
 
-TEST(TensorWrapperTest, GetStaticTensorDataTest) {
+TEST(TensorWrapperTest, GetTensorDataTest) {
   std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
   ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
   TensorWrapper tensor_wrapper{"", QNN_TENSOR_TYPE_STATIC,
                                QNN_DATATYPE_UFIXED_POINT_8, q_param,
                                dummy_dims};
 
-  EXPECT_FALSE(tensor_wrapper.GetStaticTensorData<float>().has_value());
-  EXPECT_FALSE(tensor_wrapper.GetStaticTensorData<std::int8_t>().has_value());
-  EXPECT_FALSE(tensor_wrapper.GetStaticTensorData<std::uint8_t>().has_value());
+  EXPECT_FALSE(tensor_wrapper.GetTensorData<float>().has_value());
+  EXPECT_FALSE(tensor_wrapper.GetTensorData<std::int8_t>().has_value());
+  EXPECT_FALSE(tensor_wrapper.GetTensorData<std::uint8_t>().has_value());
   std::vector<std::uint8_t> data = {1, 2, 3};
   tensor_wrapper.SetTensorData<std::uint8_t>(
       absl::MakeSpan(data.data(), data.size()));
   const auto tensor_data =
-      *(tensor_wrapper.GetStaticTensorData<std::uint8_t>());
+      *(tensor_wrapper.GetTensorData<std::uint8_t>());
   for (size_t i = 0; i < data.size(); i++) {
     EXPECT_EQ(tensor_data[i], data[i]);
   }
@@ -308,7 +308,7 @@ TEST(TensorWrapperTest, ConvertQint16ToQuint16Test) {
       std::get<ScaleOffsetQuantizeParamsWrapper>(uint16_q_param_ref)
           .GetZeroPoint();
   const auto uint16_data =
-      *(tensor_wrapper.GetStaticTensorData<std::uint16_t>());
+      *(tensor_wrapper.GetTensorData<std::uint16_t>());
   std::vector<float> deq_data;
   for (size_t i = 0; i < data.size(); i++) {
     deq_data.emplace_back(

--- a/litert/vendors/qualcomm/qnn_backend_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/BUILD
@@ -1,0 +1,31 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    default_visibility = ["//litert:__subpackages__"],
+)
+
+cc_test(
+    name = "qnn_model_test",
+    srcs = [
+        "qnn_model_test.cc",
+    ],
+    deps = [
+        ":test_utils",
+        "//litert/vendors/qualcomm/core:common",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "test_utils",
+    hdrs = ["test_utils.h"],
+    deps = [
+        "//litert/vendors/qualcomm:qnn_manager",
+        "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/utils:miscs",
+        "//litert/vendors/qualcomm/core/utils:qnn_model",
+    ],
+)

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -1,0 +1,23 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    default_visibility = ["//litert:__subpackages__"],
+)
+
+cc_test(
+    name = "relu_test",
+    srcs = [
+        "relu_test.cc",
+    ],
+    deps = [
+        "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:relu_op_builder",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "@com_google_googletest//:gtest_main",
+        "@qairt//:qnn_lib_headers",
+    ],
+)

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/relu_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/relu_test.cc
@@ -1,0 +1,52 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "QnnTypes.h"  // from @qairt
+#include "litert/vendors/qualcomm/core/builders/relu_op_builder.h"
+#include "litert/vendors/qualcomm/core/common.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+
+using testing::FloatNear;
+using testing::Pointwise;
+namespace litert::qnn {
+namespace {
+
+TEST_F(QnnModelTest, SingleRelu) {
+  SetUpQnnModel(::qnn::Options(), "SM8650");
+
+  const std::vector<std::uint32_t> kDims{1, 2, 2, 1};
+  auto& input_0 = tensor_pool_.CreateInputTensorWithSuffix(
+      QNN_DATATYPE_FLOAT_32, {}, kDims, "");
+  auto& output_0 = tensor_pool_.CreateOutpuTensorWithSuffix(
+      QNN_DATATYPE_FLOAT_32, {}, kDims, "");
+  auto ops = ::qnn::BuildReluOp(tensor_pool_, {input_0}, {output_0});
+  ASSERT_FALSE(ops.empty());
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_0);
+  auto output_idx = qnn_model_.AddOutputTensor(output_0);
+
+  qnn_model_.SetInputData<float>(input_idx, {-1.f, 0.f, 1.f, 2.f});
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<float>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_EQ(output_data->size(), 4);
+  ASSERT_THAT(output_data.value(), Pointwise(FloatNear(1e-3), {0, 0, 1, 2}));
+}
+
+}  // namespace
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/qnn_backend_test/qnn_model_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/qnn_model_test.cc
@@ -1,0 +1,23 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+
+namespace litert::qnn {
+
+namespace {
+
+TEST_F(QnnModelTest, Sanity) {
+  SetUpQnnModel(::qnn::Options(), "SM8650");
+  EXPECT_NE(qnn_manager_ptr_->BackendHandle(), nullptr);
+  EXPECT_NE(context_handle_.get(), nullptr);
+  EXPECT_NE(qnn_manager_ptr_->Api(), nullptr);
+  EXPECT_TRUE(qnn_model_.ValidateOpConfig());
+  // no nodes to finalize
+  EXPECT_FALSE(qnn_model_.Finalize());
+}
+
+}  // namespace
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/qnn_backend_test/test_utils.h
+++ b/litert/vendors/qualcomm/qnn_backend_test/test_utils.h
@@ -1,0 +1,51 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_QNN_BACKEND_TEST_TEST_UTILS_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_QNN_BACKEND_TEST_TEST_UTILS_H_
+
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+#include "litert/vendors/qualcomm/core/common.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/utils/miscs.h"
+#include "litert/vendors/qualcomm/core/utils/qnn_model.h"
+#include "litert/vendors/qualcomm/qnn_manager.h"
+
+namespace litert::qnn {
+
+class QnnModelTest : public testing::Test {
+ protected:
+  QnnManager::Ptr qnn_manager_ptr_;
+  QnnManager::ContextHandle context_handle_;
+  ::qnn::QnnModel qnn_model_;
+  ::qnn::TensorPool tensor_pool_;
+
+  void SetUpQnnModel(const ::qnn::Options& options,
+                     std::string_view soc_model_name) {
+    // TODO (chunhsue-qti) get rid of QnnManager and move to core/
+    auto qnn_manager = QnnManager::Create(options, std::nullopt,
+                                          ::qnn::FindSocModel(soc_model_name));
+    ASSERT_TRUE(qnn_manager) << "Failed to create QnnManager";
+    auto context_configs = QnnManager::DefaultContextConfigs();
+    auto context_handle =
+        (**qnn_manager)
+            .CreateContextHandle(context_configs, options.GetProfiling());
+    ASSERT_TRUE(context_handle) << "Failed to create Context Handle";
+
+    std::swap(qnn_manager_ptr_, *qnn_manager);
+    context_handle_ = std::move(context_handle.Value());
+
+    auto qnn_model =
+        ::qnn::QnnModel(qnn_manager_ptr_->BackendHandle(),
+                        qnn_manager_ptr_->Api(), context_handle_.get());
+
+    std::swap(qnn_model_, qnn_model);
+  }
+};
+
+}  // namespace litert::qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_QNN_BACKEND_TEST_TEST_UTILS_H_

--- a/litert/vendors/qualcomm/qnn_manager.h
+++ b/litert/vendors/qualcomm/qnn_manager.h
@@ -199,6 +199,8 @@ class QnnManager::ContextHandle {
         free_fn_(free_fn),
         profile_free_fn_(profile_free_fn) {}
 
+  ContextHandle() = default;
+
   ~ContextHandle() {
     if (profile_ && profile_free_fn_) {
       if (auto status = profile_free_fn_(profile_); status != QNN_SUCCESS) {


### PR DESCRIPTION
# What
- Provide utilities for accuracy check on op builders.
- With a model converted to op_wrappers, the provided function can help check validation, finalization, and output data.
- To make test work both on x86 and aarch64. Qnn manager checks platform info before using provided soc info.

# Test
```
======================== Test Summary ========================
//litert/vendors/qualcomm/core/utils:utils_test
[----------] Global test environment tear-down
[==========] 12 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 6 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (55 ms total)
[  PASSED  ] 2 tests.

//litert/c/options:litert_qualcomm_options_test
[----------] Global test environment tear-down
[==========] 10 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 10 tests.

//litert/c:litert_op_options_test
[----------] Global test environment tear-down
[==========] 31 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 31 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[----------] Global test environment tear-down
[==========] 7 tests from 4 test suites ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[----------] Global test environment tear-down
[==========] 186 tests from 4 test suites ran. (36563 ms total)
[  PASSED  ] 186 tests.
```