### PR TITLE
Fixed 'ReferenceError: GPUBuffer is not defined' in WASM mode when WebGPU is not supported by browser

### DIFF
--- a/litert/js/packages/core/src/tensor.ts
+++ b/litert/js/packages/core/src/tensor.ts
@@ -93,10 +93,10 @@ function parseData(remainingArgs: Arg[]): {
   const liteRtWasm = getGlobalLiteRt().liteRtWasm;
   if (data instanceof liteRtWasm.LiteRtTensorBuffer) {
     return {liteRtTensorBuffer: data};
-  } else if (data instanceof GPUBuffer) {
-    return {gpuBuffer: data};
   } else if (ArrayBuffer.isView(data)) {
     return {typedArray: data};
+  } else if (data instanceof GPUBuffer) {
+    return {gpuBuffer: data};
   } else {
     throw new Error(`Unknown type (${
         data?.constructor.name ?? data}) provided to create a Tensor`);


### PR DESCRIPTION
After upgrading to LiteRT.js v2, application is crashing with 'ReferenceError: GPUBuffer is not defined' error on browsers without WebGPU support (Firefox).
Proposed change is to reorder checks in parseData() of Tensor constructor, to pick ArrayBuffer data first.