### PR TITLE
Handle all exceptions inside intel_openvino

### DIFF
--- a/litert/vendors/intel_openvino/dispatch/BUILD
+++ b/litert/vendors/intel_openvino/dispatch/BUILD
@@ -34,7 +34,6 @@ litert_dynamic_lib(
     ],
     copts = [
         "-Os",
-        "-fno-exceptions",
         "-fno-unwind-tables",
         "-fno-asynchronous-unwind-tables",
         "-ffunction-sections",


### PR DESCRIPTION
Google's coding guidlines discourage usage of exceptions. This change handles exceptions within the intel_openvino libraries.