### PR TITLE
Qualcomm AI Engine Direct - Convert FC bias from int64 to int32

### DIFF
--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -98,6 +98,7 @@ cc_library(
     deps = [
         ":op_builder",
         "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/utils:log",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
         "@qairt//:qnn_lib_headers",


### PR DESCRIPTION
### Summary:
1. int64 bias is not supported in QNN, convert it to int32 to pass op validation.
2. Assume the value of bias won't exceed the range of int32.

### TEST:
- op validation pass for the FC ops in new Gemma3n 2b.
