### PR TITLE
Qualcomm AI Engine Direct - Optimize fast vlm

### DIFF
--- a/litert/vendors/qualcomm/core/transformation/BUILD
+++ b/litert/vendors/qualcomm/core/transformation/BUILD
@@ -87,6 +87,7 @@ cc_library(
         "//litert/vendors/qualcomm/core/builders:concatenation_op_builder",
         "//litert/vendors/qualcomm/core/builders:reshape_op_builder",
         "//litert/vendors/qualcomm/core/builders:split_op_builder",
+        "//litert/vendors/qualcomm/core/builders:unpack_op_builder",
         "//litert/vendors/qualcomm/core/utils:log",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
@@ -156,6 +156,8 @@ void GraphToGraphTransform(const G2GConfig g2g_option,
     Transform(validate_op_config, ops, tensor_pool, gemma3_mha_prefill,
               OptimizeMHAPrefill);
   }
+
+  // Mask Gemma Optimization
   const std::vector<QnnOpCode> gemma3_mask = {
       QnnOpCode::kElementWiseNot,
       QnnOpCode::kCast,
@@ -165,6 +167,7 @@ void GraphToGraphTransform(const G2GConfig g2g_option,
   Transform(validate_op_config, ops, tensor_pool, gemma3_mask,
             TransformQuantizeInMask);
 
+  // Embedding Gemma Optimization
   const std::vector<QnnOpCode> embedding_gemma = {
       QnnOpCode::kElementWiseMultiply,
       QnnOpCode::kTranspose,
@@ -179,5 +182,27 @@ void GraphToGraphTransform(const G2GConfig g2g_option,
   };
   Transform(validate_op_config, ops, tensor_pool, embedding_gemma,
             TransformEmbeddingGemma);
+
+  // Fast Vlm Optimization
+  const std::vector<QnnOpCode> fast_vlm_mha_prefill = {
+      QnnOpCode::kElementWiseMultiply,
+      QnnOpCode::kReshape,
+      QnnOpCode::kMatMul,
+      QnnOpCode::kMatMul,
+      QnnOpCode::kConcat,
+      QnnOpCode::kReshape,
+      QnnOpCode::kElementWiseAdd,
+      QnnOpCode::kReshape,
+      QnnOpCode::kSoftmax,
+      QnnOpCode::kStridedSlice,
+      QnnOpCode::kStridedSlice,
+      QnnOpCode::kMatMul,
+      QnnOpCode::kMatMul,
+      QnnOpCode::kElementWiseAdd,
+      QnnOpCode::kReshape,
+      QnnOpCode::kTranspose,
+      QnnOpCode::kReshape};
+  Transform(validate_op_config, ops, tensor_pool, fast_vlm_mha_prefill,
+            OptimizeMHAFastVlmPrefill);
 }
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
@@ -17,6 +17,7 @@
 #include "litert/vendors/qualcomm/core/builders/concatenation_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/reshape_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/split_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/unpack_op_builder.h"
 #include "litert/vendors/qualcomm/core/op_code.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/utils/log.h"
@@ -61,13 +62,13 @@ constexpr size_t kSlice3rdAxisEndIndex = 7;
 // This function copies the source_op and updates the tensors according to
 // inputs and outputs. The std::nullopt input/output element indicates that the
 // tensor will not be updated.
-void EmplaceOpWithIO(
+OpWrapper& EmplaceOpWithIO(
     std::vector<OpWrapper>& new_ops, const OpWrapper& source_op,
     const std::vector<std::optional<qnn::TensorWrapperRef>>& inputs,
     const std::vector<std::optional<qnn::TensorWrapperRef>>& outputs) {
   OpWrapper ret = source_op;
   ret.UpdateTensors(inputs, outputs);
-  new_ops.emplace_back(ret);
+  return new_ops.emplace_back(ret);
 }
 
 TensorWrapper& BuildSingleSHA(std::vector<OpWrapper>& ops, size_t start_index,
@@ -189,6 +190,165 @@ TensorWrapper& BuildSingleSHA(std::vector<OpWrapper>& ops, size_t start_index,
   EmplaceOpWithIO(new_ops, ops[start_index + kAdd2Index],
                   {matmul1_v_output, matmul2_v_output}, {add_final_output});
   return add_final_output;
+}
+
+TensorWrapper& BuildSingleSHA(
+    std::vector<OpWrapper>& new_ops, TensorPool& tensor_pool,
+    TensorWrapper& v_cache, TensorWrapper& q_slice,
+    TensorWrapper& sha_mul_input, TensorWrapper& sha_add_input_1,
+    TensorWrapper& sha_add_input_2, TensorWrapper& v_slice,
+    const uint32_t num_attn_per_kv_heads, const OpWrapper& mul,
+    const OpWrapper& matmul_k1, const OpWrapper& add_1,
+    const OpWrapper& matmul_k2, const OpWrapper& concat, const OpWrapper& add_2,
+    const OpWrapper& reshape_3, const OpWrapper& softmax,
+    const OpWrapper& slice_1, const OpWrapper& slice_2,
+    const OpWrapper& matmul_v1, const OpWrapper& matmul_v2,
+    const OpWrapper& add_3) {
+  // Mul
+  auto mul_output_dims = mul.GetOutputTensor(0).GetDims();
+  mul_output_dims.erase(mul_output_dims.begin() + 1);
+  auto& mul_output = tensor_pool.CloneNativeTensorFrom(mul.GetOutputTensor(0),
+                                                       mul_output_dims);
+  EmplaceOpWithIO(new_ops, mul, {sha_mul_input, std::nullopt}, {mul_output});
+
+  // Matmul q
+  auto matmul_q_output_dims = matmul_k1.GetOutputTensor(0).GetDims();
+  matmul_q_output_dims.erase(matmul_q_output_dims.begin() + 1);
+  matmul_q_output_dims[1] /= num_attn_per_kv_heads;
+  auto& matmul_q_output = tensor_pool.CloneNativeTensorFrom(
+      matmul_k1.GetOutputTensor(0), matmul_q_output_dims);
+  EmplaceOpWithIO(new_ops, matmul_k1, {mul_output, q_slice}, {matmul_q_output});
+
+  // Add
+  auto add_1_output_dims = add_1.GetOutputTensor(0).GetDims();
+  add_1_output_dims.erase(add_1_output_dims.begin() + 1);
+  auto& add_1_output = tensor_pool.CloneNativeTensorFrom(
+      add_1.GetOutputTensor(0), add_1_output_dims);
+  EmplaceOpWithIO(new_ops, add_1, {sha_add_input_1, sha_add_input_2},
+                  {add_1_output});
+
+  // Matmul k
+  auto matmul_qk_output_dims = matmul_k2.GetOutputTensor(0).GetDims();
+  matmul_qk_output_dims.erase(matmul_qk_output_dims.begin() + 1);
+  matmul_qk_output_dims[1] /= num_attn_per_kv_heads;
+  auto& matmul_qk_output = tensor_pool.CloneNativeTensorFrom(
+      matmul_k2.GetOutputTensor(0), matmul_qk_output_dims);
+  EmplaceOpWithIO(new_ops, matmul_k2, {mul_output, add_1_output},
+                  {matmul_qk_output});
+
+  // Concat
+  std::uint32_t adjusted_axis = 2;
+  auto concat_output_dims = concat.GetOutputTensor(0).GetDims();
+  concat_output_dims.erase(concat_output_dims.begin() + 1);
+  concat_output_dims[1] /= num_attn_per_kv_heads;
+  auto& concat_output = tensor_pool.CloneNativeTensorFrom(
+      concat.GetOutputTensor(0), concat_output_dims);
+  auto concat_op =
+      BuildConcatenationOp(tensor_pool, {matmul_q_output, matmul_qk_output},
+                           {concat_output}, adjusted_axis);
+  std::move(concat_op.begin(), concat_op.end(), std::back_inserter(new_ops));
+
+  // Add 2
+  auto add_2_output_dims = add_2.GetOutputTensor(0).GetDims();
+  add_2_output_dims[0] = 1;
+  add_2_output_dims[1] = 1;
+  auto& add_2_output = tensor_pool.CloneNativeTensorFrom(
+      add_2.GetOutputTensor(0), add_2_output_dims);
+  EmplaceOpWithIO(new_ops, add_2, {concat_output, std::nullopt},
+                  {add_2_output});
+
+  // Reshape 3
+  auto reshape_3_output_dims = reshape_3.GetOutputTensor(0).GetDims();
+  reshape_3_output_dims.erase(reshape_3_output_dims.begin() + 1);
+  reshape_3_output_dims[1] /= num_attn_per_kv_heads;
+  auto& reshape_3_output = tensor_pool.CloneNativeTensorFrom(
+      reshape_3.GetOutputTensor(0), reshape_3_output_dims);
+  EmplaceOpWithIO(new_ops, reshape_3, {add_2_output}, {reshape_3_output});
+
+  // Softmax
+  auto softmax_output_dims = softmax.GetOutputTensor(0).GetDims();
+  softmax_output_dims.erase(softmax_output_dims.begin() + 1);
+  softmax_output_dims[1] /= num_attn_per_kv_heads;
+  auto& softmax_output = tensor_pool.CloneNativeTensorFrom(
+      softmax.GetOutputTensor(0), softmax_output_dims);
+  EmplaceOpWithIO(new_ops, softmax, {reshape_3_output}, {softmax_output});
+
+  // Slice 1
+  auto slice_1_param = slice_1.GetTensorPararm(0).GetTensor();
+  auto slice_1_param_data = slice_1_param.GetTensorData<int32_t>();
+  std::vector<int32_t> slice_1_ranges(slice_1_param_data.value().begin(),
+                                      slice_1_param_data.value().end());
+  slice_1_ranges.erase(slice_1_ranges.begin() + 3, slice_1_ranges.begin() + 6);
+  slice_1_ranges[4] /= num_attn_per_kv_heads;
+  std::vector<uint32_t> slice_1_param_dims = {
+      static_cast<uint32_t>(slice_1_ranges.size() / 3), 3};
+  auto& slice_1_param_tensor = tensor_pool.CreateStaticTensor(
+      slice_1_param.GetDataType(), slice_1_param.GetQuantParams(),
+      slice_1_param_dims, sizeof(int32_t) * slice_1_ranges.size(),
+      slice_1_ranges.data());
+  auto slice_1_output_dims = slice_1.GetOutputTensor(0).GetDims();
+  slice_1_output_dims.erase(slice_1_output_dims.begin() + 1);
+  slice_1_output_dims[1] /= num_attn_per_kv_heads;
+  auto& slice_1_output = tensor_pool.CloneNativeTensorFrom(
+      slice_1.GetOutputTensor(0), slice_1_output_dims);
+  auto& slice_op_1 =
+      EmplaceOpWithIO(new_ops, slice_1, {softmax_output}, {slice_1_output});
+  slice_op_1.ClearTensorParams();
+  slice_op_1.AddTensorParam(QNN_OP_STRIDED_SLICE_PARAM_RANGES,
+                            slice_1_param_tensor);
+
+  // Slice 2
+  auto slice_2_param = slice_2.GetTensorPararm(0).GetTensor();
+  auto slice_2_param_data = slice_2_param.GetTensorData<int32_t>();
+  std::vector<int32_t> slice_2_ranges(slice_2_param_data.value().begin(),
+                                      slice_2_param_data.value().end());
+  slice_2_ranges.erase(slice_2_ranges.begin() + 3, slice_2_ranges.begin() + 6);
+  slice_2_ranges[4] /= num_attn_per_kv_heads;
+  std::vector<uint32_t> slice_2_param_dims = {
+      static_cast<uint32_t>(slice_2_ranges.size() / 3), 3};
+  auto& slice_2_param_tensor = tensor_pool.CreateStaticTensor(
+      slice_2_param.GetDataType(), slice_2_param.GetQuantParams(),
+      slice_2_param_dims, sizeof(int32_t) * slice_2_ranges.size(),
+      slice_2_ranges.data());
+  auto slice_2_output_dims = slice_2.GetOutputTensor(0).GetDims();
+  slice_2_output_dims.erase(slice_2_output_dims.begin() + 1);
+  slice_2_output_dims[1] /= num_attn_per_kv_heads;
+  auto& slice_2_output = tensor_pool.CloneNativeTensorFrom(
+      slice_2.GetOutputTensor(0), slice_2_output_dims);
+  auto& slice_op_2 =
+      EmplaceOpWithIO(new_ops, slice_2, {softmax_output}, {slice_2_output});
+  slice_op_2.ClearTensorParams();
+  slice_op_2.AddTensorParam(QNN_OP_STRIDED_SLICE_PARAM_RANGES,
+                            slice_2_param_tensor);
+
+  // Matmul v1
+  auto matmul_v1_output_dims = matmul_v1.GetOutputTensor(0).GetDims();
+  matmul_v1_output_dims.erase(matmul_v1_output_dims.begin() + 1);
+  matmul_v1_output_dims[1] /= num_attn_per_kv_heads;
+  auto& matmul_v1_output = tensor_pool.CloneNativeTensorFrom(
+      matmul_v1.GetOutputTensor(0), matmul_v1_output_dims);
+  EmplaceOpWithIO(new_ops, matmul_v1, {slice_1_output, v_cache},
+                  {matmul_v1_output});
+
+  // Matmul v2
+  auto matmul_v2_output_dims = matmul_v2.GetOutputTensor(0).GetDims();
+  matmul_v2_output_dims.erase(matmul_v2_output_dims.begin() + 1);
+  matmul_v2_output_dims[1] /= num_attn_per_kv_heads;
+  auto& matmul_v2_output = tensor_pool.CloneNativeTensorFrom(
+      matmul_v2.GetOutputTensor(0), matmul_v2_output_dims);
+  EmplaceOpWithIO(new_ops, matmul_v2, {slice_2_output, v_slice},
+                  {matmul_v2_output});
+
+  // Add 3
+  auto add_3_output_dims = add_3.GetOutputTensor(0).GetDims();
+  add_3_output_dims.erase(add_3_output_dims.begin() + 1);
+  add_3_output_dims[1] /= num_attn_per_kv_heads;
+  auto& add_3_output = tensor_pool.CloneNativeTensorFrom(
+      add_3.GetOutputTensor(0), add_3_output_dims);
+  EmplaceOpWithIO(new_ops, add_3, {matmul_v1_output, matmul_v2_output},
+                  {add_3_output});
+
+  return add_3_output;
 }
 
 void CloneNamespace(OpWrapper& source, std::vector<OpWrapper>& ops) {
@@ -407,4 +567,225 @@ size_t OptimizeMHADecode(std::function<bool(OpWrapper&)> validate_op_config,
       "[G2G] Validation failed. Rolling back to the original graph.");
   return 1;
 }
+
+size_t OptimizeMHAFastVlmPrefill(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size) {
+  constexpr size_t add_1_index = -2;
+  constexpr size_t mul_index = 0;
+  constexpr size_t reshape_1_index = 1;
+  constexpr size_t matmul_q_index = 2;
+  constexpr size_t matmul_qk_index = 3;
+  constexpr size_t concat_index = 4;
+  constexpr size_t reshape_2_index = 5;
+  constexpr size_t add_2_index = 6;
+  constexpr size_t reshape_3_index = 7;
+  constexpr size_t softmax_index = 8;
+  constexpr size_t slice_1_index = 9;
+  constexpr size_t slice_2_index = 10;
+  constexpr size_t matmul_v1_index = 11;
+  constexpr size_t matmul_v2_index = 12;
+  constexpr size_t add_3_index = 13;
+  constexpr size_t reshape_4_index = 14;
+  constexpr size_t transpose_2_index = 15;
+  constexpr size_t reshape_5_index = 16;
+
+  const auto is_connected =
+      [&ops, &start_index](size_t output_op_index, size_t output_tensor_index,
+                           size_t input_op_index,
+                           size_t input_tensor_index) -> bool {
+    return ops[start_index + output_op_index].GetOutputTensor(
+               output_tensor_index) ==
+           ops[start_index + input_op_index].GetInputTensor(input_tensor_index);
+  };
+  if (!(is_connected(add_1_index, 0, matmul_qk_index, 1) &&
+        is_connected(mul_index, 0, reshape_1_index, 0) &&
+        is_connected(reshape_1_index, 0, matmul_q_index, 0) &&
+        is_connected(reshape_1_index, 0, matmul_qk_index, 0) &&
+        is_connected(matmul_q_index, 0, concat_index, 0) &&
+        is_connected(matmul_qk_index, 0, concat_index, 1) &&
+        is_connected(concat_index, 0, reshape_2_index, 0) &&
+        is_connected(reshape_2_index, 0, add_2_index, 0) &&
+        is_connected(add_2_index, 0, reshape_3_index, 0) &&
+        is_connected(reshape_3_index, 0, softmax_index, 0) &&
+        is_connected(softmax_index, 0, slice_1_index, 0) &&
+        is_connected(softmax_index, 0, slice_2_index, 0) &&
+        is_connected(slice_1_index, 0, matmul_v1_index, 0) &&
+        is_connected(slice_2_index, 0, matmul_v2_index, 0) &&
+        is_connected(matmul_v1_index, 0, add_3_index, 0) &&
+        is_connected(matmul_v2_index, 0, add_3_index, 1) &&
+        is_connected(add_3_index, 0, reshape_4_index, 0) &&
+        is_connected(reshape_4_index, 0, transpose_2_index, 0) &&
+        is_connected(transpose_2_index, 0, reshape_5_index, 0))) {
+    return 1;
+  }
+  QNN_LOG_INFO("[G2G] MHA optimization (fast vlm Prefill)");
+
+  // QKV Unpack
+  const auto& matmul_v1_in =
+      ops[start_index + matmul_v1_index].GetInputTensor(1);
+  auto unpack_1_dims =
+      ops[start_index + matmul_v1_index].GetInputTensor(1).GetDims();
+  uint32_t num_kv_heads = unpack_1_dims[1];
+  const auto& matmul_q_in = ops[start_index + matmul_q_index].GetInputTensor(1);
+  auto unpack_2_dims = matmul_q_in.GetDims();
+  const auto& mul_in = ops[start_index + mul_index].GetInputTensor(0);
+  auto unpack_3_dims = mul_in.GetDims();
+  uint32_t num_attn_heads = unpack_3_dims[1];
+  uint32_t num_attn_per_kv_heads = num_attn_heads / num_kv_heads;
+  const auto& add_1_in_1 = ops[start_index + add_1_index].GetInputTensor(0);
+  auto unpack_4_dims = add_1_in_1.GetDims();
+  const auto& add_1_in_2 = ops[start_index + add_1_index].GetInputTensor(1);
+  auto unpack_5_dims = add_1_in_2.GetDims();
+  const auto& matmul_v2_in =
+      ops[start_index + matmul_v2_index].GetInputTensor(1);
+  auto unpack_6_dims = matmul_v2_in.GetDims();
+  const auto& pattern_output =
+      ops[start_index + pattern_size - 1].GetOutputTensor(0);
+  auto mha_output_dims = pattern_output.GetDims();
+  if (!(num_kv_heads == unpack_2_dims[1] &&
+        num_kv_heads == (unpack_3_dims[1] / 7) &&
+        num_kv_heads == unpack_4_dims[1] && num_kv_heads == unpack_5_dims[1] &&
+        num_kv_heads == unpack_6_dims[1] &&
+        num_kv_heads == (mha_output_dims[1] / 64))) {
+    QNN_LOG_WARNING(
+        "[G2G] num_kv heads: %d not match heads in [unpack_2: %d, unpack_3: "
+        "%d, unpack_4: %d, unpack_5: %d, unpack_6: %d, "
+        "mha_output: %d]",
+        num_kv_heads, unpack_2_dims[1], unpack_3_dims[1] / 7, unpack_4_dims[1],
+        unpack_5_dims[1], unpack_6_dims[1], mha_output_dims[1] / 64);
+    return 1;
+  }
+  QNN_LOG_INFO("[G2G] num_kv_heads match...");
+
+  std::vector<OpWrapper> new_ops;
+  std::vector<TensorWrapperRef> unpack_1_sha_inputs;
+  std::vector<TensorWrapperRef> unpack_2_sha_inputs;
+  std::vector<TensorWrapperRef> unpack_3_sha_inputs;
+  std::vector<TensorWrapperRef> unpack_4_sha_inputs;
+  std::vector<TensorWrapperRef> unpack_5_sha_inputs;
+  std::vector<TensorWrapperRef> unpack_6_sha_inputs;
+
+  unpack_1_dims.erase(unpack_1_dims.begin() + 1);
+  unpack_2_dims.erase(unpack_2_dims.begin() + 1);
+  unpack_3_dims.erase(unpack_3_dims.begin() + 1);
+  unpack_4_dims.erase(unpack_4_dims.begin() + 1);
+  unpack_5_dims.erase(unpack_5_dims.begin() + 1);
+  unpack_6_dims.erase(unpack_6_dims.begin() + 1);
+
+  unpack_1_sha_inputs.reserve(num_kv_heads);
+  unpack_2_sha_inputs.reserve(num_kv_heads);
+  unpack_3_sha_inputs.reserve(num_attn_heads);
+  unpack_4_sha_inputs.reserve(num_kv_heads);
+  unpack_5_sha_inputs.reserve(num_kv_heads);
+  unpack_6_sha_inputs.reserve(num_kv_heads);
+
+  for (int i = 0; i < num_kv_heads; i++) {
+    auto& unpack_1 =
+        tensor_pool.CloneNativeTensorFrom(matmul_v1_in, unpack_1_dims);
+    unpack_1_sha_inputs.emplace_back(unpack_1);
+    auto& unpack_2 =
+        tensor_pool.CloneNativeTensorFrom(matmul_q_in, unpack_2_dims);
+    unpack_2_sha_inputs.emplace_back(unpack_2);
+    for (int j = 0; j < num_attn_per_kv_heads; j++) {
+      auto& unpack_3 = tensor_pool.CloneNativeTensorFrom(mul_in, unpack_3_dims);
+      unpack_3_sha_inputs.emplace_back(unpack_3);
+    }
+    auto& unpack_4 =
+        tensor_pool.CloneNativeTensorFrom(add_1_in_1, unpack_4_dims);
+    unpack_4_sha_inputs.emplace_back(unpack_4);
+    auto& unpack_5 =
+        tensor_pool.CloneNativeTensorFrom(add_1_in_2, unpack_5_dims);
+    unpack_5_sha_inputs.emplace_back(unpack_5);
+    auto& unpack_6 =
+        tensor_pool.CloneNativeTensorFrom(matmul_v2_in, unpack_6_dims);
+    unpack_6_sha_inputs.emplace_back(unpack_6);
+  }
+
+  // Unpack 1-5
+  auto unpack_1_op = BuildUnpackOp(
+      tensor_pool, {const_cast<::qnn::TensorWrapper&>(matmul_v1_in)},
+      unpack_1_sha_inputs, 1);
+  std::move(unpack_1_op.begin(), unpack_1_op.end(),
+            std::back_inserter(new_ops));
+  auto unpack_2_op = BuildUnpackOp(
+      tensor_pool, {const_cast<::qnn::TensorWrapper&>(matmul_q_in)},
+      unpack_2_sha_inputs, 1);
+  std::move(unpack_2_op.begin(), unpack_2_op.end(),
+            std::back_inserter(new_ops));
+  auto unpack_3_op =
+      BuildUnpackOp(tensor_pool, {const_cast<::qnn::TensorWrapper&>(mul_in)},
+                    unpack_3_sha_inputs, 1);
+  std::move(unpack_3_op.begin(), unpack_3_op.end(),
+            std::back_inserter(new_ops));
+  auto unpack_4_op = BuildUnpackOp(
+      tensor_pool, {const_cast<::qnn::TensorWrapper&>(add_1_in_1)},
+      unpack_4_sha_inputs, 1);
+  std::move(unpack_4_op.begin(), unpack_4_op.end(),
+            std::back_inserter(new_ops));
+  auto unpack_5_op = BuildUnpackOp(
+      tensor_pool, {const_cast<::qnn::TensorWrapper&>(add_1_in_2)},
+      unpack_5_sha_inputs, 1);
+  std::move(unpack_5_op.begin(), unpack_5_op.end(),
+            std::back_inserter(new_ops));
+  auto unpack_6_op = BuildUnpackOp(
+      tensor_pool, {const_cast<::qnn::TensorWrapper&>(matmul_v2_in)},
+      unpack_6_sha_inputs, 1);
+  std::move(unpack_6_op.begin(), unpack_6_op.end(),
+            std::back_inserter(new_ops));
+
+  // build num_head SHAs
+  std::vector<TensorWrapperRef> sha_outputs;
+  sha_outputs.reserve(num_attn_heads);
+  for (size_t i = 0; i < num_kv_heads; ++i) {
+    for (size_t j = 0; j < num_attn_per_kv_heads; ++j) {
+      auto& sha_output = BuildSingleSHA(
+          new_ops, tensor_pool, unpack_1_sha_inputs[i], unpack_2_sha_inputs[i],
+          unpack_3_sha_inputs[i * num_attn_per_kv_heads + j],
+          unpack_4_sha_inputs[i], unpack_5_sha_inputs[i],
+          unpack_6_sha_inputs[i], num_attn_per_kv_heads,
+          ops[start_index + mul_index], ops[start_index + matmul_q_index],
+          ops[start_index + add_1_index], ops[start_index + matmul_qk_index],
+          ops[start_index + concat_index], ops[start_index + add_2_index],
+          ops[start_index + reshape_3_index], ops[start_index + softmax_index],
+          ops[start_index + slice_1_index], ops[start_index + slice_2_index],
+          ops[start_index + matmul_v1_index],
+          ops[start_index + matmul_v2_index], ops[start_index + add_3_index]);
+      sha_outputs.emplace_back(sha_output);
+    }
+  }
+
+  // Concat
+  auto concat_op = BuildConcatenationOp(
+      tensor_pool, sha_outputs,
+      {const_cast<::qnn::TensorWrapper&>(pattern_output)}, 2);
+  std::move(concat_op.begin(), concat_op.end(), std::back_inserter(new_ops));
+
+  // Validate new graph.
+  const bool is_valid =
+      std::all_of(new_ops.begin(), new_ops.end(),
+                  [validate_op_config](::qnn::OpWrapper& op_wrapper) -> bool {
+                    return validate_op_config(op_wrapper);
+                  });
+  if (is_valid) {
+    // Adjust the name to avoid a name collision in the Qnn JSON dump.
+    for (size_t i = 0; i < new_ops.size(); ++i) {
+      new_ops[i].AddSuffixToName(absl::StrCat("_qcg2g_", i));
+    }
+    // Replace the matched pattern with a newly generated subgraph.
+    size_t step_size = new_ops.size();
+    ops.insert(ops.begin() + start_index + pattern_size,
+               std::make_move_iterator(new_ops.begin()),
+               std::make_move_iterator(new_ops.end()));
+    ops.erase(ops.begin() + start_index,
+              ops.begin() + start_index + pattern_size);
+    return step_size;
+  }
+
+  QNN_LOG_WARNING(
+      "[G2G] Validation failed. Rolling back to the original graph.");
+  return 1;
+}
+
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.h
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.h
@@ -21,6 +21,11 @@ size_t OptimizeMHADecode(std::function<bool(OpWrapper&)> validate_op_config,
                          std::vector<OpWrapper>& ops, size_t start_index,
                          TensorPool& tensor_pool, size_t pattern_size);
 
+size_t OptimizeMHAFastVlmPrefill(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size);
+
 }  // namespace qnn
 
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_MHA_TO_SHA_H_


### PR DESCRIPTION
Summary:

- Add MHA to SHA optimization

Test result:

- Improve 88% performance on prefill model

MHA2SHA Flow:
<img width="2407" height="903" alt="image" src="https://github.com/user-attachments/assets/f822bee4-965e-4d8a-9bf7-633160db30e6" />


Unit test result:
======================== Test Summary ========================
//litert/c:litert_op_options_test


//litert/c/options:litert_qualcomm_options_test
[==========] 17 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 17 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[==========] 8 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (10 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

//litert/vendors/qualcomm/core/backends:qnn_backend_test
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
YOU HAVE 4 DISABLED TESTS

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:common_test
[==========] 13 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 6 tests from 4 test suites ran. (2 ms total)
[  PASSED  ] 6 tests.

//litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

//litert/vendors/qualcomm/qnn_backend_test:qnn_backend_test
[==========] 2 tests from 1 test suite ran. (253 ms total)
[  PASSED  ] 1 test.

//litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (222 ms total)
[  PASSED  ] 3 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[==========] 232 tests from 4 test suites ran. (49757 ms total)
[  PASSED  ] 232 tests.
