### PR TITLE
Qualcomm AI Engine Direct - Optimize memory footprint and init time.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -284,7 +284,8 @@ LiteRtStatus ConvertTensor(const litert::Tensor& litert_tensor,
     auto& res = tensor_pool.CreateStaticTensorWithSuffix(
         qnn_data_type, quantize_params, dimentions, litert_suffix,
         litert_tensor.Weights().Bytes().size(),
-        reinterpret_cast<const void*>(litert_tensor.Weights().Bytes().data()));
+        reinterpret_cast<const void*>(litert_tensor.Weights().Bytes().data()),
+        false);
     tensor_wrapper = &res;
   } else {
     auto& res = tensor_pool.CreateNativeTensorWithSuffix(

--- a/litert/vendors/qualcomm/core/tensor_pool.cc
+++ b/litert/vendors/qualcomm/core/tensor_pool.cc
@@ -63,20 +63,20 @@ TensorWrapper& TensorPool::CreateStaticTensor(
     const void* data) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + kQnnSuffix;
-  return tensor_wrappers_.emplace_back(std::move(tensor_name),
-                                       QNN_TENSOR_TYPE_STATIC, data_type,
-                                       quant_params, dimentions, bytes, data);
+  return tensor_wrappers_.emplace_back(
+      std::move(tensor_name), QNN_TENSOR_TYPE_STATIC, data_type, quant_params,
+      dimentions, bytes, data, true);
 }
 
 TensorWrapper& TensorPool::CreateStaticTensorWithSuffix(
     Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
     const std::vector<std::uint32_t>& dimentions, std::string_view suffix,
-    std::uint32_t bytes, const void* data) {
+    std::uint32_t bytes, const void* data, bool copy_data) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + std::string(suffix);
-  return tensor_wrappers_.emplace_back(std::move(tensor_name),
-                                       QNN_TENSOR_TYPE_STATIC, data_type,
-                                       quant_params, dimentions, bytes, data);
+  return tensor_wrappers_.emplace_back(
+      std::move(tensor_name), QNN_TENSOR_TYPE_STATIC, data_type, quant_params,
+      dimentions, bytes, data, copy_data);
 }
 
 TensorWrapper& TensorPool::CloneNativeTensorFrom(const TensorWrapper& src) {
@@ -100,10 +100,11 @@ TensorWrapper& TensorPool::CloneStaticTensorFrom(const TensorWrapper& src,
                                                  Qnn_DataType_t data_type) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + kQnnSuffix;
-  return tensor_wrappers_.emplace_back(
-      std::move(tensor_name), QNN_TENSOR_TYPE_STATIC, data_type,
-      src.quantize_params_, src.dimentions_, src.owned_data_.size(),
-      src.owned_data_.data());
+  return tensor_wrappers_.emplace_back(std::move(tensor_name),
+                                       QNN_TENSOR_TYPE_STATIC, data_type,
+                                       src.quantize_params_, src.dimentions_,
+                                       src.qnn_tensor_.v2.clientBuf.dataSize,
+                                       src.qnn_tensor_.v2.clientBuf.data, true);
 }
 
 TensorWrapper& TensorPool::CloneStaticTensorFrom(
@@ -113,7 +114,8 @@ TensorWrapper& TensorPool::CloneStaticTensorFrom(
   return tensor_wrappers_.emplace_back(
       std::move(tensor_name), QNN_TENSOR_TYPE_STATIC,
       src.qnn_tensor_.v2.dataType, src.quantize_params_, dimentions,
-      src.qnn_tensor_.v2.clientBuf.dataSize, src.qnn_tensor_.v2.clientBuf.data);
+      src.qnn_tensor_.v2.clientBuf.dataSize, src.qnn_tensor_.v2.clientBuf.data,
+      true);
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/tensor_pool.h
+++ b/litert/vendors/qualcomm/core/tensor_pool.h
@@ -56,7 +56,7 @@ class TensorPool {
       Qnn_DataType_t data_type,
       const QuantizeParamsWrapperVariant& quant_params,
       const std::vector<std::uint32_t>& dimentions, std::string_view suffix,
-      std::uint32_t bytes, const void* data);
+      std::uint32_t bytes, const void* data, bool copy_data);
 
   TensorWrapper& CloneNativeTensorFrom(const TensorWrapper& src);
 
