### PR TITLE
Qualcomm AI Engine Direct - Improve SoC info usage.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -76,10 +76,10 @@ constexpr LiteRtParamIndex kDefaultPartitionNum = 1;
 static constexpr absl::string_view kEntryPointNameFmt = "qnn_partition_%d";
 
 bool IsWeightSharingSupported(::qnn::DspArch dsp_arch) {
-#ifdef __ANDROID__
-  return false;
-#else
+#if defined(__x86_64__) || defined(_M_X64)
   return dsp_arch >= ::qnn::DspArch::V73;
+#else
+  return false;
 #endif
 }
 

--- a/litert/vendors/qualcomm/core/backends/htp_backend.h
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.h
@@ -66,11 +66,9 @@ class HtpBackend : public QnnBackend {
 
   QnnDevicePlatformInfo CreateDevicePlatformInfo();
 
-  // TODO: Remove this after user can pass graph options to QNN
-  ::qnn::SocInfo soc_info_ = ::qnn::kSocInfos[7];  // V75
+  ::qnn::SocInfo soc_info_ = ::qnn::kSocInfos[0];
   std::list<QnnHtpDevice_CustomConfig_t> htp_device_configs_;
   std::list<QnnHtpDevice_DeviceInfoExtension_t> htp_device_info_extensions_;
-  QnnDevicePlatformInfo qnn_device_platform_info_;
   std::unique_ptr<PerfControl> perf_control_{nullptr};
 };
 

--- a/litert/vendors/qualcomm/core/backends/qnn_backend_test.cc
+++ b/litert/vendors/qualcomm/core/backends/qnn_backend_test.cc
@@ -52,8 +52,11 @@ TEST_P(QnnBackendTest, DISABLED_InitializeWithLogLevelOffTest) {
 
   switch (GetParam()) {
     case BackendType::kHtpBackend:
-      // Use V75 to test with HTP backend
-      ASSERT_TRUE(backend_->Init(options, ::qnn::kSocInfos[7]));
+#if defined(__x86_64__) || defined(_M_X64)
+      ASSERT_TRUE(backend_->Init(options, ::qnn::kSocInfos[8]));
+#else
+      ASSERT_TRUE(backend_->Init(options, std::nullopt));
+#endif
       ASSERT_NE(backend_->GetDeviceHandle(), nullptr);
       break;
     case BackendType::kIrBackend:
@@ -75,8 +78,8 @@ TEST_P(QnnBackendTest, DISABLED_InitializeWithLogLevelVerboseTest) {
 
   switch (GetParam()) {
     case BackendType::kHtpBackend:
-      // Use V75 to test with HTP backend
-      ASSERT_TRUE(backend_->Init(options, ::qnn::kSocInfos[7]));
+      // Use V75 to test with HTP backend.
+      ASSERT_TRUE(backend_->Init(options, ::qnn::kSocInfos[8]));
       ASSERT_NE(backend_->GetDeviceHandle(), nullptr);
       break;
     case BackendType::kIrBackend:

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -385,14 +385,10 @@ LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
       LITERT_RETURN_IF_ERROR(
           ResolveApi(::qnn::HtpBackend::GetExpectedBackendVersion()));
 
-      backend_ = std::make_unique<::qnn::HtpBackend>(Api());
-      LITERT_RETURN_IF_ERROR(backend_->Init(options_, soc_info));
-      auto* htp_backend = dynamic_cast<::qnn::HtpBackend*>(backend_.get());
-      if (!htp_backend) {
-        LITERT_LOG(LITERT_ERROR, "dynamic_cast to HtpBackend failed");
-        return kLiteRtStatusErrorRuntimeFailure;
-      }
+      auto htp_backend = std::make_unique<::qnn::HtpBackend>(Api());
+      LITERT_RETURN_IF_ERROR(htp_backend->Init(options_, soc_info));
       soc_info_ = htp_backend->GetSocInfo();
+      backend_ = std::move(htp_backend);
 
       break;
     }

--- a/litert/vendors/qualcomm/qnn_manager.h
+++ b/litert/vendors/qualcomm/qnn_manager.h
@@ -183,7 +183,7 @@ class QnnManager {
   const QnnSystemInterface_t* system_interface_ = nullptr;
 
   std::unique_ptr<::qnn::QnnBackend> backend_ = nullptr;
-  ::qnn::SocInfo soc_info_ = ::qnn::kSocInfos[7];  // V75
+  ::qnn::SocInfo soc_info_ = ::qnn::kSocInfos[0];
   ::qnn::Options options_;
 };
 

--- a/litert/vendors/qualcomm/qnn_manager_test.cc
+++ b/litert/vendors/qualcomm/qnn_manager_test.cc
@@ -26,16 +26,21 @@ using ::testing::HasSubstr;
 
 // NOTE: This tests that all of the dynamic loading works properly and
 // the QNN SDK instance can be properly initialized and destroyed.
+auto CreateQnnManager(const ::qnn::Options& options) {
+#if defined(__x86_64__) || defined(_M_X64)
+  return QnnManager::Create(options, {}, ::qnn::kSocInfos[8]);
+#else
+  return QnnManager::Create(options);
+#endif
+}
 
 TEST(QnnManagerTest, SetupQnnManager) {
-  auto options = ::qnn::Options();
-  auto qnn = QnnManager::Create(options);
+  auto qnn = CreateQnnManager(::qnn::Options());
   ASSERT_TRUE(qnn);
 }
 
 TEST(QnnManagerTest, Dump) {
-  auto options = ::qnn::Options();
-  auto qnn = QnnManager::Create(options);
+  auto qnn = CreateQnnManager(::qnn::Options());
   ASSERT_TRUE(qnn);
 
   auto dump = Dump(**qnn);
@@ -46,7 +51,7 @@ TEST(QnnManagerTest, Dump) {
 
 TEST(QnnManagerTest, GetOptions) {
   auto options = ::qnn::Options();
-  auto qnn = QnnManager::Create(options);
+  auto qnn = CreateQnnManager(options);
   ASSERT_TRUE(qnn);
 
   const auto& options_ref = (*qnn)->GetOptions();


### PR DESCRIPTION
Summary:
- Remove the qnn_device_platform_info_ member from HtpBackend.
- Eliminate the use of RTTI for obtaining SoC info.
- Update online/offline determination logic to use #if defined(__x86_64__) || defined(_M_X64).

Test:
```
CMake Build Test PASSED
```
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 39.0s
```
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 19 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 9 tests from 6 test suites ran. (0 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 16 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 19 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 16 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 24 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 19 tests from 5 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 16 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 24 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 19 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 7 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 7 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 16 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 24 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 19 tests from 5 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 15 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 15 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 7 tests from 4 test suites ran. (11 ms total)
[  PASSED  ] 7 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (355 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (469 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (453 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (456 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (897 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (310 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 4 tests from 1 test suite ran. (404 ms total)
[  PASSED  ] 4 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (366 ms total)
[  PASSED  ] 2 tests.
```