### PR TITLE
docker_build: move bash shebang to top of build scripts

### DIFF
--- a/docker_build/build_with_docker.sh
+++ b/docker_build/build_with_docker.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 # Change to the directory of this script.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/docker_build/verify_android_env.sh
+++ b/docker_build/verify_android_env.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2025 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 # This script is designed to be executed inside the container to verify Android SDK/NDK setup
 # You can run it outside of the container too if you want ot check your local environment setup


### PR DESCRIPTION
Move shebang to the first line so they reliably run with bash when executed directly. 
This fixes the problem when system default sh is not bash.