@@ -163,7 +163,7 @@ TensorWrapper* TensorPool::ConvertStaticTensorFrom(
   auto& back = tensor_wrappers_.emplace_back(
       std::move(tensor_name), QNN_TENSOR_TYPE_STATIC,
       GetQnnDataType<T>(src_tensor.IsQuant()), src_tensor.GetQuantParams(),
-      src_tensor.GetDims(), sizeof(T) * dst_data.size(), dst_data.data());
+      src_tensor.GetDims(), sizeof(T) * dst_data.size(), dst_data.data(), true);
   return &back;
 }
 

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -102,7 +102,7 @@ class TensorWrapper final {
                          Qnn_DataType_t data_type,
                          const QuantizeParamsWrapperVariant& quantize_params,
                          const std::vector<std::uint32_t>& dimentions,
-                         std::uint32_t bytes, const void* data);
+                         std::uint32_t bytes, const void* data, bool copy_data);
 
   TensorWrapper(const Qnn_Tensor_t& qnn_tensor);
 
@@ -340,7 +340,7 @@ class TensorWrapper final {
     qnn_tensor_.v2.dataType = data_type;
   }
 
-  void SetDataBy(std::uint32_t bytes, const void* data);
+  void SetDataBy(std::uint32_t bytes, const void* data, bool copy_data);
 
   bool HasStaticData() const {
     return qnn_tensor_.v2.clientBuf.dataSize != 0 &&

--- a/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
@@ -93,7 +93,8 @@ TEST(OpWrapperTest, OpConfigTest) {
                                QuantizeParamsWrapperVariant(),
                                dummy_dims,
                                static_cast<uint32_t>(data_size),
-                               data_ptr};
+                               data_ptr,
+                               true};
 
   Qnn_Tensor_t golden_qnn_tensor;
   tensor_wrapper.CloneTo(golden_qnn_tensor);
@@ -137,7 +138,8 @@ TEST(OpWrapperTest, MoveConstructorTest) {
                                QuantizeParamsWrapperVariant(),
                                dummy_dims,
                                static_cast<uint32_t>(data.size()),
-                               data_ptr};
+                               data_ptr,
+                               true};
   Qnn_Tensor_t golden_qnn_tensor;
   tensor_wrapper.CloneTo(golden_qnn_tensor);
   std::uint8_t value = 255;

--- a/litert/vendors/qualcomm/core/wrappers/tests/param_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/param_wrapper_test.cc
@@ -201,7 +201,8 @@ TEST(ParamWrapperTest, TensorParamTest) {
                                QuantizeParamsWrapperVariant(),
                                dummy_dims,
                                static_cast<uint32_t>(data_size),
-                               data_ptr};
+                               data_ptr,
+                               true};
 
   TensorParamWrapper tensor_param{"tensor_param", tensor_wrapper};
 

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -84,7 +84,8 @@ TEST(TensorWrapperTest, MoveTensorTest) {
                                dummy_dims,
 
                                static_cast<uint32_t>(data.size()),
-                               data_ptr};
+                               data_ptr,
+                               true};
   TensorWrapper moved{tensor_wrapper};
 
   EXPECT_EQ(moved.GetRank(), 3);
@@ -119,7 +120,8 @@ TEST(TensorWrapperTest, QnnTensorTest) {
                                QuantizeParamsWrapperVariant(),
                                dummy_dims,
                                static_cast<uint32_t>(data_size),
-                               data_ptr};
+                               data_ptr,
+                               true};
 
   Qnn_Tensor_t cloned;
   tensor_wrapper.CloneTo(cloned);
