### PR TITLE
Qualcomm AI Engine Direct - Enable saver as a debug tool.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -48,6 +48,7 @@ struct LiteRtQualcommOptionsT {
       kHtpOptimizeForInferenceO3;
   LiteRtQualcommOptionsGraphPriority graph_priority =
       kLiteRTQualcommGraphPriorityDefault;
+  std::string saver_output_dir;
 };
 
 LiteRtStatus LiteRtQualcommOptionsCreate(LiteRtOpaqueOptions* options) {
@@ -152,6 +153,29 @@ LiteRtStatus LiteRtQualcommOptionsGetProfiling(
   }
 
   *profiling = options->profiling;
+
+  return kLiteRtStatusOk;
+}
+
+// Saver -------------------------------------------------------------------
+LiteRtStatus LiteRtQualcommOptionsSetSaverOutputDir(LiteRtQualcommOptions options,
+                                               const char* saver_output_dir) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->saver_output_dir = saver_output_dir;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetSaverOutputDir(LiteRtQualcommOptions options,
+                                               const char** saver_output_dir) {
+  if (options == nullptr || saver_output_dir == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *saver_output_dir = options->saver_output_dir.c_str();
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -245,6 +245,11 @@ LiteRtStatus LiteRtQualcommOptionsSetBackend(
 LiteRtStatus LiteRtQualcommOptionsGetBackend(
     LiteRtQualcommOptions options, LiteRtQualcommOptionsBackend* qnn_backend);
 
+LiteRtStatus LiteRtQualcommOptionsSetSaverOutputDir(LiteRtQualcommOptions options,
+                                            const char* saver_output_dir);
+
+LiteRtStatus LiteRtQualcommOptionsGetSaverOutputDir(LiteRtQualcommOptions options,
+                                            const char** saver_output_dir);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -313,6 +313,24 @@ TEST(LiteRtQualcommOptionsTest, UseFoldReLU) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
+TEST(LiteRtQualcommOptionsTest, SaverOutputDir) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsSetSaverOutputDir(qualcomm_options, "tmp/"));
+
+  const char* saver_output_dir;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetSaverOutputDir(qualcomm_options,
+                                                          &saver_output_dir));
+  EXPECT_STREQ(saver_output_dir, "tmp/");
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
 TEST(QualcommOptionsTest, CppApi) {
   auto options = QualcommOptions::Create();
   ASSERT_TRUE(options);
@@ -390,6 +408,10 @@ TEST(QualcommOptionsTest, CppApi) {
   EXPECT_EQ(options->GetBackend(), QualcommOptions::Backend::kHtp);
   options->SetBackend(QualcommOptions::Backend::kDsp);
   EXPECT_EQ(options->GetBackend(), QualcommOptions::Backend::kDsp);
+
+  EXPECT_EQ(options->GetSaverOutputDir(), "");
+  options->SetSaverOutputDir("tmp");
+  EXPECT_EQ(options->GetSaverOutputDir(), "tmp");
 }
 
 TEST(QualcommOptionsTest, FindFromChain) {

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -243,6 +243,18 @@ QualcommOptions::Backend QualcommOptions::GetBackend() {
   return static_cast<QualcommOptions::Backend>(qnn_backend);
 }
 
+void QualcommOptions::SetSaverOutputDir(const std::string& saver_output_dir) {
+  internal::AssertOk(LiteRtQualcommOptionsSetSaverOutputDir, Data(),
+                     saver_output_dir.c_str());
+}
+
+absl::string_view QualcommOptions::GetSaverOutputDir() {
+  const char* saver_output_dir;
+  internal::AssertOk(LiteRtQualcommOptionsGetSaverOutputDir, Data(),
+                     &saver_output_dir);
+  return absl::string_view(saver_output_dir);
+}
+
 Expected<QualcommOptions> QualcommOptions::Create(OpaqueOptions& options) {
   const auto id = options.GetIdentifier();
   if (!id || *id != Discriminator()) {

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -164,6 +164,9 @@ class QualcommOptions : public OpaqueOptions {
   void SetBackend(Backend qnn_backend);
   Backend GetBackend();
 
+  void SetSaverOutputDir(const std::string& saver_output_dir);
+  absl::string_view GetSaverOutputDir();
+
  private:
   LiteRtQualcommOptions Data() const;
 };

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -260,6 +260,12 @@ ABSL_FLAG(litert::qualcomm::QualcommOptions::GraphPriority,
           "QNN graph priority, If the option is set to 'default', the "
           "QNN_PRIORITY_DEFAULT (Equal to QNN_PRIORITY_NORMAL) will be used.");
 
+ABSL_FLAG(std::string, qualcomm_saver_output_dir, "",
+          "Saver output directory. If provided, you can obtain saver_output.c "
+          "and params.bin. Saver records all QNN API calls into files which "
+          "can be replayed on any QNN backend. See Qualcomm "
+          "AI Runtime (QAIRT) SDK document for more details.");
+
 namespace litert::qualcomm {
 
 bool AbslParseFlag(absl::string_view text,
@@ -457,6 +463,10 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
 
   const auto qnn_backend = absl::GetFlag(FLAGS_qualcomm_backend);
   opts.SetBackend(qnn_backend);
+
+  const std::string saver_output_dir =
+      absl::GetFlag(FLAGS_qualcomm_saver_output_dir);
+  opts.SetSaverOutputDir(saver_output_dir);
 
   return {};
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -69,6 +69,8 @@ ABSL_DECLARE_FLAG(std::string, qualcomm_ir_json_dir);
 
 ABSL_DECLARE_FLAG(std::string, qualcomm_dlc_dir);
 
+ABSL_DECLARE_FLAG(std::string, qualcomm_saver_output_dir);
+
 ABSL_DECLARE_FLAG(uint32_t, qualcomm_vtcm_size);
 
 ABSL_DECLARE_FLAG(uint32_t, qualcomm_num_hvx_thread);

--- a/litert/vendors/qualcomm/BUILD
+++ b/litert/vendors/qualcomm/BUILD
@@ -69,6 +69,7 @@ litert_cc_lib_with_qnn(
     ungrte = True,
     deps = [
         ":common",
+        ":qnn_saver_utils",
         "//litert/c:litert_runtime_c_api_shared_lib",
         "//litert/c/internal:litert_logging",
         "//litert/cc:litert_expected",
@@ -147,5 +148,19 @@ build_test(
     targets = [
         "//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_so",
         "//litert/vendors/qualcomm/dispatch:dispatch_api_so",
+    ],
+)
+
+cc_library(
+    name = "qnn_saver_utils",
+    srcs = ["qnn_saver_utils.cc"],
+    hdrs = ["qnn_saver_utils.h"],
+    deps = [
+        "//litert/c:litert_runtime_c_api_shared_lib",
+        "//litert/c/internal:litert_logging",
+        "//litert/cc/internal:litert_shared_library",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+        "@qairt//:qnn_lib_headers",
     ],
 )

--- a/litert/vendors/qualcomm/CMakeLists.txt
+++ b/litert/vendors/qualcomm/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(qnn_manager
         absl::statusor
         absl::strings
         absl::str_format
+        qnn_saver_utils
 )
 
 # Context Binary Info library
@@ -81,6 +82,25 @@ target_link_libraries(qnn_context_binary_info
     PUBLIC
         absl::status
         absl::statusor
+)
+
+# Qnn Saver Utils
+add_library(qnn_saver_utils STATIC
+    qnn_saver_utils.cc
+)
+
+target_include_directories(qnn_saver_utils
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<$<BOOL:${QAIRT_HEADERS_DIR}>:${QAIRT_HEADERS_DIR}>
+)
+
+target_link_libraries(qnn_saver_utils
+    PUBLIC
+        absl::strings
+        absl::span
+        litert_runtime_c_api_shared_lib
+        litert_cc_api
 )
 
 # Add subdirectories for modular build

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -126,6 +126,7 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetGraphPriority(
       static_cast<::qnn::GraphPriority>(qualcomm_options.GetGraphPriority()));
   qnn_options.SetDumpTensorIds(qualcomm_options.GetDumpTensorIds());
+  qnn_options.SetSaverOutputDir(qualcomm_options.GetSaverOutputDir());
 
   LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
   return kLiteRtStatusOk;

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -143,6 +143,12 @@ void Options::SetGraphPriority(GraphPriority graph_priority) {
   graph_priority_ = graph_priority;
 }
 
+absl::string_view Options::GetSaverOutputDir() const { return saver_output_dir_; }
+
+void Options::SetSaverOutputDir(absl::string_view saver_output_dir) {
+  saver_output_dir_ = saver_output_dir;
+}
+
 std::string Options::Dump() const {
   static constexpr absl::string_view kQnnOptionsDumpFormat =
       "\
@@ -162,7 +168,8 @@ DlcDir: %s\n\
 VtcmSize: %d\n\
 HvxThread: %d\n\
 OptimizationLevel: %d\n\
-GraphPriority: %d\n";  // NOLINT
+GraphPriority: %d\n\
+SaverOutputDir: %s\n";  // NOLINT
 
   std::string dump_tensor_ids = absl::StrJoin(dump_tensor_ids_, ",");
 
@@ -171,7 +178,7 @@ GraphPriority: %d\n";  // NOLINT
       use_htp_preference_, use_qint16_as_quint16_, enable_weight_sharing_,
       use_conv_hmx_, use_fold_relu_, htp_performance_mode_, dump_tensor_ids,
       ir_json_dir_, dlc_dir_, vtcm_size_, num_hvx_threads_, optimization_level_,
-      graph_priority_);
+      graph_priority_, saver_output_dir_);
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -121,6 +121,9 @@ class Options {
 
   std::string Dump() const;
 
+  absl::string_view GetSaverOutputDir() const;
+  void SetSaverOutputDir(absl::string_view saver_output_dir);
+
  private:
   LogLevel log_level_ = LogLevel::kInfo;
   BackendType backend_type_ = BackendType::kHtpBackend;
@@ -139,6 +142,7 @@ class Options {
   OptimizationLevel optimization_level_ =
       OptimizationLevel::kHtpOptimizeForInferenceO3;
   GraphPriority graph_priority_ = GraphPriority::kDefault;
+  std::string saver_output_dir_;
 };
 
 // Gets a default logger implementation to stdout.

--- a/litert/vendors/qualcomm/qnn_saver_utils.cc
+++ b/litert/vendors/qualcomm/qnn_saver_utils.cc
@@ -1,0 +1,46 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/qnn_saver_utils.h"
+
+#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/c/internal/litert_logging.h"
+#include "litert/c/litert_common.h"
+#include "litert/cc/internal/litert_shared_library.h"
+#include "Saver/QnnSaver.h"  // from @qairt
+
+namespace litert::qnn {
+
+typedef Qnn_ErrorHandle_t (*QnnSaverInitFn_t)(const QnnSaver_Config_t**);
+
+constexpr char kLibQnnSaverSymbol[] = "QnnSaver_initialize";
+
+absl::Span<const QnnSaver_Config_t*> GetDefaultSaverConfigs(
+    absl::string_view saver_output_dir) {
+  static std::array<QnnSaver_Config_t, 1> saver_configs;
+  saver_configs[0].option = QNN_SAVER_CONFIG_OPTION_OUTPUT_DIRECTORY;
+  saver_configs[0].outputDirectory = saver_output_dir.data();
+
+  static std::array<const QnnSaver_Config_t*, 2> result = {&saver_configs[0],
+                                                           nullptr};
+  return absl::MakeSpan(result.data(), result.size());
+}
+
+LiteRtStatus InitSaver(const SharedLibrary& lib,
+                       absl::string_view saver_output_dir) {
+  // saver_config must be set before backend initialization
+  LITERT_ASSIGN_OR_RETURN(
+      QnnSaverInitFn_t saver_initialize,
+      lib.LookupSymbol<QnnSaverInitFn_t>(kLibQnnSaverSymbol));
+  if (Qnn_ErrorHandle_t error =
+          saver_initialize(GetDefaultSaverConfigs(saver_output_dir).data());
+      error != QNN_SUCCESS) {
+    LITERT_LOG(LITERT_ERROR,
+               "Qnn saver backend failed to initialize. Error code: %d.",
+               QNN_GET_ERROR_CODE(error));
+    return kLiteRtStatusErrorDynamicLoading;
+  }
+  return kLiteRtStatusOk;
+}
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/qnn_saver_utils.h
+++ b/litert/vendors/qualcomm/qnn_saver_utils.h
@@ -1,0 +1,30 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_QNN_SAVER_UTILS_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_QNN_SAVER_UTILS_H_
+
+#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/c/litert_common.h"
+#include "litert/cc/internal/litert_shared_library.h"
+#include "QnnTypes.h"  // from @qairt
+#include "Saver/QnnSaverCommon.h"  // from @qairt
+
+namespace litert::qnn {
+
+constexpr char kSaverLibraryName[] = "libQnnSaver.so";
+
+inline Qnn_Version_t GetExpectedSaverVersion() {
+  Qnn_Version_t backend_version;
+  backend_version.major = QNN_SAVER_API_VERSION_MAJOR;
+  backend_version.minor = QNN_SAVER_API_VERSION_MINOR;
+  backend_version.patch = QNN_SAVER_API_VERSION_PATCH;
+  return backend_version;
+}
+
+LiteRtStatus InitSaver(const SharedLibrary& lib,
+                       absl::string_view saver_output_dir);
+
+}  // namespace litert::qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_QNN_SAVER_UTILS_H_


### PR DESCRIPTION
# What

- Enable new debug tool, saver. 
- Can be enabled by new option, `saver_output_dir`.

# Test
```
======================== Test Summary ========================
//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.5s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.3s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 65.0s
```
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 9 tests from 6 test suites ran. (0 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 19 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 11 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 24 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 19 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 11 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 24 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 19 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 11 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 24 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 19 tests from 5 test suites ran. (2 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 11 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 15 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 15 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 15 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 15 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (12 ms total)
[  PASSED  ] 8 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (535 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (577 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (1043 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (529 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (525 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (426 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 4 tests from 1 test suite ran. (422 ms total)
[  PASSED  ] 4 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (382 ms total)
[  PASSED  ] 2 tests.
```