### PR TITLE
Qualcomm AI Engine Direct - Support INT2 quantization.

### DIFF
--- a/litert/vendors/qualcomm/core/utils/miscs.h
+++ b/litert/vendors/qualcomm/core/utils/miscs.h
@@ -25,6 +25,7 @@
 namespace qnn {
 constexpr uint32_t kUint16ZeroPoint = -std::numeric_limits<std::int16_t>::min();
 constexpr uint32_t kQuantBitWidth4 = 4;
+constexpr uint32_t kQuantBitWidth2 = 2;
 
 template <typename...>
 inline constexpr bool always_false = false;
@@ -48,8 +49,14 @@ void ConvertDataFromInt16toUInt16(absl::Span<const std::int16_t> src,
 void ConvertDataFromUInt16toInt16(absl::Span<const std::uint16_t> src,
                                   std::vector<std::int16_t>& dst);
 
-void ConvertDataFromInt4ToInt8(const void* src, std::vector<std::int8_t>& dst,
-                               size_t num_bytes);
+void ConvertDataFromInt4ToInt8(const void* src, size_t num_bytes,
+                               std::vector<std::int8_t>& dst);
+
+void ConvertDataFromInt2ToInt8(const void* src, size_t num_bytes,
+                               std::vector<std::int8_t>& dst);
+
+void ConvertDataFromInt8ToInt2(const std::vector<std::int8_t>& src,
+                               std::vector<std::int8_t>& dst);
 
 bool CreateDirectoryRecursive(const std::filesystem::path& dir_name);
 

--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
@@ -99,6 +99,10 @@ class BwScaleOffsetQuantizeParamsWrapper final {
 
   void CloneTo(Qnn_QuantizeParams_t& dst);
 
+  std::uint32_t GetBitwidth() const {
+    return qnn_quantize_param_.bwScaleOffsetEncoding.bitwidth;
+  }
+
  private:
   Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
 };
@@ -119,6 +123,10 @@ class BwAxisScaleOffsetQuantizeParamsWrapper final {
   void CloneTo(Qnn_QuantizeParams_t& dst);
 
   void SetAxis(const std::int32_t axis);
+
+  std::uint32_t GetBitwidth() const {
+    return qnn_quantize_param_.bwAxisScaleOffsetEncoding.bitwidth;
+  }
 
  private:
   Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;

--- a/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
@@ -167,7 +167,7 @@ TEST(ScaleOffsetQuantizeParamsWrapperTest, QnnConstructorTest) {
   wrapper1.CloneTo(dst1);
   ScaleOffsetQuantizeParamsWrapper wrapper2(dst1.scaleOffsetEncoding);
   Qnn_QuantizeParams_t dst2 = QNN_QUANTIZE_PARAMS_INIT;
-  wrapper1.CloneTo(dst2);
+  wrapper2.CloneTo(dst2);
   EXPECT_EQ(dst1.encodingDefinition, dst2.encodingDefinition);
   EXPECT_EQ(dst1.quantizationEncoding, dst2.quantizationEncoding);
   EXPECT_FLOAT_EQ(dst1.scaleOffsetEncoding.scale,
@@ -184,7 +184,7 @@ TEST(AxisScaleOffsetQuantizeParamsWrapperTest, QnnConstructorTest) {
   wrapper1.CloneTo(dst1);
   AxisScaleOffsetQuantizeParamsWrapper wrapper2(dst1.axisScaleOffsetEncoding);
   Qnn_QuantizeParams_t dst2 = QNN_QUANTIZE_PARAMS_INIT;
-  wrapper1.CloneTo(dst2);
+  wrapper2.CloneTo(dst2);
   EXPECT_EQ(dst1.encodingDefinition, dst2.encodingDefinition);
   EXPECT_EQ(dst1.quantizationEncoding, dst2.quantizationEncoding);
   EXPECT_EQ(dst1.axisScaleOffsetEncoding.numScaleOffsets,
@@ -195,6 +195,98 @@ TEST(AxisScaleOffsetQuantizeParamsWrapperTest, QnnConstructorTest) {
     EXPECT_EQ(dst1.axisScaleOffsetEncoding.scaleOffset[i].offset,
               dst2.axisScaleOffsetEncoding.scaleOffset[i].offset);
   }
+}
+
+TEST(BwScaleOffsetQuantizeParamsWrapperTest, CopyConstructorTest) {
+  BwScaleOffsetQuantizeParamsWrapper wrapper1(4, 1.5f, 10);
+  Qnn_QuantizeParams_t dst1 = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper1.CloneTo(dst1);
+  BwScaleOffsetQuantizeParamsWrapper wrapper2(wrapper1);
+  Qnn_QuantizeParams_t dst2 = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper2.CloneTo(dst2);
+  ASSERT_EQ(dst1.encodingDefinition, dst2.encodingDefinition);
+  ASSERT_EQ(dst1.quantizationEncoding, dst2.quantizationEncoding);
+  ASSERT_EQ(dst1.bwScaleOffsetEncoding.bitwidth,
+            dst2.bwScaleOffsetEncoding.bitwidth);
+  ASSERT_FLOAT_EQ(dst1.bwScaleOffsetEncoding.scale,
+                  dst2.bwScaleOffsetEncoding.scale);
+  ASSERT_EQ(dst1.bwScaleOffsetEncoding.offset,
+            dst2.bwScaleOffsetEncoding.offset);
+}
+
+TEST(BwScaleOffsetQuantizeParamsWrapperTest, MoveConstructorTest) {
+  BwScaleOffsetQuantizeParamsWrapper wrapper1(4, 1.5f, 10);
+  Qnn_QuantizeParams_t dst1 = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper1.CloneTo(dst1);
+  BwScaleOffsetQuantizeParamsWrapper wrapper2(std::move(wrapper1));
+  Qnn_QuantizeParams_t dst2 = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper2.CloneTo(dst2);
+  ASSERT_EQ(dst1.encodingDefinition, dst2.encodingDefinition);
+  ASSERT_EQ(dst1.quantizationEncoding, dst2.quantizationEncoding);
+  ASSERT_EQ(dst1.bwScaleOffsetEncoding.bitwidth,
+            dst2.bwScaleOffsetEncoding.bitwidth);
+  ASSERT_FLOAT_EQ(dst1.bwScaleOffsetEncoding.scale,
+                  dst2.bwScaleOffsetEncoding.scale);
+  ASSERT_EQ(dst1.bwScaleOffsetEncoding.offset,
+            dst2.bwScaleOffsetEncoding.offset);
+}
+
+TEST(BwScaleOffsetQuantizeParamsWrapperTest, GetBitwidthTest) {
+  BwScaleOffsetQuantizeParamsWrapper wrapper(4, 1.5f, 10);
+  ASSERT_EQ(wrapper.GetBitwidth(), 4);
+}
+
+TEST(BwAxisScaleOffsetQuantizeParamsWrapperTest, CopyConstructorTest) {
+  std::uint32_t bw = 4;
+  std::int32_t axis = 1;
+  std::vector<float> scales = {1.5f, 2.5f};
+  std::vector<std::int32_t> zero_points = {10, 20};
+  BwAxisScaleOffsetQuantizeParamsWrapper wrapper1(bw, axis, scales,
+                                                  zero_points);
+  BwAxisScaleOffsetQuantizeParamsWrapper wrapper2(wrapper1);
+  Qnn_QuantizeParams_t dst = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper2.CloneTo(dst);
+  ASSERT_EQ(dst.encodingDefinition, QNN_DEFINITION_DEFINED);
+  ASSERT_EQ(dst.quantizationEncoding,
+            QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET);
+  ASSERT_EQ(dst.bwAxisScaleOffsetEncoding.bitwidth, bw);
+  ASSERT_EQ(dst.bwAxisScaleOffsetEncoding.axis, axis);
+  ASSERT_EQ(dst.bwAxisScaleOffsetEncoding.numElements, scales.size());
+  for (size_t i = 0; i < scales.size(); ++i) {
+    ASSERT_FLOAT_EQ(dst.bwAxisScaleOffsetEncoding.scales[i], scales[i]);
+    ASSERT_EQ(dst.bwAxisScaleOffsetEncoding.offsets[i], -zero_points[i]);
+  }
+}
+
+TEST(BwAxisScaleOffsetQuantizeParamsWrapperTest, MoveConstructorTest) {
+  std::uint32_t bw = 4;
+  std::int32_t axis = 1;
+  std::vector<float> scales = {1.5f, 2.5f};
+  std::vector<std::int32_t> zero_points = {10, 20};
+  BwAxisScaleOffsetQuantizeParamsWrapper wrapper1(bw, axis, scales,
+                                                  zero_points);
+  BwAxisScaleOffsetQuantizeParamsWrapper wrapper2(std::move(wrapper1));
+  Qnn_QuantizeParams_t dst = QNN_QUANTIZE_PARAMS_INIT;
+  wrapper2.CloneTo(dst);
+  ASSERT_EQ(dst.encodingDefinition, QNN_DEFINITION_DEFINED);
+  ASSERT_EQ(dst.quantizationEncoding,
+            QNN_QUANTIZATION_ENCODING_BW_AXIS_SCALE_OFFSET);
+  ASSERT_EQ(dst.bwAxisScaleOffsetEncoding.bitwidth, bw);
+  ASSERT_EQ(dst.bwAxisScaleOffsetEncoding.axis, axis);
+  ASSERT_EQ(dst.bwAxisScaleOffsetEncoding.numElements, scales.size());
+  for (size_t i = 0; i < scales.size(); ++i) {
+    ASSERT_FLOAT_EQ(dst.bwAxisScaleOffsetEncoding.scales[i], scales[i]);
+    ASSERT_EQ(dst.bwAxisScaleOffsetEncoding.offsets[i], -zero_points[i]);
+  }
+}
+
+TEST(BwAxisScaleOffsetQuantizeParamsWrapperTest, GetBitwidthTest) {
+  std::uint32_t bw = 4;
+  std::int32_t axis = 1;
+  std::vector<float> scales = {1.5f, 2.5f};
+  std::vector<std::int32_t> zero_points = {10, 20};
+  BwAxisScaleOffsetQuantizeParamsWrapper wrapper(bw, axis, scales, zero_points);
+  ASSERT_EQ(wrapper.GetBitwidth(), 4);
 }
 }  // namespace
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -458,7 +458,7 @@ TEST(TensorWrapperTest, ConstQnnTensorPerTensorQuantConstructTest) {
   EXPECT_EQ(ref.v2.clientBuf.data, qnn_tensor.v2.clientBuf.data);
 }
 
-template <typename T>
+template <typename T, bool is_quant_defined = false>
 void ValidateTensor(const Qnn_Tensor_t& tensor,
                     const Qnn_DataType_t expected_datatype,
                     const std::vector<uint32_t>& expected_dims,
@@ -468,8 +468,13 @@ void ValidateTensor(const Qnn_Tensor_t& tensor,
   EXPECT_EQ(tensor.v2.type, QNN_TENSOR_TYPE_APP_WRITE);
   EXPECT_EQ(tensor.v2.dataFormat, QNN_TENSOR_DATA_FORMAT_FLAT_BUFFER);
   EXPECT_EQ(tensor.v2.dataType, expected_datatype);
-  EXPECT_EQ(tensor.v2.quantizeParams.encodingDefinition,
-            QNN_DEFINITION_UNDEFINED);
+  if constexpr (is_quant_defined) {
+    EXPECT_EQ(tensor.v2.quantizeParams.encodingDefinition,
+              QNN_DEFINITION_DEFINED);
+  } else {
+    EXPECT_EQ(tensor.v2.quantizeParams.encodingDefinition,
+              QNN_DEFINITION_UNDEFINED);
+  }
   EXPECT_EQ(tensor.v2.memType, QNN_TENSORMEMTYPE_RAW);
 
   // Validate dimensions.
@@ -486,12 +491,17 @@ void ValidateTensor(const Qnn_Tensor_t& tensor,
       ::testing::ElementsAreArray(expected_data));
 }
 
-template <typename T, bool is_int4 = false>
+template <typename T, size_t bitwidth = 0>
 void RunQnnTensorImplicitCopyTest(Qnn_DataType_t datatype) {
   const std::vector<std::uint32_t> kDims = {1, 1, 4};
-  std::vector<T> data = {1, 2, 3, 4};
-  if constexpr (is_int4) {
+  std::vector<T> data = {1, 0, 1, 0};
+  QuantizeParamsWrapperVariant quant_param;
+  if constexpr (bitwidth == kQuantBitWidth4) {
     std::vector<int8_t> packed_data;
+    // TODO (chunhsue-qti): Maybe BwAxisScaleOffsetQuantizeParamsWrapper should
+    // also be tested.
+    quant_param.emplace<BwScaleOffsetQuantizeParamsWrapper>(kQuantBitWidth4,
+                                                            1.0f, 0);
     packed_data.reserve(data.size() / 2);
     for (size_t i = 0; i < data.size() / 2; ++i) {
       uint8_t low_nibble = data[i * 2] & 0x0F;
@@ -499,25 +509,38 @@ void RunQnnTensorImplicitCopyTest(Qnn_DataType_t datatype) {
       packed_data.emplace_back((high_nibble << 4) | low_nibble);
     }
     data = packed_data;
+  } else if constexpr (bitwidth == kQuantBitWidth2) {
+    quant_param.emplace<BwScaleOffsetQuantizeParamsWrapper>(kQuantBitWidth2,
+                                                            1.0f, 0);
+    std::vector<int8_t> packed_data;
+    ConvertDataFromInt8ToInt2(data, packed_data);
+    data = packed_data;
   }
 
   const auto data_size = data.size() * sizeof(T);
   const void* data_ptr = static_cast<const void*>(data.data());
 
-  TensorWrapper tensor_wrapper{"",       QNN_TENSOR_TYPE_APP_WRITE,
-                               datatype, QuantizeParamsWrapperVariant(),
-                               kDims,    static_cast<uint32_t>(data_size),
-                               data_ptr, false};
+  TensorWrapper tensor_wrapper{
+      "",    QNN_TENSOR_TYPE_APP_WRITE,        datatype, quant_param,
+      kDims, static_cast<uint32_t>(data_size), data_ptr, false};
 
   Qnn_Tensor_t cloned_tensor;
   tensor_wrapper.CloneTo(cloned_tensor);
   Qnn_Tensor_t& ref_tensor = tensor_wrapper.GetQnnTensor();
-  if constexpr (is_int4) {
+  if constexpr (bitwidth == kQuantBitWidth4) {
     std::vector<std::int8_t> int8_data;
-    ConvertDataFromInt4ToInt8(data.data(), int8_data, data.size());
-    ValidateTensor(cloned_tensor, QNN_DATATYPE_SFIXED_POINT_8, kDims,
-                   int8_data);
-    ValidateTensor(ref_tensor, QNN_DATATYPE_SFIXED_POINT_8, kDims, int8_data);
+    ConvertDataFromInt4ToInt8(data.data(), data.size(), int8_data);
+    ValidateTensor<int8_t, true>(cloned_tensor, QNN_DATATYPE_SFIXED_POINT_8,
+                                 kDims, int8_data);
+    ValidateTensor<int8_t, true>(ref_tensor, QNN_DATATYPE_SFIXED_POINT_8, kDims,
+                                 int8_data);
+  } else if constexpr (bitwidth == kQuantBitWidth2) {
+    std::vector<std::int8_t> int8_data;
+    ConvertDataFromInt2ToInt8(data.data(), data.size(), int8_data);
+    ValidateTensor<int8_t, true>(cloned_tensor, QNN_DATATYPE_SFIXED_POINT_8,
+                                 kDims, int8_data);
+    ValidateTensor<int8_t, true>(ref_tensor, QNN_DATATYPE_SFIXED_POINT_8, kDims,
+                                 int8_data);
   } else {
     ValidateTensor(cloned_tensor, datatype, kDims, data);
     ValidateTensor(ref_tensor, datatype, kDims, data);
@@ -537,7 +560,12 @@ TEST(TensorWrapperDatatypeTest, SFIXED_POINT_16) {
   RunQnnTensorImplicitCopyTest<std::int16_t>(QNN_DATATYPE_SFIXED_POINT_16);
 }
 TEST(TensorWrapperDatatypeTest, SFIXED_POINT_4) {
-  RunQnnTensorImplicitCopyTest<std::int8_t, true>(QNN_DATATYPE_SFIXED_POINT_4);
+  RunQnnTensorImplicitCopyTest<std::int8_t, kQuantBitWidth4>(
+      QNN_DATATYPE_SFIXED_POINT_8);
+}
+TEST(TensorWrapperDatatypeTest, SFIXED_POINT_2) {
+  RunQnnTensorImplicitCopyTest<std::int8_t, kQuantBitWidth2>(
+      QNN_DATATYPE_SFIXED_POINT_8);
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -71,3 +71,36 @@ litert_test(
         "@qairt//:qnn_lib_headers",
     ],
 )
+
+litert_test(
+    name = "fully_connected_int2_test",
+    srcs = [
+        "fully_connected_int2_test.cc",
+    ],
+    linkopts = select({
+        "@org_tensorflow//tensorflow:android": [],
+        "//conditions:default": [
+            make_rpaths([
+                "//litert/c:litert_runtime_c_api_so",
+            ]),
+        ],
+    }),
+    linkstatic = True,
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "no-remote-exec",
+        "nobuilder",
+        "notap",
+    ],
+    ungrte = True,
+    use_sys_malloc = True,
+    deps = [
+        "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:fully_connected_op_builder",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "//litert/vendors/qualcomm/core/utils:miscs",
+        "@qairt//:qnn_lib_headers",
+    ],
+)

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/fully_connected_int2_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/fully_connected_int2_test.cc
@@ -1,0 +1,78 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "QnnTypes.h"  // from @qairt
+#include "litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h"
+#include "litert/vendors/qualcomm/core/common.h"
+#include "litert/vendors/qualcomm/core/utils/miscs.h"
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+
+using testing::Pointwise;
+namespace litert::qnn {
+namespace {
+INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
+                         QnnTestPrinter);
+
+TEST_P(QnnModelTest, FullyConnectedInt2Sanity) {
+  constexpr float kScale = 0.001;
+
+  auto input_quant = ::qnn::ScaleOffsetQuantizeParamsWrapper(kScale, 0);
+  auto output_quant = ::qnn::ScaleOffsetQuantizeParamsWrapper(kScale, 0);
+  const std::vector<std::uint32_t> kInDims{1, 2};
+  const std::vector<std::uint32_t> kOutDims{1, 2};
+
+  auto& input_0 = tensor_pool_.CreateInputTensorWithSuffix(
+      QNN_DATATYPE_SFIXED_POINT_16, input_quant, kInDims, "");
+  auto& output_0 = tensor_pool_.CreateOutpuTensorWithSuffix(
+      QNN_DATATYPE_SFIXED_POINT_16, output_quant, kOutDims, "");
+
+  const std::vector<std::uint32_t> kFilterDims{2, 2};
+  auto weight_quant_param =
+      ::qnn::BwScaleOffsetQuantizeParamsWrapper(2, kScale, 0);
+
+  std::vector<int8_t> weight_data = {1, -1, -1, 1};
+  std::vector<int8_t> int2_weight_data;
+  ::qnn::ConvertDataFromInt8ToInt2(weight_data, int2_weight_data);
+  auto& weight_tensor = tensor_pool_.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, kFilterDims,
+      int2_weight_data.size(), int2_weight_data.data());
+
+  auto ops = ::qnn::BuildFullyConnectedOp(
+      tensor_pool_, {input_0, weight_tensor}, {output_0}, true);
+  ASSERT_FALSE(ops.empty());
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_0);
+  auto output_idx = qnn_model_.AddOutputTensor(output_0);
+
+  std::vector<int16_t> in_data = {1000, 0};
+  qnn_model_.SetInputData<int16_t>(input_idx, in_data);
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<int16_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_EQ(output_data->size(), 2);
+  ASSERT_THAT(
+      output_data.value(),
+      Pointwise(testing::Eq(), {::qnn::Quantize<int16_t>(0.001, kScale, 0),
+                                ::qnn::Quantize<int16_t>(-0.001, kScale, 0)}));
+}
+
+}  // namespace
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/qnn_backend_test/test_utils.h
+++ b/litert/vendors/qualcomm/qnn_backend_test/test_utils.h
@@ -5,6 +5,7 @@
 #define ODML_LITERT_LITERT_VENDORS_QUALCOMM_QNN_BACKEND_TEST_TEST_UTILS_H_
 
 #include <string_view>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include "litert/vendors/qualcomm/core/common.h"
@@ -39,10 +40,15 @@ class QnnModelTest : public testing::TestWithParam<
 };
 
 inline auto GetDefaultQnnModelParams() {
+#if !defined(__ANDROID__)
+  std::vector<std::string_view> socs = {"SM8650", "SM8750", "SM8850"};
+#else
+  // On device, qnn manager will use online soc for compilation.
+  std::vector<std::string_view> socs = {"SOC_UNKNOWN"};
+#endif
   return ::testing::Combine(::testing::Values(kTestingDefaultQnnOptions),
-                            ::testing::Values("SM8650", "SM8750", "SM8850"));
+                            ::testing::ValuesIn(socs));
 }
-
 }  // namespace litert::qnn
 
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_QNN_BACKEND_TEST_TEST_UTILS_H_


### PR DESCRIPTION
Summary:
 - Add a qualcomm test for int2 fully connected op
 - Support int2 to int8 data conversion

# Test
```
======================== Test Summary ========================
//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.2s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.6s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.6s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.6s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.3s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 64.5s
```