### PR TITLE
Qualcomm AI Engine Direct - Enable more customized options

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -37,6 +37,10 @@ struct LiteRtQualcommOptionsT {
       kLiteRtQualcommHtpPerformanceModeDefault;
   std::vector<std::int32_t> dump_tensor_ids;
   std::string ir_json_dir;
+  std::uint32_t vtcm_size = 0;
+  std::uint32_t num_hvx_threads = 0;
+  LiteRtQualcommOptionsOptimizationLevel optimization_level =
+      kHtpOptimizeForInferenceO3;
 };
 
 LiteRtStatus LiteRtQualcommOptionsCreate(LiteRtOpaqueOptions* options) {
@@ -267,6 +271,74 @@ LiteRtStatus LiteRtQualcommOptionsGetIrJsonDir(LiteRtQualcommOptions options,
   }
 
   *ir_json_dir = options->ir_json_dir.c_str();
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetVtcmSize(LiteRtQualcommOptions options,
+                                              std::uint32_t vtcm_size) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->vtcm_size = vtcm_size;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetVtcmSize(LiteRtQualcommOptions options,
+                                              std::uint32_t* vtcm_size) {
+  if (options == nullptr || vtcm_size == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *vtcm_size = options->vtcm_size;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetNumHvxThreads(
+    LiteRtQualcommOptions options, std::uint32_t num_hvx_threads) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->num_hvx_threads = num_hvx_threads;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetNumHvxThreads(
+    LiteRtQualcommOptions options, std::uint32_t* num_hvx_threads) {
+  if (options == nullptr || num_hvx_threads == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *num_hvx_threads = options->num_hvx_threads;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetOptimizationLevel(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsOptimizationLevel optimization_level) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->optimization_level = optimization_level;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetOptimizationLevel(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsOptimizationLevel* optimization_level) {
+  if (options == nullptr || optimization_level == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *optimization_level = options->optimization_level;
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -163,6 +163,32 @@ LiteRtStatus LiteRtQualcommOptionsSetIrJsonDir(LiteRtQualcommOptions options,
 LiteRtStatus LiteRtQualcommOptionsGetIrJsonDir(LiteRtQualcommOptions options,
                                                const char** ir_json_dir);
 
+LiteRtStatus LiteRtQualcommOptionsSetVtcmSize(LiteRtQualcommOptions options,
+                                              uint32_t vtcm_size);
+
+LiteRtStatus LiteRtQualcommOptionsGetVtcmSize(LiteRtQualcommOptions options,
+                                              uint32_t* vtcm_size);
+
+LiteRtStatus LiteRtQualcommOptionsSetNumHvxThreads(
+    LiteRtQualcommOptions options, uint32_t num_hvx_threads);
+
+LiteRtStatus LiteRtQualcommOptionsGetNumHvxThreads(
+    LiteRtQualcommOptions options, uint32_t* num_hvx_threads);
+
+typedef enum LiteRtQualcommOptionsOptimizationLevel {
+  kHtpOptimizeForInference = 0,
+  kHtpOptimizeForPrepare,
+  kHtpOptimizeForInferenceO3,
+} LiteRtQualcommOptionsOptimizationLevel;
+
+LiteRtStatus LiteRtQualcommOptionsSetOptimizationLevel(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsOptimizationLevel optimization_level);
+
+LiteRtStatus LiteRtQualcommOptionsGetOptimizationLevel(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsOptimizationLevel* optimization_level);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -170,6 +170,58 @@ TEST(LiteRtQualcommOptionsTest, IrJsonDir) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
+TEST(LiteRtQualcommOptionsTest, VtcmSize) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetVtcmSize(qualcomm_options, 4));
+
+  uint32_t vtcm_size;
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsGetVtcmSize(qualcomm_options, &vtcm_size));
+  EXPECT_EQ(vtcm_size, 4);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
+TEST(LiteRtQualcommOptionsTest, HvxThread) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetNumHvxThreads(qualcomm_options, 4));
+
+  uint32_t num_hvx_threads;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetNumHvxThreads(qualcomm_options,
+                                                         &num_hvx_threads));
+  EXPECT_EQ(num_hvx_threads, 4);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
+TEST(LiteRtQualcommOptionsTest, OptimizationLevel) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetOptimizationLevel(
+      qualcomm_options, kHtpOptimizeForPrepare));
+
+  LiteRtQualcommOptionsOptimizationLevel optimization_level;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetOptimizationLevel(
+      qualcomm_options, &optimization_level));
+  EXPECT_EQ(optimization_level, kHtpOptimizeForPrepare);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
 TEST(LiteRtQualcommOptionsTest, DumpTensorIds) {
   LiteRtOpaqueOptions options;
   LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
@@ -234,6 +286,18 @@ TEST(QualcommOptionsTest, CppApi) {
   EXPECT_EQ(options->GetIrJsonDir(), "");
   options->SetIrJsonDir("tmp");
   EXPECT_EQ(options->GetIrJsonDir(), "tmp");
+
+  EXPECT_EQ(options->GetVtcmSize(), 0);
+  options->SetVtcmSize(4);
+  EXPECT_EQ(options->GetVtcmSize(), 4);
+
+  EXPECT_EQ(options->GetNumHvxThreads(), 0);
+  options->SetNumHvxThreads(4);
+  EXPECT_EQ(options->GetNumHvxThreads(), 4);
+
+  EXPECT_EQ(options->GetOptimizationLevel(), kHtpOptimizeForInferenceO3);
+  options->SetOptimizationLevel(kHtpOptimizeForPrepare);
+  EXPECT_EQ(options->GetOptimizationLevel(), kHtpOptimizeForPrepare);
 }
 
 TEST(QualcommOptionsTest, FindFromChain) {

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -148,6 +148,41 @@ absl::string_view QualcommOptions::GetIrJsonDir() {
   return absl::string_view(ir_json_dir);
 }
 
+void QualcommOptions::SetVtcmSize(std::uint32_t vtcm_size) {
+  internal::AssertOk(LiteRtQualcommOptionsSetVtcmSize, Data(), vtcm_size);
+}
+
+std::uint32_t QualcommOptions::GetVtcmSize() {
+  std::uint32_t vtcm_size;
+  internal::AssertOk(LiteRtQualcommOptionsGetVtcmSize, Data(), &vtcm_size);
+  return vtcm_size;
+}
+
+void QualcommOptions::SetNumHvxThreads(std::uint32_t num_hvx_threads) {
+  internal::AssertOk(LiteRtQualcommOptionsSetNumHvxThreads, Data(),
+                     num_hvx_threads);
+}
+
+std::uint32_t QualcommOptions::GetNumHvxThreads() {
+  std::uint32_t num_hvx_threads;
+  internal::AssertOk(LiteRtQualcommOptionsGetNumHvxThreads, Data(),
+                     &num_hvx_threads);
+  return num_hvx_threads;
+}
+
+void QualcommOptions::SetOptimizationLevel(
+    LiteRtQualcommOptionsOptimizationLevel optimization_level) {
+  internal::AssertOk(LiteRtQualcommOptionsSetOptimizationLevel, Data(),
+                     optimization_level);
+}
+
+LiteRtQualcommOptionsOptimizationLevel QualcommOptions::GetOptimizationLevel() {
+  LiteRtQualcommOptionsOptimizationLevel optimization_level;
+  internal::AssertOk(LiteRtQualcommOptionsGetOptimizationLevel, Data(),
+                     &optimization_level);
+  return optimization_level;
+}
+
 Expected<QualcommOptions> QualcommOptions::Create(OpaqueOptions& options) {
   const auto id = options.GetIdentifier();
   if (!id || *id != Discriminator()) {

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -66,6 +66,16 @@ class QualcommOptions : public OpaqueOptions {
   void SetIrJsonDir(const std::string& ir_json_dir);
   absl::string_view GetIrJsonDir();
 
+  void SetVtcmSize(std::uint32_t vtcm_size);
+  std::uint32_t GetVtcmSize();
+
+  void SetNumHvxThreads(std::uint32_t num_hvx_threads);
+  std::uint32_t GetNumHvxThreads();
+
+  void SetOptimizationLevel(
+      LiteRtQualcommOptionsOptimizationLevel optimization_level);
+  LiteRtQualcommOptionsOptimizationLevel GetOptimizationLevel();
+
  private:
   LiteRtQualcommOptions Data() const;
 };

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -221,6 +221,47 @@ ABSL_FLAG(
     "Qnn IR JSON directory. If provided, you can obtain Qnn IR in Qnn JSON "
     "format.");
 
+ABSL_FLAG(uint32_t, qualcomm_vtcm_size, 0,
+          "The vtcm size of the target device. If this option is set to 0, the "
+          "max size of vtcm size will be used.");
+
+ABSL_FLAG(uint32_t, qualcomm_num_hvx_thread, 0,
+          "The number of hvx threads for the target device. If this option is "
+          "set to 0, the max number of hvx threads will be used.");
+
+ABSL_FLAG(LiteRtQualcommOptionsOptimizationLevel, qualcomm_optimization_level,
+          kHtpOptimizeForInferenceO3, "QNN optimization level");
+
+bool AbslParseFlag(absl::string_view text,
+                   LiteRtQualcommOptionsOptimizationLevel* options,
+                   std::string* error) {
+  if (text == "O1") {
+    *options = kHtpOptimizeForInference;
+    return true;
+  }
+  if (text == "O2") {
+    *options = kHtpOptimizeForPrepare;
+    return true;
+  }
+  if (text == "O3") {
+    *options = kHtpOptimizeForInferenceO3;
+    return true;
+  }
+  *error = "Unknown optimization level";
+  return false;
+}
+
+std::string AbslUnparseFlag(LiteRtQualcommOptionsOptimizationLevel options) {
+  switch (options) {
+    case kHtpOptimizeForInference:
+      return "O1";
+    case kHtpOptimizeForPrepare:
+      return "O2";
+    case kHtpOptimizeForInferenceO3:
+      return "O3";
+  }
+}
+
 // NOLINTEND(*alien-types*)
 
 namespace litert::qualcomm {
@@ -259,6 +300,16 @@ Expected<QualcommOptions> QualcommOptionsFromFlags() {
 
   const std::string ir_json_dir = absl::GetFlag(FLAGS_qualcomm_ir_json_dir);
   opts.SetIrJsonDir(ir_json_dir);
+
+  const auto vtcm_size = absl::GetFlag(FLAGS_qualcomm_vtcm_size);
+  opts.SetVtcmSize(vtcm_size);
+
+  const auto num_hvx_threads = absl::GetFlag(FLAGS_qualcomm_num_hvx_thread);
+  opts.SetNumHvxThreads(num_hvx_threads);
+
+  const auto optimization_level =
+      absl::GetFlag(FLAGS_qualcomm_optimization_level);
+  opts.SetOptimizationLevel(optimization_level);
 
   return opts;
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -50,6 +50,18 @@ ABSL_DECLARE_FLAG(std::vector<std::string>, qualcomm_dump_tensor_ids);
 
 ABSL_DECLARE_FLAG(std::string, qualcomm_ir_json_dir);
 
+ABSL_DECLARE_FLAG(uint32_t, qualcomm_vtcm_size);
+
+ABSL_DECLARE_FLAG(uint32_t, qualcomm_num_hvx_thread);
+
+ABSL_DECLARE_FLAG(LiteRtQualcommOptionsOptimizationLevel,
+                  qualcomm_optimization_level);
+bool AbslParseFlag(absl::string_view text,
+                   LiteRtQualcommOptionsOptimizationLevel* optimization_level,
+                   std::string* error);
+std::string AbslUnparseFlag(
+    LiteRtQualcommOptionsOptimizationLevel optimization_level);
+
 #endif
 
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -250,6 +250,38 @@ TEST(ProfilingTest, Parse) {
   }
 }
 
+TEST(OptimizationLevelTest, Parse) {
+  std::string error;
+  LiteRtQualcommOptionsOptimizationLevel value;
+
+  {
+    static constexpr absl::string_view kOptimizationLevel = "O1";
+    static constexpr LiteRtQualcommOptionsOptimizationLevel
+        kOptimizationLevelEnum = kHtpOptimizeForInference;
+    EXPECT_TRUE(AbslParseFlag(kOptimizationLevel, &value, &error));
+    EXPECT_EQ(value, kOptimizationLevelEnum);
+    EXPECT_EQ(kOptimizationLevel, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kOptimizationLevel = "O2";
+    static constexpr LiteRtQualcommOptionsOptimizationLevel
+        kOptimizationLevelEnum = kHtpOptimizeForPrepare;
+    EXPECT_TRUE(AbslParseFlag(kOptimizationLevel, &value, &error));
+    EXPECT_EQ(value, kOptimizationLevelEnum);
+    EXPECT_EQ(kOptimizationLevel, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kOptimizationLevel = "O3";
+    static constexpr LiteRtQualcommOptionsOptimizationLevel
+        kOptimizationLevelEnum = kHtpOptimizeForInferenceO3;
+    EXPECT_TRUE(AbslParseFlag(kOptimizationLevel, &value, &error));
+    EXPECT_EQ(value, kOptimizationLevelEnum);
+    EXPECT_EQ(kOptimizationLevel, AbslUnparseFlag(value));
+  }
+}
+
 TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   Expected<QualcommOptions> options = QualcommOptionsFromFlags();
   ASSERT_TRUE(options.HasValue());
@@ -261,6 +293,9 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   EXPECT_EQ(options.Value().GetHtpPerformanceMode(),
             kLiteRtQualcommHtpPerformanceModeBurst);
   EXPECT_TRUE(options.Value().GetDumpTensorIds().empty());
+  EXPECT_EQ(options.Value().GetVtcmSize(), 0);
+  EXPECT_EQ(options.Value().GetNumHvxThreads(), 0);
+  EXPECT_EQ(options.Value().GetOptimizationLevel(), kHtpOptimizeForInferenceO3);
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -112,6 +112,10 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetHtpPerformanceMode(static_cast<::qnn::HtpPerformanceMode>(
       qualcomm_options.GetHtpPerformanceMode()));
   qnn_options.SetIrJsonDir(qualcomm_options.GetIrJsonDir());
+  qnn_options.SetVtcmSize(qualcomm_options.GetVtcmSize());
+  qnn_options.SetNumHvxThreads(qualcomm_options.GetNumHvxThreads());
+  qnn_options.SetOptimizationLevel(static_cast<::qnn::OptimizationLevel>(
+      qualcomm_options.GetOptimizationLevel()));
   qnn_options.SetDumpTensorIds(qualcomm_options.GetDumpTensorIds());
   LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
   return kLiteRtStatusOk;

--- a/litert/vendors/qualcomm/compiler/graph_mapper.h
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.h
@@ -64,7 +64,8 @@ class GraphMapper {
   }
 
   // Pick graph config based on subgraph.
-  absl::Span<const QnnGraph_Config_t*> PickGraphConfigHeuristic();
+  absl::Span<const QnnGraph_Config_t*> PickGraphConfigHeuristic(
+      const ::qnn::Options& options);
 
   inline bool IsTensorOutput(LiteRtTensor litert_tensor) {
     return graph_outpus_.contains(litert_tensor);

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -106,6 +106,24 @@ void Options::SetIrJsonDir(absl::string_view ir_json_dir) {
   ir_json_dir_ = ir_json_dir;
 }
 
+std::uint32_t Options::GetVtcmSize() const { return vtcm_size_; }
+
+void Options::SetVtcmSize(std::uint32_t vtcm_size) { vtcm_size_ = vtcm_size; }
+
+std::uint32_t Options::GetNumHvxThreads() const { return num_hvx_threads_; }
+
+void Options::SetNumHvxThreads(std::uint32_t num_hvx_threads) {
+  num_hvx_threads_ = num_hvx_threads;
+}
+
+OptimizationLevel Options::GetOptimizationLevel() const {
+  return optimization_level_;
+}
+
+void Options::SetOptimizationLevel(OptimizationLevel optimization_level) {
+  optimization_level_ = optimization_level;
+}
+
 std::string Options::Dump() const {
   static constexpr absl::string_view kQnnOptionsDumpFormat =
       "\
@@ -117,14 +135,18 @@ UseQint16AsQuint16: %v\n\
 EnableWeightSharing: %v\n\
 HtpPerformanceMode: %d\n\
 DumpTensorIds: %s\n\
-IrJsonDir: %s\n";  // NOLINT
+IrJsonDir: %s\n\
+VtcmSize: %d\n\
+HvxThread: %d\n\
+OptimizationLevel: %d\n";  // NOLINT
 
   std::string dump_tensor_ids = absl::StrJoin(dump_tensor_ids_, ",");
 
   return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, profiling_,
                          use_htp_preference_, use_qint16_as_quint16_,
                          enable_weight_sharing_, htp_performance_mode_,
-                         dump_tensor_ids, ir_json_dir_);
+                         dump_tensor_ids, ir_json_dir_, vtcm_size_,
+                         num_hvx_threads_, optimization_level_);
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -50,6 +50,12 @@ enum class HtpPerformanceMode {
   kExtremePowerSaver = 9,
 };
 
+enum class OptimizationLevel {
+  kHtpOptimizeForInference = 0,
+  kHtpOptimizeForPrepare = 1,
+  kHtpOptimizeForInferenceO3 = 2,
+};
+
 class Options {
  public:
   Options() = default;
@@ -82,6 +88,15 @@ class Options {
   absl::string_view GetIrJsonDir() const;
   void SetIrJsonDir(absl::string_view ir_json_dir);
 
+  std::uint32_t GetVtcmSize() const;
+  void SetVtcmSize(std::uint32_t vtcm_size);
+
+  std::uint32_t GetNumHvxThreads() const;
+  void SetNumHvxThreads(std::uint32_t num_hvx_threads);
+
+  void SetOptimizationLevel(OptimizationLevel optimization_level);
+  OptimizationLevel GetOptimizationLevel() const;
+
   std::string Dump() const;
 
  private:
@@ -94,6 +109,10 @@ class Options {
   HtpPerformanceMode htp_performance_mode_ = HtpPerformanceMode::kDefault;
   std::vector<std::int32_t> dump_tensor_ids_;
   std::string ir_json_dir_;
+  std::uint32_t vtcm_size_;
+  std::uint32_t num_hvx_threads_;
+  OptimizationLevel optimization_level_ =
+      OptimizationLevel::kHtpOptimizeForInferenceO3;
 };
 
 // Gets a default logger implementation to stdout.

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -134,6 +134,36 @@ TEST(QnnOptionTest, SetIrJsonDir) {
   EXPECT_TRUE(options.GetIrJsonDir().empty());
 }
 
+TEST(QnnOptionTest, SetVtcmSize) {
+  Options options;
+  options.SetVtcmSize(4);
+  EXPECT_NE(options.GetVtcmSize(), 0);
+  EXPECT_EQ(options.GetVtcmSize(), 4);
+  options.SetVtcmSize(0);
+  EXPECT_EQ(options.GetVtcmSize(), 0);
+}
+
+TEST(QnnOptionTest, SetHvxThread) {
+  Options options;
+  options.SetNumHvxThreads(4);
+  EXPECT_NE(options.GetNumHvxThreads(), 0);
+  EXPECT_EQ(options.GetNumHvxThreads(), 4);
+  options.SetNumHvxThreads(0);
+  EXPECT_EQ(options.GetNumHvxThreads(), 0);
+}
+
+TEST(QnnOptionTest, SetOptimizationLevel) {
+  Options options;
+  options.SetOptimizationLevel(OptimizationLevel::kHtpOptimizeForPrepare);
+  EXPECT_NE(options.GetOptimizationLevel(),
+            OptimizationLevel::kHtpOptimizeForInferenceO3);
+  EXPECT_EQ(options.GetOptimizationLevel(),
+            OptimizationLevel::kHtpOptimizeForPrepare);
+  options.SetOptimizationLevel(OptimizationLevel::kHtpOptimizeForInferenceO3);
+  EXPECT_EQ(options.GetOptimizationLevel(),
+            OptimizationLevel::kHtpOptimizeForInferenceO3);
+}
+
 TEST(QnnOptionTest, Default) {
   Options options;
   EXPECT_EQ(options.GetLogLevel(), LogLevel::kInfo);
@@ -144,6 +174,10 @@ TEST(QnnOptionTest, Default) {
   EXPECT_FALSE(options.GetEnableWeightSharing());
   EXPECT_EQ(options.GetHtpPerformanceMode(), HtpPerformanceMode::kDefault);
   EXPECT_TRUE(options.GetIrJsonDir().empty());
+  EXPECT_EQ(options.GetVtcmSize(), 0);
+  EXPECT_EQ(options.GetNumHvxThreads(), 0);
+  EXPECT_EQ(options.GetOptimizationLevel(),
+            OptimizationLevel::kHtpOptimizeForInferenceO3);
 }
 
 }  // namespace


### PR DESCRIPTION
Summary:
- Enable vtcm_size, hvx_thread, optimization_level in compilation flow
- Add related tests

Test Result:

- Pass with run_model in JIT mode (online prepare) for vtcm_size & hvx_thread & optimization_level
- Pass with apply_plugin_main flow (offline prepare) with specific vtcm_size & hvx_thread & optimization_level
- Pass unit tests

======================== Test Summary ========================
//litert/vendors/qualcomm/core/utils:utils_test
[----------] Global test environment tear-down
[==========] 11 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 11 tests.

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[----------] Global test environment tear-down
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:common_test
[----------] Global test environment tear-down
[==========] 10 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 10 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (51 ms total)
[  PASSED  ] 2 tests.

//litert/c/options:litert_qualcomm_options_test
[----------] Global test environment tear-down
[==========] 14 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

//litert/c:litert_op_options_test
[----------] Global test environment tear-down
[==========] 33 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 33 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[----------] Global test environment tear-down
[==========] 8 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[----------] Global test environment tear-down
[==========] 200 tests from 4 test suites ran. (14446 ms total)
[  PASSED  ] 200 tests.