### PR TITLE
Qualcomm AI Engine Direct - Improve init time.

### DIFF
--- a/litert/runtime/compiled_model.cc
+++ b/litert/runtime/compiled_model.cc
@@ -692,6 +692,9 @@ litert::Expected<bool> LiteRtCompiledModelT::ApplyPluginsWithCaching(
   if (maybe_compiled_plugins.HasValue()) {
     TryApplyPluginsImpl(&model, hw_accelerators, maybe_compiled_plugins.Value(),
                         &need_reserialization);
+    // Store the compiler plugins to a member variable to postpone its
+    // destruction and reduce initialization time.
+    maybe_compiled_plugins_ = std::move(maybe_compiled_plugins.Value());
   }
   if (!need_reserialization) {
     return false;

--- a/litert/runtime/compiled_model.h
+++ b/litert/runtime/compiled_model.h
@@ -396,6 +396,7 @@ class LiteRtCompiledModelT {
   // Otherwise, the compiled model will be compiled and saved to the cache.
   std::optional<litert::internal::CompilationCache> compilation_cache_;
   std::optional<LiteRtModelT::Ptr> cached_model_;
+  std::vector<litert::internal::CompilerPlugin> maybe_compiled_plugins_;
 #endif  // !defined(LITERT_DISABLE_NPU)
 
   // The buffer requirement maps for CPU buffers. For delegates with CPU


### PR DESCRIPTION
Summary:
- Introduce maybe_compiled_plugins_ as a member variable to reduce initialization time.