### PR TITLE
Qualcomm AI Engine Direct - Suppport more SliceOpBuilder for other use cases.

### DIFF
--- a/litert/vendors/qualcomm/core/builders/op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/op_builder.cc
@@ -53,6 +53,14 @@ std::pair<std::uint32_t, std::uint32_t> ComputePaddingBeforeAfter(
   return result;
 }
 
+std::string GetUniqueOpName(const char* op_type) {
+  // TODO(jiunkaiy): Remove the static op_index to ensure each op has a unique
+  // name.
+  static uint32_t op_index = 0;
+  const auto name = absl::StrCat(op_type, "_", op_index++);
+  return name;
+}
+
 OpWrapper& CreateOpWrapper(std::vector<OpWrapper>& ops, const char* op_type) {
   // TODO(jiunkaiy): Pass QnnOpCode in each opbuilder.
   static std::unordered_map<std::string_view, QnnOpCode>* code_type_map =
@@ -214,11 +222,7 @@ OpWrapper& CreateOpWrapper(std::vector<OpWrapper>& ops, const char* op_type) {
           {QNN_OP_UN_PACK, QnnOpCode::kUnPack},
       };
 
-  // TODO(jiunkaiy): Remove the static op_index to ensure each op has a unique
-  // name.
-  static uint32_t op_index = 0;
-  const auto name = absl::StrCat(op_type, "_", op_index++);
-
+  auto name = GetUniqueOpName(op_type);
   return ops.emplace_back(std::move(name), op_type, code_type_map->at(op_type));
 }
 

--- a/litert/vendors/qualcomm/core/builders/op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/op_builder.h
@@ -38,6 +38,8 @@ std::pair<std::uint32_t, std::uint32_t> ComputePaddingBeforeAfter(
     const std::uint32_t stride, const std::uint32_t dilation_rate,
     const PaddingType padding_type);
 
