### PR TITLE
Qualcomm AI Engine Direct - Enable DSP backend.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -33,6 +33,7 @@ struct LiteRtQualcommOptionsT {
   LiteRtQualcommOptionsProfiling profiling = kLiteRtQualcommProfilingOff;
   bool use_htp_preference = false;
   bool use_qint16_as_quint16 = false;
+  LiteRtQualcommOptionsBackend qnn_backend = kLiteRtQualcommBackendHtp;
   bool enable_weight_sharing = false;
   bool use_conv_hmx = true;
   bool use_fold_relu = true;
@@ -67,12 +68,13 @@ LiteRtStatus LiteRtQualcommOptionsCreate(LiteRtOpaqueOptions* options) {
     const LiteRtQualcommOptionsT* options =
         reinterpret_cast<const LiteRtQualcommOptionsT*>(payload);
     uint64_t ans = 0;
-    litert::HashCombine(
-        ans, options->log_level, options->profiling,
-        options->use_htp_preference, options->use_qint16_as_quint16,
-        options->enable_weight_sharing, options->htp_performance_mode,
-        options->ir_json_dir, options->dlc_dir, options->vtcm_size,
-        options->num_hvx_threads, options->optimization_level);
+    litert::HashCombine(ans, options->log_level, options->profiling,
+                        options->use_htp_preference,
+                        options->use_qint16_as_quint16, options->qnn_backend,
+                        options->enable_weight_sharing,
+                        options->htp_performance_mode, options->ir_json_dir,
+                        options->dlc_dir, options->vtcm_size,
+                        options->num_hvx_threads, options->optimization_level);
     return ans;
   };
   LITERT_RETURN_IF_ERROR(LiteRtSetOpaqueOptionsHash(*options, qti_hash));
@@ -449,6 +451,28 @@ LiteRtStatus LiteRtQualcommOptionsGetGraphPriority(
   }
 
   *graph_priority = options->graph_priority;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetBackend(
+    LiteRtQualcommOptions options, LiteRtQualcommOptionsBackend qnn_backend) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->qnn_backend = qnn_backend;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetBackend(
+    LiteRtQualcommOptions options, LiteRtQualcommOptionsBackend* qnn_backend) {
+  if (qnn_backend == nullptr || options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *qnn_backend = options->qnn_backend;
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -231,6 +231,20 @@ LiteRtStatus LiteRtQualcommOptionsGetGraphPriority(
     LiteRtQualcommOptions options,
     LiteRtQualcommOptionsGraphPriority* graph_priority);
 
+typedef enum LiteRtQualcommOptionsBackend {
+  kLiteRtQualcommBackendUndefined = 0,
+  kLiteRtQualcommBackendGpu,
+  kLiteRtQualcommBackendHtp,
+  kLiteRtQualcommBackendDsp,
+  kLiteRtQualcommBackendIr,
+} LiteRtQualcommOptionsBackend;
+
+LiteRtStatus LiteRtQualcommOptionsSetBackend(
+    LiteRtQualcommOptions options, LiteRtQualcommOptionsBackend qnn_backend);
+
+LiteRtStatus LiteRtQualcommOptionsGetBackend(
+    LiteRtQualcommOptions options, LiteRtQualcommOptionsBackend* qnn_backend);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -386,6 +386,10 @@ TEST(QualcommOptionsTest, CppApi) {
   EXPECT_TRUE(options->GetUseFoldReLU());
   options->SetUseFoldReLU(false);
   EXPECT_FALSE(options->GetUseFoldReLU());
+
+  EXPECT_EQ(options->GetBackend(), QualcommOptions::Backend::kHtp);
+  options->SetBackend(QualcommOptions::Backend::kDsp);
+  EXPECT_EQ(options->GetBackend(), QualcommOptions::Backend::kDsp);
 }
 
 TEST(QualcommOptionsTest, FindFromChain) {
@@ -428,6 +432,24 @@ TEST(LiteRtQualcommOptionsTest, Hash) {
 
   LiteRtDestroyOpaqueOptions(options1);
   LiteRtDestroyOpaqueOptions(options2);
+}
+
+TEST(LiteRtQualcommOptionsTest, Backend) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsSetBackend(qualcomm_options,
+                                                   kLiteRtQualcommBackendDsp));
+
+  LiteRtQualcommOptionsBackend qnn_backend;
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsGetBackend(qualcomm_options, &qnn_backend));
+  EXPECT_EQ(qnn_backend, kLiteRtQualcommBackendDsp);
+
+  LiteRtDestroyOpaqueOptions(options);
 }
 
 }  // namespace

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -232,6 +232,17 @@ bool QualcommOptions::GetUseFoldReLU() {
   return use_fold_relu;
 }
 
