### PR TITLE
Qualcomm AI Engine Direct - Add comparison functions for wrappers.

### DIFF
--- a/litert/vendors/qualcomm/core/utils/miscs.h
+++ b/litert/vendors/qualcomm/core/utils/miscs.h
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <limits>
 #include <memory>
@@ -23,6 +24,17 @@
 #include "QnnInterface.h"  // from @qairt
 #include "QnnTypes.h"  // from @qairt
 namespace qnn {
+namespace {
+
+inline bool IsStrEq(const char* input, const char* golden) {
+  if (input == nullptr && golden == nullptr) return true;
+  if (input == nullptr || golden == nullptr) return false;
+
+  return std::strcmp(input, golden) == 0;
+}
+
+}  // namespace
+
 constexpr uint32_t kUint16ZeroPoint = -std::numeric_limits<std::int16_t>::min();
 constexpr uint32_t kQuantBitWidth4 = 4;
 constexpr uint32_t kQuantBitWidth2 = 2;

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -3,6 +3,7 @@
 
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <functional>
 #include <optional>
@@ -32,6 +33,28 @@ OpWrapper& OpWrapper::operator=(const OpWrapper& other) {
     new (this) OpWrapper(other);
   }
   return *this;
+}
+
+bool OpWrapper::operator==(const OpWrapper& other) const {
+  if (op_code_ != other.op_code_) return false;
+  if (!IsStrEq(type_name_, other.type_name_)) return false;
+
+  if (!std::equal(
+          input_tensors_.begin(), input_tensors_.end(),
+          other.input_tensors_.begin(), other.input_tensors_.end(),
+          [](const auto& a, const auto& b) { return a.get() == b.get(); })) {
+    return false;
+  }
+
+  if (!std::equal(
+          output_tensors_.begin(), output_tensors_.end(),
+          other.output_tensors_.begin(), other.output_tensors_.end(),
+          [](const auto& a, const auto& b) { return a.get() == b.get(); })) {
+    return false;
+  }
+
+  return scalar_params_ == other.scalar_params_ &&
+         tensor_params_ == other.tensor_params_;
 }
 
 OpWrapper::OpWrapper(OpWrapper&& other)

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -26,6 +26,8 @@ class OpWrapper final {
 
   OpWrapper& operator=(const OpWrapper& other);
 
+  bool operator==(const OpWrapper& other) const;
+
   OpWrapper(OpWrapper&& other);
 
   ~OpWrapper();

--- a/litert/vendors/qualcomm/core/wrappers/param_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/param_wrapper.cc
@@ -8,6 +8,53 @@
 
 namespace qnn {
 
+bool ScalarParamWrapper::operator==(const ScalarParamWrapper& other) const {
+  if (qnn_scalar_.dataType != other.qnn_scalar_.dataType) return false;
+
+  switch (qnn_scalar_.dataType) {
+    case QNN_DATATYPE_FLOAT_32:
+      if (qnn_scalar_.floatValue != other.qnn_scalar_.floatValue) return false;
+      break;
+    case QNN_DATATYPE_BOOL_8:
+      if (qnn_scalar_.bool8Value != other.qnn_scalar_.bool8Value) return false;
+      break;
+    case QNN_DATATYPE_UFIXED_POINT_8:
+    case QNN_DATATYPE_UINT_8:
+      if (qnn_scalar_.uint8Value != other.qnn_scalar_.uint8Value) return false;
+      break;
+    case QNN_DATATYPE_SFIXED_POINT_8:
+    case QNN_DATATYPE_INT_8:
+      if (qnn_scalar_.int8Value != other.qnn_scalar_.int8Value) return false;
+      break;
+    case QNN_DATATYPE_UFIXED_POINT_16:
+    case QNN_DATATYPE_UINT_16:
+      if (qnn_scalar_.uint16Value != other.qnn_scalar_.uint16Value)
+        return false;
+      break;
+    case QNN_DATATYPE_SFIXED_POINT_16:
+    case QNN_DATATYPE_INT_16:
+      if (qnn_scalar_.int16Value != other.qnn_scalar_.int16Value) return false;
+      break;
+    case QNN_DATATYPE_UFIXED_POINT_32:
+    case QNN_DATATYPE_UINT_32:
+      if (qnn_scalar_.uint32Value != other.qnn_scalar_.uint32Value)
+        return false;
+      break;
+    case QNN_DATATYPE_SFIXED_POINT_32:
+    case QNN_DATATYPE_INT_32:
+      if (qnn_scalar_.int32Value != other.qnn_scalar_.int32Value) return false;
+      break;
+    default:
+      QNN_LOG_ERROR(
+          "Unsupported data type for comparing scalar param: input: %#x, "
+          "golden: %#x",
+          qnn_scalar_.dataType, other.qnn_scalar_.dataType);
+      return false;
+  }
+
+  return true;
+}
+
 void ScalarParamWrapper::CloneTo(Qnn_Param_t& dst) const {
   dst.name = name_;
   dst.paramType = QNN_PARAMTYPE_SCALAR;
@@ -17,6 +64,10 @@ void ScalarParamWrapper::CloneTo(Qnn_Param_t& dst) const {
 TensorParamWrapper::TensorParamWrapper(const char* name,
                                        const TensorWrapper& tensor)
     : name_{name}, tensor_{tensor} {}
+
+bool TensorParamWrapper::operator==(const TensorParamWrapper& other) const {
+  return tensor_ == other.tensor_;
+}
 
 void TensorParamWrapper::CloneTo(Qnn_Param_t& dst) const {
   dst.name = name_;

--- a/litert/vendors/qualcomm/core/wrappers/param_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/param_wrapper.h
@@ -55,6 +55,8 @@ class ScalarParamWrapper {
     }
   }
 
+  bool operator==(const ScalarParamWrapper& other) const;
+
   void CloneTo(Qnn_Param_t& dst) const;
 
  private:
@@ -65,6 +67,8 @@ class ScalarParamWrapper {
 class TensorParamWrapper {
  public:
   explicit TensorParamWrapper(const char* name, const TensorWrapper& tensor);
+
+  bool operator==(const TensorParamWrapper& other) const;
 
   void CloneTo(Qnn_Param_t& dst) const;
 

--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
@@ -2,6 +2,7 @@
 // All Rights Reserved.
 #include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -20,6 +21,14 @@ UndefinedQuantizeParamsWrapper::UndefinedQuantizeParamsWrapper(
 
 UndefinedQuantizeParamsWrapper::UndefinedQuantizeParamsWrapper(
     UndefinedQuantizeParamsWrapper&&) = default;
+
+bool UndefinedQuantizeParamsWrapper::operator==(
+    const UndefinedQuantizeParamsWrapper& other) const {
+  return qnn_quantize_param_.encodingDefinition ==
+             other.qnn_quantize_param_.encodingDefinition &&
+         qnn_quantize_param_.quantizationEncoding ==
+             other.qnn_quantize_param_.quantizationEncoding;
+}
 
 void UndefinedQuantizeParamsWrapper::CloneTo(Qnn_QuantizeParams_t& dst) {
   dst = qnn_quantize_param_;
@@ -48,6 +57,17 @@ ScaleOffsetQuantizeParamsWrapper::ScaleOffsetQuantizeParamsWrapper(
 ScaleOffsetQuantizeParamsWrapper::ScaleOffsetQuantizeParamsWrapper(
     ScaleOffsetQuantizeParamsWrapper&&) = default;
 
+bool ScaleOffsetQuantizeParamsWrapper::operator==(
+    const ScaleOffsetQuantizeParamsWrapper& other) const {
+  return qnn_quantize_param_.encodingDefinition ==
+             other.qnn_quantize_param_.encodingDefinition &&
+         qnn_quantize_param_.quantizationEncoding ==
+             other.qnn_quantize_param_.quantizationEncoding &&
+         qnn_quantize_param_.scaleOffsetEncoding.scale ==
+             other.qnn_quantize_param_.scaleOffsetEncoding.scale &&
+         qnn_quantize_param_.scaleOffsetEncoding.offset ==
+             other.qnn_quantize_param_.scaleOffsetEncoding.offset;
+}
 void ScaleOffsetQuantizeParamsWrapper::CloneTo(Qnn_QuantizeParams_t& dst) {
   dst = qnn_quantize_param_;
 }
@@ -105,6 +125,30 @@ AxisScaleOffsetQuantizeParamsWrapper::AxisScaleOffsetQuantizeParamsWrapper(
       scale_offsets_.data();
 }
 
+bool AxisScaleOffsetQuantizeParamsWrapper::operator==(
+    const AxisScaleOffsetQuantizeParamsWrapper& other) const {
+  if (qnn_quantize_param_.encodingDefinition !=
+      other.qnn_quantize_param_.encodingDefinition)
+    return false;
+  if (qnn_quantize_param_.quantizationEncoding !=
+      other.qnn_quantize_param_.quantizationEncoding)
+    return false;
+  if (qnn_quantize_param_.axisScaleOffsetEncoding.axis !=
+      other.qnn_quantize_param_.axisScaleOffsetEncoding.axis)
+    return false;
+  if (qnn_quantize_param_.axisScaleOffsetEncoding.numScaleOffsets !=
+      other.qnn_quantize_param_.axisScaleOffsetEncoding.numScaleOffsets)
+    return false;
+
+  return std::equal(
+      qnn_quantize_param_.axisScaleOffsetEncoding.scaleOffset,
+      qnn_quantize_param_.axisScaleOffsetEncoding.scaleOffset +
+          qnn_quantize_param_.axisScaleOffsetEncoding.numScaleOffsets,
+      other.qnn_quantize_param_.axisScaleOffsetEncoding.scaleOffset,
+      [](const Qnn_ScaleOffset_t& a, const Qnn_ScaleOffset_t& b) {
+        return a.scale == b.scale && a.offset == b.offset;
+      });
+}
 void AxisScaleOffsetQuantizeParamsWrapper::CloneTo(Qnn_QuantizeParams_t& dst) {
   dst = qnn_quantize_param_;
 }
@@ -152,6 +196,20 @@ BwScaleOffsetQuantizeParamsWrapper::BwScaleOffsetQuantizeParamsWrapper(
 BwScaleOffsetQuantizeParamsWrapper::BwScaleOffsetQuantizeParamsWrapper(
     BwScaleOffsetQuantizeParamsWrapper&& rhs) = default;
 
+bool BwScaleOffsetQuantizeParamsWrapper::operator==(
+    const BwScaleOffsetQuantizeParamsWrapper& other) const {
+  return qnn_quantize_param_.encodingDefinition ==
+             other.qnn_quantize_param_.encodingDefinition &&
+         qnn_quantize_param_.quantizationEncoding ==
+             other.qnn_quantize_param_.quantizationEncoding &&
+         qnn_quantize_param_.bwScaleOffsetEncoding.bitwidth ==
+             other.qnn_quantize_param_.bwScaleOffsetEncoding.bitwidth &&
+         qnn_quantize_param_.bwScaleOffsetEncoding.scale ==
+             other.qnn_quantize_param_.bwScaleOffsetEncoding.scale &&
+         qnn_quantize_param_.bwScaleOffsetEncoding.offset ==
+             other.qnn_quantize_param_.bwScaleOffsetEncoding.offset;
+}
+
 void BwScaleOffsetQuantizeParamsWrapper::CloneTo(Qnn_QuantizeParams_t& dst) {
   dst = qnn_quantize_param_;
 }
@@ -192,6 +250,36 @@ BwAxisScaleOffsetQuantizeParamsWrapper::BwAxisScaleOffsetQuantizeParamsWrapper(
       offsets_{std::move(rhs.offsets_)} {
   qnn_quantize_param_.bwAxisScaleOffsetEncoding.scales = scales_.data();
   qnn_quantize_param_.bwAxisScaleOffsetEncoding.offsets = offsets_.data();
+}
+
+bool BwAxisScaleOffsetQuantizeParamsWrapper::operator==(
+    const BwAxisScaleOffsetQuantizeParamsWrapper& other) const {
+  if (qnn_quantize_param_.encodingDefinition !=
+      other.qnn_quantize_param_.encodingDefinition)
+    return false;
+  if (qnn_quantize_param_.quantizationEncoding !=
+      other.qnn_quantize_param_.quantizationEncoding)
+    return false;
+  if (qnn_quantize_param_.bwAxisScaleOffsetEncoding.bitwidth !=
+      other.qnn_quantize_param_.bwAxisScaleOffsetEncoding.bitwidth)
+    return false;
+  if (qnn_quantize_param_.bwAxisScaleOffsetEncoding.axis !=
+      other.qnn_quantize_param_.bwAxisScaleOffsetEncoding.axis)
+    return false;
+  if (qnn_quantize_param_.bwAxisScaleOffsetEncoding.numElements !=
+      other.qnn_quantize_param_.bwAxisScaleOffsetEncoding.numElements)
+    return false;
+
+  return std::equal(
+             qnn_quantize_param_.bwAxisScaleOffsetEncoding.scales,
+             qnn_quantize_param_.bwAxisScaleOffsetEncoding.scales +
+                 qnn_quantize_param_.bwAxisScaleOffsetEncoding.numElements,
+             other.qnn_quantize_param_.bwAxisScaleOffsetEncoding.scales) &&
+         std::equal(
+             qnn_quantize_param_.bwAxisScaleOffsetEncoding.offsets,
+             qnn_quantize_param_.bwAxisScaleOffsetEncoding.offsets +
+                 qnn_quantize_param_.bwAxisScaleOffsetEncoding.numElements,
+             other.qnn_quantize_param_.bwAxisScaleOffsetEncoding.offsets);
 }
 
 void BwAxisScaleOffsetQuantizeParamsWrapper::CloneTo(

--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
@@ -21,6 +21,8 @@ class UndefinedQuantizeParamsWrapper final {
 
   UndefinedQuantizeParamsWrapper(UndefinedQuantizeParamsWrapper&&);
 
+  bool operator==(const UndefinedQuantizeParamsWrapper& other) const;
+
   void CloneTo(Qnn_QuantizeParams_t& dst);
 
  private:
@@ -37,6 +39,8 @@ class ScaleOffsetQuantizeParamsWrapper final {
   ScaleOffsetQuantizeParamsWrapper(const ScaleOffsetQuantizeParamsWrapper&);
 
   ScaleOffsetQuantizeParamsWrapper(ScaleOffsetQuantizeParamsWrapper&&);
+
+  bool operator==(const ScaleOffsetQuantizeParamsWrapper& other) const;
 
   void CloneTo(Qnn_QuantizeParams_t& dst);
 
@@ -71,6 +75,8 @@ class AxisScaleOffsetQuantizeParamsWrapper final {
   AxisScaleOffsetQuantizeParamsWrapper(
       AxisScaleOffsetQuantizeParamsWrapper&& rhs);
 
+  bool operator==(const AxisScaleOffsetQuantizeParamsWrapper& other) const;
+
   void CloneTo(Qnn_QuantizeParams_t& dst);
 
   std::int32_t GetAxis() const;
@@ -97,6 +103,8 @@ class BwScaleOffsetQuantizeParamsWrapper final {
 
   BwScaleOffsetQuantizeParamsWrapper(BwScaleOffsetQuantizeParamsWrapper&& rhs);
 
+  bool operator==(const BwScaleOffsetQuantizeParamsWrapper& other) const;
+
   void CloneTo(Qnn_QuantizeParams_t& dst);
 
   std::uint32_t GetBitwidth() const {
@@ -119,6 +127,8 @@ class BwAxisScaleOffsetQuantizeParamsWrapper final {
 
   BwAxisScaleOffsetQuantizeParamsWrapper(
       BwAxisScaleOffsetQuantizeParamsWrapper&& rhs);
+
+  bool operator==(const BwAxisScaleOffsetQuantizeParamsWrapper& other) const;
 
   void CloneTo(Qnn_QuantizeParams_t& dst);
 

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -174,6 +174,40 @@ Qnn_DataType_t TensorWrapper::GetDataType() const {
   return qnn_tensor_.v2.dataType;
 }
 
+bool TensorWrapper::operator==(const TensorWrapper& other) const {
+  // Compare the address
+  if (this == &other) {
+    return true;
+  }
+
+  // Compare the value
+  if (qnn_tensor_.version != other.qnn_tensor_.version) return false;
+  if (qnn_tensor_.v2.type != other.qnn_tensor_.v2.type) return false;
+  if (qnn_tensor_.v2.dataFormat != other.qnn_tensor_.v2.dataFormat)
+    return false;
+  if (qnn_tensor_.v2.dataType != other.qnn_tensor_.v2.dataType) return false;
+  if (qnn_tensor_.v2.rank != other.qnn_tensor_.v2.rank) return false;
+  if (!std::equal(qnn_tensor_.v2.dimensions,
+                  qnn_tensor_.v2.dimensions + qnn_tensor_.v2.rank,
+                  other.qnn_tensor_.v2.dimensions))
+    return false;
+  if (qnn_tensor_.v2.memType != other.qnn_tensor_.v2.memType) return false;
+  if (qnn_tensor_.v2.clientBuf.dataSize !=
+      other.qnn_tensor_.v2.clientBuf.dataSize)
+    return false;
+  // Since the clientBuf may store different data types (e.g., float,
+  // int32_t), and type-aware comparison could fail or misinterpret
+  // padding/alignment, compare client buffer contents byte-by-byte to
+  // ensure we have an exact match.
+  if (std::memcmp(qnn_tensor_.v2.clientBuf.data,
+                  other.qnn_tensor_.v2.clientBuf.data,
+                  qnn_tensor_.v2.clientBuf.dataSize) != 0)
+    return false;
+
+  // Compare quantize params
+  return quantize_params_ == other.quantize_params_;
+}
+
 void TensorWrapper::CloneTo(Qnn_Tensor_t& dst) const { dst = qnn_tensor_; }
 
 std::uint32_t TensorWrapper::GetRank() const { return qnn_tensor_.v2.rank; }

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -112,9 +112,11 @@ class TensorWrapper final {
 
   ~TensorWrapper();
 
-  bool operator==(const TensorWrapper& other) const { return this == &other; }
+  bool operator==(const TensorWrapper& other) const;
 
-  bool operator!=(const TensorWrapper& other) const { return this != &other; }
+  bool operator!=(const TensorWrapper& other) const {
+    return !(*this == other);
+  }
 
   void CloneTo(Qnn_Tensor_t& dst) const;
 

--- a/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
@@ -209,5 +209,219 @@ TEST(OpWrapperTest, ChangeOpName) {
   EXPECT_STREQ(op_wrapper_1.GetOpConfig().v1.name, "namespace/name_new");
 }
 
+TensorWrapper CreateTensor(const std::vector<uint32_t>& dims,
+                           Qnn_TensorType_t type,
+                           std::optional<uint8_t> val = std::nullopt) {
+  std::vector<uint8_t> data(
+      std::accumulate(dims.begin(), dims.end(), 1u, std::multiplies<>()));
+  if (val.has_value()) {
+    std::fill(data.begin(), data.end(), *val);
+  }
+  return TensorWrapper("", type, QNN_DATATYPE_UFIXED_POINT_8,
+                       QuantizeParamsWrapperVariant(), dims,
+                       static_cast<uint32_t>(data.size()), data.data(), true);
+}
+
+TEST(OpWrapperEqualityOperatorTest, TypeName) {
+  std::vector<uint32_t> dims = {1, 1, 3};
+  auto input = CreateTensor(dims, QNN_TENSOR_TYPE_NATIVE);
+  auto output = input;
+  auto param_tensor = CreateTensor(dims, QNN_TENSOR_TYPE_STATIC, 1);
+
+  qnn::OpWrapper op1{"op", "TYPE_A", QnnOpCode::kUnknown};
+  op1.AddInputTensor(input);
+  op1.AddOutputTensor(output);
+  op1.AddScalarParam<std::uint8_t>("param", 255, false);
+  op1.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op2{"op", "TYPE_A", QnnOpCode::kUnknown};
+  op2.AddInputTensor(input);
+  op2.AddOutputTensor(output);
+  op2.AddScalarParam<std::uint8_t>("param", 255, false);
+  op2.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op3{"op", "TYPE_B", QnnOpCode::kUnknown};
+  op3.AddInputTensor(input);
+  op3.AddOutputTensor(output);
+  op3.AddScalarParam<std::uint8_t>("param", 255, false);
+  op3.AddTensorParam("tensor_param", param_tensor);
+
+  EXPECT_TRUE(op1 == op2);
+  EXPECT_FALSE(op1 == op3);
+}
+
+TEST(OpWrapperEqualityOperatorTest, OpCode) {
+  std::vector<uint32_t> dims = {1, 1, 3};
+  auto input = CreateTensor(dims, QNN_TENSOR_TYPE_NATIVE);
+  auto output = input;
+  auto param_tensor = CreateTensor(dims, QNN_TENSOR_TYPE_STATIC, 1);
+
+  qnn::OpWrapper op1{"op", "OP_TYPE", QnnOpCode::kElementWiseAdd};
+  op1.AddInputTensor(input);
+  op1.AddOutputTensor(output);
+  op1.AddScalarParam<std::uint8_t>("param", 255, false);
+  op1.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op2{"op", "OP_TYPE", QnnOpCode::kElementWiseAdd};
+  op2.AddInputTensor(input);
+  op2.AddOutputTensor(output);
+  op2.AddScalarParam<std::uint8_t>("param", 255, false);
+  op2.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op3{"op", "OP_TYPE", QnnOpCode::kElementWiseMultiply};
+  op3.AddInputTensor(input);
+  op3.AddOutputTensor(output);
+  op3.AddScalarParam<std::uint8_t>("param", 255, false);
+  op3.AddTensorParam("tensor_param", param_tensor);
+
+  EXPECT_TRUE(op1 == op2);
+  EXPECT_FALSE(op1 == op3);
+}
+
+TEST(OpWrapperEqualityOperatorTest, InputDims) {
+  std::vector<uint32_t> dims1 = {1, 1, 3};
+  std::vector<uint32_t> dims2 = {1, 1, 4};
+  auto input1 = CreateTensor(dims1, QNN_TENSOR_TYPE_NATIVE);
+  auto input2 = CreateTensor(dims2, QNN_TENSOR_TYPE_NATIVE);
+  auto output = input1;
+  auto param_tensor = CreateTensor(dims1, QNN_TENSOR_TYPE_STATIC, 1);
+
+  qnn::OpWrapper op1{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op1.AddInputTensor(input1);
+  op1.AddOutputTensor(output);
+  op1.AddScalarParam<std::uint8_t>("param", 255, false);
+  op1.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op2{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op2.AddInputTensor(input1);
+  op2.AddOutputTensor(output);
+  op2.AddScalarParam<std::uint8_t>("param", 255, false);
+  op2.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op3{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op3.AddInputTensor(input2);
+  op3.AddOutputTensor(output);
+  op3.AddScalarParam<std::uint8_t>("param", 255, false);
+  op3.AddTensorParam("tensor_param", param_tensor);
+
+  EXPECT_TRUE(op1 == op2);
+  EXPECT_FALSE(op1 == op3);
+}
+
+TEST(OpWrapperEqualityOperatorTest, ScalarParam) {
+  std::vector<uint32_t> dims = {1, 1, 3};
+  auto input = CreateTensor(dims, QNN_TENSOR_TYPE_NATIVE);
+  auto output = input;
+  auto param_tensor = CreateTensor(dims, QNN_TENSOR_TYPE_STATIC, 1);
+
+  qnn::OpWrapper op1{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op1.AddInputTensor(input);
+  op1.AddOutputTensor(output);
+  op1.AddScalarParam<std::uint8_t>("param", 255, false);
+  op1.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op2{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op2.AddInputTensor(input);
+  op2.AddOutputTensor(output);
+  op2.AddScalarParam<std::uint8_t>("param", 255, false);
+  op2.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op3{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op3.AddInputTensor(input);
+  op3.AddOutputTensor(output);
+  op3.AddScalarParam<std::uint8_t>("param", 252, false);
+  op3.AddTensorParam("tensor_param", param_tensor);
+
+  EXPECT_TRUE(op1 == op2);
+  EXPECT_FALSE(op1 == op3);
+}
+
+TEST(OpWrapperEqualityOperatorTest, TensorParam) {
+  std::vector<uint32_t> dims = {1, 1, 3};
+  auto input = CreateTensor(dims, QNN_TENSOR_TYPE_NATIVE);
+  auto output = input;
+  auto param_tensor = CreateTensor(dims, QNN_TENSOR_TYPE_STATIC, 1);
+  auto param_tensor_diff = CreateTensor(dims, QNN_TENSOR_TYPE_STATIC, 2);
+
+  qnn::OpWrapper op1{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op1.AddInputTensor(input);
+  op1.AddOutputTensor(output);
+  op1.AddScalarParam<std::uint8_t>("param", 255, false);
+  op1.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op2{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op2.AddInputTensor(input);
+  op2.AddOutputTensor(output);
+  op2.AddScalarParam<std::uint8_t>("param", 255, false);
+  op2.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op3{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op3.AddInputTensor(input);
+  op3.AddOutputTensor(output);
+  op3.AddScalarParam<std::uint8_t>("param", 255, false);
+  op3.AddTensorParam("tensor_param", param_tensor_diff);
+
+  EXPECT_TRUE(op1 == op2);
+  EXPECT_FALSE(op1 == op3);
+}
+
+TEST(OpWrapperEqualityOperatorTest, InputSize) {
+  std::vector<uint32_t> dims = {1, 1, 3};
+  auto input = CreateTensor(dims, QNN_TENSOR_TYPE_NATIVE);
+  auto output = input;
+  auto param_tensor = CreateTensor(dims, QNN_TENSOR_TYPE_STATIC, 1);
+
+  qnn::OpWrapper op1{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op1.AddInputTensor(input);
+  op1.AddOutputTensor(output);
+  op1.AddScalarParam<std::uint8_t>("param", 255, false);
+  op1.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op2{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op2.AddInputTensor(input);
+  op2.AddOutputTensor(output);
+  op2.AddScalarParam<std::uint8_t>("param", 255, false);
+  op2.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op3{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op3.AddInputTensor(input);
+  op3.AddInputTensor(input);
+  op3.AddOutputTensor(output);
+  op3.AddScalarParam<std::uint8_t>("param", 255, false);
+  op3.AddTensorParam("tensor_param", param_tensor);
+
+  EXPECT_TRUE(op1 == op2);
+  EXPECT_FALSE(op1 == op3);
+}
+
+TEST(OpWrapperEqualityOperatorTest, InputData) {
+  std::vector<uint32_t> dims = {1, 1, 3};
+  auto input1 = CreateTensor(dims, QNN_TENSOR_TYPE_APP_WRITE, 1);
+  auto input2 = CreateTensor(dims, QNN_TENSOR_TYPE_APP_WRITE, 2);
+  auto output = CreateTensor(dims, QNN_TENSOR_TYPE_APP_READ, 2);
+  auto param_tensor = CreateTensor(dims, QNN_TENSOR_TYPE_STATIC, 1);
+
+  qnn::OpWrapper op1{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op1.AddInputTensor(input1);
+  op1.AddOutputTensor(output);
+  op1.AddScalarParam<std::uint8_t>("param", 255, false);
+  op1.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op2{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op2.AddInputTensor(input1);
+  op2.AddOutputTensor(output);
+  op2.AddScalarParam<std::uint8_t>("param", 255, false);
+  op2.AddTensorParam("tensor_param", param_tensor);
+
+  qnn::OpWrapper op3{"op", "OP_TYPE", QnnOpCode::kUnknown};
+  op3.AddInputTensor(input2);
+  op3.AddOutputTensor(output);
+  op3.AddScalarParam<std::uint8_t>("param", 255, false);
+  op3.AddTensorParam("tensor_param", param_tensor);
+
+  EXPECT_TRUE(op1 == op2);
+  EXPECT_FALSE(op1 == op3);
+}
+
 }  // namespace
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
@@ -40,6 +40,13 @@ TEST(UndefinedQuantizeParamsWrapperTest, MoveConstructorTest) {
   EXPECT_EQ(dst.quantizationEncoding, QNN_QUANTIZATION_ENCODING_UNDEFINED);
 }
 
+TEST(UndefinedQuantizeParamsWrapperTest, EqualityOperatorTest) {
+  UndefinedQuantizeParamsWrapper wrapper1;
+  UndefinedQuantizeParamsWrapper wrapper2;
+
+  EXPECT_TRUE(wrapper1 == wrapper2);
+}
+
 TEST(ScaleOffsetQuantizeParamsWrapperTest, ConstructorTest) {
   float scale = 1.5f;
   std::int32_t zero_point = 10;
@@ -86,6 +93,29 @@ TEST(ScaleOffsetQuantizeParamsWrapperTest, GetterTest) {
   EXPECT_EQ(wrapper.GetZeroPoint(), zero_point);
   EXPECT_EQ(wrapper.GetOffset(), -zero_point);
 }
+
+using ScaleOffsetParamsWithType = std::tuple<float, int32_t, float, int32_t>;
+class ScaleOffsetEqualTestWithType
+    : public ::testing::TestWithParam<ScaleOffsetParamsWithType> {};
+TEST_P(ScaleOffsetEqualTestWithType, EqualityOperator) {
+  auto [scale1, offset1, scale2, offset2] = GetParam();
+
+  qnn::ScaleOffsetQuantizeParamsWrapper wrapper1(scale1, offset1);
+  qnn::ScaleOffsetQuantizeParamsWrapper wrapper2(scale2, offset2);
+  qnn::ScaleOffsetQuantizeParamsWrapper wrapper3(scale2, offset2);
+
+  const bool expected_equal = (scale1 == scale2) && (offset1 == offset2);
+  EXPECT_EQ(wrapper1 == wrapper2, expected_equal);
+  EXPECT_EQ(wrapper1 == wrapper3, expected_equal);
+  EXPECT_TRUE(wrapper2 == wrapper3);
+}
+// Data type, scale and offset
+INSTANTIATE_TEST_SUITE_P(ScaleOffsetQuantizeParamsWrapperTest_Combine,
+                         ScaleOffsetEqualTestWithType,
+                         ::testing::Combine(::testing::Values(1.5f),
+                                            ::testing::Values(10),
+                                            ::testing::Values(1.5f, 1.6f),
+                                            ::testing::Values(10, 12)));
 
 TEST(AxisScaleOffsetQuantizeParamsWrapperTest, ConstructorTest) {
   std::int32_t axis = 1;
@@ -148,6 +178,7 @@ TEST(AxisScaleOffsetQuantizeParamsWrapperTest, MoveConstructorTest) {
               -zero_points[i]);
   }
 }
+
 TEST(AxisScaleOffsetQuantizeParamsWrapperTest, GetterTest) {
   std::int32_t axis = 1;
   std::vector<float> scales = {1.5f, 2.5f};
@@ -288,5 +319,96 @@ TEST(BwAxisScaleOffsetQuantizeParamsWrapperTest, GetBitwidthTest) {
   BwAxisScaleOffsetQuantizeParamsWrapper wrapper(bw, axis, scales, zero_points);
   ASSERT_EQ(wrapper.GetBitwidth(), 4);
 }
+using AxisScaleOffsetParamsWithType =
+    std::tuple<int32_t, std::vector<float>, std::vector<int32_t>, int32_t,
+               std::vector<float>, std::vector<int32_t>>;
+class AxisScaleOffsetEqualTestWithType
+    : public ::testing::TestWithParam<AxisScaleOffsetParamsWithType> {};
+TEST_P(AxisScaleOffsetEqualTestWithType, EqualityOperator) {
+  const auto& [axis1, scale1, offsets1, axis2, scales2, offsets2] = GetParam();
+
+  qnn::AxisScaleOffsetQuantizeParamsWrapper wrapper1(axis1, scale1, offsets1);
+  qnn::AxisScaleOffsetQuantizeParamsWrapper wrapper2(axis2, scales2, offsets2);
+  qnn::AxisScaleOffsetQuantizeParamsWrapper wrapper3(wrapper2);
+
+  const bool expected_equal =
+      (axis1 == axis2) && (scale1 == scales2) && (offsets1 == offsets2);
+  EXPECT_EQ(wrapper1 == wrapper2, expected_equal);
+  EXPECT_EQ(wrapper1 == wrapper3, expected_equal);
+  EXPECT_TRUE(wrapper2 == wrapper3);
+}
+// Data type, axis, scales and zero_points
+INSTANTIATE_TEST_SUITE_P(
+    AxisScaleOffsetQuantizeParamsWrapperTest_Combine,
+    AxisScaleOffsetEqualTestWithType,
+    ::testing::Combine(::testing::Values(1),
+                       ::testing::Values(std::vector<float>{1.5f, 2.5f}),
+                       ::testing::Values(std::vector<int32_t>{10, 20}),
+                       ::testing::Values(1, 0),
+                       ::testing::Values(std::vector<float>{1.5f, 2.5f},
+                                         std::vector<float>{1.5f, 2.6f}),
+                       ::testing::Values(std::vector<int32_t>{10, 20},
+                                         std::vector<int32_t>{10, 30})));
+
+using BwScaleOffsetParams =
+    std::tuple<uint32_t, float, int32_t, uint32_t, float, int32_t>;
+class BwScaleOffsetEqualTest
+    : public ::testing::TestWithParam<BwScaleOffsetParams> {};
+TEST_P(BwScaleOffsetEqualTest, EqualityOperator) {
+  const auto& [bitwidth1, scale1, offset1, bitwidth2, scale2, offset2] =
+      GetParam();
+
+  qnn::BwScaleOffsetQuantizeParamsWrapper wrapper1(bitwidth1, scale1, offset1);
+  qnn::BwScaleOffsetQuantizeParamsWrapper wrapper2(bitwidth2, scale2, offset2);
+  qnn::BwScaleOffsetQuantizeParamsWrapper wrapper3(wrapper2);
+
+  const bool expected_equal =
+      (bitwidth1 == bitwidth2) && (scale1 == scale2) && (offset1 == offset2);
+  EXPECT_EQ(wrapper1 == wrapper2, expected_equal);
+  EXPECT_EQ(wrapper1 == wrapper3, expected_equal);
+  EXPECT_TRUE(wrapper2 == wrapper3);
+}
+// Bitwidth, scale and offset
+INSTANTIATE_TEST_SUITE_P(
+    BwScaleOffsetQuantizeParamsWrapperTest_Combine, BwScaleOffsetEqualTest,
+    ::testing::Combine(::testing::Values(2u, 4u), ::testing::Values(1.5f),
+                       ::testing::Values(10), ::testing::Values(2u, 4u),
+                       ::testing::Values(1.5f, 1.6f),
+                       ::testing::Values(10, 12)));
+
+using BwAxisScaleOffsetParams =
+    std::tuple<uint32_t, int32_t, std::vector<float>, std::vector<int32_t>,
+               uint32_t, int32_t, std::vector<float>, std::vector<int32_t>>;
+class BwAxisScaleOffsetEqualTest
+    : public ::testing::TestWithParam<BwAxisScaleOffsetParams> {};
+TEST_P(BwAxisScaleOffsetEqualTest, EqualityOperator) {
+  const auto& [bitwidth1, axis1, scales1, offsets1, bitwidth2, axis2, scales2,
+               offsets2] = GetParam();
+
+  qnn::BwAxisScaleOffsetQuantizeParamsWrapper wrapper1(bitwidth1, axis1,
+                                                       scales1, offsets1);
+  qnn::BwAxisScaleOffsetQuantizeParamsWrapper wrapper2(bitwidth2, axis2,
+                                                       scales2, offsets2);
+  qnn::BwAxisScaleOffsetQuantizeParamsWrapper wrapper3(wrapper2);
+
+  const bool expected_equal = (bitwidth1 == bitwidth2) && (axis1 == axis2) &&
+                              (scales1 == scales2) && (offsets1 == offsets2);
+  EXPECT_EQ(wrapper1 == wrapper2, expected_equal);
+  EXPECT_EQ(wrapper1 == wrapper3, expected_equal);
+  EXPECT_TRUE(wrapper2 == wrapper3);
+}
+// Bitwidth, axis, scales and offsets
+INSTANTIATE_TEST_SUITE_P(
+    BwAxisScaleOffsetQuantizeParamsWrapperTest_Combine,
+    BwAxisScaleOffsetEqualTest,
+    ::testing::Combine(::testing::Values(4u), ::testing::Values(1),
+                       ::testing::Values(std::vector<float>{1.5f, 2.5f}),
+                       ::testing::Values(std::vector<int32_t>{10, 20}),
+                       ::testing::Values(4u, 2u), ::testing::Values(1, 0),
+                       ::testing::Values(std::vector<float>{1.5f, 2.5f},
+                                         std::vector<float>{1.5f, 2.6f}),
+                       ::testing::Values(std::vector<int32_t>{10, 20},
+                                         std::vector<int32_t>{10, 30})));
+
 }  // namespace
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -568,5 +568,102 @@ TEST(TensorWrapperDatatypeTest, SFIXED_POINT_2) {
       QNN_DATATYPE_SFIXED_POINT_8);
 }
 
+using TensorEqualParams =
+    std::tuple<Qnn_TensorType_t, Qnn_TensorType_t, Qnn_DataType_t,
+               Qnn_DataType_t, std::vector<uint32_t>, std::vector<uint32_t>,
+               bool>;
+class TensorWrapperEqualTest
+    : public ::testing::TestWithParam<TensorEqualParams> {};
+TEST_P(TensorWrapperEqualTest, EqualityOperator) {
+  auto [tensor_type1, tensor_type2, data_tensor_type1, data_tensor_type2, dims1,
+        dims2, tweak_data] = GetParam();
+
+  auto make_data = [](const std::vector<uint32_t>& dims, uint8_t fill) {
+    uint32_t count =
+        std::accumulate(dims.begin(), dims.end(), 1u, std::multiplies<>());
+    return std::vector<uint8_t>(count, fill);
+  };
+  std::vector<uint8_t> data1 = make_data(dims1, 1);
+  std::vector<uint8_t> data2 = make_data(dims2, 1);
+
+  if (tweak_data && tensor_type1 == tensor_type2 &&
+      data_tensor_type1 == data_tensor_type2 && dims1 == dims2 &&
+      !data2.empty()) {
+    data2[0] = 100;
+  }
+
+  TensorWrapper wrapper1{"",
+                         tensor_type1,
+                         data_tensor_type1,
+                         QuantizeParamsWrapperVariant(),
+                         dims1,
+                         static_cast<uint32_t>(data1.size()),
+                         data1.data(),
+                         true};
+  TensorWrapper wrapper2{"",
+                         tensor_type2,
+                         data_tensor_type2,
+                         QuantizeParamsWrapperVariant(),
+                         dims2,
+                         static_cast<uint32_t>(data2.size()),
+                         data2.data(),
+                         true};
+
+  const bool expected_equal = (tensor_type1 == tensor_type2) &&
+                              (data_tensor_type1 == data_tensor_type2) &&
+                              (dims1 == dims2) && !tweak_data;
+  EXPECT_EQ(wrapper1 == wrapper2, expected_equal);
+}
+INSTANTIATE_TEST_SUITE_P(TensorWrapperTest_Combinations, TensorWrapperEqualTest,
+                         ::testing::Values(
+                             // All fields same
+                             TensorEqualParams{QNN_TENSOR_TYPE_STATIC,
+                                               QNN_TENSOR_TYPE_STATIC,
+                                               QNN_DATATYPE_UFIXED_POINT_8,
+                                               QNN_DATATYPE_UFIXED_POINT_8,
+                                               {1, 1, 3},
+                                               {1, 1, 3},
+                                               false},
+                             // Tensor type
+                             TensorEqualParams{
+                                 QNN_TENSOR_TYPE_STATIC,
+                                 QNN_TENSOR_TYPE_UPDATEABLE_STATIC,
+                                 QNN_DATATYPE_UFIXED_POINT_8,
+                                 QNN_DATATYPE_UFIXED_POINT_8,
+                                 {1, 1, 3},
+                                 {1, 1, 3},
+                                 false},
+                             // Data type
+                             TensorEqualParams{QNN_TENSOR_TYPE_STATIC,
+                                               QNN_TENSOR_TYPE_STATIC,
+                                               QNN_DATATYPE_UFIXED_POINT_8,
+                                               QNN_DATATYPE_FLOAT_32,
+                                               {1, 1, 3},
+                                               {1, 1, 3},
+                                               false},
+                             // Rank
+                             TensorEqualParams{QNN_TENSOR_TYPE_STATIC,
+                                               QNN_TENSOR_TYPE_STATIC,
+                                               QNN_DATATYPE_UFIXED_POINT_8,
+                                               QNN_DATATYPE_UFIXED_POINT_8,
+                                               {1, 1, 3},
+                                               {1, 1, 3, 1},
+                                               false},
+                             // Dimensions
+                             TensorEqualParams{QNN_TENSOR_TYPE_STATIC,
+                                               QNN_TENSOR_TYPE_STATIC,
+                                               QNN_DATATYPE_UFIXED_POINT_8,
+                                               QNN_DATATYPE_UFIXED_POINT_8,
+                                               {1, 1, 3},
+                                               {1, 1, 4},
+                                               false},
+                             // Data value
+                             TensorEqualParams{QNN_TENSOR_TYPE_STATIC,
+                                               QNN_TENSOR_TYPE_STATIC,
+                                               QNN_DATATYPE_UFIXED_POINT_8,
+                                               QNN_DATATYPE_UFIXED_POINT_8,
+                                               {1, 1, 3},
+                                               {1, 1, 3},
+                                               true}));
 }  // namespace
 }  // namespace qnn


### PR DESCRIPTION
Summary:
- Add comparison operator for wrappers.
- Enable related test for all wrappers.


Test Result:
======================== Test Summary ========================
//litert/c:litert_op_options_test


//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.5s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.3s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 56.2s