+std::string GetUniqueOpName(const char* op_type);
+
 OpWrapper& CreateOpWrapper(std::vector<OpWrapper>& ops, const char* op_type);
 
 OpWrapper& CreateSimpleActivationOp(std::vector<OpWrapper>& ops,

--- a/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
@@ -63,13 +63,20 @@ std::vector<OpWrapper> BuildSliceOp(
       QNN_DATATYPE_INT_32, begin_tensor.GetQuantParams(),
       {input_rank, kRangeNumElements}, sizeof(std::int32_t) * range_data.size(),
       range_data.data());
-
-  auto& slice_op = CreateOpWrapper(res, QNN_OP_STRIDED_SLICE);
-  slice_op.AddTensorParam(QNN_OP_STRIDED_SLICE_PARAM_RANGES, range_tensor);
-  slice_op.AddInputTensor(input_tensor);
-  slice_op.AddOutputTensor(outputs[0]);
-
+  
+  BuildSliceOp(res.emplace_back(), input_tensor, outputs[0], range_tensor);
   return res;
+}
+
+bool BuildSliceOp(OpWrapper& op, const TensorWrapper& input,
+                  const TensorWrapper& output, const TensorWrapper& ranges) {
+  auto name = GetUniqueOpName(QNN_OP_STRIDED_SLICE);
+  op.SetName(std::move(name));
+  op.SetType(QNN_OP_STRIDED_SLICE, QnnOpCode::kStridedSlice);
+  op.AddInputTensor(input);
+  op.AddOutputTensor(output);
+  op.AddTensorParam(QNN_OP_STRIDED_SLICE_PARAM_RANGES, ranges);
+  return true;
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/slice_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/slice_op_builder.h
@@ -14,6 +14,10 @@ namespace qnn {
 std::vector<OpWrapper> BuildSliceOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs);
+
+bool BuildSliceOp(OpWrapper& op, const TensorWrapper& input,
+                  const TensorWrapper& output, const TensorWrapper& ranges);
+
 }  // namespace qnn
 
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SLICE_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/core/transformation/BUILD
+++ b/litert/vendors/qualcomm/core/transformation/BUILD
@@ -90,6 +90,7 @@ cc_library(
         "//litert/vendors/qualcomm/core/builders:elementwise_op_builder",
         "//litert/vendors/qualcomm/core/builders:pack_op_builder",
         "//litert/vendors/qualcomm/core/builders:reshape_op_builder",
+        "//litert/vendors/qualcomm/core/builders:slice_op_builder",
         "//litert/vendors/qualcomm/core/builders:split_op_builder",
         "//litert/vendors/qualcomm/core/builders:transpose_op_builder",
         "//litert/vendors/qualcomm/core/builders:unpack_op_builder",

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -48,6 +48,13 @@ OpWrapper::OpWrapper(OpWrapper&& other)
 
 OpWrapper::~OpWrapper() = default;
 
+void OpWrapper::SetName(std::string name) { name_ = std::move(name); }
+
+void OpWrapper::SetType(const char* op_type, QnnOpCode op_code) {
+  type_name_ = op_type;
+  op_code_ = op_code;
+}
+
 void OpWrapper::AddInputTensor(const TensorWrapper& tensor) {
   input_tensors_.emplace_back(tensor);
 }
@@ -124,8 +131,6 @@ const qnn::TensorParamWrapper& OpWrapper::GetTensorPararm(size_t i) const {
 void OpWrapper::SwapOutputs(OpWrapper& other) {
   this->output_tensors_.swap(other.output_tensors_);
 }
-
-void OpWrapper::ClearTensorParams() { tensor_params_.clear(); }
 
 void OpWrapper::UpdateTensors(
     const std::vector<std::optional<qnn::TensorWrapperRef>>& inputs,

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -20,6 +20,8 @@ namespace qnn {
 
 class OpWrapper final {
  public:
+  explicit OpWrapper() = default;
+
   explicit OpWrapper(std::string name, const char* op_type, QnnOpCode op_code);
 
   OpWrapper(const OpWrapper& other);
@@ -29,6 +31,10 @@ class OpWrapper final {
   OpWrapper(OpWrapper&& other);
 
   ~OpWrapper();
+
+  void SetName(std::string name);
+
+  void SetType(const char*op_type, QnnOpCode op_code);
 
   void AddInputTensor(const TensorWrapper& tensor);
 
@@ -63,8 +69,6 @@ class OpWrapper final {
   void UpdateTensors(
       const std::vector<std::optional<qnn::TensorWrapperRef>>& inputs,
       const std::vector<std::optional<qnn::TensorWrapperRef>>& outputs);
-
-  void ClearTensorParams();
 
   void AddPrefixToName(absl::string_view prefix);
 

--- a/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
@@ -42,10 +42,26 @@ void EXPECT_TENSOR_EQ(Qnn_Tensor_t actual, Qnn_Tensor_t expected) {
   }
 }
 
+TEST(OpWrapperTest, DefaultConstructor) {
+  OpWrapper op_wrapper;
+  EXPECT_EQ(op_wrapper.IsOpCode(QnnOpCode::kUnknown), true);
+  const Qnn_OpConfig_t op_config = op_wrapper.GetOpConfig();
+  EXPECT_EQ(op_config.version, QNN_OPCONFIG_VERSION_1);
+  EXPECT_STREQ(op_config.v1.name, "");
+  EXPECT_STREQ(op_config.v1.packageName, QNN_OP_PACKAGE_NAME_QTI_AISW);
+  EXPECT_EQ(op_config.v1.typeName, nullptr);
+  EXPECT_EQ(op_config.v1.numOfParams, 0);
+  EXPECT_EQ(op_config.v1.params, nullptr);
+  EXPECT_EQ(op_config.v1.numOfInputs, 0);
+  EXPECT_EQ(op_config.v1.inputTensors, nullptr);
+  EXPECT_EQ(op_config.v1.numOfOutputs, 0);
+  EXPECT_EQ(op_config.v1.outputTensors, nullptr);
+}
+
 TEST(OpWrapperTest, SanityTest) {
   OpWrapper op_wrapper{"name", "OP_TYPE", QnnOpCode::kUnknown};
   EXPECT_EQ(op_wrapper.IsOpCode(QnnOpCode::kUnknown), true);
-  const Qnn_OpConfig_t& op_config = op_wrapper.GetOpConfig();
+  const Qnn_OpConfig_t op_config = op_wrapper.GetOpConfig();
   EXPECT_EQ(op_config.version, QNN_OPCONFIG_VERSION_1);
 
   const Qnn_OpConfigV1_t& op_config_v1 = op_config.v1;
@@ -64,7 +80,7 @@ TEST(OpWrapperTest, MoveCtorSanityTest) {
   OpWrapper op_wrapper{"name", "OP_TYPE", QnnOpCode::kUnknown};
   OpWrapper moved{std::move(op_wrapper)};
   EXPECT_EQ(moved.IsOpCode(QnnOpCode::kUnknown), true);
-  const Qnn_OpConfig_t& op_config = moved.GetOpConfig();
+  const Qnn_OpConfig_t op_config = moved.GetOpConfig();
   EXPECT_EQ(op_config.version, QNN_OPCONFIG_VERSION_1);
 
   const Qnn_OpConfigV1_t& op_config_v1 = op_config.v1;
@@ -212,6 +228,21 @@ TEST(OpWrapperTest, ChangeOpName) {
   EXPECT_STREQ(op.GetName().data(), "namespace/name");
   op.AddSuffixToName("_new");
   EXPECT_STREQ(op.GetName().data(), "namespace/name_new");
+}
+
+TEST(OpWrapperTest, SetName) {
+  OpWrapper op_wrapper;
+  op_wrapper.SetName("test_name");
+  const Qnn_OpConfig_t op_config = op_wrapper.GetOpConfig();
+  EXPECT_STREQ(op_config.v1.name, "test_name");
+}
+
+TEST(OpWrapperTest, SetType) {
+  OpWrapper op_wrapper;
+  op_wrapper.SetType(QNN_OP_CONV_2D, QnnOpCode::kConv2d);
+  const Qnn_OpConfig_t op_config = op_wrapper.GetOpConfig();
+  EXPECT_TRUE(op_wrapper.IsOpCode(QnnOpCode::kConv2d));
+  EXPECT_EQ(op_config.v1.typeName, QNN_OP_CONV_2D);
 }
 
 }  // namespace


### PR DESCRIPTION
# WHAT
- Add default constructor for `OpWrapper`, also support more setter.
- Support more builder function to construct slice op from the prepared QNN tensors.
- Builder function accept a reference of `OpWrapper`, it will construct required QNN parameter on it. 

# TEST
```
======================== Test Summary ========================
//litert/c:litert_op_options_test


//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.2s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 43.7s

```