### PR TITLE
Qualcomm AI Engine Direct - Support HadamardTransform.

### DIFF
--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -177,6 +177,7 @@ litert_lib(
         "//litert/vendors/qualcomm/core/builders:gathernd_op_builder",
         "//litert/vendors/qualcomm/core/builders:gelu_op_builder",
         "//litert/vendors/qualcomm/core/builders:group_norm_op_builder",
+        "//litert/vendors/qualcomm/core/builders:hadamard_transform_op_builder",
         "//litert/vendors/qualcomm/core/builders:l2_norm_op_builder",
         "//litert/vendors/qualcomm/core/builders:leaky_relu_op_builder",
         "//litert/vendors/qualcomm/core/builders:log_softmax_op_builder",

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -59,6 +59,7 @@
 #include "litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/fully_connected_op_builder_htp.h"
+#include "litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/gather_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/gathernd_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/gelu_op_builder.h"
@@ -556,7 +557,13 @@ LiteRtStatus BuildFullyConnectedOp(
 
   auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
       tensor_pool, fused_activation, output_tensors);
-  if (use_htp_preferences) {
+  const auto scale = GetSylvesterHadamardScale(input_tensors[1]);
+  if (scale) {
+    LITERT_LOG(LITERT_INFO, "Convert FC to HadamardTransform.");
+    op_wrappers = ::qnn::BuildHadamardTransformOp(
+        tensor_pool, input_tensors, {activation_input}, keep_num_dims);
+  }
+  if (op_wrappers.empty() && use_htp_preferences) {
     op_wrappers = ::qnn::BuildFullyConnectedOpHtp(
         tensor_pool, input_tensors, {activation_input}, keep_num_dims);
   }

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -701,3 +701,18 @@ cc_library(
         "@qairt//:qnn_lib_headers",
     ],
 )
+
+cc_library(
+    name = "hadamard_transform_op_builder",
+    srcs = ["hadamard_transform_op_builder.cc"],
+    hdrs = ["hadamard_transform_op_builder.h"],
+    deps = [
+        "@com_google_absl//absl/numeric:bits",
+        ":op_builder",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/utils:log",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@qairt//:qnn_lib_headers",
+    ],
+)

--- a/litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.cc
@@ -1,0 +1,95 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+#include <cmath>
+#include "QnnOpDef.h"  // from @qairt
+#include "absl/numeric/bits.h"  // from @com_google_absl
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+namespace qnn {
+
+namespace {
+constexpr std::size_t kInputIndex = 0;
+constexpr std::size_t kOutputIndex = 0;
+}  // namespace
+
+std::optional<float> GetSylvesterHadamardScale(const TensorWrapper& weight) {
+  if (weight.GetRank() != 2) return std::nullopt;
+  if (weight.GetDimension(0) != weight.GetDimension(1)) return std::nullopt;
+  const std::uint32_t n = weight.GetDimension(0);
+
+  // Ensure the size is power-of-two.
+  if (n == 0 || (n & (n - 1)) != 0) return std::nullopt;
+
+  // Get weight data.
+  if (weight.GetDataType() != Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_8) {
+    return std::nullopt;
+  }
+  auto hadamard = weight.GetTensorData<std::int8_t>();
+  if (!hadamard.has_value()) return std::nullopt;
+
+  std::int8_t hadamard_value = hadamard.value()[0];
+
+  // Ensure the matrix adheres Sylvester's construction.
+  for (std::uint32_t i = 0; i < n; ++i) {
+    for (std::uint32_t j = 0; j < n; ++j) {
+      int bits = absl::popcount(i & j);
+      std::int8_t val = ((bits & 1) == 0) ? +hadamard_value : -hadamard_value;
+      if (hadamard.value()[i * n + j] != val) {
+        return std::nullopt;
+      }
+    }
+  }
+
+  // QNN HadamardTransform: out = HadamardTransform(in) * scale
+  //
+  // HadamardTransform() applies the Hadamard matrix with a normalization factor
+  // of 1/sqrt(n), where n is the size of the last dimension of the input and
+  // output tensors.
+  //
+  // As the dequantized weight is S * (hadamard_value - Z), to match the
+  // normalized form, the required scale is:
+  //     scale = S * (hadamard_value - Z) * sqrt(n)
+  // where S and Z are the quantization scale and zero-point.
+  if (const auto* p = std::get_if<BwScaleOffsetQuantizeParamsWrapper>(
+          &weight.GetQuantParams())) {
+    return p->GetScale() * (hadamard_value - p->GetZeroPoint()) * std::sqrt(n);
+  } else if (const auto* p = std::get_if<ScaleOffsetQuantizeParamsWrapper>(
+                 &weight.GetQuantParams())) {
+    return p->GetScale() * (hadamard_value + p->GetZeroPoint()) * std::sqrt(n);
+  } else if (const auto* p = std::get_if<AxisScaleOffsetQuantizeParamsWrapper>(
+                 &weight.GetQuantParams())) {
+    std::vector<float> scales = p->GetScales();
+    std::vector<std::int32_t> zero_points = p->GetZeroPoints();
+    if (scales.empty() || scales.size() != zero_points.size())
+      return std::nullopt;
+    // Validate the assumption that all scale–zero_point pairs are the same.
+    if (std::all_of(scales.begin(), scales.end(),
+                    [&scales](float s) { return s == scales.front(); }) &&
+        std::all_of(
+            zero_points.begin(), zero_points.end(),
+            [&zero_points](float z) { return z == zero_points.front(); })) {
+      return scales[0] * (hadamard_value + zero_points[0]) * std::sqrt(n);
+    }
+  }
+  return std::nullopt;
+}
+
+std::vector<OpWrapper> BuildHadamardTransformOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, float scale) {
+  std::vector<OpWrapper> res;
+  auto& op = CreateOpWrapper(res, QNN_OP_HADAMARD_TRANSFORM);
+  op.AddScalarParam<float>(QNN_OP_HADAMARD_TRANSFORM_PARAM_SCALE, scale);
+  op.AddInputTensor(inputs[kInputIndex]);
+  op.AddOutputTensor(outputs[kOutputIndex]);
+  return res;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.h
@@ -1,0 +1,26 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_HADAMARD_TRANSFORM_OP_BUILDER_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_HADAMARD_TRANSFORM_OP_BUILDER_H_
+
+#include <optional>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildHadamardTransformOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, float scale = 1);
+
+// Returns the corresponding scale factor if the given static tensor forms a
+// valid Sylvester Hadamard matrix; otherwise returns std::nullopt.
+std::optional<float> GetSylvesterHadamardScale(const TensorWrapper& weight);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_HADAMARD_TRANSFORM_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/core/builders/op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/op_builder.cc
@@ -155,6 +155,7 @@ OpWrapper& CreateOpWrapper(std::vector<OpWrapper>& ops, const char* op_type) {
           {QNN_OP_GRID_SAMPLE, QnnOpCode::kGridSample},
           {QNN_OP_GROUP_NORM, QnnOpCode::kGroupNorm},
           {QNN_OP_GRU, QnnOpCode::kGru},
+          {QNN_OP_HADAMARD_TRANSFORM, QnnOpCode::kHadamardTransform},
           {QNN_OP_HARD_SWISH, QnnOpCode::kHardSwish},
           {QNN_OP_HEAT_MAP_MAX_KEY_POINT, QnnOpCode::kHeatMapMaxKeyPoint},
           {QNN_OP_IM2_COL, QnnOpCode::kIm2Col},

--- a/litert/vendors/qualcomm/core/op_code.h
+++ b/litert/vendors/qualcomm/core/op_code.h
@@ -93,6 +93,7 @@ enum class QnnOpCode {
   kGridSample,
   kGroupNorm,
   kGru,
+  kHadamardTransform,
   kHardSwish,
   kHeatMapMaxKeyPoint,
   kIm2Col,

--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
@@ -107,6 +107,14 @@ class BwScaleOffsetQuantizeParamsWrapper final {
   void SetBitwidth(std::uint32_t bitwidth) {
     qnn_quantize_param_.bwScaleOffsetEncoding.bitwidth = bitwidth;
   }
+  
+  float GetScale() const {
+    return qnn_quantize_param_.bwScaleOffsetEncoding.scale;
+  }
+
+  std::int32_t GetZeroPoint() const {
+    return -qnn_quantize_param_.bwScaleOffsetEncoding.offset;
+  }
 
  private:
   Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;

--- a/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
@@ -261,9 +261,11 @@ TEST(BwScaleOffsetQuantizeParamsWrapperTest, MoveConstructorTest) {
             dst2.bwScaleOffsetEncoding.offset);
 }
 
-TEST(BwScaleOffsetQuantizeParamsWrapperTest, GetBitwidthTest) {
+TEST(BwScaleOffsetQuantizeParamsWrapperTest, GetterTest) {
   BwScaleOffsetQuantizeParamsWrapper wrapper(4, 1.5f, 10);
-  ASSERT_EQ(wrapper.GetBitwidth(), 4);
+  EXPECT_EQ(wrapper.GetBitwidth(), 4);
+  EXPECT_EQ(wrapper.GetScale(), 1.5f);
+  EXPECT_EQ(wrapper.GetZeroPoint(), 10);
 }
 
 TEST(BwScaleOffsetQuantizeParamsWrapperTest, SetBitwidthTest) {

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -140,3 +140,35 @@ litert_test(
         "@qairt//:qnn_lib_headers",
     ],
 )
+
+litert_test(
+    name = "hadamard_transform_test",
+    srcs = [
+        "hadamard_transform_test.cc",
+    ],
+    linkopts = select({
+        "@org_tensorflow//tensorflow:android": [],
+        "//conditions:default": [
+            make_rpaths([
+                "//litert/c:litert_runtime_c_api_so",
+            ]),
+        ],
+    }),
+    linkstatic = True,
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "no-remote-exec",
+        "nobuilder",
+        "notap",
+    ],
+    ungrte = True,
+    use_sys_malloc = True,
+    deps = [
+        "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:hadamard_transform_op_builder",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "@qairt//:qnn_lib_headers",
+    ],
+)

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/hadamard_transform_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/hadamard_transform_test.cc
@@ -1,0 +1,86 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "QnnTypes.h"  // from @qairt
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+
+using ::testing::ElementsAreArray;
+
+namespace litert::qnn {
+namespace {
+INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
+                         QnnTestPrinter);
+
+TEST_P(QnnModelTest, HadamardTransform_INT16) {
+  constexpr std::uint32_t kDim = 256U;
+  const std::vector<std::uint32_t> kIODims{1, 1, 1, kDim};
+  const std::vector<std::uint32_t> kWeightDims{kDim, kDim};
+  const ::qnn::QuantizeParamsWrapperVariant quant_param =
+      ::qnn::ScaleOffsetQuantizeParamsWrapper(1.0, 0);
+  constexpr std::int8_t kHadamardValue = 7;
+  constexpr float kWeightScale = 1.0f / 16 / kHadamardValue;
+  const ::qnn::QuantizeParamsWrapperVariant weight_quant_param =
+      ::qnn::ScaleOffsetQuantizeParamsWrapper(kWeightScale, 0);
+  std::array<std::int8_t, kDim * kDim> hadamard_matrix;
+  // Create static weight by Sylvester's construction.
+  for (std::uint32_t i = 0; i < kWeightDims[0]; ++i) {
+    for (std::uint32_t j = 0; j < kWeightDims[1]; ++j) {
+      int bits = absl::popcount(i & j);
+      hadamard_matrix[i * 256 + j] =
+          ((bits & 1) == 0) ? +kHadamardValue : -kHadamardValue;
+    }
+  }
+
+  auto& input = tensor_pool_.CreateInputTensorWithSuffix(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, kIODims, "");
+  auto& weight = tensor_pool_.CreateStaticTensorWithSuffix(
+      QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, kWeightDims, "",
+      hadamard_matrix.size() * sizeof(hadamard_matrix[0]),
+      hadamard_matrix.data(), false);
+  auto& output = tensor_pool_.CreateOutpuTensorWithSuffix(
+      QNN_DATATYPE_SFIXED_POINT_16, quant_param, kIODims, "");
+
+  auto scale = ::qnn::GetSylvesterHadamardScale(weight);
+  ASSERT_EQ(scale.value_or(0.0f), 1.0f);
+
+  auto ops = ::qnn::BuildHadamardTransformOp(tensor_pool_, {input}, {output},
+                                             scale.value());
+  ASSERT_FALSE(ops.empty());
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+
+  // TODO(jiunkaiy): Uncomment the following ValidateOpConfig after HTP supports
+  // SINT16 HadamardTransform. ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+  auto input_idx = qnn_model_.AddInputTensor(input);
+  auto output_idx = qnn_model_.AddOutputTensor(output);
+
+  // Set input data as a vector of 256 ones, matching the first row of the
+  // Hadamard matrix.
+  qnn_model_.SetInputData<int16_t>(input_idx, std::vector<int16_t>(256, 1));
+  // Execute the model.
+  ASSERT_TRUE(qnn_model_.Execute());
+  // Get output.
+  auto output_data = qnn_model_.GetOutputData<int16_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_EQ(output_data->size(), 256);
+  // All expected values are set to zero, except for the first element, as the
+  // rows in a Hadamard matrix are mutually orthogonal, and the input vector is
+  // the first row. The first element is n times the normalization factor
+  // (1/sqrt(n)) for an n*n Hadamard matrix.
+  std::vector<int16_t> expected(256, 0);
+  expected[0] = 16;
+  ASSERT_THAT(output_data.value(), ElementsAreArray(expected));
+}
+
+}  // namespace
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -336,6 +336,13 @@ LiteRtStatus QnnManager::GenerateContextBinary(
 }
 
 LiteRtStatus QnnManager::ValidateOp(::qnn::OpWrapper& op) {
+  // TODO: Apply QNN validation for HadamardTransform.
+  if (absl::StrContains(op.GetName(), "HadamardTransform")) {
+    LITERT_LOG(LITERT_WARNING,
+               "Bypass HadamardTransform op validation");
+    return kLiteRtStatusOk;
+  }
+
   // TODO(jiunkaiy): Remove version check and break backward compatibility when
   // acceptable.
   const auto sdk_version = GetSdkVersion();
@@ -387,7 +394,6 @@ LiteRtStatus QnnManager::ValidateOp(::qnn::OpWrapper& op) {
 
   return kLiteRtStatusOk;
 }
-
 
 LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
                               std::optional<::qnn::SocInfo> soc_info,


### PR DESCRIPTION
Summary:
- Change FC to HadamardTransform if the weight matrix is a Hadamard matrix.

⚠️ This PR aggressively converts FC to HadamardTransform whenever possible, regardless of backend support.
* OP Validator OFF (current implementation): 
The op validator is bypassed. This may cause ungraceful failures on non‑HTP backends.
* OP Validator ON: 
The conversion will fall back to the TFLite runtime.