### PR TITLE
Qualcomm AI Engine Direct - Support DLC output directory option.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -40,6 +40,7 @@ struct LiteRtQualcommOptionsT {
       kLiteRtQualcommHtpPerformanceModeDefault;
   std::vector<std::int32_t> dump_tensor_ids;
   std::string ir_json_dir;
+  std::string dlc_dir;
   std::uint32_t vtcm_size = 0;
   std::uint32_t num_hvx_threads = 0;
   LiteRtQualcommOptionsOptimizationLevel optimization_level =
@@ -68,8 +69,8 @@ LiteRtStatus LiteRtQualcommOptionsCreate(LiteRtOpaqueOptions* options) {
         ans, options->log_level, options->profiling,
         options->use_htp_preference, options->use_qint16_as_quint16,
         options->enable_weight_sharing, options->htp_performance_mode,
-        options->ir_json_dir, options->vtcm_size, options->num_hvx_threads,
-        options->optimization_level);
+        options->ir_json_dir, options->dlc_dir, options->vtcm_size,
+        options->num_hvx_threads, options->optimization_level);
     return ans;
   };
   LITERT_RETURN_IF_ERROR(LiteRtSetOpaqueOptionsHash(*options, qti_hash));
@@ -332,6 +333,28 @@ LiteRtStatus LiteRtQualcommOptionsGetIrJsonDir(LiteRtQualcommOptions options,
   }
 
   *ir_json_dir = options->ir_json_dir.c_str();
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetDlcDir(LiteRtQualcommOptions options,
+                                            const char* dlc_dir) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->dlc_dir = dlc_dir;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetDlcDir(LiteRtQualcommOptions options,
+                                            const char** dlc_dir) {
+  if (options == nullptr || dlc_dir == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *dlc_dir = options->dlc_dir.c_str();
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -183,6 +183,12 @@ LiteRtStatus LiteRtQualcommOptionsSetIrJsonDir(LiteRtQualcommOptions options,
 LiteRtStatus LiteRtQualcommOptionsGetIrJsonDir(LiteRtQualcommOptions options,
                                                const char** ir_json_dir);
 
+LiteRtStatus LiteRtQualcommOptionsSetDlcDir(LiteRtQualcommOptions options,
+                                            const char* dlc_dir);
+
+LiteRtStatus LiteRtQualcommOptionsGetDlcDir(LiteRtQualcommOptions options,
+                                            const char** dlc_dir);
+
 LiteRtStatus LiteRtQualcommOptionsSetVtcmSize(LiteRtQualcommOptions options,
                                               uint32_t vtcm_size);
 

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -170,6 +170,22 @@ TEST(LiteRtQualcommOptionsTest, IrJsonDir) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
+TEST(LiteRtQualcommOptionsTest, DlcDir) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetDlcDir(qualcomm_options, "tmp/"));
+
+  const char* dlc_dir;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetDlcDir(qualcomm_options, &dlc_dir));
+  EXPECT_STREQ(dlc_dir, "tmp/");
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
 TEST(LiteRtQualcommOptionsTest, VtcmSize) {
   LiteRtOpaqueOptions options;
   LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
@@ -320,6 +336,10 @@ TEST(QualcommOptionsTest, CppApi) {
   EXPECT_EQ(options->GetIrJsonDir(), "");
   options->SetIrJsonDir("tmp");
   EXPECT_EQ(options->GetIrJsonDir(), "tmp");
+
+  EXPECT_EQ(options->GetDlcDir(), "");
+  options->SetDlcDir("tmp");
+  EXPECT_EQ(options->GetDlcDir(), "tmp");
 
   EXPECT_EQ(options->GetVtcmSize(), 0);
   options->SetVtcmSize(4);

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -178,6 +178,16 @@ absl::string_view QualcommOptions::GetIrJsonDir() {
   return absl::string_view(ir_json_dir);
 }
 
+void QualcommOptions::SetDlcDir(const std::string& dlc_dir) {
+  internal::AssertOk(LiteRtQualcommOptionsSetDlcDir, Data(), dlc_dir.c_str());
+}
+
+absl::string_view QualcommOptions::GetDlcDir() {
+  const char* dlc_dir;
+  internal::AssertOk(LiteRtQualcommOptionsGetDlcDir, Data(), &dlc_dir);
+  return absl::string_view(dlc_dir);
+}
+
 void QualcommOptions::SetVtcmSize(std::uint32_t vtcm_size) {
   internal::AssertOk(LiteRtQualcommOptionsSetVtcmSize, Data(), vtcm_size);
 }

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -140,6 +140,9 @@ class QualcommOptions : public OpaqueOptions {
   void SetIrJsonDir(const std::string& ir_json_dir);
   absl::string_view GetIrJsonDir();
 
+  void SetDlcDir(const std::string& dlc_dir);
+  absl::string_view GetDlcDir();
+
   void SetVtcmSize(std::uint32_t vtcm_size);
   std::uint32_t GetVtcmSize();
 

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -223,6 +223,10 @@ ABSL_FLAG(
     "Qnn IR JSON directory. If provided, you can obtain Qnn IR in Qnn JSON "
     "format.");
 
+ABSL_FLAG(
+    std::string, qualcomm_dlc_dir, "",
+    "DLC directory. If provided, you can obtain Qnn graphs in DLC format.");
+
 ABSL_FLAG(uint32_t, qualcomm_vtcm_size, 0,
           "The vtcm size of the target device. If this option is set to 0, the "
           "max size of vtcm size will be used.");
@@ -313,6 +317,9 @@ Expected<QualcommOptions> QualcommOptionsFromFlags() {
 
   const std::string ir_json_dir = absl::GetFlag(FLAGS_qualcomm_ir_json_dir);
   opts.SetIrJsonDir(ir_json_dir);
+
+  const std::string dlc_dir = absl::GetFlag(FLAGS_qualcomm_dlc_dir);
+  opts.SetDlcDir(dlc_dir);
 
   const auto vtcm_size = absl::GetFlag(FLAGS_qualcomm_vtcm_size);
   opts.SetVtcmSize(vtcm_size);

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -50,6 +50,8 @@ ABSL_DECLARE_FLAG(std::vector<std::string>, qualcomm_dump_tensor_ids);
 
 ABSL_DECLARE_FLAG(std::string, qualcomm_ir_json_dir);
 
+ABSL_DECLARE_FLAG(std::string, qualcomm_dlc_dir);
+
 ABSL_DECLARE_FLAG(uint32_t, qualcomm_vtcm_size);
 
 ABSL_DECLARE_FLAG(uint32_t, qualcomm_num_hvx_thread);

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -121,6 +121,17 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetOptimizationLevel(static_cast<::qnn::OptimizationLevel>(
       qualcomm_options.GetOptimizationLevel()));
   qnn_options.SetDumpTensorIds(qualcomm_options.GetDumpTensorIds());
+
+  // TODO(jiunkaiy): Set backend type based on qualcomm options.
+  // However, if a DLC directory is set, we must use the IR backend.
+  qnn_options.SetDlcDir(qualcomm_options.GetDlcDir());
+  if (!qualcomm_options.GetDlcDir().empty() &&
+      qnn_options.GetBackendType() != ::qnn::BackendType::kIrBackend) {
+    LITERT_LOG(LITERT_WARNING,
+               "Overriding backend type to IR Backend because DLC dir is set.");
+    qnn_options.SetBackendType(::qnn::BackendType::kIrBackend);
+  }
+
   LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
   return kLiteRtStatusOk;
 }

--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -236,6 +236,7 @@ litert_lib(
         "//litert/vendors/qualcomm:qnn_manager",
         "//litert/vendors/qualcomm/core:common",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@qairt//:qnn_lib_headers",

--- a/litert/vendors/qualcomm/compiler/graph_mapper.cc
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.cc
@@ -20,9 +20,11 @@
 #include <stdio.h>
 
 #include <array>
+#include <filesystem>
 
 #include "IR/QnnIrGraph.h"
 #include "absl/strings/string_view.h"  // from @com_google_absl
+#include "absl/strings/str_cat.h"  // from @com_google_absl
 #include "absl/types/span.h"  // from @com_google_absl
 #include "litert/c/internal/litert_logging.h"
 #include "litert/c/litert_common.h"
@@ -158,13 +160,17 @@ inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
   return absl::MakeSpan(result.data(), num_config + 1);
 }
 
-absl::Span<const QnnGraph_Config_t*> GetDefaultIrGraphConfigs() {
+absl::Span<const QnnGraph_Config_t*> GetDefaultIrGraphConfigs(
+    const ::qnn::Options& options, absl::string_view qnn_graph_name) {
   static std::array<QnnIrGraph_CustomConfig_t, 1> graph_custom_configs;
-  // TODO(Alen): pass dlc path by options.
   graph_custom_configs[0].option = QNN_IR_GRAPH_CONFIG_OPTION_SERIALIZATION;
   graph_custom_configs[0].serializationOption.serializationType =
       QNN_IR_GRAPH_SERIALIZATION_TYPE_FLAT_BUFFER;
-  graph_custom_configs[0].serializationOption.outputPath = "";
+  static std::string dlc_path;
+  // Set DLC path based on the qnn graph name and DLC directory from options.
+  std::filesystem::path dlc_dir = options.GetDlcDir();
+  dlc_path = (dlc_dir / absl::StrCat(qnn_graph_name, ".dlc")).string();
+  graph_custom_configs[0].serializationOption.outputPath = dlc_path.c_str();
 
   static std::array<QnnGraph_Config_t, 1> graph_configs;
   graph_configs[0] = QNN_GRAPH_CONFIG_INIT;
@@ -208,7 +214,8 @@ LiteRtStatus GraphMapper::InitQnnGraph(absl::string_view qnn_graph_name,
     case ::qnn::BackendType::kIrBackend: {
       LITERT_RETURN_STATUS_IF_QNN_NOT_OK(qnn_.Api()->graphCreate(
           context_handle_, qnn_graph_name.data(),
-          GetDefaultIrGraphConfigs().data(), &QnnGraph()));
+          GetDefaultIrGraphConfigs(options, qnn_graph_name).data(),
+          &QnnGraph()));
       break;
     }
     default: {

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -476,13 +476,21 @@ LiteRtStatus LiteRtCompilerPluginCompile(
     LITERT_LOG(LITERT_INFO, "%s", "Graph composed");
   }
 
-  // Generate context binary.
-  result->context_bin.resize(next_context_handle_idx);
-  for (int i = 0; i < next_context_handle_idx; ++i) {
-    LITERT_LOG(LITERT_INFO, "%s", "Generating context binary");
-    LITERT_RETURN_IF_ERROR(qnn_manager->GenerateContextBinary(
-        context_handles[i].get(), result->context_bin[i]));
-    LITERT_LOG(LITERT_INFO, "Context binary %d generated", i);
+  if (compiler_plugin->Options().GetBackendType() ==
+      ::qnn::BackendType::kIrBackend) {
+    LITERT_LOG(LITERT_WARNING,
+               "Since IR backend is enabled, functional context binaries are "
+               "excluded from the compiled TFLite.");
+    return kLiteRtStatusErrorUnsupported;
+  } else {
+    // Generate context binary.
+    result->context_bin.resize(next_context_handle_idx);
+    for (int i = 0; i < next_context_handle_idx; ++i) {
+      LITERT_LOG(LITERT_INFO, "%s", "Generating context binary");
+      LITERT_RETURN_IF_ERROR(qnn_manager->GenerateContextBinary(
+          context_handles[i].get(), result->context_bin[i]));
+      LITERT_LOG(LITERT_INFO, "Context binary %d generated", i);
+    }
   }
   *compiled_result = result.release();
 

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -12,7 +12,6 @@
 #include "absl/strings/str_format.h"  // from @com_google_absl
 #include "absl/strings/str_join.h"  // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
-#include "QnnLog.h"  // from @qairt
 
 namespace qnn {
 namespace {
@@ -116,6 +115,10 @@ void Options::SetIrJsonDir(absl::string_view ir_json_dir) {
   ir_json_dir_ = ir_json_dir;
 }
 
+absl::string_view Options::GetDlcDir() const { return dlc_dir_; }
+
+void Options::SetDlcDir(absl::string_view dlc_dir) { dlc_dir_ = dlc_dir; }
+
 std::uint32_t Options::GetVtcmSize() const { return vtcm_size_; }
 
 void Options::SetVtcmSize(std::uint32_t vtcm_size) { vtcm_size_ = vtcm_size; }
@@ -148,17 +151,18 @@ UseFoldReLU: %v\n\
 HtpPerformanceMode: %d\n\
 DumpTensorIds: %s\n\
 IrJsonDir: %s\n\
+DlcDir: %s\n\
 VtcmSize: %d\n\
 HvxThread: %d\n\
 OptimizationLevel: %d\n";  // NOLINT
 
   std::string dump_tensor_ids = absl::StrJoin(dump_tensor_ids_, ",");
 
-  return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, profiling_,
-                         use_htp_preference_, use_qint16_as_quint16_,
-                         enable_weight_sharing_, use_conv_hmx_, use_fold_relu_,
-                         htp_performance_mode_, dump_tensor_ids, ir_json_dir_,
-                         vtcm_size_, num_hvx_threads_, optimization_level_);
+  return absl::StrFormat(
+      kQnnOptionsDumpFormat, log_level_, profiling_, use_htp_preference_,
+      use_qint16_as_quint16_, enable_weight_sharing_, use_conv_hmx_,
+      use_fold_relu_, htp_performance_mode_, dump_tensor_ids, ir_json_dir_,
+      dlc_dir_, vtcm_size_, num_hvx_threads_, optimization_level_);
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -94,6 +94,9 @@ class Options {
   absl::string_view GetIrJsonDir() const;
   void SetIrJsonDir(absl::string_view ir_json_dir);
 
+  absl::string_view GetDlcDir() const;
+  void SetDlcDir(absl::string_view dlc_dir);
+
   std::uint32_t GetVtcmSize() const;
   void SetVtcmSize(std::uint32_t vtcm_size);
 
@@ -117,6 +120,7 @@ class Options {
   HtpPerformanceMode htp_performance_mode_ = HtpPerformanceMode::kDefault;
   std::vector<std::int32_t> dump_tensor_ids_;
   std::string ir_json_dir_;
+  std::string dlc_dir_;
   std::uint32_t vtcm_size_ = 0;
   std::uint32_t num_hvx_threads_ = 0;
   OptimizationLevel optimization_level_ =

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -150,6 +150,15 @@ TEST(QnnOptionTest, SetIrJsonDir) {
   EXPECT_TRUE(options.GetIrJsonDir().empty());
 }
 
+TEST(QnnOptionTest, SetDlcDir) {
+  Options options;
+  options.SetDlcDir("tmp/");
+  EXPECT_FALSE(options.GetDlcDir().empty());
+  EXPECT_EQ(options.GetDlcDir(), "tmp/");
+  options.SetDlcDir("");
+  EXPECT_TRUE(options.GetDlcDir().empty());
+}
+
 TEST(QnnOptionTest, SetVtcmSize) {
   Options options;
   options.SetVtcmSize(4);
@@ -192,6 +201,7 @@ TEST(QnnOptionTest, Default) {
   EXPECT_TRUE(options.GetUseFoldReLU());
   EXPECT_EQ(options.GetHtpPerformanceMode(), HtpPerformanceMode::kDefault);
   EXPECT_TRUE(options.GetIrJsonDir().empty());
+  EXPECT_TRUE(options.GetDlcDir().empty());
   EXPECT_EQ(options.GetVtcmSize(), 0);
   EXPECT_EQ(options.GetNumHvxThreads(), 0);
   EXPECT_EQ(options.GetOptimizationLevel(),

--- a/litert/vendors/qualcomm/qnn_manager_test.cc
+++ b/litert/vendors/qualcomm/qnn_manager_test.cc
@@ -61,6 +61,7 @@ TEST(QnnManagerTest, GetOptions) {
             options_ref.GetHtpPerformanceMode());
   EXPECT_EQ(options.GetDumpTensorIds(), options_ref.GetDumpTensorIds());
   EXPECT_EQ(options.GetIrJsonDir(), options_ref.GetIrJsonDir());
+  EXPECT_EQ(options.GetDlcDir(), options_ref.GetDlcDir());
 }
 
 }  // namespace


### PR DESCRIPTION
Summary:
- Add support for specifying the DLC output directory, with an implicit switch to the IR backend.
- Introduce unit tests to validate the new functionality.

<img width="875" height="71" alt="image" src="https://github.com/user-attachments/assets/d89ea5fd-91b0-4448-9b5a-4a181b817078" />

======================== Test Summary ========================
//litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

//litert/vendors/qualcomm/core/backends:qnn_backend_test
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
YOU HAVE 4 DISABLED TESTS

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 19 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 19 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:common_test
[==========] 14 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 14 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (222 ms total)
[  PASSED  ] 3 tests.

//litert/c/options:litert_qualcomm_options_test
[==========] 18 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

//litert/c:litert_op_options_test
[==========] 36 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 36 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[==========] 8 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[==========] 232 tests from 4 test suites ran. (49617 ms total)
[  PASSED  ] 232 tests.

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 5 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 5 tests.

//litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

