### PR TITLE
Qualcomm AI Engine Direct - Workaround for Gemma3N

### DIFF
--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -95,6 +95,7 @@ cc_library(
     deps = [
         ":op_builder",
         "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/utils:log",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
         "@qairt//:qnn_lib_headers",

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
@@ -10,6 +10,7 @@
 
 #include "litert/vendors/qualcomm/core/builders/op_builder.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 #include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
 #include "QnnOpDef.h"  // from @qairt
@@ -32,7 +33,25 @@ std::vector<OpWrapper> BuildFullyConnectedOp(
   fully_connected_op.AddInputTensor(weight_tensor);
   if (inputs.size() - 1 >= kBiasIdx) {
     TensorWrapper& bias_tensor = inputs[kBiasIdx];
-    fully_connected_op.AddInputTensor(bias_tensor);
+    if (bias_tensor.IsTensorStatic() &&
+        bias_tensor.GetDataType() == QNN_DATATYPE_INT_64) {
+      const auto original_data = bias_tensor.GetStaticTensorData<int64_t>();
+      const auto num_elements = bias_tensor.GetTensorNumElements();
+      std::vector<int32_t> converted_data(num_elements);
+      for (size_t i = 0; i < num_elements; ++i) {
+        converted_data[i] = static_cast<int32_t>((*original_data)[i]);
+      }
+      auto& converted_bias_tensor = tensor_pool.CreateStaticTensor(
+          QNN_DATATYPE_SFIXED_POINT_32, bias_tensor.GetQuantParams(),
+          bias_tensor.GetDims(), num_elements * sizeof(int32_t),
+          converted_data.data());
+
+      fully_connected_op.AddInputTensor(converted_bias_tensor);
+      QNN_LOG_WARNING(
+          "Convert bias tensor in fully connected op from int64 to int32.");
+    } else {
+      fully_connected_op.AddInputTensor(bias_tensor);
+    }
   }
 
   TensorWrapper& output_tensor = outputs[0];

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -365,6 +365,28 @@ LiteRtStatus QnnManager::ValidateOp(const Qnn_OpConfig_t& op_config) {
     return kLiteRtStatusOk;
   }
 
+  if (strcmp(op_config.v1.typeName, QNN_OP_QUANTIZE) == 0 &&
+      op_config.v1.inputTensors[0].v2.dataType == QNN_DATATYPE_FLOAT_32 &&
+      op_config.v1.outputTensors[0].v2.dataType ==
+          QNN_DATATYPE_SFIXED_POINT_16) {
+    return kLiteRtStatusOk;
+  }
+  if (strcmp(op_config.v1.typeName, QNN_OP_DEQUANTIZE) == 0 &&
+      op_config.v1.inputTensors[0].v2.dataType ==
+          QNN_DATATYPE_SFIXED_POINT_16 &&
+      op_config.v1.outputTensors[0].v2.dataType == QNN_DATATYPE_FLOAT_32) {
+    return kLiteRtStatusOk;
+  }
+  if (strcmp(op_config.v1.typeName, QNN_OP_ELEMENT_WISE_DIVIDE) == 0 &&
+      op_config.v1.inputTensors[0].v2.dataType ==
+          QNN_DATATYPE_SFIXED_POINT_16 &&
+      op_config.v1.inputTensors[1].v2.dataType ==
+          QNN_DATATYPE_SFIXED_POINT_16 &&
+      op_config.v1.outputTensors[0].v2.dataType ==
+          QNN_DATATYPE_SFIXED_POINT_16) {
+    return kLiteRtStatusOk;
+  }
+
   if (Qnn_ErrorHandle_t error =
           Api()->backendValidateOpConfig(BackendHandle(), op_config);
       QNN_SUCCESS != error) {


### PR DESCRIPTION
Summary:
1. Skip quantize op validation when input type is float32 and output type is int16.
2. Skip dequantize op validation when input type is int16 and output type is float32.
3. Skip elementwise devide op validation whne input and output type is int16.
4. Convert bias tensor of fully connected op from int64 to int32.