### PR TITLE
Qualcomm AI Engine Direct - Build qualcomm compile so with cmake.

### DIFF
--- a/litert/c/CMakeLists.txt
+++ b/litert/c/CMakeLists.txt
@@ -180,7 +180,7 @@ set(_litert_runtime_c_api_private_archives
     "${TFLITE_BUILD_DIR}/libxnnpack-delegate.a"
     "${TFLITE_BUILD_DIR}/_deps/xnnpack-build/libXNNPACK.a"
     "${TFLITE_BUILD_DIR}/_deps/xnnpack-build/libxnnpack-microkernels-prod.a"
-    "${TFLITE_BUILD_DIR}/kleidiai/libkleidiai.a"
+    $<$<NOT:$<STREQUAL:${CMAKE_SYSTEM_PROCESSOR},x86_64>>:${TFLITE_BUILD_DIR}/kleidiai/libkleidiai.a>
     "${TFLITE_BUILD_DIR}/_deps/ruy-build/ruy/libruy_allocator.a"
     "${TFLITE_BUILD_DIR}/_deps/ruy-build/ruy/libruy_apply_multiplier.a"
     "${TFLITE_BUILD_DIR}/_deps/ruy-build/ruy/libruy_block_map.a"

--- a/litert/cc/CMakeLists.txt
+++ b/litert/cc/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(litert_cc_api STATIC
     internal/litert_rewriter.cc
     internal/litert_shared_library.cc
     internal/litert_tensor_buffer_utils.cc
+    internal/litert_extended_model.cc
     litert_compiled_model.cc
     litert_macros.cc
     litert_model.cc

--- a/litert/tools/CMakeLists.txt
+++ b/litert/tools/CMakeLists.txt
@@ -112,6 +112,31 @@ target_link_libraries(litert_npu_numerics_check
 # Add flags
 add_subdirectory(flags)
 
+# Common libraries for tools that use TFLite
+set(LITERT_TOOL_COMMON_LIBS
+    litert_c_api
+    litert_cc_api
+    litert_cc_internal
+    litert_cc_options
+    litert_compiler_plugin
+    litert_core
+    litert_core_model
+    litert_runtime
+)
+
+set(ABSEIL_TOOL_LIBS
+    absl::flags
+    absl::flags_parse
+    absl::log
+    absl::log_internal_check_op
+    absl::log_internal_message
+    absl::random_random
+    absl::string_view
+    absl::span
+    absl::status
+    absl::statusor
+)
+
 # run_model
 add_executable(run_model
     run_model.cc
@@ -124,30 +149,36 @@ target_include_directories(run_model
         ${TENSORFLOW_SOURCE_DIR}
 )
 
-target_link_libraries(run_model
-    PRIVATE
-        litert_tool_display
-        litert_c_api
-        litert_cc_api
-        litert_cc_internal
-        litert_cc_options
-        litert_core
-        litert_core_model
-        litert_runtime
-        tensorflow-lite
-        litert_tool_flags_google_tensor
-        litert_tool_flags_intel_openvino
-        litert_tool_flags_mediatek
-        litert_tool_flags_qualcomm
-        absl::flags
-        absl::flags_parse
-        absl::random_random
-        absl::log
-        absl::log_internal_check_op
-        absl::string_view
-        absl::span
-        Threads::Threads
-)
+# Platform-aware linking
+if(ANDROID OR APPLE)
+    target_link_libraries(run_model
+        PRIVATE
+            litert_tool_display
+            litert_tool_flags_google_tensor
+            litert_tool_flags_intel_openvino
+            litert_tool_flags_mediatek
+            litert_tool_flags_qualcomm
+            ${LITERT_TOOL_COMMON_LIBS}
+            tensorflow-lite
+            ${ABSEIL_TOOL_LIBS}
+            Threads::Threads
+    )
+else()
+    target_link_libraries(run_model
+        PRIVATE
+            litert_tool_display
+            litert_tool_flags_google_tensor
+            litert_tool_flags_intel_openvino
+            litert_tool_flags_mediatek
+            litert_tool_flags_qualcomm
+            Threads::Threads
+            tensorflow-lite
+            "-Wl,--start-group"
+            ${ABSEIL_TOOL_LIBS}
+            ${LITERT_TOOL_COMMON_LIBS}
+            "-Wl,--end-group"
+    )
+endif()
 
 # analyze_model
 add_executable(analyze_model
@@ -161,19 +192,37 @@ target_include_directories(analyze_model
         ${TENSORFLOW_SOURCE_DIR}
 )
 
-target_link_libraries(analyze_model
-    PRIVATE
-        litert_dump
-        litert_tool_display
-        litert_core
-        litert_core_model
-        tensorflow-lite
-        absl::flags
-        absl::flags_parse
-        absl::log
-        absl::status
-        absl::statusor
-)
+# Platform-aware linking for analyze_model
+if(ANDROID OR APPLE)
+    target_link_libraries(analyze_model
+        PRIVATE
+            litert_dump
+            litert_tool_display
+            litert_c_api
+            litert_core
+            litert_core_model
+            tensorflow-lite
+            absl::flags
+            absl::flags_parse
+            absl::log
+            absl::status
+            absl::statusor
+    )
+else()
+    target_link_libraries(analyze_model
+        PRIVATE
+            Threads::Threads
+            tensorflow-lite
+            "-Wl,--start-group"
+            ${ABSEIL_TOOL_LIBS}
+            litert_dump
+            litert_tool_display
+            litert_c_api
+            litert_core
+            litert_core_model
+            "-Wl,--end-group"
+    )
+endif()
 
 # apply_plugin
 add_executable(apply_plugin_main
@@ -187,30 +236,44 @@ target_include_directories(apply_plugin_main
         ${TENSORFLOW_SOURCE_DIR}
 )
 
-target_link_libraries(apply_plugin_main
-    PRIVATE
-        litert_apply_plugin
-        litert_dump
-        litert_tool_flags_apply_plugin
-        litert_tool_flags_common
-        litert_tool_flags_google_tensor
-        litert_tool_flags_intel_openvino
-        litert_tool_flags_mediatek
-        litert_tool_flags_qualcomm
-
-        litert_tool_display
-        litert_core
-        litert_core_model
-        litert_runtime
-        tensorflow-lite
-        absl::flags
-        absl::flags_parse
-        absl::log
-        absl::log_internal_check_op
-        absl::status
-        absl::statusor
-)
-
+# Platform-aware linking
+if(ANDROID OR APPLE)
+    target_link_libraries(apply_plugin_main
+        PRIVATE
+            litert_tool_display
+            litert_apply_plugin
+            litert_dump
+            litert_tool_flags_apply_plugin
+            litert_tool_flags_common
+            litert_tool_flags_google_tensor
+            litert_tool_flags_intel_openvino
+            litert_tool_flags_mediatek
+            litert_tool_flags_qualcomm
+            ${LITERT_TOOL_COMMON_LIBS}
+            tensorflow-lite
+            ${ABSEIL_TOOL_LIBS}
+            Threads::Threads
+        )
+else()
+    target_link_libraries(apply_plugin_main
+        PRIVATE
+            litert_tool_flags_apply_plugin
+            litert_tool_flags_common
+            litert_tool_flags_google_tensor
+            litert_tool_flags_intel_openvino
+            litert_tool_flags_mediatek
+            litert_tool_flags_qualcomm
+            Threads::Threads
+            tensorflow-lite
+            "-Wl,--start-group"
+            litert_tool_display
+            litert_apply_plugin
+            litert_dump
+            ${ABSEIL_TOOL_LIBS}
+            ${LITERT_TOOL_COMMON_LIBS}
+            "-Wl,--end-group"
+    )
+endif()
 # Platform-specific configurations for all executables
 if(LITERT_PLATFORM_ANDROID)
     target_link_libraries(run_model PRIVATE ${LOG_LIB})

--- a/litert/vendors/CMakeLists.txt
+++ b/litert/vendors/CMakeLists.txt
@@ -255,6 +255,7 @@ if(QAIRT_HEADERS_DIR AND NOT LITERT_ENABLE_QUALCOMM)
   set(LITERT_ENABLE_QUALCOMM ON CACHE BOOL "" FORCE)
 endif()
 if(LITERT_ENABLE_QUALCOMM)
-  _litert_add_dispatch_so(Qualcomm "qualcomm/dispatch" "Qualcomm")
+  # Use modular CMake structure for Qualcomm
+  add_subdirectory(qualcomm)
 endif()
 

--- a/litert/vendors/qualcomm/CMakeLists.txt
+++ b/litert/vendors/qualcomm/CMakeLists.txt
@@ -1,0 +1,94 @@
+# Copyright 2025 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Qualcomm QNN Build Configuration
+cmake_minimum_required(VERSION 3.20)
+
+# This file is included from litert/vendors/CMakeLists.txt
+# Variables available: QAIRT_HEADERS_DIR, TFLITE_BUILD_DIR, etc.
+
+message(STATUS "Configuring Qualcomm QNN support")
+
+# Fetch dependencies needed by core libraries (dump needs nlohmann_json)
+include(FetchContent)
+
+FetchContent_Declare(
+        nlohmann_json
+        GIT_REPOSITORY https://github.com/nlohmann/json.git
+        GIT_TAG v3.11.3
+    )
+    FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.12.x
+    )
+    FetchContent_Declare(
+        googlebenchmark
+        GIT_REPOSITORY https://github.com/google/benchmark.git
+        GIT_TAG 0d98dba29d66e93259db7daa53a9327df767a415 # v1.6.1
+)
+
+FetchContent_MakeAvailable(nlohmann_json)
+FetchContent_MakeAvailable(googletest)
+
+# Disable -Werror for googlebenchmark to avoid -Wunused-but-set-variable errors
+set(BENCHMARK_ENABLE_WERROR OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googlebenchmark)
+
+# Root-level libraries (used by core and other components)
+# QNN Manager library
+add_library(qnn_manager STATIC
+    qnn_manager.cc
+)
+
+target_include_directories(qnn_manager
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<$<BOOL:${QAIRT_HEADERS_DIR}>:${QAIRT_HEADERS_DIR}>
+)
+
+target_link_libraries(qnn_manager
+    PUBLIC
+        absl::status
+        absl::statusor
+        absl::strings
+        absl::str_format
+)
+
+# Context Binary Info library
+add_library(qnn_context_binary_info STATIC
+    context_binary_info.cc
+)
+
+target_include_directories(qnn_context_binary_info
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<$<BOOL:${QAIRT_HEADERS_DIR}>:${QAIRT_HEADERS_DIR}>
+)
+
+target_link_libraries(qnn_context_binary_info
+    PUBLIC
+        absl::status
+        absl::statusor
+)
+
+# Add subdirectories for modular build
+add_subdirectory(core)
+add_subdirectory(dispatch)
+add_subdirectory(compiler)
+
+# Optionally add tests
+if(LITERT_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/litert/vendors/qualcomm/compiler/CMakeLists.txt
+++ b/litert/vendors/qualcomm/compiler/CMakeLists.txt
@@ -1,0 +1,57 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Qualcomm Compiler Plugin Shared Library
+cmake_minimum_required(VERSION 3.20)
+
+message(STATUS "Building Qualcomm compiler plugin for host")
+
+# Dependencies (nlohmann_json, googletest, googlebenchmark) are fetched at parent level
+
+# Create compiler plugin shared library
+add_library(qnn_compiler_plugin SHARED
+    qnn_compiler_plugin.cc
+    qnn_compose_graph.cc
+    graph_mapper.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../cc/namespace_heuristics.cc
+)
+
+target_include_directories(qnn_compiler_plugin
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+)
+
+target_link_libraries(qnn_compiler_plugin
+    PUBLIC
+        qnn_core
+    PRIVATE
+        qnn_builders
+        qnn_manager
+        qnn_transformation
+        qnn_dump
+        qnn_context_binary_info
+        tensorflow-lite
+        absl::log
+        absl::check
+)
+
+set_target_properties(qnn_compiler_plugin PROPERTIES
+    OUTPUT_NAME "LiteRtCompilerPlugin_Qualcomm"
+)
+
+if(UNIX AND NOT APPLE)
+    target_link_options(qnn_compiler_plugin PRIVATE 
+        "-Wl,-soname=libLiteRtCompilerPlugin_Qualcomm.so"
+    )
+
+    target_link_libraries(qnn_compiler_plugin PRIVATE 
+        "-Wl,--start-group"
+        litert_runtime_c_api_shared_lib 
+        tensorflow-lite
+        Threads::Threads
+        litert_compiler_plugin
+        litert_cc_api
+        litert_cc_options
+        "-Wl,--end-group"
+    )
+endif()

--- a/litert/vendors/qualcomm/core/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Qualcomm QNN Core Library
+cmake_minimum_required(VERSION 3.20)
+
+# Core QNN library - shared between dispatch and compiler
+add_library(qnn_core STATIC
+    # Core
+    common.cc
+    tensor_pool.cc
+    
+    # Utils
+    utils/miscs.cc
+    
+    # Schema
+    schema/soc_table.cc
+)
+
+# Platform-specific logging
+if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+    target_sources(qnn_core PRIVATE utils/log_android.cc)
+else()
+    target_sources(qnn_core PRIVATE utils/log_default.cc)
+endif()
+
+target_include_directories(qnn_core
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<$<BOOL:${QAIRT_HEADERS_DIR}>:${QAIRT_HEADERS_DIR}>
+)
+
+target_link_libraries(qnn_core
+    PUBLIC
+        absl::status
+        absl::statusor
+        absl::strings
+        absl::str_format
+        absl::span
+        absl::string_view
+        qnn_backends
+        qnn_wrappers
+)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+    target_link_libraries(qnn_core PUBLIC android log)
+endif()
+
+# Add subdirectories for backends, wrappers, builders, transformation, dump (used by compiler)
+add_subdirectory(backends)
+add_subdirectory(wrappers)
+add_subdirectory(builders)
+add_subdirectory(transformation)
+add_subdirectory(dump)

--- a/litert/vendors/qualcomm/core/backends/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/backends/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# QNN Backends Library
+cmake_minimum_required(VERSION 3.20)
+
+# Create backends library with explicit source list
+add_library(qnn_backends STATIC)
+
+target_sources(qnn_backends
+    PRIVATE
+        htp_backend.cc
+        htp_perf_control.cc
+        ir_backend.cc
+        qnn_backend.cc
+)
+
+target_include_directories(qnn_backends
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+        $<$<BOOL:${QAIRT_HEADERS_DIR}>:${QAIRT_HEADERS_DIR}>
+)
+
+target_link_libraries(qnn_backends
+    PRIVATE
+        absl::status
+        absl::statusor
+        absl::strings
+        absl::str_format
+        absl::span
+        absl::string_view
+)

--- a/litert/vendors/qualcomm/core/builders/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/builders/CMakeLists.txt
@@ -1,0 +1,77 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# QNN Op Builders Library
+cmake_minimum_required(VERSION 3.20)
+
+# Create builders library with explicit source list
+# Using explicit list instead of file(GLOB) for better CMake practices:
+# - CMake auto-reconfigures when this file changes
+# - Explicit is better than implicit
+# - Prevents accidental inclusion of temporary/test files
+# - Better for code review and CI/CD
+add_library(qnn_builders STATIC)
+
+target_sources(qnn_builders
+    PRIVATE
+        arg_min_max_op_builder.cc
+        broadcast_to_op_builder.cc
+        cast_op_builder.cc
+        concatenation_op_builder.cc
+        conv2d_op_builder.cc
+        conv3d_op_builder.cc
+        cumsum_op_builder.cc
+        depthwise_conv2d_op_builder.cc
+        dynamic_update_slice_op_builder.cc
+        elementwise_op_builder.cc
+        embedding_lookup_op_builder.cc
+        fully_connected_op_builder.cc
+        fully_connected_op_builder_htp.cc
+        gather_op_builder.cc
+        gathernd_op_builder.cc
+        gelu_op_builder.cc
+        l2_norm_op_builder.cc
+        leaky_relu_op_builder.cc
+        logistic_op_builder.cc
+        matmul_op_builder.cc
+        op_builder.cc
+        pack_op_builder.cc
+        pad_op_builder.cc
+        pool2d_op_builder.cc
+        prelu_op_builder.cc
+        quantize_op_builder.cc
+        reduce_op_builder.cc
+        relu_0to1_op_builder.cc
+        relu_n1to1_op_builder.cc
+        relu_op_builder.cc
+        relu6_op_builder.cc
+        reshape_op_builder.cc
+        resize_op_builder.cc
+        reverse_op_builder.cc
+        rms_norm_op_builder.cc
+        select_op_builder.cc
+        slice_op_builder.cc
+        softmax_op_builder.cc
+        spatial_transform_op_builder.cc
+        split_op_builder.cc
+        strided_slice_op_builder.cc
+        tanh_op_builder.cc
+        tile_op_builder.cc
+        transpose_conv_op_builder.cc
+        transpose_op_builder.cc
+        unpack_op_builder.cc
+        log_softmax_op_builder.cc
+        scatter_nd_op_builder.cc
+        topk_op_builder.cc
+        group_norm_op_builder.cc
+)
+
+target_include_directories(qnn_builders
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+target_link_libraries(qnn_builders
+    PUBLIC
+        qnn_core
+)

--- a/litert/vendors/qualcomm/core/dump/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/dump/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# QNN Dump Utilities Library
+cmake_minimum_required(VERSION 3.20)
+
+# Create dump library with explicit source list
+add_library(qnn_dump STATIC)
+
+target_sources(qnn_dump
+    PRIVATE
+        dump_graph.cc
+)
+
+target_include_directories(qnn_dump
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+target_link_libraries(qnn_dump
+    PUBLIC
+        qnn_core
+        absl::status
+        absl::statusor
+        nlohmann_json::nlohmann_json
+)

--- a/litert/vendors/qualcomm/core/transformation/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/transformation/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# QNN Graph Transformation Library
+cmake_minimum_required(VERSION 3.20)
+
+add_library(qnn_transformation STATIC)
+
+target_sources(qnn_transformation
+    PRIVATE
+        graph_to_graph.cc
+        matmul_convert.cc
+        embedding_gemma.cc
+        mask.cc
+        mha_to_sha.cc
+)
+
+target_include_directories(qnn_transformation
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+target_link_libraries(qnn_transformation
+    PUBLIC
+        qnn_core
+)

--- a/litert/vendors/qualcomm/core/wrappers/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/wrappers/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# QNN Wrappers Library
+cmake_minimum_required(VERSION 3.20)
+
+# Create wrappers library with explicit source list
+add_library(qnn_wrappers STATIC)
+
+target_sources(qnn_wrappers
+    PRIVATE
+        op_wrapper.cc
+        param_wrapper.cc
+        quantize_params_wrapper.cc
+        tensor_wrapper.cc
+)
+
+target_include_directories(qnn_wrappers
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+        $<$<BOOL:${QAIRT_HEADERS_DIR}>:${QAIRT_HEADERS_DIR}>
+)
+
+target_link_libraries(qnn_wrappers
+    PUBLIC
+        absl::status
+        absl::statusor
+        absl::strings
+        absl::str_format
+        absl::span
+        absl::string_view
+)

--- a/litert/vendors/qualcomm/dispatch/CMakeLists.txt
+++ b/litert/vendors/qualcomm/dispatch/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Qualcomm Dispatch API Shared Library
+cmake_minimum_required(VERSION 3.20)
+
+add_library(dispatch_api_qualcomm_so SHARED)
+
+target_sources(dispatch_api_qualcomm_so
+    PRIVATE
+        dispatch_api.cc
+        litert_dispatch_device_context.cc
+        litert_dispatch_invocation_context.cc
+)
+
+target_include_directories(dispatch_api_qualcomm_so
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)
+
+target_link_libraries(dispatch_api_qualcomm_so
+    PUBLIC
+        qnn_core
+    PRIVATE
+        qnn_manager
+        qnn_context_binary_info
+        litert_runtime_c_api_static
+)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+    target_link_libraries(dispatch_api_qualcomm_so PRIVATE android log)
+endif()
+
+set_target_properties(dispatch_api_qualcomm_so PROPERTIES
+    OUTPUT_NAME "LiteRtDispatch_Qualcomm"
+)
+
+if(UNIX AND NOT APPLE)
+    # Set soname
+    target_link_options(dispatch_api_qualcomm_so PRIVATE 
+        "-Wl,-soname=libLiteRtDispatch_Qualcomm.so"
+    )
+
+    target_link_libraries(dispatch_api_qualcomm_so PRIVATE 
+        "-Wl,--start-group"
+        litert_runtime_c_api_shared_lib 
+        litert_compiler_plugin
+        litert_cc_api
+        litert_cc_options
+        tensorflow-lite
+        Threads::Threads
+        "-Wl,--end-group"
+    )
+endif()

--- a/litert/vendors/qualcomm/tests/CMakeLists.txt
+++ b/litert/vendors/qualcomm/tests/CMakeLists.txt
@@ -1,0 +1,179 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Qualcomm QNN Tests
+cmake_minimum_required(VERSION 3.20)
+
+# Common test library
+add_library(litert_test_common STATIC)
+
+target_sources(litert_test_common
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../test/common.cc
+)
+
+target_include_directories(litert_test_common PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../test
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../
+    ${TENSORFLOW_SOURCE_DIR}
+    ${TENSORFLOW_SOURCE_DIR}/third_party/xla/third_party/tsl
+)
+
+target_link_libraries(litert_test_common PUBLIC
+    GTest::gmock
+    tensorflow-lite
+    absl::string_view
+    flatbuffers::flatbuffers
+)
+
+# Compiler plugin test
+add_executable(qnn_compiler_plugin_test)
+
+target_sources(qnn_compiler_plugin_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../compiler/qnn_compiler_plugin_test.cc
+)
+
+target_link_libraries(qnn_compiler_plugin_test
+    PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        litert_runtime_c_api_shared_lib 
+        GTest::gtest_main
+)
+
+# QNN manager test
+add_executable(qnn_manager_test)
+
+target_sources(qnn_manager_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_manager_test.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/../tools/dump.cc
+)
+
+target_link_libraries(qnn_manager_test
+    PRIVATE
+        absl::log_internal_message
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+)
+
+# Core common test
+add_executable(common_test)
+
+target_sources(common_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/common_test.cc
+)
+target_link_libraries(common_test
+    PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+)
+
+# Tensor pool test
+add_executable(tensor_pool_test)
+
+target_sources(tensor_pool_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/tensor_pool_test.cc
+)
+
+target_link_libraries(tensor_pool_test
+    PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+)
+
+# Op wrapper test
+add_executable(op_wrapper_test)
+
+target_sources(op_wrapper_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/wrappers/tests/op_wrapper_test.cc
+)
+
+target_link_libraries(op_wrapper_test
+    PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+)
+
+# Tensor wrapper test
+add_executable(tensor_wrapper_test)
+
+target_sources(tensor_wrapper_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/wrappers/tests/tensor_wrapper_test.cc
+)
+
+target_link_libraries(tensor_wrapper_test
+    PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+)
+
+# Param wrapper test
+add_executable(param_wrapper_test)
+
+target_sources(param_wrapper_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/wrappers/tests/param_wrapper_test.cc
+)
+
+target_link_libraries(param_wrapper_test
+    PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+)
+
+# Quantize params wrapper test
+add_executable(quantize_params_wrapper_test)
+
+target_sources(quantize_params_wrapper_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/wrappers/tests/quantize_params_wrapper_test.cc
+)
+
+target_link_libraries(quantize_params_wrapper_test
+    PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+)
+
+# Utils test
+add_executable(utils_test)
+
+target_sources(utils_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/utils/utils_test.cc
+)
+
+target_link_libraries(utils_test
+    PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+)
+
+# QNN backend test
+add_executable(qnn_backend_test)
+
+target_sources(qnn_backend_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/backends/qnn_backend_test.cc
+)
+
+target_link_libraries(qnn_backend_test
+    PRIVATE
+        qnn_compiler_plugin
+        litert_test_common
+        GTest::gtest_main
+)


### PR DESCRIPTION
Summary:

- Build libLiteRtCompilerPlugin_Qualcomm.so and related Qualcomm test file on x86
- Qualcomm build has been restructured from a single monolithic CMakeLists.txt into a modular.
- Use "--start-group" instead of "--whole-archive" to reduce share. libraries size to 2MB.