### PR TITLE
Qualcomm AI Engine Direct - Pass Profiling Level via Option.

### DIFF
--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -91,9 +91,11 @@ ABSL_FLAG(bool, qualcomm_use_qint16_as_quint16, false,
           "Whether to automatically convert a quantized int16 model into a "
           "quantized uin16 model.");
 
+// Default should be kLiteRtQualcommHtpPerformanceModeDefault since we need
+// default performance model during compilation.
 ABSL_FLAG(LiteRtQualcommOptionsHtpPerformanceMode,
-          qualcomm_htp_performance_mode, kLiteRtQualcommHtpPerformanceModeBurst,
-          "HTP performance mode.");
+          qualcomm_htp_performance_mode,
+          kLiteRtQualcommHtpPerformanceModeDefault, "HTP performance mode.");
 
 ABSL_FLAG(std::vector<std::string>, qualcomm_dump_tensor_ids, {},
           "Debug Feature. Ids to dump as outputs. Comma-separated list of "

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -259,7 +259,7 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   EXPECT_FALSE(options.Value().GetUseQint16AsQuint16());
   EXPECT_FALSE(options.Value().GetEnableWeightSharing());
   EXPECT_EQ(options.Value().GetHtpPerformanceMode(),
-            kLiteRtQualcommHtpPerformanceModeBurst);
+            kLiteRtQualcommHtpPerformanceModeDefault);
   EXPECT_TRUE(options.Value().GetDumpTensorIds().empty());
 }
 

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -238,8 +238,6 @@ class LiteRtCompilerPluginT {
     if (qualcomm_options_.HasValue()) {
       InitQnnOptions(qnn_options_, qualcomm_options_.Value());
     }
-    // Reset performance options to default for compilation.
-    qnn_options_.SetHtpPerformanceMode(::qnn::HtpPerformanceMode::kDefault);
   }
 
   const ::qnn::Options& Options() const { return qnn_options_; }

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
@@ -153,11 +153,8 @@ LiteRtDispatchInvocationContextT::Create(
   }
 
   auto configs = QnnManager::DefaultContextConfigs();
-
-  // TODO: Add profiling_level as an option & related test code with different
-  // profiling level after having option interface
-  auto profiling_level = ::qnn::Profiling::kOff;
-
+  
+  auto profiling_level = qnn.GetOptions().GetProfiling();
   Qnn_ProfileHandle_t profile_handle = nullptr;
   if (profiling_level != ::qnn::Profiling::kOff) {
     if (auto status = qnn.Api()->profileCreate(

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -356,14 +356,15 @@ LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
   LITERT_RETURN_IF_ERROR(LoadSystemLib(kLibQnnSystemSo));
   LITERT_RETURN_IF_ERROR(ResolveSystemApi());
 
-  switch (options.GetBackendType()) {
+  options_ = options;
+  switch (options_.GetBackendType()) {
     case ::qnn::BackendType::kHtpBackend: {
       LITERT_RETURN_IF_ERROR(LoadLib(::qnn::HtpBackend::GetLibraryName()));
       LITERT_RETURN_IF_ERROR(
           ResolveApi(::qnn::HtpBackend::GetExpectedBackendVersion()));
 
       backend_ = std::make_unique<::qnn::HtpBackend>(Api());
-      LITERT_RETURN_IF_ERROR(backend_->Init(options, soc_info));
+      LITERT_RETURN_IF_ERROR(backend_->Init(options_, soc_info));
       auto* htp_backend = dynamic_cast<::qnn::HtpBackend*>(backend_.get());
       if (!htp_backend) {
         LITERT_LOG(LITERT_ERROR, "dynamic_cast to HtpBackend failed");
@@ -379,13 +380,13 @@ LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
           ResolveApi(::qnn::IrBackend::GetExpectedBackendVersion()));
 
       backend_ = std::make_unique<::qnn::IrBackend>(Api());
-      LITERT_RETURN_IF_ERROR(backend_->Init(options, std::nullopt));
+      LITERT_RETURN_IF_ERROR(backend_->Init(options_, std::nullopt));
 
       break;
     }
     default: {
       LITERT_LOG(LITERT_ERROR, "Unsupported backend type: %d",
-                 options.GetBackendType());
+                 options_.GetBackendType());
       return kLiteRtStatusErrorRuntimeFailure;
     }
   }

--- a/litert/vendors/qualcomm/qnn_manager.h
+++ b/litert/vendors/qualcomm/qnn_manager.h
@@ -134,6 +134,8 @@ class QnnManager {
   // called.
   Qnn_BackendHandle_t BackendHandle() { return backend_->GetBackendHandle(); }
 
+  const ::qnn::Options& GetOptions() const { return options_; }
+
  private:
   QnnManager() = default;
 
@@ -182,6 +184,7 @@ class QnnManager {
 
   std::unique_ptr<::qnn::QnnBackend> backend_ = nullptr;
   ::qnn::SocInfo soc_info_ = ::qnn::kSocInfos[7];  // V75
+  ::qnn::Options options_;
 };
 
 // Unfortunately we can't use std::unique_ptr with a deleter because

--- a/litert/vendors/qualcomm/qnn_manager_test.cc
+++ b/litert/vendors/qualcomm/qnn_manager_test.cc
@@ -44,4 +44,23 @@ TEST(QnnManagerTest, Dump) {
   EXPECT_THAT(dump, HasSubstr("< QnnSystemInterface_t >"));
 }
 
+TEST(QnnManagerTest, GetOptions) {
+  auto options = ::qnn::Options();
+  auto qnn = QnnManager::Create(options);
+  ASSERT_TRUE(qnn);
+
+  const auto& options_ref = (*qnn)->GetOptions();
+  EXPECT_EQ(options.GetLogLevel(), options_ref.GetLogLevel());
+  EXPECT_EQ(options.GetProfiling(), options_ref.GetProfiling());
+  EXPECT_EQ(options.GetUseHtpPreference(), options_ref.GetUseHtpPreference());
+  EXPECT_EQ(options.GetUseQint16AsQuint16(),
+            options_ref.GetUseQint16AsQuint16());
+  EXPECT_EQ(options.GetEnableWeightSharing(),
+            options_ref.GetEnableWeightSharing());
+  EXPECT_EQ(options.GetHtpPerformanceMode(),
+            options_ref.GetHtpPerformanceMode());
+  EXPECT_EQ(options.GetDumpTensorIds(), options_ref.GetDumpTensorIds());
+  EXPECT_EQ(options.GetIrJsonDir(), options_ref.GetIrJsonDir());
+}
+
 }  // namespace


### PR DESCRIPTION
Summary:
- Remove hardcoded profiling level in dispatch.
- Save a copy of option in qnn manager.

# Test
```
//litert/vendors/qualcomm/core/utils:utils_test
[----------] Global test environment tear-down
[==========] 11 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 11 tests.

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[----------] Global test environment tear-down
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[----------] Global test environment tear-down
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[----------] Global test environment tear-down
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (51 ms total)
[  PASSED  ] 3 tests.

//litert/c/options:litert_qualcomm_options_test
[----------] Global test environment tear-down
[==========] 11 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 11 tests.

//litert/c:litert_op_options_test
[----------] Global test environment tear-down
[==========] 33 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 33 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[----------] Global test environment tear-down
[==========] 7 tests from 4 test suites ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[----------] Global test environment tear-down
[==========] 200 tests from 4 test suites ran. (37504 ms total)
[  PASSED  ] 200 tests.
```