### PR TITLE
Replace deprecated stb_image_resize with updated version

### DIFF
--- a/litert/samples/async_segmentation/image_utils.cc
+++ b/litert/samples/async_segmentation/image_utils.cc
@@ -27,7 +27,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"  // from @stblib
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
-#include "deprecated/stb_image_resize.h"  // from @stblib
+#include "stb_image_resize.h"  // from @stblib
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"  // from @stblib
 


### PR DESCRIPTION
Hi, Team
This PR fixes a build failure in the `async_segmentation` example by correcting the include path for the `stb_image_resize.h` header file. The file `litert/samples/async_segmentation/image_utils.cc` was trying to include `stb_image_resize.h` from a deprecated subdirectory. However, the `stblib` build configuration does not expose this subdirectory, leading to a "file not found" error during compilation.

This PR updates the include path in image_utils.cc to correctly reference `stb_image_resize.h` from the root of the `stblib` library. This aligns with the includes definition in the stblib.BUILD file and resolves the build failure.

This change is related to the build failures reported in https://github.com/google-ai-edge/LiteRT/issues/3895