### PR TITLE
Qualcomm AI Engine Direct - Enable graph priority option.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -45,6 +45,8 @@ struct LiteRtQualcommOptionsT {
   std::uint32_t num_hvx_threads = 0;
   LiteRtQualcommOptionsOptimizationLevel optimization_level =
       kHtpOptimizeForInferenceO3;
+  LiteRtQualcommOptionsGraphPriority graph_priority =
+      kLiteRTQualcommGraphPriorityDefault;
 };
 
 LiteRtStatus LiteRtQualcommOptionsCreate(LiteRtOpaqueOptions* options) {
@@ -423,6 +425,30 @@ LiteRtStatus LiteRtQualcommOptionsGetOptimizationLevel(
   }
 
   *optimization_level = options->optimization_level;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetGraphPriority(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsGraphPriority graph_priority) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->graph_priority = graph_priority;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetGraphPriority(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsGraphPriority* graph_priority) {
+  if (options == nullptr || graph_priority == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *graph_priority = options->graph_priority;
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -215,6 +215,22 @@ LiteRtStatus LiteRtQualcommOptionsGetOptimizationLevel(
     LiteRtQualcommOptions options,
     LiteRtQualcommOptionsOptimizationLevel* optimization_level);
 
+typedef enum LiteRtQualcommOptionsGraphPriority {
+  kLiteRTQualcommGraphPriorityDefault = 0,
+  kLiteRTQualcommGraphPriorityLow,
+  kLiteRTQualcommGraphPriorityNormal,
+  kLiteRTQualcommGraphPriorityNormalHigh,
+  kLiteRTQualcommGraphPriorityHigh,
+} LiteRtQualcommOptionsGraphPriority;
+
+LiteRtStatus LiteRtQualcommOptionsSetGraphPriority(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsGraphPriority graph_priority);
+
+LiteRtStatus LiteRtQualcommOptionsGetGraphPriority(
+    LiteRtQualcommOptions options,
+    LiteRtQualcommOptionsGraphPriority* graph_priority);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -238,6 +238,24 @@ TEST(LiteRtQualcommOptionsTest, OptimizationLevel) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
+TEST(LiteRtQualcommOptionsTest, GraphPriority) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetGraphPriority(
+      qualcomm_options, kLiteRTQualcommGraphPriorityHigh));
+
+  LiteRtQualcommOptionsGraphPriority graph_priority;
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsGetGraphPriority(qualcomm_options, &graph_priority));
+  EXPECT_EQ(graph_priority, kLiteRTQualcommGraphPriorityHigh);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
 TEST(LiteRtQualcommOptionsTest, DumpTensorIds) {
   LiteRtOpaqueOptions options;
   LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
@@ -355,6 +373,11 @@ TEST(QualcommOptionsTest, CppApi) {
       QualcommOptions::OptimizationLevel::kOptimizeForPrepare);
   EXPECT_EQ(options->GetOptimizationLevel(),
             QualcommOptions::OptimizationLevel::kOptimizeForPrepare);
+
+  EXPECT_EQ(options->GetGraphPriority(),
+            QualcommOptions::GraphPriority::kDefault);
+  options->SetGraphPriority(QualcommOptions::GraphPriority::kHigh);
+  EXPECT_EQ(options->GetGraphPriority(), QualcommOptions::GraphPriority::kHigh);
 
   EXPECT_TRUE(options->GetUseConvHMX());
   options->SetUseConvHMX(false);

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -59,10 +59,9 @@ QualcommOptions::LogLevel QualcommOptions::GetLogLevel() {
 
 void QualcommOptions::SetHtpPerformanceMode(
     QualcommOptions::HtpPerformanceMode htp_performance_mode) {
-  internal::AssertOk(
-      LiteRtQualcommOptionsSetHtpPerformanceMode, Data(),
-      static_cast<LiteRtQualcommOptionsHtpPerformanceMode>(
-          htp_performance_mode));
+  internal::AssertOk(LiteRtQualcommOptionsSetHtpPerformanceMode, Data(),
+                     static_cast<LiteRtQualcommOptionsHtpPerformanceMode>(
+                         htp_performance_mode));
 }
 
 QualcommOptions::HtpPerformanceMode QualcommOptions::GetHtpPerformanceMode() {
@@ -194,8 +193,21 @@ QualcommOptions::OptimizationLevel QualcommOptions::GetOptimizationLevel() {
   LiteRtQualcommOptionsOptimizationLevel optimization_level;
   internal::AssertOk(LiteRtQualcommOptionsGetOptimizationLevel, Data(),
                      &optimization_level);
-  return static_cast<QualcommOptions::OptimizationLevel>(
-      optimization_level);
+  return static_cast<QualcommOptions::OptimizationLevel>(optimization_level);
+}
+
+void QualcommOptions::SetGraphPriority(
+    QualcommOptions::GraphPriority graph_priority) {
+  internal::AssertOk(
+      LiteRtQualcommOptionsSetGraphPriority, Data(),
+      static_cast<LiteRtQualcommOptionsGraphPriority>(graph_priority));
+}
+
+QualcommOptions::GraphPriority QualcommOptions::GetGraphPriority() {
+  LiteRtQualcommOptionsGraphPriority graph_priority;
+  internal::AssertOk(LiteRtQualcommOptionsGetGraphPriority, Data(),
+                     &graph_priority);
+  return static_cast<QualcommOptions::GraphPriority>(graph_priority);
 }
 
 void QualcommOptions::SetUseConvHMX(bool use_conv_hmx) {

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -136,6 +136,17 @@ class QualcommOptions : public OpaqueOptions {
   void SetOptimizationLevel(OptimizationLevel optimization_level);
   OptimizationLevel GetOptimizationLevel();
 
+  enum class GraphPriority : int {
+    kDefault = kLiteRTQualcommGraphPriorityDefault,
+    kLow = kLiteRTQualcommGraphPriorityLow,
+    kNormal = kLiteRTQualcommGraphPriorityNormal,
+    kNormalHigh = kLiteRTQualcommGraphPriorityNormalHigh,
+    kHigh = kLiteRTQualcommGraphPriorityHigh,
+  };
+
+  void SetGraphPriority(GraphPriority graph_priority);
+  GraphPriority GetGraphPriority();
+
  private:
   LiteRtQualcommOptions Data() const;
 };

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -254,6 +254,12 @@ ABSL_FLAG(litert::qualcomm::QualcommOptions::OptimizationLevel,
               kOptimizeForInferenceO3,
           "QNN optimization level");
 
+ABSL_FLAG(litert::qualcomm::QualcommOptions::GraphPriority,
+          qualcomm_graph_priority,
+          litert::qualcomm::QualcommOptions::GraphPriority::kDefault,
+          "QNN graph priority, If the option is set to 'default', the "
+          "QNN_PRIORITY_DEFAULT (Equal to QNN_PRIORITY_NORMAL) will be used.");
+
 namespace litert::qualcomm {
 
 bool AbslParseFlag(absl::string_view text,
@@ -276,6 +282,48 @@ bool AbslParseFlag(absl::string_view text,
   }
   *error = "Unknown optimization level";
   return false;
+}
+
+bool AbslParseFlag(absl::string_view text,
+                   QualcommOptions::GraphPriority* graph_priority,
+                   std::string* error) {
+  if (text == "default") {
+    *graph_priority = QualcommOptions::GraphPriority::kDefault;
+    return true;
+  }
+  if (text == "low") {
+    *graph_priority = QualcommOptions::GraphPriority::kLow;
+    return true;
+  }
+  if (text == "normal") {
+    *graph_priority = QualcommOptions::GraphPriority::kNormal;
+    return true;
+  }
+  if (text == "normal_high") {
+    *graph_priority = QualcommOptions::GraphPriority::kNormalHigh;
+    return true;
+  }
+  if (text == "high") {
+    *graph_priority = QualcommOptions::GraphPriority::kHigh;
+    return true;
+  }
+  *error = "Unknown graph priority";
+  return false;
+}
+
+std::string AbslUnparseFlag(QualcommOptions::GraphPriority graph_priority) {
+  switch (graph_priority) {
+    case QualcommOptions::GraphPriority::kDefault:
+      return "default";
+    case QualcommOptions::GraphPriority::kLow:
+      return "low";
+    case QualcommOptions::GraphPriority::kNormal:
+      return "normal";
+    case QualcommOptions::GraphPriority::kNormalHigh:
+      return "normal_high";
+    case QualcommOptions::GraphPriority::kHigh:
+      return "high";
+  }
 }
 
 std::string AbslUnparseFlag(
@@ -351,6 +399,9 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
   const auto optimization_level =
       absl::GetFlag(FLAGS_qualcomm_optimization_level);
   opts.SetOptimizationLevel(optimization_level);
+
+  const auto graph_priority = absl::GetFlag(FLAGS_qualcomm_graph_priority);
+  opts.SetGraphPriority(graph_priority);
 
   const auto use_conv_hmx = absl::GetFlag(FLAGS_qualcomm_use_conv_hmx);
   opts.SetUseConvHMX(use_conv_hmx);

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -64,6 +64,8 @@ ABSL_DECLARE_FLAG(uint32_t, qualcomm_num_hvx_thread);
 
 ABSL_DECLARE_FLAG(litert::qualcomm::QualcommOptions::OptimizationLevel,
                   qualcomm_optimization_level);
+ABSL_DECLARE_FLAG(litert::qualcomm::QualcommOptions::GraphPriority,
+                  qualcomm_graph_priority);
 
 namespace litert::qualcomm {
 
@@ -73,6 +75,12 @@ bool AbslParseFlag(absl::string_view text,
 
 std::string AbslUnparseFlag(
     QualcommOptions::OptimizationLevel optimization_level);
+
+bool AbslParseFlag(absl::string_view text,
+                   QualcommOptions::GraphPriority* graph_priority,
+                   std::string* error);
+
+std::string AbslUnparseFlag(QualcommOptions::GraphPriority graph_priority);
 
 }  // namespace litert::qualcomm
 

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -282,6 +282,56 @@ TEST(OptimizationLevelTest, Parse) {
   }
 }
 
+TEST(GraphPriorityTest, Parse) {
+  std::string error;
+  QualcommOptions::GraphPriority value;
+
+  {
+    static constexpr absl::string_view kGraphPriority = "default";
+    static constexpr QualcommOptions::GraphPriority kGraphPriorityEnum =
+        QualcommOptions::GraphPriority::kDefault;
+    EXPECT_TRUE(AbslParseFlag(kGraphPriority, &value, &error));
+    EXPECT_EQ(value, kGraphPriorityEnum);
+    EXPECT_EQ(kGraphPriority, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kGraphPriority = "low";
+    static constexpr QualcommOptions::GraphPriority kGraphPriorityEnum =
+        QualcommOptions::GraphPriority::kLow;
+    EXPECT_TRUE(AbslParseFlag(kGraphPriority, &value, &error));
+    EXPECT_EQ(value, kGraphPriorityEnum);
+    EXPECT_EQ(kGraphPriority, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kGraphPriority = "normal";
+    static constexpr QualcommOptions::GraphPriority kGraphPriorityEnum =
+        QualcommOptions::GraphPriority::kNormal;
+    EXPECT_TRUE(AbslParseFlag(kGraphPriority, &value, &error));
+    EXPECT_EQ(value, kGraphPriorityEnum);
+    EXPECT_EQ(kGraphPriority, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kGraphPriority = "normal_high";
+    static constexpr QualcommOptions::GraphPriority kGraphPriorityEnum =
+        QualcommOptions::GraphPriority::kNormalHigh;
+    EXPECT_TRUE(AbslParseFlag(kGraphPriority, &value, &error));
+    EXPECT_EQ(value, kGraphPriorityEnum);
+    EXPECT_EQ(kGraphPriority, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kGraphPriority = "high";
+    static constexpr QualcommOptions::GraphPriority kGraphPriorityEnum =
+        QualcommOptions::GraphPriority::kHigh;
+    EXPECT_TRUE(AbslParseFlag(kGraphPriority, &value, &error));
+    EXPECT_EQ(value, kGraphPriorityEnum);
+    EXPECT_EQ(kGraphPriority, AbslUnparseFlag(value));
+  }
+}
+
 TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   Expected<QualcommOptions> options = QualcommOptions::Create();
   ASSERT_TRUE(options.HasValue());
@@ -300,6 +350,8 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   EXPECT_EQ(options.Value().GetNumHvxThreads(), 0);
   EXPECT_EQ(options.Value().GetOptimizationLevel(),
             QualcommOptions::OptimizationLevel::kOptimizeForInferenceO3);
+  EXPECT_EQ(options.Value().GetGraphPriority(),
+            QualcommOptions::GraphPriority::kDefault);
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -120,6 +120,8 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetNumHvxThreads(qualcomm_options.GetNumHvxThreads());
   qnn_options.SetOptimizationLevel(static_cast<::qnn::OptimizationLevel>(
       qualcomm_options.GetOptimizationLevel()));
+  qnn_options.SetGraphPriority(
+      static_cast<::qnn::GraphPriority>(qualcomm_options.GetGraphPriority()));
   qnn_options.SetDumpTensorIds(qualcomm_options.GetDumpTensorIds());
 
   // TODO(jiunkaiy): Set backend type based on qualcomm options.

--- a/litert/vendors/qualcomm/compiler/graph_mapper.cc
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.cc
@@ -53,11 +53,29 @@ float GetOptimizationValue(::qnn::OptimizationLevel level) {
   }
 }
 
+Qnn_Priority_t GetGraphPriorityValue(::qnn::GraphPriority graph_priority) {
+  // Default priority is NORMAL
+  switch (graph_priority) {
+    case ::qnn::GraphPriority::kDefault:
+      return QNN_PRIORITY_DEFAULT;
+    case ::qnn::GraphPriority::kLow:
+      return QNN_PRIORITY_LOW;
+    case ::qnn::GraphPriority::kNormal:
+      return QNN_PRIORITY_NORMAL;
+    case ::qnn::GraphPriority::kNormalHigh:
+      return QNN_PRIORITY_NORMAL_HIGH;
+    case ::qnn::GraphPriority::kHigh:
+      return QNN_PRIORITY_HIGH;
+    default:
+      return QNN_PRIORITY_UNDEFINED;
+  }
+}
+
 inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
     const ::qnn::Options& options) {
   static std::array<QnnHtpGraph_CustomConfig_t, 6> graph_custom_configs;
-  static std::array<QnnGraph_Config_t, 6> graph_configs;
-  static std::array<const QnnGraph_Config_t*, 7> result;
+  static std::array<QnnGraph_Config_t, 7> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 8> result;
 
   // QNN suggest always enable relax precision.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
@@ -105,6 +123,14 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
     result[i] = &graph_configs[i];
   }
 
+  // Graph Priority
+  graph_configs[num_config] = QNN_GRAPH_CONFIG_INIT;
+  graph_configs[num_config].option = QNN_GRAPH_CONFIG_OPTION_PRIORITY;
+  graph_configs[num_config].priority =
+      GetGraphPriorityValue(options.GetGraphPriority());
+  result[num_config] = &graph_configs[num_config];
+  num_config++;
+
   result[num_config] = nullptr;
   return absl::MakeSpan(result.data(), num_config + 1);
 }
@@ -112,8 +138,8 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
 inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
     const ::qnn::Options& options) {
   static std::array<QnnHtpGraph_CustomConfig_t, 5> graph_custom_configs;
-  static std::array<QnnGraph_Config_t, 5> graph_configs;
-  static std::array<const QnnGraph_Config_t*, 6> result;
+  static std::array<QnnGraph_Config_t, 6> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 7> result;
   // Default use O3 for now.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[0].option = QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
@@ -156,6 +182,14 @@ inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
     graph_configs[i].customConfig = &graph_custom_configs[i];
     result[i] = &graph_configs[i];
   }
+
+  // Graph Priority
+  graph_configs[num_config] = QNN_GRAPH_CONFIG_INIT;
+  graph_configs[num_config].option = QNN_GRAPH_CONFIG_OPTION_PRIORITY;
+  graph_configs[num_config].priority =
+      GetGraphPriorityValue(options.GetGraphPriority());
+  result[num_config] = &graph_configs[num_config];
+  num_config++;
 
   result[num_config] = nullptr;
   return absl::MakeSpan(result.data(), num_config + 1);

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -137,6 +137,12 @@ void Options::SetOptimizationLevel(OptimizationLevel optimization_level) {
   optimization_level_ = optimization_level;
 }
 
+GraphPriority Options::GetGraphPriority() const { return graph_priority_; }
+
+void Options::SetGraphPriority(GraphPriority graph_priority) {
+  graph_priority_ = graph_priority;
+}
+
 std::string Options::Dump() const {
   static constexpr absl::string_view kQnnOptionsDumpFormat =
       "\
@@ -154,15 +160,17 @@ IrJsonDir: %s\n\
 DlcDir: %s\n\
 VtcmSize: %d\n\
 HvxThread: %d\n\
-OptimizationLevel: %d\n";  // NOLINT
+OptimizationLevel: %d\n\
+GraphPriority: %d\n";  // NOLINT
 
   std::string dump_tensor_ids = absl::StrJoin(dump_tensor_ids_, ",");
 
-  return absl::StrFormat(
-      kQnnOptionsDumpFormat, log_level_, profiling_, use_htp_preference_,
-      use_qint16_as_quint16_, enable_weight_sharing_, use_conv_hmx_,
-      use_fold_relu_, htp_performance_mode_, dump_tensor_ids, ir_json_dir_,
-      dlc_dir_, vtcm_size_, num_hvx_threads_, optimization_level_);
+  return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, profiling_,
+                         use_htp_preference_, use_qint16_as_quint16_,
+                         enable_weight_sharing_, use_conv_hmx_, use_fold_relu_,
+                         htp_performance_mode_, dump_tensor_ids, ir_json_dir_,
+                         dlc_dir_, vtcm_size_, num_hvx_threads_,
+                         optimization_level_, graph_priority_);
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -56,6 +56,14 @@ enum class OptimizationLevel {
   kHtpOptimizeForInferenceO3 = 2,
 };
 
+enum class GraphPriority {
+  kDefault = 0,
+  kLow = 1,
+  kNormal = 2,
+  kNormalHigh = 3,
+  kHigh = 4,
+};
+
 class Options {
  public:
   Options() = default;
@@ -106,6 +114,9 @@ class Options {
   void SetOptimizationLevel(OptimizationLevel optimization_level);
   OptimizationLevel GetOptimizationLevel() const;
 
+  void SetGraphPriority(GraphPriority graph_priority);
+  GraphPriority GetGraphPriority() const;
+
   std::string Dump() const;
 
  private:
@@ -125,6 +136,7 @@ class Options {
   std::uint32_t num_hvx_threads_ = 0;
   OptimizationLevel optimization_level_ =
       OptimizationLevel::kHtpOptimizeForInferenceO3;
+  GraphPriority graph_priority_ = GraphPriority::kDefault;
 };
 
 // Gets a default logger implementation to stdout.

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -189,6 +189,15 @@ TEST(QnnOptionTest, SetOptimizationLevel) {
             OptimizationLevel::kHtpOptimizeForInferenceO3);
 }
 
+TEST(QnnOptionTest, SetGraphPriority) {
+  Options options;
+  options.SetGraphPriority(GraphPriority::kHigh);
+  EXPECT_NE(options.GetGraphPriority(), GraphPriority::kDefault);
+  EXPECT_EQ(options.GetGraphPriority(), GraphPriority::kHigh);
+  options.SetGraphPriority(GraphPriority::kDefault);
+  EXPECT_EQ(options.GetGraphPriority(), GraphPriority::kDefault);
+}
+
 TEST(QnnOptionTest, Default) {
   Options options;
   EXPECT_EQ(options.GetLogLevel(), LogLevel::kInfo);
@@ -206,6 +215,7 @@ TEST(QnnOptionTest, Default) {
   EXPECT_EQ(options.GetNumHvxThreads(), 0);
   EXPECT_EQ(options.GetOptimizationLevel(),
             OptimizationLevel::kHtpOptimizeForInferenceO3);
+  EXPECT_EQ(options.GetGraphPriority(), GraphPriority::kDefault);
 }
 
 }  // namespace


### PR DESCRIPTION
Summary:
- Add --qualcomm_graph_priority in compilation flow.
- Add related tests.

Test Result:
======================== Test Summary ========================
//litert/c:litert_op_options_test
[==========] 36 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 36 tests.

//litert/c/options:litert_qualcomm_options_test
[==========] 19 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[==========] 9 tests from 6 test suites ran. (0 ms total)
[  PASSED  ] 9 tests.

//litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

//litert/vendors/qualcomm/core/backends:qnn_backend_test
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
YOU HAVE 4 DISABLED TESTS

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 19 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 19 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:common_test
[==========] 15 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 15 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 7 tests from 4 test suites ran. (1 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

//litert/vendors/qualcomm/qnn_backend_test:qnn_backend_test
[==========] 3 tests from 1 test suite ran. (366 ms total)
[  PASSED  ] 1 test.

//litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (219 ms total)
[  PASSED  ] 3 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[==========] 240 tests from 4 test suites ran. (51130 ms total)
[  PASSED  ] 240 tests.