### PR TITLE
Update TensorFlow fetch to commit that uses FlatBuffers v25

### DIFF
--- a/tflite/CMakeLists.txt
+++ b/tflite/CMakeLists.txt
@@ -51,7 +51,7 @@ if(NOT TENSORFLOW_SOURCE_DIR)
   FetchContent_Declare(
     tensorflow
     GIT_REPOSITORY https://github.com/tensorflow/tensorflow.git
-    GIT_TAG v2.19.0
+    GIT_TAG 6f3bab216d91a50960faf120f80b11c3e1c010ed  # <- updated from v2.19.0
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE
     SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/tensorflow-src


### PR DESCRIPTION
Hi, Team
This PR resolves a dependency conflict by upgrading the TensorFlow version in the CMake build to be compatible with the flatbuffers version required by LiteRT.

Currently, the `tflite/CMakeLists.txt` file fetches TensorFlow version v2.19.0. This version of TensorFlow has a dependency on flatbuffers version `v24.3.25`. However, the rest of the LiteRT project requires flatbuffers version `v25.9.23` as specified in `litert/CMakeLists.txt` and asserted in the generated flatbuffer headers. This version mismatch leads to build failures.

This PR updates the GIT_TAG for the TensorFlow dependency in tflite/CMakeLists.txt to a more recent version that is compatible with flatbuffers `v25.9.23`. This resolves the dependency conflict and allows the project to build successfully.

  Related Issue : Fixes #3979

I would request you to please review this PR, if you've any feedback or suggestion please let me know that will be very helpful. Thank you for your consideration.