### PR TITLE
Qualcomm AI Engine Direct - Support SC8380XP.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
@@ -163,11 +163,13 @@ const auto kSupportedSocModels = Values(
     "SA8295",
     "SA8255",
     "SM8350",
+    "SC8380XP",
     "SM8450",
     "SM8475",
     "SM8550",
     "SM8650",
-    "SM8750"
+    "SM8750",
+    "SM8850"
 );
 // clang-format on
 
@@ -179,7 +181,7 @@ TEST(TestQnnPlugin, GetConfigInfo) {
   LiteRtParamIndex num_supported_soc_models;
   LITERT_ASSERT_OK(LiteRtGetNumCompilerPluginSupportedSocModels(
       plugin.get(), &num_supported_soc_models));
-  ASSERT_EQ(num_supported_soc_models, 10);
+  ASSERT_EQ(num_supported_soc_models, 11);
 
   const char* config_id;
   LITERT_ASSERT_OK(

--- a/litert/vendors/qualcomm/core/schema/soc_table.cc
+++ b/litert/vendors/qualcomm/core/schema/soc_table.cc
@@ -24,6 +24,9 @@ constexpr SocInfo kSocInfos[] = {
     {SocInfo("SM8475", SnapdragonModel::SM8475, DspArch::V69,
              8  // vtcm_size_in_mb
              )},
+    {SocInfo("SC8380XP", SnapdragonModel::SC8380XP, DspArch::V73,
+             8  // vtcm_size_in_mb
+             )},
     {SocInfo("SM8550", SnapdragonModel::SM8550, DspArch::V73,
              8  // vtcm_size_in_mb
              )},

--- a/litert/vendors/qualcomm/core/schema/soc_table.h
+++ b/litert/vendors/qualcomm/core/schema/soc_table.h
@@ -15,6 +15,7 @@ enum class SnapdragonModel {
   SM8550 = 43,
   SA8255 = 52,
   SM8650 = 57,
+  SC8380XP = 60,
   SM8750 = 69,
   SM8850 = 87,
 };

--- a/litert/vendors/qualcomm/supported_soc.csv
+++ b/litert/vendors/qualcomm/supported_soc.csv
@@ -17,6 +17,7 @@ Qualcomm,SM7435,v73,
 Qualcomm,SM6450,v73,50
 Qualcomm,QCM8550LA,v73,66
 Qualcomm,QCM8550LE,v73,66
+Qualcomm,SC8380XP,v73,60
 Qualcomm,SM8475,v69,42
 Qualcomm,SM8450,v69,36
 Qualcomm,SM7475,v69,54


### PR DESCRIPTION
`run_model` successfully run a test model on SC8380XP.
```
0000 00:00:1762389540.165346   15104 run_model.cc:361] First run took 2072 microseconds
I0000 00:00:1762389540.165373   15104 run_model.cc:362] Slowest run took 2072 microseconds
I0000 00:00:1762389540.165394   15104 run_model.cc:365] Fastest run took 782 microseconds
I0000 00:00:1762389540.165417   15104 run_model.cc:368] All runs took average 835 microseconds
I0000 00:00:1762389540.165437   15104 run_model.cc:381] Model run completed
```

# Test
```
======================== Test Summary ========================
//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:qnn_backend_test
//litert/vendors/qualcomm/core/backends:qnn_backend_test                 PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.4s

//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 66.0s

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_backend_test              PASSED in 0.5s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.1s
```