### PR TITLE
Qualcomm AI Engine Direct - Support TopK Op

### DIFF
--- a/litert/test/testdata/simple_topk_op.mlir
+++ b/litert/test/testdata/simple_topk_op.mlir
@@ -1,0 +1,8 @@
+
+module {
+  func.func @main(%arg0: tensor<1x128xf32>) -> (tensor<1x10xf32>, tensor<1x10xi32>) {
+    %k = "tfl.pseudo_const"() {value = dense<10> : tensor<i32>} : () -> tensor<i32>
+    %values, %indices = "tfl.topk_v2"(%arg0, %k) : (tensor<1x128xf32>, tensor<i32>) -> (tensor<1x10xf32>, tensor<1x10xi32>)
+    return %values, %indices : tensor<1x10xf32>, tensor<1x10xi32>
+  }
+}

--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -202,6 +202,7 @@ litert_lib(
         "//litert/vendors/qualcomm/core/builders:tile_op_builder",
         "//litert/vendors/qualcomm/core/builders:transpose_conv_op_builder",
         "//litert/vendors/qualcomm/core/builders:transpose_op_builder",
+        "//litert/vendors/qualcomm/core/builders:topk_op_builder",
         "//litert/vendors/qualcomm/core/builders:unpack_op_builder",
         "//litert/vendors/qualcomm/core/dump:dump_graph",
         "//litert/vendors/qualcomm/core/transformation:graph_to_graph",

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
@@ -130,6 +130,7 @@ const auto kSupportedOps =
                     "simple_sum_op.tflite",
                     "simple_tanh_op.tflite",
                     "simple_tile_op.tflite",
+                    "simple_topk_op.tflite",
                     "simple_transpose_conv_fused_tanh.tflite",
                     "simple_transpose_conv_op.tflite",
                     "simple_transpose_op.tflite",

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -84,6 +84,7 @@
 #include "litert/vendors/qualcomm/core/builders/strided_slice_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/tanh_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/tile_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/topk_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/transpose_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/unpack_op_builder.h"
@@ -656,6 +657,36 @@ LiteRtStatus ConvertOp(const bool use_htp_preferences,
     case LiteRtOpCode::kLiteRtOpCodeTflTile: {
       op_wrappers =
           ::qnn::BuildTileOp(tensor_pool, input_tensors, output_tensors);
+      break;
+    }
+    case LiteRtOpCode::kLiteRtOpCodeTflTopkV2: {
+      // TODO (Graham): Refactor all OpBuilder to follow QNN master definition
+      ::qnn::TensorWrapper k_tensor = input_tensors[1].get();
+      if (!k_tensor.IsTensorStatic() || k_tensor.GetTensorNumElements() != 1) {
+        QNN_LOG_ERROR(
+            "The param 'k' of TopK OP is not static or not 1 element");
+        return {};
+      }
+
+      std::uint32_t k_data = 0;
+      switch (k_tensor.GetDataType()) {
+        case QNN_DATATYPE_UINT_32:
+          if (auto k = k_tensor.GetTensorData<std::uint32_t>(); k.has_value()) {
+            k_data = k.value()[0];
+          }
+          break;
+        case QNN_DATATYPE_INT_32:
+          if (auto k = k_tensor.GetTensorData<std::int32_t>(); k.has_value()) {
+            k_data = static_cast<std::uint32_t>(k.value()[0]);
+          }
+          break;
+        default:
+          QNN_LOG_ERROR("Unsupported data type: %d for k in TopK OP",
+                        k_tensor.GetDataType());
+          return {};
+      }
+      op_wrappers = ::qnn::BuildTopKOp(tensor_pool, input_tensors,
+                                       output_tensors, k_data);
       break;
     }
     case LiteRtOpCode::kLiteRtOpCodeTflPack: {

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -349,6 +349,20 @@ cc_library(
 )
 
 cc_library(
+    name = "topk_op_builder",
+    srcs = ["topk_op_builder.cc"],
+    hdrs = ["topk_op_builder.h"],
+    deps = [
+        ":op_builder",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/utils:log",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+cc_library(
     name = "pack_op_builder",
     srcs = ["pack_op_builder.cc"],
     hdrs = ["pack_op_builder.h"],

--- a/litert/vendors/qualcomm/core/builders/topk_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/topk_op_builder.cc
@@ -1,0 +1,38 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/topk_op_builder.h"
+
+#include <vector>
+
+#include "QnnOpDef.h"  // from @qairt
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+namespace {
+constexpr bool kIsLargest = true;
+
+}  // namespace
+
+std::vector<OpWrapper> BuildTopKOp(TensorPool& tensor_pool,
+                                   const std::vector<TensorWrapperRef>& inputs,
+                                   const std::vector<TensorWrapperRef>& outputs,
+                                   std::uint32_t k) {
+  std::vector<OpWrapper> res;
+
+  auto& topk_op = CreateOpWrapper(res, QNN_OP_TOP_K);
+  topk_op.AddInputTensor(inputs[0]);
+  for (const auto& output : outputs) {
+    topk_op.AddOutputTensor(output);
+  }
+  topk_op.AddScalarParam<std::uint32_t>(QNN_OP_TOP_K_PARAM_K, k);
+  topk_op.AddScalarParam<bool>(QNN_OP_TOP_K_PARAM_LARGEST, kIsLargest);
+
+  return res;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/topk_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/topk_op_builder.h
@@ -1,0 +1,21 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TOPK_OP_BUILDER_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TOPK_OP_BUILDER_H_
+
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildTopKOp(TensorPool& tensor_pool,
+                                   const std::vector<TensorWrapperRef>& inputs,
+                                   const std::vector<TensorWrapperRef>& outputs,
+                                   std::uint32_t k);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_TOPK_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/qnn_backend_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/BUILD
@@ -36,6 +36,7 @@ litert_test(
         "//litert/vendors/qualcomm/core:common",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/builders:relu_op_builder",
+        "//litert/vendors/qualcomm/core/builders:topk_op_builder",
         "//litert/vendors/qualcomm/core/utils:miscs",
         "//litert/vendors/qualcomm/core/utils:qnn_model",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",

--- a/litert/vendors/qualcomm/qnn_backend_test/qnn_backend_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/qnn_backend_test.cc
@@ -10,6 +10,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "litert/vendors/qualcomm/core/builders/relu_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/topk_op_builder.h"
 #include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/utils/miscs.h"
@@ -17,6 +18,7 @@
 #include "litert/vendors/qualcomm/qnn_manager.h"
 #include "QnnTypes.h"  // from @qairt
 
+using testing::ElementsAre;
 using testing::FloatNear;
 using testing::Pointwise;
 namespace litert::qnn {
@@ -94,6 +96,50 @@ TEST_F(QnnModelTest, SingleRelu) {
   ASSERT_TRUE(output_data);
   ASSERT_EQ(output_data->size(), 4);
   ASSERT_THAT(output_data.value(), Pointwise(FloatNear(1e-3), {0, 0, 1, 2}));
+}
+
+TEST_F(QnnModelTest, SingleTopK) {
+  SetUpQnnModel(::qnn::Options(), "SM8650");
+
+  const std::vector<std::uint32_t> inputDims{1, 5};
+  const uint32_t k_value = 3;
+  const std::vector<std::uint32_t> outputDims{1, 3};
+
+  auto& input_tensor = tensor_pool_.CreateInputTensorWithSuffix(
+      QNN_DATATYPE_FLOAT_32, {}, inputDims, "");
+  auto& values_tensor = tensor_pool_.CreateOutpuTensorWithSuffix(
+      QNN_DATATYPE_FLOAT_32, {}, outputDims, "");
+  auto& indices_tensor = tensor_pool_.CreateOutpuTensorWithSuffix(
+      QNN_DATATYPE_UINT_32, {}, outputDims, "");
+
+  auto ops = ::qnn::BuildTopKOp(tensor_pool_, {input_tensor},
+                                {values_tensor, indices_tensor}, k_value);
+  ASSERT_FALSE(ops.empty());
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_tensor);
+  auto values_idx = qnn_model_.AddOutputTensor(values_tensor);
+  auto indices_idx = qnn_model_.AddOutputTensor(indices_tensor);
+
+  qnn_model_.SetInputData<float>(input_idx, {1.2f, 5.6f, 3.3f, 9.8f, 2.1f});
+  ASSERT_TRUE(qnn_model_.Execute());
+  auto values_data = qnn_model_.GetOutputData<float>(values_idx);
+  auto indices_data = qnn_model_.GetOutputData<std::uint32_t>(indices_idx);
+
+  ASSERT_TRUE(values_data);
+  ASSERT_TRUE(indices_data);
+  ASSERT_EQ(values_data->size(), 3);
+  ASSERT_EQ(indices_data->size(), 3);
+  ASSERT_THAT(values_data.value(),
+              Pointwise(FloatNear(1e-2), {9.8f, 5.6f, 3.3f}));
+  ASSERT_THAT(indices_data.value(), ElementsAre(3, 1, 2));
 }
 
 }  // namespace


### PR DESCRIPTION
Summary:

- Add Topk builder and related test/model.

Test Result:
======================== Test Summary ========================
//litert/c:litert_op_options_test
[==========] 36 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 36 tests.

//litert/c/options:litert_qualcomm_options_test
[==========] 17 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 17 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[==========] 8 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

//litert/vendors/qualcomm/core/backends:qnn_backend_test
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
YOU HAVE 4 DISABLED TESTS

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:common_test
[==========] 13 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 5 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 5 tests.

//litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

//litert/vendors/qualcomm/qnn_backend_test:qnn_backend_test
[==========] 3 tests from 1 test suite ran. (373 ms total)
[  PASSED  ] 1 test.

//litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (227 ms total)
[  PASSED  ] 3 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[==========] 234 tests from 4 test suites ran. (50197 ms total)
[  PASSED  ] 234 tests.