### PR TITLE
Qualcomm AI Engine Direct - Support HadamardTransform.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -635,11 +635,9 @@ LiteRtStatus BuildFullyConnectedOp(
 
   auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
       tensor_pool, fused_activation, output_tensors);
-  if (op_wrappers.empty()) {
-    op_wrappers = ::qnn::BuildFullyConnectedOp(
-        tensor_pool, input_tensors, {activation_input}, keep_num_dims,
-        use_int64_bias_as_int32);
-  }
+  op_wrappers = ::qnn::BuildFullyConnectedOp(
+      tensor_pool, input_tensors, {activation_input}, keep_num_dims,
+      use_int64_bias_as_int32);
   ::qnn::AddFusedActivationNode(op_wrappers, fused_activation, activation_input,
                                 output_tensors[0]);
   return kLiteRtStatusOk;

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -734,3 +734,17 @@ cc_library(
         "@qairt//:qnn_lib_headers",
     ],
 )
+
+cc_library(
+    name = "hadamard_transform_op_builder",
+    srcs = ["hadamard_transform_op_builder.cc"],
+    hdrs = ["hadamard_transform_op_builder.h"],
+    deps = [
+        ":op_builder",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@com_google_absl//absl/numeric:bits",
+        "@qairt//:qnn_lib_headers",
+    ],
+)

