### PR TITLE
Qualcomm AI Engine Direct - Enable DLC output for non-IR backend partitions.

### DIFF
--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -116,6 +116,7 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetHtpPerformanceMode(static_cast<::qnn::HtpPerformanceMode>(
       qualcomm_options.GetHtpPerformanceMode()));
   qnn_options.SetIrJsonDir(qualcomm_options.GetIrJsonDir());
+  qnn_options.SetDlcDir(qualcomm_options.GetDlcDir());
   qnn_options.SetVtcmSize(qualcomm_options.GetVtcmSize());
   qnn_options.SetNumHvxThreads(qualcomm_options.GetNumHvxThreads());
   qnn_options.SetOptimizationLevel(static_cast<::qnn::OptimizationLevel>(
@@ -123,16 +124,6 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetGraphPriority(
       static_cast<::qnn::GraphPriority>(qualcomm_options.GetGraphPriority()));
   qnn_options.SetDumpTensorIds(qualcomm_options.GetDumpTensorIds());
-
-  // TODO(jiunkaiy): Set backend type based on qualcomm options.
-  // However, if a DLC directory is set, we must use the IR backend.
-  qnn_options.SetDlcDir(qualcomm_options.GetDlcDir());
-  if (!qualcomm_options.GetDlcDir().empty() &&
-      qnn_options.GetBackendType() != ::qnn::BackendType::kIrBackend) {
-    LITERT_LOG(LITERT_WARNING,
-               "Overriding backend type to IR Backend because DLC dir is set.");
-    qnn_options.SetBackendType(::qnn::BackendType::kIrBackend);
-  }
 
   LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
   return kLiteRtStatusOk;


### PR DESCRIPTION
======================== Test Summary ========================
//litert/c:litert_op_options_test


//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 39.1s
