### PR TITLE
Qualcomm AI Engine Direct - Enable ConvHMX and FoldReLU options.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -34,6 +34,8 @@ struct LiteRtQualcommOptionsT {
   bool use_htp_preference = false;
   bool use_qint16_as_quint16 = false;
   bool enable_weight_sharing = false;
+  bool use_conv_hmx = true;
+  bool use_fold_relu = true;
   LiteRtQualcommOptionsHtpPerformanceMode htp_performance_mode =
       kLiteRtQualcommHtpPerformanceModeDefault;
   std::vector<std::int32_t> dump_tensor_ids;
@@ -239,6 +241,50 @@ LiteRtStatus LiteRtQualcommOptionsGetDumpTensorIds(
   }
   *ids = options->dump_tensor_ids.data();
   *number_of_ids = options->dump_tensor_ids.size();
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetUseConvHMX(LiteRtQualcommOptions options,
+                                                bool use_conv_hmx) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->use_conv_hmx = use_conv_hmx;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetUseConvHMX(LiteRtQualcommOptions options,
+                                                bool* use_conv_hmx) {
+  if (use_conv_hmx == nullptr || options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *use_conv_hmx = options->use_conv_hmx;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetUseFoldReLU(LiteRtQualcommOptions options,
+                                                 bool use_fold_relu) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->use_fold_relu = use_fold_relu;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetUseFoldReLU(LiteRtQualcommOptions options,
+                                                 bool* use_fold_relu) {
+  if (use_fold_relu == nullptr || options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *use_fold_relu = options->use_fold_relu;
+
   return kLiteRtStatusOk;
 }
 

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -109,6 +109,26 @@ LiteRtStatus LiteRtQualcommOptionsSetDumpTensorIds(
 LiteRtStatus LiteRtQualcommOptionsGetDumpTensorIds(
     LiteRtQualcommOptions options, int32_t** ids, uint32_t* number_of_ids);
 
+// When using short conv hmx, one might have better performance, but convolution
+// that have short depth and/or weights that are not symmetric could exhibit
+// inaccurate results.
+
+LiteRtStatus LiteRtQualcommOptionsSetUseConvHMX(LiteRtQualcommOptions options,
+                                                bool use_conv_hmx);
+
+LiteRtStatus LiteRtQualcommOptionsGetUseConvHMX(LiteRtQualcommOptions options,
+                                                bool* use_conv_hmx);
+
+// When using fold relu, one might have better performance. This optimization is
+// correct when quantization ranges for convolution are equal to or are subset
+// of the Relu operation.
+
+LiteRtStatus LiteRtQualcommOptionsSetUseFoldReLU(LiteRtQualcommOptions options,
+                                                 bool use_fold_relu);
+
+LiteRtStatus LiteRtQualcommOptionsGetUseFoldReLU(LiteRtQualcommOptions options,
+                                                 bool* use_fold_relu);
+
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////
 
 // htp_performance_mode

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -245,6 +245,40 @@ TEST(LiteRtQualcommOptionsTest, DumpTensorIds) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
+TEST(LiteRtQualcommOptionsTest, UseConvHMX) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetUseConvHMX(qualcomm_options, true));
+
+  bool use_conv_hmx;
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsGetUseConvHMX(qualcomm_options, &use_conv_hmx));
+  EXPECT_TRUE(use_conv_hmx);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
+TEST(LiteRtQualcommOptionsTest, UseFoldReLU) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetUseFoldReLU(qualcomm_options, true));
+
+  bool use_fold_relu;
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsGetUseFoldReLU(qualcomm_options, &use_fold_relu));
+  EXPECT_TRUE(use_fold_relu);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
 TEST(QualcommOptionsTest, CppApi) {
   auto options = QualcommOptions::Create();
   ASSERT_TRUE(options);
@@ -298,6 +332,14 @@ TEST(QualcommOptionsTest, CppApi) {
   EXPECT_EQ(options->GetOptimizationLevel(), kHtpOptimizeForInferenceO3);
   options->SetOptimizationLevel(kHtpOptimizeForPrepare);
   EXPECT_EQ(options->GetOptimizationLevel(), kHtpOptimizeForPrepare);
+
+  EXPECT_TRUE(options->GetUseConvHMX());
+  options->SetUseConvHMX(false);
+  EXPECT_FALSE(options->GetUseConvHMX());
+
+  EXPECT_TRUE(options->GetUseFoldReLU());
+  options->SetUseFoldReLU(false);
+  EXPECT_FALSE(options->GetUseFoldReLU());
 }
 
 TEST(QualcommOptionsTest, FindFromChain) {

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -183,6 +183,28 @@ LiteRtQualcommOptionsOptimizationLevel QualcommOptions::GetOptimizationLevel() {
   return optimization_level;
 }
 
+void QualcommOptions::SetUseConvHMX(bool use_conv_hmx) {
+  internal::AssertOk(LiteRtQualcommOptionsSetUseConvHMX, Data(), use_conv_hmx);
+}
+
+bool QualcommOptions::GetUseConvHMX() {
+  bool use_conv_hmx;
+  internal::AssertOk(LiteRtQualcommOptionsGetUseConvHMX, Data(), &use_conv_hmx);
+  return use_conv_hmx;
+}
+
+void QualcommOptions::SetUseFoldReLU(bool use_fold_relu) {
+  internal::AssertOk(LiteRtQualcommOptionsSetUseFoldReLU, Data(),
+                     use_fold_relu);
+}
+
+bool QualcommOptions::GetUseFoldReLU() {
+  bool use_fold_relu;
+  internal::AssertOk(LiteRtQualcommOptionsGetUseFoldReLU, Data(),
+                     &use_fold_relu);
+  return use_fold_relu;
+}
+
 Expected<QualcommOptions> QualcommOptions::Create(OpaqueOptions& options) {
   const auto id = options.GetIdentifier();
   if (!id || *id != Discriminator()) {

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -57,6 +57,12 @@ class QualcommOptions : public OpaqueOptions {
   void SetEnableWeightSharing(bool weight_sharing_enabled);
   bool GetEnableWeightSharing();
 
+  void SetUseConvHMX(bool use_conv_hmx);
+  bool GetUseConvHMX();
+
+  void SetUseFoldReLU(bool use_fold_relu);
+  bool GetUseFoldReLU();
+
   void SetProfiling(LiteRtQualcommOptionsProfiling profiling);
   LiteRtQualcommOptionsProfiling GetProfiling();
 

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -265,6 +265,16 @@ std::string AbslUnparseFlag(
   }
 }
 
+ABSL_FLAG(bool, qualcomm_use_conv_hmx, true,
+          "When using short conv hmx, one might have better performance, but "
+          "convolution that have short depth and/or weights that are not "
+          "symmetric could exhibit inaccurate results.");
+
+ABSL_FLAG(bool, qualcomm_use_fold_relu, true,
+          "When using fold relu, one might have better performance. This "
+          "optimization is correct when quantization ranges for convolution "
+          "are equal to or are subset of the Relu operation.");
+
 // NOLINTEND(*alien-types*)
 
 namespace litert::qualcomm {
@@ -313,6 +323,12 @@ Expected<QualcommOptions> QualcommOptionsFromFlags() {
   const auto optimization_level =
       absl::GetFlag(FLAGS_qualcomm_optimization_level);
   opts.SetOptimizationLevel(optimization_level);
+
+  const auto use_conv_hmx = absl::GetFlag(FLAGS_qualcomm_use_conv_hmx);
+  opts.SetUseConvHMX(use_conv_hmx);
+
+  const auto use_fold_relu = absl::GetFlag(FLAGS_qualcomm_use_fold_relu);
+  opts.SetUseFoldReLU(use_fold_relu);
 
   return opts;
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -62,6 +62,10 @@ bool AbslParseFlag(absl::string_view text,
 std::string AbslUnparseFlag(
     LiteRtQualcommOptionsOptimizationLevel optimization_level);
 
+ABSL_DECLARE_FLAG(bool, qualcomm_use_conv_hmx);
+
+ABSL_DECLARE_FLAG(bool, qualcomm_use_fold_relu);
+
 #endif
 
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -290,6 +290,8 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   EXPECT_FALSE(options.Value().GetUseHtpPreference());
   EXPECT_FALSE(options.Value().GetUseQint16AsQuint16());
   EXPECT_FALSE(options.Value().GetEnableWeightSharing());
+  EXPECT_TRUE(options.Value().GetUseConvHMX());
+  EXPECT_TRUE(options.Value().GetUseFoldReLU());
   EXPECT_EQ(options.Value().GetHtpPerformanceMode(),
             kLiteRtQualcommHtpPerformanceModeDefault);
   EXPECT_TRUE(options.Value().GetDumpTensorIds().empty());

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -109,6 +109,8 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetUseHtpPreference(qualcomm_options.GetUseHtpPreference());
   qnn_options.SetUseQint16AsQuint16(qualcomm_options.GetUseQint16AsQuint16());
   qnn_options.SetEnableWeightSharing(qualcomm_options.GetEnableWeightSharing());
+  qnn_options.SetUseConvHMX(qualcomm_options.GetUseConvHMX());
+  qnn_options.SetUseFoldReLU(qualcomm_options.GetUseFoldReLU());
   qnn_options.SetHtpPerformanceMode(static_cast<::qnn::HtpPerformanceMode>(
       qualcomm_options.GetHtpPerformanceMode()));
   qnn_options.SetIrJsonDir(qualcomm_options.GetIrJsonDir());

--- a/litert/vendors/qualcomm/compiler/graph_mapper.cc
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.cc
@@ -38,9 +38,9 @@ namespace litert::qnn {
 
 inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
     const ::qnn::Options& options) {
-  static std::array<QnnHtpGraph_CustomConfig_t, 5> graph_custom_configs;
-  static std::array<QnnGraph_Config_t, 5> graph_configs;
-  static std::array<const QnnGraph_Config_t*, 6> result;
+  static std::array<QnnHtpGraph_CustomConfig_t, 6> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 6> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 7> result;
 
   // QNN suggest always enable relax precision.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
@@ -63,18 +63,24 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
   graph_custom_configs[3] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[3].option =
       QNN_HTP_GRAPH_CONFIG_OPTION_FOLD_RELU_ACTIVATION_INTO_CONV_OFF;
-  graph_custom_configs[3].foldReluActivationIntoConvOff = true;
+  graph_custom_configs[3].foldReluActivationIntoConvOff =
+      !options.GetUseFoldReLU();
+  // ConvHMX Off
+  graph_custom_configs[4] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+  graph_custom_configs[4].option =
+      QNN_HTP_GRAPH_CONFIG_OPTION_SHORT_DEPTH_CONV_ON_HMX_OFF;
+  graph_custom_configs[4].shortDepthConvOnHmxOff = !options.GetUseConvHMX();
 
   // Hvx Thread
   bool has_hvx = options.GetNumHvxThreads() != 0;
   if (has_hvx) {
-    graph_custom_configs[4] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
-    graph_custom_configs[4].option =
+    graph_custom_configs[5] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[5].option =
         QNN_HTP_GRAPH_CONFIG_OPTION_NUM_HVX_THREADS;
-    graph_custom_configs[4].numHvxThreads = options.GetNumHvxThreads();
+    graph_custom_configs[5].numHvxThreads = options.GetNumHvxThreads();
   }
 
-  size_t num_config = has_hvx ? 5 : 4;
+  size_t num_config = has_hvx ? 6 : 5;
   for (size_t i = 0; i < num_config; ++i) {
     graph_configs[i] = QNN_GRAPH_CONFIG_INIT;
     graph_configs[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
@@ -88,9 +94,9 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
 
 inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
     const ::qnn::Options& options) {
-  static std::array<QnnHtpGraph_CustomConfig_t, 4> graph_custom_configs;
-  static std::array<QnnGraph_Config_t, 4> graph_configs;
-  static std::array<const QnnGraph_Config_t*, 5> result;
+  static std::array<QnnHtpGraph_CustomConfig_t, 5> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 5> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 6> result;
   // Default use O3 for now.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[0].option = QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
@@ -109,18 +115,24 @@ inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
   graph_custom_configs[2] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[2].option =
       QNN_HTP_GRAPH_CONFIG_OPTION_FOLD_RELU_ACTIVATION_INTO_CONV_OFF;
-  graph_custom_configs[2].foldReluActivationIntoConvOff = true;
+  graph_custom_configs[2].foldReluActivationIntoConvOff =
+      !options.GetUseFoldReLU();
+  // ConvHMX Off
+  graph_custom_configs[3] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+  graph_custom_configs[3].option =
+      QNN_HTP_GRAPH_CONFIG_OPTION_SHORT_DEPTH_CONV_ON_HMX_OFF;
+  graph_custom_configs[3].shortDepthConvOnHmxOff = !options.GetUseConvHMX();
 
   // Hvx Thread
   bool has_hvx = options.GetNumHvxThreads() != 0;
   if (has_hvx) {
-    graph_custom_configs[3] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
-    graph_custom_configs[3].option =
+    graph_custom_configs[4] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[4].option =
         QNN_HTP_GRAPH_CONFIG_OPTION_NUM_HVX_THREADS;
-    graph_custom_configs[3].numHvxThreads = options.GetNumHvxThreads();
+    graph_custom_configs[4].numHvxThreads = options.GetNumHvxThreads();
   }
 
-  size_t num_config = has_hvx ? 4 : 3;
+  size_t num_config = has_hvx ? 5 : 4;
   for (size_t i = 0; i < num_config; ++i) {
     graph_configs[i] = QNN_GRAPH_CONFIG_INIT;
     graph_configs[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -84,6 +84,16 @@ void Options::SetEnableWeightSharing(bool enable_weight_sharing) {
 
 bool Options::GetEnableWeightSharing() const { return enable_weight_sharing_; }
 
+void Options::SetUseConvHMX(bool use_conv_hmx) { use_conv_hmx_ = use_conv_hmx; }
+
+bool Options::GetUseConvHMX() const { return use_conv_hmx_; }
+
+void Options::SetUseFoldReLU(bool use_fold_relu) {
+  use_fold_relu_ = use_fold_relu;
+}
+
+bool Options::GetUseFoldReLU() const { return use_fold_relu_; }
+
 void Options::SetHtpPerformanceMode(HtpPerformanceMode htp_performance_mode) {
   htp_performance_mode_ = htp_performance_mode;
 }
@@ -133,6 +143,8 @@ Profiling: %d\n\
 UseHtpPreference: %v\n\
 UseQint16AsQuint16: %v\n\
 EnableWeightSharing: %v\n\
+UseConvHMX: %v\n\
+UseFoldReLU: %v\n\
 HtpPerformanceMode: %d\n\
 DumpTensorIds: %s\n\
 IrJsonDir: %s\n\
@@ -144,9 +156,9 @@ OptimizationLevel: %d\n";  // NOLINT
 
   return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, profiling_,
                          use_htp_preference_, use_qint16_as_quint16_,
-                         enable_weight_sharing_, htp_performance_mode_,
-                         dump_tensor_ids, ir_json_dir_, vtcm_size_,
-                         num_hvx_threads_, optimization_level_);
+                         enable_weight_sharing_, use_conv_hmx_, use_fold_relu_,
+                         htp_performance_mode_, dump_tensor_ids, ir_json_dir_,
+                         vtcm_size_, num_hvx_threads_, optimization_level_);
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -78,6 +78,12 @@ class Options {
   void SetEnableWeightSharing(bool enable_weight_sharing);
   bool GetEnableWeightSharing() const;
 
+  void SetUseConvHMX(bool use_conv_hmx);
+  bool GetUseConvHMX() const;
+
+  void SetUseFoldReLU(bool use_fold_relu);
+  bool GetUseFoldReLU() const;
+
   void SetHtpPerformanceMode(HtpPerformanceMode htp_performance_mode);
   HtpPerformanceMode GetHtpPerformanceMode() const;
 
@@ -106,6 +112,8 @@ class Options {
   bool use_htp_preference_ = false;
   bool use_qint16_as_quint16_ = false;
   bool enable_weight_sharing_ = false;
+  bool use_conv_hmx_ = true;
+  bool use_fold_relu_ = true;
   HtpPerformanceMode htp_performance_mode_ = HtpPerformanceMode::kDefault;
   std::vector<std::int32_t> dump_tensor_ids_;
   std::string ir_json_dir_;

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -125,6 +125,22 @@ TEST(QnnOptionTest, EnableWeightSharing) {
   EXPECT_EQ(options.GetEnableWeightSharing(), false);
 }
 
+TEST(QnnOptionTest, UseConvHMX) {
+  Options options;
+  options.SetUseConvHMX(true);
+  EXPECT_EQ(options.GetUseConvHMX(), true);
+  options.SetUseConvHMX(false);
+  EXPECT_EQ(options.GetUseConvHMX(), false);
+}
+
+TEST(QnnOptionTest, UseFoldReLU) {
+  Options options;
+  options.SetUseFoldReLU(true);
+  EXPECT_EQ(options.GetUseFoldReLU(), true);
+  options.SetUseFoldReLU(false);
+  EXPECT_EQ(options.GetUseFoldReLU(), false);
+}
+
 TEST(QnnOptionTest, SetIrJsonDir) {
   Options options;
   options.SetIrJsonDir("tmp/");
@@ -172,6 +188,8 @@ TEST(QnnOptionTest, Default) {
   EXPECT_FALSE(options.GetUseHtpPreference());
   EXPECT_FALSE(options.GetUseQint16AsQuint16());
   EXPECT_FALSE(options.GetEnableWeightSharing());
+  EXPECT_TRUE(options.GetUseConvHMX());
+  EXPECT_TRUE(options.GetUseFoldReLU());
   EXPECT_EQ(options.GetHtpPerformanceMode(), HtpPerformanceMode::kDefault);
   EXPECT_TRUE(options.GetIrJsonDir().empty());
   EXPECT_EQ(options.GetVtcmSize(), 0);


### PR DESCRIPTION
# WHAT
- Enable ConvHMX option.
- Enable FoldReLU option.
- Enable them by default to align the behavior of QAIRT.


# TEST
======================== Test Summary ========================
//litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

//litert/vendors/qualcomm/core/backends:qnn_backend_test
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
YOU HAVE 4 DISABLED TESTS

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:common_test
[==========] 13 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (186 ms total)
[  PASSED  ] 3 tests.

//litert/c/options:litert_qualcomm_options_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/c:litert_op_options_test
[==========] 33 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 33 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[==========] 8 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[==========] 208 tests from 4 test suites ran. (27951 ms total)
[  PASSED  ] 208 tests.