### PR TITLE
Qualcomm AI Engine Direct - Use Pointer as Parameter of UpdateTensor.

### DIFF
--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -124,21 +124,21 @@ void OpWrapper::SwapOutputs(OpWrapper& other) {
 void OpWrapper::ClearTensorParams() { tensor_params_.clear(); }
 
 void OpWrapper::UpdateTensors(
-    const std::vector<std::optional<qnn::TensorWrapperRef>>& inputs,
-    const std::vector<std::optional<qnn::TensorWrapperRef>>& outputs) {
+    const std::vector<const TensorWrapper*>& inputs,
+    const std::vector<const TensorWrapper*>& outputs) {
   if (inputs.size() != input_tensors_.size() ||
       outputs.size() != output_tensors_.size()) {
     QNN_LOG_WARNING("UpdateTensors skipped due to incorrect tensor count.");
     return;
   }
   for (size_t i = 0; i < inputs.size(); ++i) {
-    if (inputs[i].has_value()) {
-      input_tensors_[i] = inputs[i].value().get();
+    if (inputs[i]) {
+      input_tensors_[i] = *inputs[i];
     }
   }
   for (size_t i = 0; i < outputs.size(); ++i) {
-    if (outputs[i].has_value()) {
-      output_tensors_[i] = outputs[i].value().get();
+    if (outputs[i]) {
+      output_tensors_[i] = *outputs[i];
     }
   }
 }

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -58,9 +58,10 @@ class OpWrapper final {
 
   void SwapOutputs(OpWrapper& other);
 
-  void UpdateTensors(
-      const std::vector<std::optional<qnn::TensorWrapperRef>>& inputs,
-      const std::vector<std::optional<qnn::TensorWrapperRef>>& outputs);
+  // Updates input and output tensors if the provided TensorWrapper pointers
+  // are not nullptr. Otherwise, retains the current TensorWrapper instances.
+  void UpdateTensors(const std::vector<const TensorWrapper*>& inputs,
+                     const std::vector<const TensorWrapper*>& outputs);
 
   void ClearTensorParams();
 

--- a/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
@@ -209,5 +209,39 @@ TEST(OpWrapperTest, ChangeOpName) {
   EXPECT_STREQ(op_wrapper_1.GetOpConfig().v1.name, "namespace/name_new");
 }
 
+TEST(OpWrapperTest, UpdateTensor) {
+  TensorWrapper original_input_0{};
+  TensorWrapper original_input_1{};
+  TensorWrapper original_output_0{};
+  TensorWrapper original_output_1{};
+  OpWrapper op_wrapper{"name", "OP_TYPE", QnnOpCode::kUnknown};
+  op_wrapper.AddInputTensor(original_input_0);
+  op_wrapper.AddInputTensor(original_input_1);
+  op_wrapper.AddOutputTensor(original_output_0);
+  op_wrapper.AddOutputTensor(original_output_1);
+
+  ASSERT_TRUE(&op_wrapper.GetInputTensor(0) == &original_input_0);
+  ASSERT_TRUE(&op_wrapper.GetInputTensor(1) == &original_input_1);
+  ASSERT_TRUE(&op_wrapper.GetOutputTensor(0) == &original_output_0);
+  ASSERT_TRUE(&op_wrapper.GetOutputTensor(1) == &original_output_1);
+
+  // Failed to update tensors because of the incorrect size of input and output
+  // tensors.
+  op_wrapper.UpdateTensors({nullptr}, {nullptr});
+  ASSERT_TRUE(&op_wrapper.GetInputTensor(0) == &original_input_0);
+  ASSERT_TRUE(&op_wrapper.GetInputTensor(1) == &original_input_1);
+  ASSERT_TRUE(&op_wrapper.GetOutputTensor(0) == &original_output_0);
+  ASSERT_TRUE(&op_wrapper.GetOutputTensor(1) == &original_output_1);
+
+  TensorWrapper modified_input_1{};
+  TensorWrapper modified_output_0{};
+  op_wrapper.UpdateTensors({nullptr, &modified_input_1},
+                           {&modified_output_0, nullptr});
+  ASSERT_TRUE(&op_wrapper.GetInputTensor(0) == &original_input_0);
+  ASSERT_TRUE(&op_wrapper.GetInputTensor(1) == &modified_input_1);
+  ASSERT_TRUE(&op_wrapper.GetOutputTensor(0) == &modified_output_0);
+  ASSERT_TRUE(&op_wrapper.GetOutputTensor(1) == &original_output_1);
+}
+
 }  // namespace
 }  // namespace qnn


### PR DESCRIPTION
# WHAT
- `TensorWrapper::UpdateTensor` use `std::optional<std::reference_wrapper<>>` as parameter, which is complicate. 
- Try to use pointer as parameter, also add `const` qualification.

# TEST
```
======================== Test Summary ========================
//litert/c:litert_op_options_test
[==========] 36 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 36 tests.

//litert/c/options:litert_qualcomm_options_test
[==========] 18 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

//litert/tools/flags/vendors:qualcomm_flags_test
[==========] 8 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

//litert/vendors/qualcomm/core/backends:qnn_backend_test
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
YOU HAVE 4 DISABLED TESTS

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 8 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 8 tests.

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 19 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 19 tests.

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 13 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

//litert/vendors/qualcomm/core:common_test
[==========] 14 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 14 tests.

//litert/vendors/qualcomm/core:tensor_pool_test
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 7 tests from 4 test suites ran. (1 ms total)
[  PASSED  ] 7 tests.

//litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

//litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (194 ms total)
[  PASSED  ] 3 tests.

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[==========] 238 tests from 4 test suites ran. (45078 ms total)
[  PASSED  ] 238 tests.
```