### PR TITLE
Qualcomm AI Engine Direct - Fix litert_op_options_test.

### DIFF
--- a/litert/c/BUILD
+++ b/litert/c/BUILD
@@ -352,7 +352,10 @@ cc_library(
 cc_test(
     name = "litert_op_options_test",
     srcs = ["litert_op_options_test.cc"],
-    data = ["//litert/test:mlir_test_data"],
+    data = [
+        "//litert/test:mlir_test_data",
+        "//litert/test:tflite_test_data",   
+    ],
     tags = ["no_oss"],
     deps = [
         ":litert_common",


### PR DESCRIPTION
# What 
Met error in litert_op_options_test
```
[ RUN      ] GetOpOptionTest.TestGetReshapeOptions2x3To3x2
[       OK ] GetOpOptionTest.TestGetReshapeOptions2x3To3x2 (0 ms)
[ RUN      ] GetOpOptionTest.TestGetSumOptions
[       OK ] GetOpOptionTest.TestGetSumOptions (0 ms)
[ RUN      ] GetOpOptionTest.TestGetReduceMaxOptions
[       OK ] GetOpOptionTest.TestGetReduceMaxOptions (0 ms)
[ RUN      ] GetOpOptionTest.TestGetReduceMinOptions
ERROR: Could not open 'litert/test/testdata/simple_reducemin_op.tflite'.
```

# Test
```
//litert/c:litert_op_options_test
[==========] 36 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 36 tests.
```
