### PR TITLE
Qualcomm AI Engine Direct - Support custom input in npu_numerics_check.

### DIFF
--- a/litert/tools/BUILD
+++ b/litert/tools/BUILD
@@ -566,6 +566,7 @@ cc_binary(
     srcs = ["npu_numerics_check.cc"],
     deps = NUMERICS_CHECK_DEPS + [
         "//litert/cc:litert_common",
+        "//litert/tools:tensor_utils",
         "//litert/tools/flags/vendors:google_tensor_flags",
         "//litert/tools/flags/vendors:mediatek_flags",
         "//litert/tools/flags/vendors:qualcomm_flags",

--- a/litert/tools/README.md
+++ b/litert/tools/README.md
@@ -283,6 +283,38 @@ the NPU implementation.
 npu_numerics_check --cpu_model=<cpu_model_path> --npu_model=<npu_model_path> --dispatch_library_dir=<path_to_dispatch_lib>
 ```
 
+### Test with Custom Inputs
+
+Prepare an input folder containing all input files in .raw format, with each filename corresponding to the model's input signature. See Python example below:
+
+```py
+import numpy as np
+from ai_edge_litert.compiled_model import CompiledModel
+from pathlib import Path
+
+MODEL_PATH = "/path/to/model.tflite"
+OUTPUT_FOLDER = "/output/folder/for/raw_files"
+
+Path(OUTPUT_FOLDER).mkdir(parents=True, exist_ok=True)
+
+compiled_model = CompiledModel.from_file(MODEL_PATH)
+
+# The signature key of the first signature is used in this example.
+signature_key = compiled_model.get_signature_by_index(0)["key"]
+input_details = compiled_model.get_input_tensor_details(signature_key)
+
+for tensor_name, detail in input_details.items():
+    # Random data is used below, or you can read inputs from images here.
+    # Use np.random.randint with dtype for integer types.
+    data = np.random.random(detail["shape"]).astype(detail["dtype"])
+    data.tofile(Path(OUTPUT_FOLDER) / f"{tensor_name}.raw")
+```
+
+Then specify the input folder at `--input_dir` when running `npu_numerics_check`.
+```bash
+npu_numerics_check --cpu_model=<cpu_model_path> --npu_model=<npu_model_path> --dispatch_library_dir=<path_to_dispatch_lib> --input_dir=<path_to_input_folder>
+```
+
 ## `culprit_finder`
 
 A powerful debugging tool to identify the specific operator ("culprit") in a

--- a/litert/tools/tensor_utils.h
+++ b/litert/tools/tensor_utils.h
@@ -19,11 +19,16 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <limits>
+#include <numeric>
 #include <type_traits>
 #include <vector>
 
 #include "absl/log/absl_log.h"  // from @com_google_absl
+#include "litert/cc/litert_expected.h"
+#include "litert/cc/litert_tensor_buffer.h"
 
 namespace litert {
 namespace tensor_utils {
@@ -194,6 +199,130 @@ void PrintTensorSamples(const std::vector<T>& data, size_t total_elements,
       print_element(i);
     }
   }
+}
+
+Expected<std::vector<char>> ReadTensorDataFromRawFile(
+    absl::string_view file_path) {
+  std::ifstream file(file_path, std::ios::binary);
+  if (!file.is_open()) {
+    return Unexpected(
+        kLiteRtStatusErrorNotFound,
+        absl::StrFormat("Failed to find input file %s.", file_path));
+  }
+  std::vector<char> input_data(std::filesystem::file_size(file_path));
+  file.read(input_data.data(), input_data.size());
+  return input_data;
+}
+
+template <typename T>
+void WriteBufferAs(TensorBuffer& buffer, const std::vector<char>& data) {
+  buffer.Write<T>(
+      absl::Span<T>(reinterpret_cast<T*>(const_cast<char*>(data.data())),
+                    data.size() / sizeof(T)));
+}
+
+// Fill tensor buffer with custom data
+Expected<void> FillBufferWithCustomData(TensorBuffer& buffer,
+                                        const std::vector<char>& data) {
+  auto buffer_size = buffer.Size();
+  if (data.size() != buffer_size.Value()) {
+    return Unexpected(
+        kLiteRtStatusErrorRuntimeFailure,
+        absl::StrFormat("Mismatched input size, input data size: %d bytes != "
+                        "model buffer size: %d bytes.",
+                        data.size(), buffer_size.Value()));
+  }
+  LITERT_ASSIGN_OR_RETURN(auto type, buffer.TensorType());
+
+  switch (type.ElementType()) {
+    case ElementType::Float32:
+      WriteBufferAs<float>(buffer, data);
+      break;
+    case ElementType::Int64:
+      WriteBufferAs<int64_t>(buffer, data);
+      break;
+    case ElementType::Int32:
+      WriteBufferAs<int32_t>(buffer, data);
+      break;
+    case ElementType::Int16:
+      WriteBufferAs<int16_t>(buffer, data);
+      break;
+    case ElementType::Int8:
+      WriteBufferAs<int8_t>(buffer, data);
+      break;
+    case ElementType::UInt8:
+    case ElementType::Bool:
+      WriteBufferAs<uint8_t>(buffer, data);
+      break;
+
+    // Half-precision formats written as raw 16-bit payloads.
+    case ElementType::Float16:
+    case ElementType::BFloat16:
+      WriteBufferAs<uint16_t>(buffer, data);
+      break;
+
+    default:
+      return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                        "Unsupported element type.");
+  }
+  return {};
+}
+
+// Fill tensor buffer with random data
+Expected<void> FillBufferWithRandomData(TensorBuffer& buffer) {
+  constexpr float kScale = 0.12345f;
+  LITERT_ASSIGN_OR_RETURN(auto type, buffer.TensorType());
+  const auto& layout = type.Layout();
+  size_t total_elements =
+      std::accumulate(layout.Dimensions().begin(), layout.Dimensions().end(), 1,
+                      std::multiplies<size_t>());
+  if (type.ElementType() == ElementType::Float16 ||
+      type.ElementType() == ElementType::Float32 ||
+      type.ElementType() == ElementType::BFloat16) {
+    std::vector<float> data(total_elements);
+    for (size_t i = 0; i < total_elements; ++i) {
+      data[i] = std::sin(i * kScale);
+    }
+    buffer.Write<float>(absl::MakeConstSpan(data));
+  } else if (type.ElementType() == ElementType::Int32) {
+    std::vector<int32_t> data(total_elements);
+    unsigned int seed = 7;
+    for (size_t i = 0; i < total_elements; ++i) {
+      data[i] = rand_r(&seed) % 1024 + 1;
+    }
+    buffer.Write<int32_t>(absl::MakeConstSpan(data));
+  } else if (type.ElementType() == ElementType::Int16) {
+    std::vector<int16_t> data(total_elements);
+    for (size_t i = 0; i < total_elements; ++i) {
+      data[i] = i % 2048;
+    }
+    buffer.Write<int16_t>(absl::MakeConstSpan(data));
+  } else if (type.ElementType() == ElementType::Int64) {
+    std::vector<int64_t> data(total_elements);
+    for (size_t i = 0; i < total_elements; ++i) {
+      data[i] = i % 2048;
+    }
+    buffer.Write<int64_t>(absl::MakeConstSpan(data));
+  } else if (type.ElementType() == ElementType::Int8) {
+    std::vector<int8_t> data(total_elements);
+    for (size_t i = 0; i < total_elements; ++i) {
+      data[i] = i % 256 - 128;
+    }
+    buffer.Write<int8_t>(absl::MakeConstSpan(data));
+  } else if (type.ElementType() == ElementType::UInt8) {
+    std::vector<uint8_t> data(total_elements);
+    for (size_t i = 0; i < total_elements; ++i) {
+      data[i] = i % 256;
+    }
+    buffer.Write<uint8_t>(absl::MakeConstSpan(data));
+  } else if (type.ElementType() == ElementType::Bool) {
+    std::vector<uint8_t> data(total_elements);
+    for (size_t i = 0; i < total_elements; ++i) {
+      data[i] = i % 2;
+    }
+    buffer.Write<uint8_t>(absl::MakeConstSpan(data));
+  }
+  return {};
 }
 
 }  // namespace tensor_utils


### PR DESCRIPTION
Summary:
 - Add new flag, --input_dir, a folder storing all inputs.
 - Read inputs from input_dir by their signature names.
 - Add an example in README.md.

# Test
Test with `testdata/attention.tflite` with random inputs.
```
Max diff: 3.976e-05
Min diff: 4.36557e-11
Top 0 diff: 3.976e-05 @ element #: 55211, CPU val: -0.0171906 , NPU val: -0.0171509
Top 1 diff: 3.88976e-05 @ element #: 52907, CPU val: -0.0171898 , NPU val: -0.0171509
Top 2 diff: 3.87356e-05 @ element #: 58155, CPU val: -0.0171896 , NPU val: -0.0171509
Top 3 diff: 3.84841e-05 @ element #: 2603, CPU val: -0.017876 , NPU val: -0.0178375
Top 4 diff: 3.83481e-05 @ element #: 58923, CPU val: -0.0171892 , NPU val: -0.0171509
Top 5 diff: 3.82327e-05 @ element #: 1323, CPU val: -0.0178758 , NPU val: -0.0178375
Top 6 diff: 3.81842e-05 @ element #: 6059, CPU val: -0.0178757 , NPU val: -0.0178375
Top 7 diff: 3.80427e-05 @ element #: 65835, CPU val: -0.0178908 , NPU val: -0.0178528
Top 8 diff: 3.8011e-05 @ element #: 18987, CPU val: -0.0179366 , NPU val: -0.0178986
Top 9 diff: 3.8011e-05 @ element #: 14891, CPU val: -0.0179366 , NPU val: -0.0178986
Top 10 diff: 3.79831e-05 @ element #: 21547, CPU val: -0.0179365 , NPU val: -0.0178986
Top 11 diff: 3.79123e-05 @ element #: 14507, CPU val: -0.0179365 , NPU val: -0.0178986
Top 12 diff: 3.78937e-05 @ element #: 15659, CPU val: -0.0179365 , NPU val: -0.0178986
Top 13 diff: 3.78806e-05 @ element #: 24747, CPU val: -0.0179364 , NPU val: -0.0178986
Top 14 diff: 3.7875e-05 @ element #: 70315, CPU val: -0.0178907 , NPU val: -0.0178528
Top 15 diff: 3.78732e-05 @ element #: 16939, CPU val: -0.0179364 , NPU val: -0.0178986
Top 16 diff: 3.78732e-05 @ element #: 7211, CPU val: -0.0178754 , NPU val: -0.0178375
Top 17 diff: 3.78452e-05 @ element #: 13483, CPU val: -0.0179364 , NPU val: -0.0178986
Top 18 diff: 3.78359e-05 @ element #: 18475, CPU val: -0.0179364 , NPU val: -0.0178986
Top 19 diff: 3.78042e-05 @ element #: 64427, CPU val: -0.0178906 , NPU val: -0.0178528
CPU magnitude: 2.5515
NPU magnitude: 2.54303
Mean diff: 6.74272e-06
Cosine similarity: 1
MSE: 7.45076e-11
SNR: 55.2429 dB
PSNR: 66.3528 dB
Pearson correlation: 1
Total 0 out of 102400 are different elements, for output #0, threshold - 0.0001
```