--- a/litert/vendors/qualcomm/core/builders/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/builders/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(qnn_builders
         gather_op_builder.cc
         gathernd_op_builder.cc
         gelu_op_builder.cc
+        hadamard_transform_op_builder.cc
         layer_norm_op_builder.cc
         l2_norm_op_builder.cc
         leaky_relu_op_builder.cc

--- a/litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.cc
@@ -1,0 +1,88 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.h"
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+
+#include "QnnOpDef.h"  // from @qairt
+#include "absl/numeric/bits.h"  // from @com_google_absl
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::optional<float> GetSylvesterHadamardScale(const TensorWrapper& weight) {
+  if (weight.GetRank() != 2) return std::nullopt;
+  if (weight.GetDimension(0) != weight.GetDimension(1)) return std::nullopt;
+  const std::uint32_t n = weight.GetDimension(0);
+
+  // Ensure the size is power-of-two.
+  if (n == 0 || (n & (n - 1)) != 0) return std::nullopt;
+
+  // Get weight data.
+  if (weight.GetDataType() != Qnn_DataType_t::QNN_DATATYPE_SFIXED_POINT_8) {
+    return std::nullopt;
+  }
+  auto hadamard = weight.GetTensorData<std::int8_t>();
+  if (!hadamard.has_value()) return std::nullopt;
+
+  std::int8_t hadamard_value = hadamard.value()[0];
+  // Reject all-zero weight tensors: the Sylvester check below would trivially
+  // succeed and return scale = 0, miscompiling the op into a zero output.
+  if (hadamard_value == 0) return std::nullopt;
+
+  // Ensure the matrix adheres Sylvester's construction.
+  for (std::uint32_t i = 0; i < n; ++i) {
+    for (std::uint32_t j = 0; j < n; ++j) {
+      int bits = absl::popcount(i & j);
+      std::int8_t val = ((bits & 1) == 0) ? +hadamard_value : -hadamard_value;
+      if (hadamard.value()[i * n + j] != val) {
+        return std::nullopt;
+      }
+    }
+  }
+
+  // QNN HadamardTransform: out = HadamardTransform(in) * scale
+  //
+  // Dequantized weight is defined as: S * (q - Z),
+  // where q is the stored int8 value and Z is the zero-point.
+  //
+  // For a valid Hadamard matrix, the zero-point Z must be 0.
+  // Otherwise, the dequantized weights will not preserve the
+  // Hadamard property (i.e., symmetric +/- structure).
+  //
+  // Specifically, elements must satisfy:
+  //   S * (q - Z) == -S * (-q - Z)
+  // => S * (q - Z) == S * (q + Z)
+  // => Z == 0
+  //
+  // Therefore, if Z != 0, the weight cannot represent a Hadamard matrix.
+  if (const auto* p = std::get_if<BwScaleOffsetQuantizeParamsWrapper>(
+          &weight.GetQuantParams())) {
+    if (p->GetZeroPoint() != 0) return std::nullopt;
+    return p->GetScale() * hadamard_value * std::sqrt(n);
+  } else if (const auto* p = std::get_if<ScaleOffsetQuantizeParamsWrapper>(
+                 &weight.GetQuantParams())) {
+    if (p->GetZeroPoint() != 0) return std::nullopt;
+    return p->GetScale() * hadamard_value * std::sqrt(n);
+  }
+  return std::nullopt;
+}
+
+OpWrapper CreateHadamardTransformOp(const TensorWrapper& input,
+                                    const TensorWrapper& output, float scale) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_HADAMARD_TRANSFORM),
+               QNN_OP_HADAMARD_TRANSFORM, QnnOpCode::kHadamardTransform);
+  op.AddInputTensor(input);
+  op.AddOutputTensor(output);
+  op.AddScalarParam<float>(QNN_OP_HADAMARD_TRANSFORM_PARAM_SCALE, scale);
+  return op;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.h
@@ -1,0 +1,24 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_HADAMARD_TRANSFORM_OP_BUILDER_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_HADAMARD_TRANSFORM_OP_BUILDER_H_
+
+#include <optional>
+
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+OpWrapper CreateHadamardTransformOp(const TensorWrapper& input,
+                                    const TensorWrapper& output,
+                                    float scale = 1.0f);
+
+// Returns the corresponding scale factor if the given static tensor forms a
+// valid Sylvester Hadamard matrix; otherwise returns std::nullopt.
+std::optional<float> GetSylvesterHadamardScale(const TensorWrapper& weight);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_HADAMARD_TRANSFORM_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/core/builders/op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/op_builder.cc
@@ -155,6 +155,7 @@ OpWrapper& CreateOpWrapper(std::vector<OpWrapper>& ops, const char* op_type) {
           {QNN_OP_GRID_SAMPLE, QnnOpCode::kGridSample},
           {QNN_OP_GROUP_NORM, QnnOpCode::kGroupNorm},
           {QNN_OP_GRU, QnnOpCode::kGru},
+          {QNN_OP_HADAMARD_TRANSFORM, QnnOpCode::kHadamardTransform},
           {QNN_OP_HARD_SWISH, QnnOpCode::kHardSwish},
           {QNN_OP_HEAT_MAP_MAX_KEY_POINT, QnnOpCode::kHeatMapMaxKeyPoint},
           {QNN_OP_IM2_COL, QnnOpCode::kIm2Col},

--- a/litert/vendors/qualcomm/core/op_code.h
+++ b/litert/vendors/qualcomm/core/op_code.h
@@ -93,6 +93,7 @@ enum class QnnOpCode {
   kGridSample,
   kGroupNorm,
   kGru,
+  kHadamardTransform,
   kHardSwish,
   kHeatMapMaxKeyPoint,
   kIm2Col,

--- a/litert/vendors/qualcomm/core/transformation/BUILD
+++ b/litert/vendors/qualcomm/core/transformation/BUILD
@@ -30,6 +30,8 @@ cc_test(
         "//litert/vendors/qualcomm/core/builders:cast_op_builder",
         "//litert/vendors/qualcomm/core/builders:concatenation_op_builder",
         "//litert/vendors/qualcomm/core/builders:elementwise_op_builder",
+        "//litert/vendors/qualcomm/core/builders:fully_connected_op_builder",
+        "//litert/vendors/qualcomm/core/builders:hadamard_transform_op_builder",
         "//litert/vendors/qualcomm/core/builders:matmul_op_builder",
         "//litert/vendors/qualcomm/core/builders:op_builder",
         "//litert/vendors/qualcomm/core/builders:quantize_op_builder",
@@ -41,6 +43,7 @@ cc_test(
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@com_google_absl//absl/numeric:bits",
         "@qairt//:qnn_lib_headers",
     ] + select({
         "@org_tensorflow//tensorflow:linux_x86_64": [
@@ -62,6 +65,7 @@ cc_library(
         ":mask",
         ":matmul_convert",
         ":mha_to_sha",
+        ":rotation_quant",
         "//litert/vendors/qualcomm/core:op_code",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
@@ -232,4 +236,23 @@ cc_test(
         ],
         "//conditions:default": [],
     }) + gtest_main_no_heapcheck_deps(),
+)
+
+cc_library(
+    name = "rotation_quant",
+    srcs = ["rotation_quant.cc"],
+    hdrs = ["rotation_quant.h"],
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "nobuilder",
+    ],
+    deps = [
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:concatenation_op_builder",
+        "//litert/vendors/qualcomm/core/builders:hadamard_transform_op_builder",
+        "//litert/vendors/qualcomm/core/builders:split_op_builder",
+        "//litert/vendors/qualcomm/core/utils:log",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "@com_google_absl//absl/strings",
+    ],
 )

--- a/litert/vendors/qualcomm/core/transformation/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/transformation/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(qnn_transformation
         mask.cc
         mha_to_sha.cc
         kv_swapped_attn.cc
+        rotation_quant.cc
 )
 
 target_include_directories(qnn_transformation

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
@@ -14,6 +14,7 @@
 #include "litert/vendors/qualcomm/core/transformation/mask.h"
 #include "litert/vendors/qualcomm/core/transformation/matmul_convert.h"
 #include "litert/vendors/qualcomm/core/transformation/mha_to_sha.h"
+#include "litert/vendors/qualcomm/core/transformation/rotation_quant.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 
 namespace qnn {
@@ -319,5 +320,21 @@ void GraphToGraphTransform(G2GConfig g2g_option, std::vector<OpWrapper>& ops,
       QnnOpCode::kTranspose,
   };
   Transform(validate_op_config, ops, tensor_pool, attn, OptimizeMHAAttn);
+
+  // FC -> Hadamard Transform
+  const std::vector<QnnOpCode> fc = {
+      QnnOpCode::kFullyConnected,
+  };
+  Transform(validate_op_config, ops, tensor_pool, fc,
+            ConvertFcToHadamardTransform);
+
+  // Non-power-of-two Hadamard Transform
+  const std::vector<QnnOpCode> hadamard_transform = {
+      QnnOpCode::kReshape,
+      QnnOpCode::kHadamardTransform,
+      QnnOpCode::kReshape,
+  };
+  Transform(validate_op_config, ops, tensor_pool, hadamard_transform,
+            ParallelizeHadamardTransform);
 }
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
@@ -12,9 +12,12 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "absl/numeric/bits.h"  // from @com_google_absl
 #include "litert/vendors/qualcomm/core/builders/cast_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/concatenation_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/elementwise_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/matmul_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/quantize_op_builder.h"
@@ -1441,5 +1444,188 @@ TEST(MHAOptimization, AttentionWithSelect) {
   ASSERT_TRUE(op_wrappers[41].IsOpCode(QnnOpCode::kPack));
 }
 
+TEST(RotQuant, ReshapeHadamardReshape) {
+  // G2G Test case:
+  //
+  // ------------Before------------
+  //              Input
+  //                |
+  //             Reshape0
+  //                |
+  //        HadamardTransform
+  //                |
+  //             Reshape1
+  //                |
+  //              Output
+  //    
+  // ------------After------------
+  //              Input
+  //                |
+  //              Split
+  //             /     \\\
+  //            /       \\\
+  //  HadamardTransform  ...  
+  //            \       ///
+  //             \     ///
+  //              Concat
+  //                |
+  //              Output
+  //
+
+  TensorPool tensor_pool;
+  QuantizeParamsWrapperVariant quant_param;
+  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  auto& input = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_16,
+                                               quant_param, {1, 128, 1152});
+  auto& rot_input = tensor_pool.CloneNativeTensorFrom(input, {1152, 128});
+  auto& rot_output = tensor_pool.CloneNativeTensorFrom(rot_input);
+  auto& output = tensor_pool.CloneNativeTensorFrom(input);
+  std::vector<OpWrapper> op_wrappers =
+      MakeVector(CreateReshapeOp(input, rot_input),
+                 CreateHadamardTransformOp(rot_input, rot_output),
+                 CreateReshapeOp(rot_output, output));
+
+  const ::qnn::G2GConfig g2g_option = ::qnn::G2GConfig::kMHAOpt;
+  GraphToGraphTransform(g2g_option, op_wrappers, tensor_pool,
+                        [](OpWrapper& op) { return true; });
+  // Check the optimized graph is correct.
+  constexpr std::size_t num_rotation = 1152 / 128;
+  constexpr std::size_t op_size = 2 + num_rotation;
+  ASSERT_EQ(op_wrappers.size(), op_size);
+  EXPECT_TRUE(op_wrappers[0].IsOpCode(QnnOpCode::kSplit));
+  for (std::size_t i = 1; i < 1 + num_rotation; ++i) {
+    EXPECT_TRUE(op_wrappers[i].IsOpCode(QnnOpCode::kHadamardTransform));
+  }
+  EXPECT_TRUE(op_wrappers[op_size - 1].IsOpCode(QnnOpCode::kConcat));
+}
+namespace {
+
+// Builds an n*n Sylvester Hadamard matrix with cell magnitude `value`.
+template <std::size_t N>
+constexpr std::array<std::int8_t, N * N> MakeSylvesterHadamard(
+    std::int8_t value) {
+  std::array<std::int8_t, N * N> m{};
+  for (std::uint32_t i = 0; i < N; ++i) {
+    for (std::uint32_t j = 0; j < N; ++j) {
+      const int bits = absl::popcount(i & j);
+      m[i * N + j] = ((bits & 1) == 0) ? +value : -value;
+    }
+  }
+  return m;
+}
+
+}  // namespace
+
+TEST(RotQuant, ConvertFcToHadamardTransform_Sylvester) {
+  // FC with a Sylvester Hadamard weight should be rewritten to a single
+  // HadamardTransform op.
+
+  QuantizeParamsWrapperVariant io_quant_param;
+  io_quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  QuantizeParamsWrapperVariant weight_quant_param;
+  weight_quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1.0f, 0);
+
+  static constexpr std::uint32_t kDim = 16;
+  static constexpr std::int8_t kHadamardValue = 1;
+  static constexpr auto kHadamardMatrix =
+      MakeSylvesterHadamard<kDim>(kHadamardValue);
+
+  TensorPool tensor_pool;
+  auto& input = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_16,
+                                               io_quant_param, {1, kDim});
+  auto& weight = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, {kDim, kDim},
+      kHadamardMatrix.size() * sizeof(std::int8_t), kHadamardMatrix.data());
+  auto& output = tensor_pool.CloneNativeTensorFrom(input);
+
+  std::vector<OpWrapper> op_wrappers = ::qnn::BuildFullyConnectedOp(
+      tensor_pool, {input, weight}, {output},
+      /*keep_num_dims=*/false, /*use_int64_bias_as_int32=*/false);
+  ASSERT_EQ(op_wrappers.size(), 1u);
+  ASSERT_TRUE(op_wrappers[0].IsOpCode(QnnOpCode::kFullyConnected));
+
+  GraphToGraphTransform(::qnn::G2GConfig::kMHAOpt, op_wrappers, tensor_pool,
+                        [](OpWrapper& op) { return true; });
+
+  ASSERT_EQ(op_wrappers.size(), 1u);
+  EXPECT_TRUE(op_wrappers[0].IsOpCode(QnnOpCode::kHadamardTransform));
+}
+
+TEST(RotQuant, ConvertFcToHadamardTransform_NonHadamardWeight_NoOp) {
+  // FC whose weight is not a Sylvester Hadamard matrix must remain an FC.
+
+  QuantizeParamsWrapperVariant io_quant_param;
+  io_quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  QuantizeParamsWrapperVariant weight_quant_param;
+  weight_quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1.0f, 0);
+
+  // All-ones weight: violates Sylvester at (i=j=1) where popcount(1) is odd
+  // but cell value is +1.
+  static constexpr std::uint32_t kDim = 16;
+  static constexpr auto kNonHadamard = [] {
+    std::array<std::int8_t, kDim * kDim> a{};
+    for (std::size_t i = 0; i < a.size(); ++i) a[i] = 1;
+    return a;
+  }();
+
+  TensorPool tensor_pool;
+  auto& input = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_16,
+                                               io_quant_param, {1, kDim});
+  auto& weight = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, {kDim, kDim},
+      kNonHadamard.size() * sizeof(std::int8_t), kNonHadamard.data());
+  auto& output = tensor_pool.CloneNativeTensorFrom(input);
+
+  std::vector<OpWrapper> op_wrappers = ::qnn::BuildFullyConnectedOp(
+      tensor_pool, {input, weight}, {output},
+      /*keep_num_dims=*/false, /*use_int64_bias_as_int32=*/false);
+  ASSERT_EQ(op_wrappers.size(), 1u);
+
+  GraphToGraphTransform(::qnn::G2GConfig::kMHAOpt, op_wrappers, tensor_pool,
+                        [](OpWrapper& op) { return true; });
+
+  ASSERT_EQ(op_wrappers.size(), 1u);
+  EXPECT_TRUE(op_wrappers[0].IsOpCode(QnnOpCode::kFullyConnected));
+}
+
+TEST(RotQuant, ConvertFcToHadamardTransform_WithBias_NoOp) {
+  // FC carrying a bias must not be rewritten, since HadamardTransform has no
+  // bias input.
+
+  QuantizeParamsWrapperVariant io_quant_param;
+  io_quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  QuantizeParamsWrapperVariant weight_quant_param;
+  weight_quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1.0f, 0);
+  QuantizeParamsWrapperVariant bias_quant_param;
+  bias_quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+
+  static constexpr std::uint32_t kDim = 16;
+  static constexpr std::int8_t kHadamardValue = 1;
+  static constexpr auto kHadamardMatrix =
+      MakeSylvesterHadamard<kDim>(kHadamardValue);
+  std::array<std::int32_t, kDim> bias_data{};
+
+  TensorPool tensor_pool;
+  auto& input = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_16,
+                                               io_quant_param, {1, kDim});
+  auto& weight = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, {kDim, kDim},
+      kHadamardMatrix.size() * sizeof(std::int8_t), kHadamardMatrix.data());
+  auto& bias = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_32, bias_quant_param, {kDim},
+      bias_data.size() * sizeof(std::int32_t), bias_data.data());
+  auto& output = tensor_pool.CloneNativeTensorFrom(input);
+
+  std::vector<OpWrapper> op_wrappers = ::qnn::BuildFullyConnectedOp(
+      tensor_pool, {input, weight, bias}, {output},
+      /*keep_num_dims=*/false, /*use_int64_bias_as_int32=*/false);
+  ASSERT_EQ(op_wrappers.size(), 1u);
+
+  GraphToGraphTransform(::qnn::G2GConfig::kMHAOpt, op_wrappers, tensor_pool,
+                        [](OpWrapper& op) { return true; });
+
+  ASSERT_EQ(op_wrappers.size(), 1u);
+  EXPECT_TRUE(op_wrappers[0].IsOpCode(QnnOpCode::kFullyConnected));
+}
 }  // namespace
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/rotation_quant.cc
+++ b/litert/vendors/qualcomm/core/transformation/rotation_quant.cc
@@ -1,0 +1,179 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/transformation/rotation_quant.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/str_cat.h"  // from @com_google_absl
+#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/vendors/qualcomm/core/builders/concatenation_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/split_op_builder.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+
+namespace qnn {
+namespace {
+
+void CloneNamespace(const OpWrapper& source, OpWrapper& destination,
+                    absl::string_view additional_namespace = {}) {
+  absl::string_view start_op_name = source.GetName();
+  size_t pos = start_op_name.rfind('/');
+  if (pos == absl::string_view::npos) {
+    return;
+  }
+  if (additional_namespace.empty()) {
+    destination.AddPrefixToName(
+        absl::StrCat(start_op_name.substr(0, pos), "/"));
+  } else {
+    destination.AddPrefixToName(absl::StrCat(start_op_name.substr(0, pos), "/",
+                                             additional_namespace, "/"));
+  }
+}
+
+}  // namespace
+
+size_t ConvertFcToHadamardTransform(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size) {
+  // Refuse to convert FC ops that carry a bias, since HadamardTransform has no
+  // bias input.
+  if (ops[start_index].GetInputCount() > 2) return 1;
+
+  // Attempt to replace FC with HadamardTransform.
+  const auto& weight = ops[start_index].GetInputTensor(1);
+  const auto scale_from_weight = ::qnn::GetSylvesterHadamardScale(weight);
+  if (!scale_from_weight.has_value()) return 1;
+
+  QNN_LOG_INFO("[G2G] FC -> HadamardTransform");
+  auto op = ::qnn::CreateHadamardTransformOp(
+      ops[start_index].GetInputTensor(0), ops[start_index].GetOutputTensor(0),
+      scale_from_weight.value());
+  // Validate new graph.
+  if (validate_op_config(op)) {
+    CloneNamespace(ops[start_index], op);
+    // Replace the matched pattern with a newly generated subgraph.
+    ops[start_index] = std::move(op);
+    return 1;
+  }
+  QNN_LOG_WARNING(
+      "[G2G] Validation failed. Rolling back to the original graph.");
+  return 1;
+}
+
+size_t ParallelizeHadamardTransform(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size) {
+  static constexpr size_t kPreReshapeIndex = 0;
+  static constexpr size_t kHadamardTransformIndex = 1;
+  static constexpr size_t kPostReshapeIndex = 2;
+  // Check connection.
+  const auto& hadamard_transform = ops[start_index + kHadamardTransformIndex];
+  const auto& h_input = hadamard_transform.GetInputTensor(0);
+  if (!(ops[start_index + kPreReshapeIndex].GetOutputTensor(0) == h_input &&
+        hadamard_transform.GetOutputTensor(0) ==
+            ops[start_index + kPostReshapeIndex].GetInputTensor(0))) {
+    return 1;
+  }
+
+  const auto& input = ops[start_index + kPreReshapeIndex].GetInputTensor(0);
+  const auto& output = ops[start_index + kPostReshapeIndex].GetOutputTensor(0);
+  const std::uint32_t input_size = input.GetDimension(input.GetRank() - 1);
+  const std::uint32_t hadamard_size =
+      h_input.GetDimension(h_input.GetRank() - 1);
+
+  // Check both reshape ops are for non-power-of-two Hadamard.
+  if (!(input.GetDimensions() == output.GetDimensions() &&
+        input_size > hadamard_size && input_size % hadamard_size == 0)) {
+    return 1;
+  }
+
+  QNN_LOG_INFO("[G2G] ParallelizeHadamardTransform @ %d", start_index);
+
+  std::vector<OpWrapper> new_ops;
+
+  // Compute the number of HadamardTransform ops.
+  const std::uint32_t num_h = input_size / hadamard_size;
+
+  // Prepare inputs for parallel Hadamard Transform.
+  std::vector<qnn::ConstTensorWrapperRef> hadamard_transform_inputs;
+  hadamard_transform_inputs.reserve(num_h);
+  auto io_dims = input.GetDimensions();
+  io_dims[input.GetRank() - 1] /= num_h;
+  for (std::uint32_t i = 0; i < num_h; ++i) {
+    hadamard_transform_inputs.emplace_back(
+        tensor_pool.CloneNativeTensorFrom(input, io_dims));
+  }
+
+  // Split
+  const std::uint32_t axis = input.GetRank() - 1;
+  std::vector<std::uint32_t> split_indice;
+  split_indice.reserve(num_h - 1);
+  for (std::uint32_t i = 1; i < num_h; i++) {
+    split_indice.emplace_back(i * input.GetDimension(axis) / num_h);
+  }
+  const auto& split_indice_tensor = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, {},
+      {static_cast<std::uint32_t>(split_indice.size())},
+      sizeof(std::uint32_t) * split_indice.size(), split_indice.data());
+  auto& split = new_ops.emplace_back(CreateSplitOp(
+      input, hadamard_transform_inputs, axis, split_indice_tensor));
+  CloneNamespace(ops[start_index + kHadamardTransformIndex], split,
+                 std::to_string(start_index));
+
+  // HadamardTransform
+  std::vector<qnn::ConstTensorWrapperRef> hadamard_transform_outputs;
+  hadamard_transform_outputs.reserve(hadamard_transform_inputs.size());
+  for (const auto& input_tensor : hadamard_transform_inputs) {
+    const auto& output_tensor = hadamard_transform_outputs.emplace_back(
+        tensor_pool.CloneNativeTensorFrom(output, io_dims));
+    auto& hadamard = new_ops.emplace_back(CreateOpWithSameParams(
+        hadamard_transform, {input_tensor}, {output_tensor}));
+    CloneNamespace(ops[start_index + kHadamardTransformIndex], hadamard,
+                   std::to_string(start_index));
+  }
+
+  // Concat
+  auto& concat = new_ops.emplace_back(
+      CreateConcatenationOp(hadamard_transform_outputs, output, axis));
+  CloneNamespace(ops[start_index + kHadamardTransformIndex], concat,
+                 std::to_string(start_index));
+
+  // Validate new graph.
+  const bool is_valid =
+      std::all_of(new_ops.begin(), new_ops.end(),
+                  [&validate_op_config](::qnn::OpWrapper& op_wrapper) -> bool {
+                    return validate_op_config(op_wrapper);
+                  });
+  if (is_valid) {
+    // Adjust the name to avoid a name collision in the Qnn JSON dump.
+    for (size_t i = 0; i < new_ops.size(); ++i) {
+      new_ops[i].AddSuffixToName(absl::StrCat("_qcg2g_", i));
+    }
+    // Replace the matched pattern with a newly generated subgraph.
+    size_t step_size = new_ops.size();
+    ops.insert(ops.begin() + start_index + pattern_size,
+               std::make_move_iterator(new_ops.begin()),
+               std::make_move_iterator(new_ops.end()));
+    ops.erase(ops.begin() + start_index,
+              ops.begin() + start_index + pattern_size);
+    return step_size;
+  }
+
+  QNN_LOG_WARNING(
+      "[G2G] Validation failed. Rolling back to the original graph.");
+  return 1;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/transformation/rotation_quant.h
+++ b/litert/vendors/qualcomm/core/transformation/rotation_quant.h
@@ -1,0 +1,27 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_ROTATION_QUANT_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_ROTATION_QUANT_H_
+
+#include <cstddef>
+#include <functional>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+
+namespace qnn {
+
+size_t ConvertFcToHadamardTransform(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size);
+
+size_t ParallelizeHadamardTransform(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size);
+
+}  // namespace qnn
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_TRANSFORMATION_ROTATION_QUANT_H_

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -123,6 +123,8 @@ const TensorWrapper& OpWrapper::GetInputTensor(size_t i) const {
   return input_tensors_[i].get();
 }
 
+size_t OpWrapper::GetInputCount() const { return input_tensors_.size(); }
+
 const TensorWrapper& OpWrapper::GetOutputTensor(size_t i) const {
   assert(i < output_tensors_.size());
   return output_tensors_[i].get();

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -63,6 +63,8 @@ class OpWrapper final {
 
   const TensorWrapper& GetInputTensor(size_t i) const;
 
+  size_t GetInputCount() const;
+
   const TensorWrapper& GetOutputTensor(size_t i) const;
 
   const TensorParamWrapper& GetTensorParam(size_t i) const;

--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
@@ -108,6 +108,14 @@ class BwScaleOffsetQuantizeParamsWrapper final {
     qnn_quantize_param_.bwScaleOffsetEncoding.bitwidth = bitwidth;
   }
 
+  float GetScale() const {
+    return qnn_quantize_param_.bwScaleOffsetEncoding.scale;
+  }
+
+  std::int32_t GetZeroPoint() const {
+    return -qnn_quantize_param_.bwScaleOffsetEncoding.offset;
+  }
+
  private:
   Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
 };

--- a/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
@@ -261,9 +261,11 @@ TEST(BwScaleOffsetQuantizeParamsWrapperTest, MoveConstructorTest) {
             dst2.bwScaleOffsetEncoding.offset);
 }
 
-TEST(BwScaleOffsetQuantizeParamsWrapperTest, GetBitwidthTest) {
+TEST(BwScaleOffsetQuantizeParamsWrapperTest, GetterTest) {
   BwScaleOffsetQuantizeParamsWrapper wrapper(4, 1.5f, 10);
-  ASSERT_EQ(wrapper.GetBitwidth(), 4);
+  EXPECT_EQ(wrapper.GetBitwidth(), 4);
+  EXPECT_EQ(wrapper.GetScale(), 1.5f);
+  EXPECT_EQ(wrapper.GetZeroPoint(), 10);
 }
 
 TEST(BwScaleOffsetQuantizeParamsWrapperTest, SetBitwidthTest) {

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -259,3 +259,37 @@ litert_test(
         "@qairt//:qnn_lib_headers",
     ],
 )
+
+litert_test(
+    name = "hadamard_transform_test",
+    srcs = [
+        "hadamard_transform_test.cc",
+    ],
+    linkopts = select({
+        "@org_tensorflow//tensorflow:android": [],
+        "//conditions:default": [
+            make_rpaths([
+                "//litert/c:litert_runtime_c_api_so",
+            ]),
+        ],
+    }),
+    linkstatic = True,
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "no-remote-exec",
+        "nobuilder",
+        "notap",
+    ],
+    ungrte = True,
+    use_sys_malloc = True,
+    deps = [
+        "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:hadamard_transform_op_builder",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "@com_google_absl//absl/numeric:bits",
+        "@qairt//:qnn_lib_headers",
+    ],
+)

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/hadamard_transform_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/hadamard_transform_test.cc
@@ -1,0 +1,88 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/hadamard_transform_op_builder.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "absl/numeric/bits.h"  // from @com_google_absl
+#include "QnnTypes.h"  // from @qairt
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+
+using ::testing::ElementsAreArray;
+
+namespace litert::qnn {
+namespace {
+INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
+                         QnnTestPrinter);
+
+TEST_P(QnnModelTest, HadamardTransform_INT16) {
+  constexpr std::uint32_t kDim = 256U;
+  const std::vector<std::uint32_t> kIODims{1, 1, 1, kDim};
+  const std::vector<std::uint32_t> kWeightDims{kDim, kDim};
+  const ::qnn::QuantizeParamsWrapperVariant quant_param =
+      ::qnn::ScaleOffsetQuantizeParamsWrapper(1.0, 0);
+  constexpr std::int8_t kHadamardValue = 7;
+  constexpr float kWeightScale = 1.0f / 16 / kHadamardValue;
+  const ::qnn::QuantizeParamsWrapperVariant weight_quant_param =
+      ::qnn::ScaleOffsetQuantizeParamsWrapper(kWeightScale, 0);
+  std::array<std::int8_t, kDim * kDim> hadamard_matrix{};
+  // Create static weight by Sylvester's construction.
+  for (std::uint32_t i = 0; i < kWeightDims[0]; ++i) {
+    for (std::uint32_t j = 0; j < kWeightDims[1]; ++j) {
+      int bits = absl::popcount(i & j);
+      hadamard_matrix[i * kDim + j] =
+          ((bits & 1) == 0) ? +kHadamardValue : -kHadamardValue;
+    }
+  }
+
+  auto& input = tensor_pool_.CreateInputTensorWithName(
+      "input", QNN_DATATYPE_SFIXED_POINT_16, quant_param, kIODims);
+  auto& weight = tensor_pool_.CreateStaticTensorWithSuffix(
+      QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, kWeightDims, "",
+      hadamard_matrix.size() * sizeof(hadamard_matrix[0]),
+      hadamard_matrix.data(), false);
+  auto& output = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_SFIXED_POINT_16, quant_param, kIODims);
+
+  auto scale = ::qnn::GetSylvesterHadamardScale(weight);
+  ASSERT_EQ(scale.value_or(0.0f), 1.0f);
+
+  qnn_model_.MoveOpsToGraph(
+      {::qnn::CreateHadamardTransformOp(input, output, scale.value())});
+
+  // TODO(jiunkaiy): Uncomment the following ValidateOpConfig after HTP supports
+  // SINT16 HadamardTransform. ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+  auto input_idx = qnn_model_.AddInputTensor(input);
+  auto output_idx = qnn_model_.AddOutputTensor(output);
+
+  // Set input data as a vector of 256 ones, matching the first row of the
+  // Hadamard matrix.
+  qnn_model_.SetInputData<int16_t>(input_idx, std::vector<int16_t>(kDim, 1));
+  // Execute the model.
+  ASSERT_TRUE(qnn_model_.Execute());
+  // Get output.
+  auto output_data = qnn_model_.GetOutputData<int16_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_EQ(output_data->size(), kDim);
+  // All expected values are set to zero, except for the first element, as the
+  // rows in a Hadamard matrix are mutually orthogonal, and the input vector is
+  // the first row. The first element is n times the normalization factor
+  // (1/sqrt(n)) for an n*n Hadamard matrix.
+  std::vector<int16_t> expected(kDim, 0);
+  expected[0] = 16;
+  ASSERT_THAT(output_data.value(), ElementsAreArray(expected));
+}
+
+}  // namespace
+}  // namespace litert::qnn


### PR DESCRIPTION
Summary:
- Change FC to HadamardTransform if the weight matrix is a Hadamard matrix.
- Optimize rotation quant pattern.

on-device:
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 13 tests from 9 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 15 tests from 3 test suites ran. (17 ms total)
[  PASSED  ] 15 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 33 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (17 ms total)
[  PASSED  ] 13 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (284 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (386 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (411 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (985 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1043 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
[==========] 2 tests from 1 test suite ran. (669 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (644 ms total)
[  PASSED  ] 10 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2167 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (16 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (7 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (507 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (442 ms total)
[  PASSED  ] 2 tests.
```

x86:
```
[======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 32.5s](https://github.com/google-ai-edge/LiteRT/pull/5194)
```
* [x] developer-verified