@@ -453,6 +455,64 @@ TEST(TensorWrapperTest, ConstQnnTensorPerTensorQuantConstructTest) {
   EXPECT_EQ(ref.v2.memType, qnn_tensor.v2.memType);
   EXPECT_EQ(ref.v2.clientBuf.dataSize, qnn_tensor.v2.clientBuf.dataSize);
   EXPECT_EQ(ref.v2.clientBuf.data, qnn_tensor.v2.clientBuf.data);
+}
+
+TEST(TensorWrapperTest, QnnTensorNoCopyTest) {
+  std::vector<std::uint32_t> dummy_dims = {1, 1, 3};
+  std::vector<std::uint8_t> data = {1, 2, 3};
+  void* data_ptr = static_cast<void*>(data.data());
+  const auto data_size =
+      std::accumulate(dummy_dims.begin(), dummy_dims.end(),
+                      sizeof(decltype(data)::value_type), std::multiplies<>());
+
+  TensorWrapper tensor_wrapper{"",
+                               QNN_TENSOR_TYPE_APP_WRITE,
+                               QNN_DATATYPE_UFIXED_POINT_8,
+                               QuantizeParamsWrapperVariant(),
+                               dummy_dims,
+                               static_cast<uint32_t>(data_size),
+                               data_ptr,
+                               false};
+
+  Qnn_Tensor_t cloned;
+  tensor_wrapper.CloneTo(cloned);
+  EXPECT_EQ(cloned.version, QNN_TENSOR_VERSION_2);
+  EXPECT_EQ(cloned.v2.id, 0);
+  EXPECT_EQ(cloned.v2.type, QNN_TENSOR_TYPE_APP_WRITE);
+  EXPECT_EQ(cloned.v2.dataFormat, QNN_TENSOR_DATA_FORMAT_FLAT_BUFFER);
+  EXPECT_EQ(cloned.v2.dataType, QNN_DATATYPE_UFIXED_POINT_8);
+  EXPECT_EQ(cloned.v2.quantizeParams.encodingDefinition,
+            QNN_DEFINITION_UNDEFINED);
+  ASSERT_EQ(cloned.v2.rank, dummy_dims.size());
+  for (size_t i = 0; i < cloned.v2.rank; i++) {
+    EXPECT_EQ(cloned.v2.dimensions[i], dummy_dims[i]);
+  }
+  EXPECT_EQ(cloned.v2.memType, QNN_TENSORMEMTYPE_RAW);
+  ASSERT_EQ(cloned.v2.clientBuf.dataSize, data_size);
+  const auto* cloned_data =
+      static_cast<const std::uint8_t*>(cloned.v2.clientBuf.data);
+  for (size_t i = 0; i < data.size(); i++) {
+    EXPECT_EQ(cloned_data[i], data[i]);
+  }
+
+  Qnn_Tensor_t& ref = tensor_wrapper.GetQnnTensor();
+  EXPECT_EQ(ref.version, QNN_TENSOR_VERSION_2);
+  EXPECT_EQ(ref.v2.id, 0);
+  EXPECT_EQ(ref.v2.type, QNN_TENSOR_TYPE_APP_WRITE);
+  EXPECT_EQ(ref.v2.dataFormat, QNN_TENSOR_DATA_FORMAT_FLAT_BUFFER);
+  EXPECT_EQ(ref.v2.dataType, QNN_DATATYPE_UFIXED_POINT_8);
+  EXPECT_EQ(ref.v2.quantizeParams.encodingDefinition, QNN_DEFINITION_UNDEFINED);
+  ASSERT_EQ(ref.v2.rank, dummy_dims.size());
+  for (size_t i = 0; i < ref.v2.rank; i++) {
+    EXPECT_EQ(ref.v2.dimensions[i], dummy_dims[i]);
+  }
+  EXPECT_EQ(ref.v2.memType, QNN_TENSORMEMTYPE_RAW);
+  ASSERT_EQ(ref.v2.clientBuf.dataSize, data_size);
+  const auto* ref_data =
+      static_cast<const std::uint8_t*>(ref.v2.clientBuf.data);
+  for (size_t i = 0; i < data.size(); i++) {
+    EXPECT_EQ(ref_data[i], data[i]);
+  }
 }
 }  // namespace
 }  // namespace qnn


### PR DESCRIPTION
Summary:
 - TensorWrapper use weight data from flatbuffer directly.

# Test
//litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

//litert/vendors/qualcomm/core/backends:qnn_backend_test
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
YOU HAVE 4 DISABLED TESTS

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:common_test
[==========] 13 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (228 ms total)
[  PASSED  ] 3 tests.

//litert/c/options:litert_qualcomm_options_test
[==========] 17 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 17 tests.

//litert/c:litert_op_options_test
[==========] 36 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 36 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[==========] 8 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[==========] 232 tests from 4 test suites ran. (51844 ms total)
[  PASSED  ] 232 tests.

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 5 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 5 tests.

//litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.