### PR TITLE
Qualcomm AI Engine Direct - Check build id in the debugger.

### DIFF
--- a/litert/vendors/qualcomm/debugger/optrace_profiling/run.py
+++ b/litert/vendors/qualcomm/debugger/optrace_profiling/run.py
@@ -87,12 +87,10 @@ def _get_ctx_bin_info(ctx_bin_path: str, qairt_sdk: Path) -> dict[str, Any]:
   if version_parse(bin_id) == version_parse(qairt_id):
     logging.info("Build ID matches.")
   else:
-    logging.warning(
-        "Ensure the context binary '%s' is built with the same SDK"
-        " version '%s'.",
-        bin_id,
-        qairt_id,
-    )
+    raise RuntimeError(
+            f"The context binary is compiled with BUILD ID: {bin_id} "
+            f"!= current qairt sdk BUILD ID: {qairt_id}"
+        )
   return json_data["info"]
 
 
@@ -365,7 +363,7 @@ def _generate_ctx_bin(model_path: Path, soc_model: str) -> Path:
       *bazel_run,
       "//litert/tools:apply_plugin_main",
       "--",
-      f"--libs={_LITERT_ROOT / 'bazel-bin/litert/vendors/qualcomm/compiler'}",
+      "--libs=litert/vendors/qualcomm/compiler",
       "--cmd=apply",
       f"--model={model_path}",
       f"--o={tmp_tflite_path}",


### PR DESCRIPTION
Summary:
- Check build id between context binary and current qairt sdk to avoid qairt feature mismatch.

# Test
```
RuntimeError: The context binary is compiled with BUILD ID: v2.41.0.251103115413_190331 != current qairt sdk BUILD ID: v2.39.0.250925215840_163802
```