### PR TITLE
Qualcomm AI Engine Direct - Fix incorrect mapping of optimization levels.

### DIFF
--- a/litert/vendors/qualcomm/compiler/graph_mapper.cc
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.cc
@@ -36,6 +36,20 @@
 
 namespace litert::qnn {
 
+float GetOptimizationValue(::qnn::OptimizationLevel level) {
+  // Default optimization level value is 2
+  switch (level) {
+    case ::qnn::OptimizationLevel::kHtpOptimizeForInference:
+      return 2.0f;
+    case ::qnn::OptimizationLevel::kHtpOptimizeForPrepare:
+      return 1.0f;
+    case ::qnn::OptimizationLevel::kHtpOptimizeForInferenceO3:
+      return 3.0f;
+    default:
+      return 2.0f;
+  }
+}
+
 inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
     const ::qnn::Options& options) {
   static std::array<QnnHtpGraph_CustomConfig_t, 6> graph_custom_configs;
@@ -53,7 +67,7 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
       QNN_HTP_GRAPH_OPTIMIZATION_TYPE_FINALIZE_OPTIMIZATION_FLAG;
   // Change to 2 if you want to use O2 (default).
   graph_custom_configs[1].optimizationOption.floatValue =
-      static_cast<float>(options.GetOptimizationLevel());
+      GetOptimizationValue(options.GetOptimizationLevel());
   // VTCM
   graph_custom_configs[2] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[2].option = QNN_HTP_GRAPH_CONFIG_OPTION_VTCM_SIZE;
@@ -104,7 +118,7 @@ inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
       QNN_HTP_GRAPH_OPTIMIZATION_TYPE_FINALIZE_OPTIMIZATION_FLAG;
   // Change to 2 if you want to use O2 (default).
   graph_custom_configs[0].optimizationOption.floatValue =
-      static_cast<float>(options.GetOptimizationLevel());
+      GetOptimizationValue(options.GetOptimizationLevel());
 
   // VTCM
   graph_custom_configs[1] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;


### PR DESCRIPTION
Qualcomm AI Engine Direct - Fix incorrect mapping of optimization levels.

Summary:
- Map kHtpOptimizeForInferenceO3 to 3.0f.
- Map kHtpOptimizeForInference to 2.0f.
- Map kHtpOptimizeForPrepare to 1.0f.


======================== Test Summary ========================
//litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

//litert/vendors/qualcomm/core/backends:qnn_backend_test
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
YOU HAVE 4 DISABLED TESTS

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:common_test
[==========] 13 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (229 ms total)
[  PASSED  ] 3 tests.

//litert/c/options:litert_qualcomm_options_test
[==========] 17 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 17 tests.

//litert/c:litert_op_options_test


//litert/tools/flags/vendors:qualcomm_flags_test
[==========] 8 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[==========] 232 tests from 4 test suites ran. (49779 ms total)
[  PASSED  ] 232 tests.