+void QualcommOptions::SetBackend(Backend qnn_backend) {
+  internal::AssertOk(LiteRtQualcommOptionsSetBackend, Data(),
+                     static_cast<LiteRtQualcommOptionsBackend>(qnn_backend));
+}
+
+QualcommOptions::Backend QualcommOptions::GetBackend() {
+  LiteRtQualcommOptionsBackend qnn_backend;
+  internal::AssertOk(LiteRtQualcommOptionsGetBackend, Data(), &qnn_backend);
+  return static_cast<QualcommOptions::Backend>(qnn_backend);
+}
+
 Expected<QualcommOptions> QualcommOptions::Create(OpaqueOptions& options) {
   const auto id = options.GetIdentifier();
   if (!id || *id != Discriminator()) {

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -153,6 +153,17 @@ class QualcommOptions : public OpaqueOptions {
   void SetGraphPriority(GraphPriority graph_priority);
   GraphPriority GetGraphPriority();
 
+  enum class Backend : int {
+    kUndefined = kLiteRtQualcommBackendUndefined,
+    kGpu = kLiteRtQualcommBackendGpu,
+    kHtp = kLiteRtQualcommBackendHtp,
+    kDsp = kLiteRtQualcommBackendDsp,
+    kIr = kLiteRtQualcommBackendIr,
+  };
+
+  void SetBackend(Backend qnn_backend);
+  Backend GetBackend();
+
  private:
   LiteRtQualcommOptions Data() const;
 };

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -354,6 +354,51 @@ ABSL_FLAG(bool, qualcomm_use_fold_relu, true,
 
 // NOLINTEND(*alien-types*)
 
+ABSL_FLAG(litert::qualcomm::QualcommOptions::Backend, qualcomm_backend,
+          litert::qualcomm::QualcommOptions::Backend::kHtp,
+          "QNN backend to use.");
+
+namespace litert::qualcomm {
+
+bool AbslParseFlag(absl::string_view text, QualcommOptions::Backend* options,
+                   std::string* error) {
+  if (text == "gpu") {
+    *options = QualcommOptions::Backend::kGpu;
+    return true;
+  }
+  if (text == "htp") {
+    *options = QualcommOptions::Backend::kHtp;
+    return true;
+  }
+  if (text == "dsp") {
+    *options = QualcommOptions::Backend::kDsp;
+    return true;
+  }
+  if (text == "ir") {
+    *options = QualcommOptions::Backend::kIr;
+    return true;
+  }
+  *error = "Unknown QNN backend";
+  return false;
+}
+
+std::string AbslUnparseFlag(QualcommOptions::Backend options) {
+  switch (options) {
+    case QualcommOptions::Backend::kUndefined:
+      return "undefined";
+    case QualcommOptions::Backend::kGpu:
+      return "gpu";
+    case QualcommOptions::Backend::kHtp:
+      return "htp";
+    case QualcommOptions::Backend::kDsp:
+      return "dsp";
+    case QualcommOptions::Backend::kIr:
+      return "ir";
+  }
+}
+
+}  // namespace litert::qualcomm
+
 namespace litert::qualcomm {
 
 Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
@@ -410,6 +455,9 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
 
   const auto use_fold_relu = absl::GetFlag(FLAGS_qualcomm_use_fold_relu);
   opts.SetUseFoldReLU(use_fold_relu);
+
+  const auto qnn_backend = absl::GetFlag(FLAGS_qualcomm_backend);
+  opts.SetBackend(qnn_backend);
 
   return {};
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -40,6 +40,17 @@ bool AbslParseFlag(absl::string_view text, QualcommOptions::LogLevel* options,
 
 }  // namespace litert::qualcomm
 
+ABSL_DECLARE_FLAG(litert::qualcomm::QualcommOptions::Backend, qualcomm_backend);
+
+namespace litert::qualcomm {
+
+bool AbslParseFlag(absl::string_view text, QualcommOptions::Backend* options,
+                   std::string* error);
+
+std::string AbslUnparseFlag(QualcommOptions::Backend options);
+
+}  // namespace litert::qualcomm
+
 #endif
 
 // COMPILATION OPTIONS /////////////////////////////////////////////////////////

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -332,6 +332,47 @@ TEST(GraphPriorityTest, Parse) {
   }
 }
 
+TEST(BackendTest, Parse) {
+  std::string error;
+  QualcommOptions::Backend value;
+
+  {
+    static constexpr absl::string_view kBackend = "gpu";
+    static constexpr QualcommOptions::Backend kBackendEnum =
+        QualcommOptions::Backend::kGpu;
+    EXPECT_TRUE(AbslParseFlag(kBackend, &value, &error));
+    EXPECT_EQ(value, kBackendEnum);
+    EXPECT_EQ(kBackend, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kBackend = "htp";
+    static constexpr QualcommOptions::Backend kBackendEnum =
+        QualcommOptions::Backend::kHtp;
+    EXPECT_TRUE(AbslParseFlag(kBackend, &value, &error));
+    EXPECT_EQ(value, kBackendEnum);
+    EXPECT_EQ(kBackend, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kBackend = "dsp";
+    static constexpr QualcommOptions::Backend kBackendEnum =
+        QualcommOptions::Backend::kDsp;
+    EXPECT_TRUE(AbslParseFlag(kBackend, &value, &error));
+    EXPECT_EQ(value, kBackendEnum);
+    EXPECT_EQ(kBackend, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kBackend = "ir";
+    static constexpr QualcommOptions::Backend kBackendEnum =
+        QualcommOptions::Backend::kIr;
+    EXPECT_TRUE(AbslParseFlag(kBackend, &value, &error));
+    EXPECT_EQ(value, kBackendEnum);
+    EXPECT_EQ(kBackend, AbslUnparseFlag(value));
+  }
+}
+
 TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   Expected<QualcommOptions> options = QualcommOptions::Create();
   ASSERT_TRUE(options.HasValue());
@@ -352,6 +393,7 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
             QualcommOptions::OptimizationLevel::kOptimizeForInferenceO3);
   EXPECT_EQ(options.Value().GetGraphPriority(),
             QualcommOptions::GraphPriority::kDefault);
+  EXPECT_EQ(options.Value().GetBackend(), QualcommOptions::Backend::kHtp);
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/BUILD
+++ b/litert/vendors/qualcomm/BUILD
@@ -76,6 +76,7 @@ litert_cc_lib_with_qnn(
         "//litert/cc/internal:litert_shared_library",
         "//litert/core:dynamic_loading",
         "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core/backends:dsp_backend",
         "//litert/vendors/qualcomm/core/backends:htp_backend",
         "//litert/vendors/qualcomm/core/backends:ir_backend",
         "//litert/vendors/qualcomm/core/backends:qnn_backend",

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -110,6 +110,8 @@ inline LiteRtStatus InitQnnOptions(
       static_cast<::qnn::Profiling>(qualcomm_options.GetProfiling()));
   qnn_options.SetUseHtpPreference(qualcomm_options.GetUseHtpPreference());
   qnn_options.SetUseQint16AsQuint16(qualcomm_options.GetUseQint16AsQuint16());
+  qnn_options.SetBackendType(
+      static_cast<::qnn::BackendType>(qualcomm_options.GetBackend()));
   qnn_options.SetEnableWeightSharing(qualcomm_options.GetEnableWeightSharing());
   qnn_options.SetUseConvHMX(qualcomm_options.GetUseConvHMX());
   qnn_options.SetUseFoldReLU(qualcomm_options.GetUseFoldReLU());

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
@@ -180,7 +180,7 @@ TEST(TestQnnPlugin, GetConfigInfo) {
   LiteRtParamIndex num_supported_soc_models;
   LITERT_ASSERT_OK(LiteRtGetNumCompilerPluginSupportedSocModels(
       plugin.get(), &num_supported_soc_models));
-  ASSERT_EQ(num_supported_soc_models, 11);
+  ASSERT_EQ(num_supported_soc_models, 13);
 
   const char* config_id;
   LITERT_ASSERT_OK(

--- a/litert/vendors/qualcomm/core/backends/BUILD
+++ b/litert/vendors/qualcomm/core/backends/BUILD
@@ -63,12 +63,27 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "dsp_backend",
+    srcs = ["dsp_backend.cc"],
+    hdrs = ["dsp_backend.h"],
+    deps = [
+        ":qnn_backend",
+        "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core/schema:soc_table",
+        "//litert/vendors/qualcomm/core/utils:log",
+        "@com_google_absl//absl/types:span",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
 cc_test(
     name = "qnn_backend_test",
     srcs = [
         "qnn_backend_test.cc",
     ],
     deps = [
+        ":dsp_backend",
         ":htp_backend",
         ":ir_backend",
         ":qnn_backend",

--- a/litert/vendors/qualcomm/core/backends/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/backends/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(qnn_backends STATIC)
 
 target_sources(qnn_backends
     PRIVATE
+        dsp_backend.cc
         htp_backend.cc
         htp_perf_control.cc
         ir_backend.cc

--- a/litert/vendors/qualcomm/core/backends/dsp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/dsp_backend.cc
@@ -1,0 +1,55 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/backends/dsp_backend.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "QnnBackend.h"       // from @qairt
+#include "QnnInterface.h"     // from @qairt
+#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/vendors/qualcomm/core/backends/qnn_backend.h"
+#include "litert/vendors/qualcomm/core/common.h"
+#include "litert/vendors/qualcomm/core/schema/soc_table.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
+
+namespace qnn {
+
+DspBackend::DspBackend(const QNN_INTERFACE_VER_TYPE* qnn_api)
+    : QnnBackend(qnn_api) {}
+
+DspBackend::~DspBackend() = default;
+
+bool DspBackend::Init(const Options& options,
+                      std::optional<::qnn::SocInfo> soc_info) {
+  // Log Handle
+  auto local_log_handle = CreateLogHandle(options.GetLogLevel());
+  if (!local_log_handle && options.GetLogLevel() != ::qnn::LogLevel::kOff) {
+    QNN_LOG_ERROR("Failed to create log handle!");
+    return false;
+  }
+
+  // Backend Handle
+  std::vector<const QnnBackend_Config_t*> backend_configs;
+  backend_configs.emplace_back(nullptr);
+
+  auto local_backend_handle = CreateBackendHandle(
+      local_log_handle.get(), absl::MakeSpan(backend_configs));
+  if (!local_backend_handle) {
+    QNN_LOG_ERROR("Failed to create backend handle!");
+    return false;
+  }
+
+  // Follow RAII pattern to manage handles.
+  log_handle_ = std::move(local_log_handle);
+  backend_handle_ = std::move(local_backend_handle);
+
+  return true;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/backends/dsp_backend.h
+++ b/litert/vendors/qualcomm/core/backends/dsp_backend.h
@@ -1,0 +1,40 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BACKENDS_DSP_BACKEND_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BACKENDS_DSP_BACKEND_H_
+
+#include <optional>
+
+#include "DSP/QnnDspCommon.h"  // from @qairt
+#include "QnnInterface.h"      // from @qairt
+#include "QnnTypes.h"          // from @qairt
+#include "litert/vendors/qualcomm/core/backends/qnn_backend.h"
+#include "litert/vendors/qualcomm/core/common.h"
+#include "litert/vendors/qualcomm/core/schema/soc_table.h"
+
+namespace qnn {
+
+class DspBackend : public QnnBackend {
+ public:
+  static const char* GetLibraryName() { return "libQnnDsp.so"; }
+
+  static Qnn_Version_t GetExpectedBackendVersion() {
+    Qnn_Version_t backend_version;
+    backend_version.major = QNN_DSP_API_VERSION_MAJOR;
+    backend_version.minor = QNN_DSP_API_VERSION_MINOR;
+    backend_version.patch = QNN_DSP_API_VERSION_PATCH;
+    return backend_version;
+  }
+
+  explicit DspBackend(const QNN_INTERFACE_VER_TYPE* qnn_api);
+
+  ~DspBackend();
+
+  bool Init(const Options& options,
+            std::optional<::qnn::SocInfo> soc_info) override;
+};
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BACKENDS_DSP_BACKEND_H_

--- a/litert/vendors/qualcomm/core/backends/qnn_backend_test.cc
+++ b/litert/vendors/qualcomm/core/backends/qnn_backend_test.cc
@@ -7,6 +7,7 @@
 #include <optional>
 
 #include <gtest/gtest.h>
+#include "litert/vendors/qualcomm/core/backends/dsp_backend.h"
 #include "litert/vendors/qualcomm/core/backends/htp_backend.h"
 #include "litert/vendors/qualcomm/core/backends/ir_backend.h"
 #include "litert/vendors/qualcomm/core/common.h"
@@ -33,6 +34,12 @@ class QnnBackendTest : public testing::TestWithParam<BackendType> {
             handle_.get(), ::qnn::IrBackend::GetExpectedBackendVersion()));
 
         break;
+      case BackendType::kDspBackend:
+        handle_ = ::qnn::CreateDLHandle(::qnn::DspBackend::GetLibraryName());
+        backend_ = std::make_unique<::qnn::DspBackend>(::qnn::ResolveQnnApi(
+            handle_.get(), ::qnn::DspBackend::GetExpectedBackendVersion()));
+
+        break;
       default:
         break;
     }
@@ -44,7 +51,8 @@ class QnnBackendTest : public testing::TestWithParam<BackendType> {
 
 INSTANTIATE_TEST_SUITE_P(QnnBackendTest, QnnBackendTest,
                          testing::Values(BackendType::kHtpBackend,
-                                         BackendType::kIrBackend));
+                                         BackendType::kIrBackend,
+                                         BackendType::kDspBackend));
 
 TEST_P(QnnBackendTest, DISABLED_InitializeWithLogLevelOffTest) {
   Options options;
@@ -59,7 +67,11 @@ TEST_P(QnnBackendTest, DISABLED_InitializeWithLogLevelOffTest) {
     case BackendType::kIrBackend:
       options.SetBackendType(BackendType::kIrBackend);
       ASSERT_TRUE(backend_->Init(options, std::nullopt));
-      ASSERT_EQ(backend_->GetDeviceHandle(), nullptr);
+      ASSERT_FALSE(backend_->GetDeviceHandle());
+      break;
+    case BackendType::kDspBackend:
+      ASSERT_TRUE(backend_->Init(options, std::nullopt));
+      ASSERT_FALSE(backend_->GetDeviceHandle());
       break;
     default:
       break;
@@ -82,7 +94,11 @@ TEST_P(QnnBackendTest, DISABLED_InitializeWithLogLevelVerboseTest) {
     case BackendType::kIrBackend:
       options.SetBackendType(BackendType::kIrBackend);
       ASSERT_TRUE(backend_->Init(options, std::nullopt));
-      ASSERT_EQ(backend_->GetDeviceHandle(), nullptr);
+      ASSERT_FALSE(backend_->GetDeviceHandle());
+      break;
+    case BackendType::kDspBackend:
+      ASSERT_TRUE(backend_->Init(options, std::nullopt));
+      ASSERT_FALSE(backend_->GetDeviceHandle());
       break;
     default:
       break;

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -148,6 +148,7 @@ std::string Options::Dump() const {
       "\
 ::qnn::Options:\n\
 LogLevel: %d\n\
+BackendType: %d\n\
 Profiling: %d\n\
 UseHtpPreference: %v\n\
 UseQint16AsQuint16: %v\n\
@@ -165,12 +166,12 @@ GraphPriority: %d\n";  // NOLINT
 
   std::string dump_tensor_ids = absl::StrJoin(dump_tensor_ids_, ",");
 
-  return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, profiling_,
-                         use_htp_preference_, use_qint16_as_quint16_,
-                         enable_weight_sharing_, use_conv_hmx_, use_fold_relu_,
-                         htp_performance_mode_, dump_tensor_ids, ir_json_dir_,
-                         dlc_dir_, vtcm_size_, num_hvx_threads_,
-                         optimization_level_, graph_priority_);
+  return absl::StrFormat(
+      kQnnOptionsDumpFormat, log_level_, backend_type_, profiling_,
+      use_htp_preference_, use_qint16_as_quint16_, enable_weight_sharing_,
+      use_conv_hmx_, use_fold_relu_, htp_performance_mode_, dump_tensor_ids,
+      ir_json_dir_, dlc_dir_, vtcm_size_, num_hvx_threads_, optimization_level_,
+      graph_priority_);
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -33,7 +33,9 @@ enum class Profiling {
 
 enum class BackendType {
   kUndefinedBackend = 0,
+  kGpuBackend,
   kHtpBackend,
+  kDspBackend,
   kIrBackend,
 };
 

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -48,6 +48,14 @@ TEST(QnnOptionTest, BackendType) {
   static constexpr BackendType kIr = BackendType::kIrBackend;
   options.SetBackendType(kIr);
   EXPECT_EQ(options.GetBackendType(), kIr);
+
+  static constexpr BackendType kDsp = BackendType::kDspBackend;
+  options.SetBackendType(kDsp);
+  EXPECT_EQ(options.GetBackendType(), kDsp);
+
+  static constexpr BackendType kGpu = BackendType::kGpuBackend;
+  options.SetBackendType(kGpu);
+  EXPECT_EQ(options.GetBackendType(), kGpu);
 }
 
 TEST(QnnOptionTest, HtpPerformanceMode) {

--- a/litert/vendors/qualcomm/core/schema/soc_table.cc
+++ b/litert/vendors/qualcomm/core/schema/soc_table.cc
@@ -9,6 +9,12 @@ constexpr SocInfo kSocInfos[] = {
     {SocInfo("UNKNOWN_SDM", SnapdragonModel::UNKNOWN_SDM, DspArch::NONE,
              0  // vtcm_size_in_mb
              )},
+    {SocInfo("SDM865", SnapdragonModel::SDM865, DspArch::V66,
+             0  // vtcm_size_in_mb
+             )},
+    {SocInfo("SM6350", SnapdragonModel::SM6350, DspArch::V66,
+             0  // vtcm_size_in_mb
+             )},
     {SocInfo("SA8255", SnapdragonModel::SA8255, DspArch::V73,
              8  // vtcm_size_in_mb
              )},

--- a/litert/vendors/qualcomm/core/schema/soc_table.h
+++ b/litert/vendors/qualcomm/core/schema/soc_table.h
@@ -8,6 +8,8 @@
 namespace qnn {
 enum class SnapdragonModel {
   UNKNOWN_SDM = 0,
+  SDM865 = 21,
+  SM6350 = 29,
   SA8295 = 39,
   SM8350 = 30,
   SM8450 = 36,

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_device_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_device_context.cc
@@ -84,20 +84,6 @@ Expected<Qnn_MemHandle_t> LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
     return Unexpected(status, "Failed to get tensor buffer type");
   }
 
-  size_t tensor_buffer_size;
-  if (auto status =
-          LiteRtGetTensorBufferSize(tensor_buffer, &tensor_buffer_size);
-      status != kLiteRtStatusOk) {
-    return Unexpected(status, "Failed to get tensor buffer size");
-  }
-
-  size_t tensor_buffer_offset;
-  if (auto status =
-          LiteRtGetTensorBufferOffset(tensor_buffer, &tensor_buffer_offset);
-      status != kLiteRtStatusOk) {
-    return Unexpected(status, "Failed to get tensor buffer offset");
-  }
-
   LiteRtRankedTensorType tensor_type;
   if (auto status =
           LiteRtGetTensorBufferTensorType(tensor_buffer, &tensor_type);
@@ -157,12 +143,6 @@ Expected<Qnn_MemHandle_t> LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
                         "Unsupported tensor buffer type");
   }
 
-  QnnMemHtp_Descriptor_t mem_htp_descriptor = {};
-  mem_htp_descriptor.type = QNN_HTP_MEM_SHARED_BUFFER;
-  mem_htp_descriptor.size = tensor_buffer_size;
-  mem_htp_descriptor.sharedBufferConfig =
-      QnnHtpMem_SharedBufferConfig_t{buffer_fd, tensor_buffer_offset};
-
   Qnn_MemDescriptor_t mem_descriptor = {};
   // QNN does not support 0-dimensional tensors.
   std::array<uint32_t, 1> dim{1};
@@ -172,8 +152,41 @@ Expected<Qnn_MemHandle_t> LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
     mem_descriptor.memShape = {tensor_rank, tensor_dimensions, nullptr};
   }
   mem_descriptor.dataType = tensor_data_type;
-  mem_descriptor.memType = QNN_MEM_TYPE_CUSTOM;
-  mem_descriptor.customInfo = &mem_htp_descriptor;
+
+  QnnMemHtp_Descriptor_t mem_htp_descriptor = {};
+  switch (qnn_manager_.GetOptions().GetBackendType()) {
+    // DSP Backend only supports QNN_MEM_TYPE_ION.
+    case ::qnn::BackendType::kDspBackend:
+      mem_descriptor.memType = QNN_MEM_TYPE_ION;
+      mem_descriptor.ionInfo.fd = buffer_fd;
+
+      break;
+    case ::qnn::BackendType::kHtpBackend:
+      [[fallthrough]];
+    default:
+      size_t tensor_buffer_size;
+      if (auto status =
+              LiteRtGetTensorBufferSize(tensor_buffer, &tensor_buffer_size);
+          status != kLiteRtStatusOk) {
+        return Unexpected(status, "Failed to get tensor buffer size");
+      }
+
+      size_t tensor_buffer_offset;
+      if (auto status =
+              LiteRtGetTensorBufferOffset(tensor_buffer, &tensor_buffer_offset);
+          status != kLiteRtStatusOk) {
+        return Unexpected(status, "Failed to get tensor buffer offset");
+      }
+
+      mem_htp_descriptor.type = QNN_HTP_MEM_SHARED_BUFFER;
+      mem_htp_descriptor.size = tensor_buffer_size;
+      mem_htp_descriptor.sharedBufferConfig =
+          QnnHtpMem_SharedBufferConfig_t{buffer_fd, tensor_buffer_offset};
+      mem_descriptor.memType = QNN_MEM_TYPE_CUSTOM;
+      mem_descriptor.customInfo = &mem_htp_descriptor;
+
+      break;
+  }
 
   if (invocation_context_ == nullptr) {
     return Unexpected(kLiteRtStatusErrorRuntimeFailure,

--- a/litert/vendors/qualcomm/qnn_backend_test/test_utils.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/test_utils.cc
@@ -34,6 +34,9 @@ std::string QnnTestPrinter(
     case ::qnn::BackendType::kIrBackend:
       ss << "Ir";
       break;
+    case ::qnn::BackendType::kDspBackend:
+      ss << "Dsp";
+      break;
     default:
       ss << "UndefinedBackend";
       break;

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -38,6 +38,7 @@
 #include "litert/cc/litert_macros.h"
 #include "litert/core/dynamic_loading.h"
 #include "litert/vendors/qualcomm/common.h"
+#include "litert/vendors/qualcomm/core/backends/dsp_backend.h"
 #include "litert/vendors/qualcomm/core/backends/htp_backend.h"
 #include "litert/vendors/qualcomm/core/backends/ir_backend.h"
 #include "litert/vendors/qualcomm/core/common.h"
@@ -403,6 +404,16 @@ LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
 
       backend_ = std::make_unique<::qnn::IrBackend>(Api());
       LITERT_RETURN_IF_ERROR(backend_->Init(options_, std::nullopt));
+
+      break;
+    }
+    case ::qnn::BackendType::kDspBackend: {
+      LITERT_RETURN_IF_ERROR(LoadLib(::qnn::DspBackend::GetLibraryName()));
+      LITERT_RETURN_IF_ERROR(
+          ResolveApi(::qnn::DspBackend::GetExpectedBackendVersion()));
+
+      backend_ = std::make_unique<::qnn::DspBackend>(Api());
+      LITERT_RETURN_IF_ERROR(backend_->Init(options_, soc_info));
 
       break;
     }

--- a/litert/vendors/qualcomm/supported_soc.csv
+++ b/litert/vendors/qualcomm/supported_soc.csv
@@ -31,6 +31,7 @@ Qualcomm,SM7350,v68,32
 Qualcomm,SM7325,v68,35
 Qualcomm,SM7315,v68,38
 Qualcomm,QCM6490,v68,35
+Qualcomm,SDM865,v66,21
 Qualcomm,SM8250,v66,21
 Qualcomm,SM8150,v66,
 Qualcomm,SM7250,v66,25

--- a/third_party/qairt/qairt.BUILD
+++ b/third_party/qairt/qairt.BUILD
@@ -13,6 +13,7 @@ cc_library(
             "include/QNN/HTP/*.h",
             "include/QNN/System/*.h",
             "include/QNN/IR/*.h",
+            "include/QNN/DSP/*.h",
         ],
         exclude = [
             "include/QNN/HTA/**/*.h",


### PR DESCRIPTION
Summary:
- Enable DSP backend for JIT flow as DSP only support online
  preparation.
- Enable SoC of DSP device (Arch <= V66).
- Add ION mem type which works on DSP backend.
- Add related tests.

Test Result:

- Pass E2E JIT with DSP backend for some of models
- Pass E2E test with HTP, IR backend
- Pass unit test:

======================== Test Summary ========================
//litert/c:litert_op_options_test


//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.9s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.5s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.3s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 58.1s