### PR TITLE
Qualcomm AI Engine Direct - followup PR to fix tensor_pool_test

### DIFF
--- a/litert/vendors/qualcomm/core/tensor_pool_test.cc
+++ b/litert/vendors/qualcomm/core/tensor_pool_test.cc
@@ -328,33 +328,33 @@ TEST(TensorPoolConvertStaticTensorTest, CreateStatictensorByValueSFixInt32) {
 }
 
 // TODO(@chengwl-qti): Re-enable this test when it passes in dbg mode.
-// TEST(TensorPoolConvertStaticTensorTest, CreateStatictensorByValueUFixInt32) {
-//   TensorPool tensor_pool;
+TEST(TensorPoolConvertStaticTensorTest, CreateStatictensorByValueUFixInt32) {
+  TensorPool tensor_pool;
 
-//   ScaleOffsetQuantizeParamsWrapper q_param(2, -5);  // offset = 5
+  ScaleOffsetQuantizeParamsWrapper q_param(2, 5);  // offset = -5
 
-//   std::vector<float> golden_data = {2, 2, 2};
+  std::vector<float> golden_data = {2, 2, 2};
 
-//   TensorWrapper* tensor_wrapper = tensor_pool.CreateStaticTensorWithValue(
-//       QNN_DATATYPE_UFIXED_POINT_32, q_param, {1, 1, 3}, 2.0);
-//   ASSERT_NE(tensor_wrapper, nullptr);
+  TensorWrapper* tensor_wrapper = tensor_pool.CreateStaticTensorWithValue(
+      QNN_DATATYPE_UFIXED_POINT_32, q_param, {1, 1, 3}, 2.0);
+  ASSERT_NE(tensor_wrapper, nullptr);
 
-//   const auto& q_param_ref = tensor_wrapper->GetQuantParams();
-//   const float scale =
-//       std::get<ScaleOffsetQuantizeParamsWrapper>(q_param_ref).GetScale();
-//   const std::int32_t zero_point =
-//       std::get<ScaleOffsetQuantizeParamsWrapper>(q_param_ref).GetZeroPoint();
+  const auto& q_param_ref = tensor_wrapper->GetQuantParams();
+  const float scale =
+      std::get<ScaleOffsetQuantizeParamsWrapper>(q_param_ref).GetScale();
+  const std::int32_t zero_point =
+      std::get<ScaleOffsetQuantizeParamsWrapper>(q_param_ref).GetZeroPoint();
 
-//   const auto tensor_data = tensor_wrapper->GetTensorData<std::uint32_t>();
+  const auto tensor_data = tensor_wrapper->GetTensorData<std::uint32_t>();
 
-//   EXPECT_TRUE(tensor_data.has_value());
+  EXPECT_TRUE(tensor_data.has_value());
 
-//   // Dequantize each element from the tensor data.
-//   for (int i = 0; i < golden_data.size(); i++) {
-//     EXPECT_NEAR(Dequantize((*tensor_data)[i], scale, zero_point),
-//                 golden_data[i], 1e-7);
-//   }
-// }
+  // Dequantize each element from the tensor data.
+  for (int i = 0; i < golden_data.size(); i++) {
+    EXPECT_NEAR(Dequantize((*tensor_data)[i], scale, zero_point),
+                golden_data[i], 1e-7);
+  }
+}
 
 TEST(TensorPoolConvertStaticTensorTest, CreateStatictensorByValueInt32) {
   TensorPool tensor_pool;


### PR DESCRIPTION
Summary:
- Fix Pull Request #3562 for CreateStatictensorByValueUFixInt32


```
INFO: Running command line: external/bazel_tools/tools/test/test-setup.sh litert/vendors/qualcomm/core/tensor_pool_test
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //litert/vendors/qualcomm/core:tensor_pool_test
-----------------------------------------------------------------------------
Running main() from gmock_main.cc
[==========] Running 17 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 17 tests from TensorPoolConvertStaticTensorTest
[ RUN      ] TensorPoolConvertStaticTensorTest.ConvertNonStaticTensor
ERROR: [Qnn] Cannot convert non-static tensor to static tensor.
[       OK ] TensorPoolConvertStaticTensorTest.ConvertNonStaticTensor (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.ExceedRangeAndFailToConvert
ERROR: [Qnn] Source data exceeds the range of destination data type.
[       OK ] TensorPoolConvertStaticTensorTest.ExceedRangeAndFailToConvert (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.SameTypeConversionFloat32
[       OK ] TensorPoolConvertStaticTensorTest.SameTypeConversionFloat32 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.SameTypeConversionInt32
[       OK ] TensorPoolConvertStaticTensorTest.SameTypeConversionInt32 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.ExpandTypeConversionFloat32
[       OK ] TensorPoolConvertStaticTensorTest.ExpandTypeConversionFloat32 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.ExpandTypeConversionInt32
[       OK ] TensorPoolConvertStaticTensorTest.ExpandTypeConversionInt32 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.NarrowTypeConversionFloat32
[       OK ] TensorPoolConvertStaticTensorTest.NarrowTypeConversionFloat32 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.NarrowTypeConversionInt32
[       OK ] TensorPoolConvertStaticTensorTest.NarrowTypeConversionInt32 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueFloat
[       OK ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueFloat (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueInt8
[       OK ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueInt8 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueUInt8
[       OK ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueUInt8 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueInt16
[       OK ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueInt16 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueUInt16
[       OK ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueUInt16 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueSFixInt32
[       OK ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueSFixInt32 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueUFixInt32
[       OK ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueUFixInt32 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueInt32
[       OK ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueInt32 (0 ms)
[ RUN      ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueUInt32
[       OK ] TensorPoolConvertStaticTensorTest.CreateStatictensorByValueUInt32 (0 ms)
[----------] 17 tests from TensorPoolConvertStaticTensorTest (0 ms total)

[----------] Global test environment tear-down
[==========] 17 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 17 tests.
```