### PR TITLE
[NeuroPilot] modify the way for loading bytecode

### DIFF
--- a/litert/vendors/mediatek/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/mediatek/dispatch/litert_dispatch_invocation_context.cc
@@ -217,11 +217,11 @@ LoadModelAndCompilation(
     const litert::mediatek::NeuronAdapterApi& neuron_adapter_api,
     const void* bytecode_addr, size_t bytecode_size, int num_inputs,
     int num_outputs) {
-  if (auto result = LoadFromDlaBytecode(neuron_adapter_api, bytecode_addr,
-                                        bytecode_size, num_inputs, num_outputs);
+  if (auto result = LoadFromCachedNetwork(neuron_adapter_api, bytecode_addr,
+                                          bytecode_size);
       !result) {
-    return LoadFromCachedNetwork(neuron_adapter_api, bytecode_addr,
-                                 bytecode_size);
+    return LoadFromDlaBytecode(neuron_adapter_api, bytecode_addr,
+                               bytecode_size, num_inputs, num_outputs);
   } else {
     return result;
   }


### PR DESCRIPTION
due to compiler plugin generates the cache, so regard the bytecode as cache first.