### PR TITLE
Qualcomm AI Engine Direct - Apply the rule of zero for OpWrapper.

### DIFF
--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -23,19 +23,6 @@
 
 namespace qnn {
 
-OpWrapper::OpWrapper(std::string name, const char* op_type, QnnOpCode op_code)
-    : type_name_{op_type}, name_{std::move(name)}, op_code_{op_code} {}
-
-OpWrapper::OpWrapper(const OpWrapper& other) = default;
-
-OpWrapper& OpWrapper::operator=(const OpWrapper& other) {
-  if (this != &other) {
-    this->~OpWrapper();
-    new (this) OpWrapper(other);
-  }
-  return *this;
-}
-
 bool OpWrapper::operator==(const OpWrapper& other) const {
   if (op_code_ != other.op_code_) return false;
   if (!miscs::IsStrEq(type_name_, other.type_name_)) return false;
@@ -57,20 +44,6 @@ bool OpWrapper::operator==(const OpWrapper& other) const {
   return scalar_params_ == other.scalar_params_ &&
          tensor_params_ == other.tensor_params_;
 }
-
-OpWrapper::OpWrapper(OpWrapper&& other)
-    : type_name_{other.type_name_},
-      name_{std::move(other.name_)},
-      input_tensors_{std::move(other.input_tensors_)},
-      output_tensors_{std::move(other.output_tensors_)},
-      scalar_params_{std::move(other.scalar_params_)},
-      tensor_params_{std::move(other.tensor_params_)},
-      qnn_input_tensors_{std::move(other.qnn_input_tensors_)},
-      qnn_output_tensors_{std::move(other.qnn_output_tensors_)},
-      qnn_params_{std::move(other.qnn_params_)},
-      op_code_{other.op_code_} {}
-
-OpWrapper::~OpWrapper() = default;
 
 void OpWrapper::SetName(std::string name) { name_ = std::move(name); }
 

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -22,17 +22,10 @@ class OpWrapper final {
  public:
   explicit OpWrapper() = default;
 
-  explicit OpWrapper(std::string name, const char* op_type, QnnOpCode op_code);
-
-  OpWrapper(const OpWrapper& other);
-
-  OpWrapper& operator=(const OpWrapper& other);
+  explicit OpWrapper(std::string name, const char* op_type, QnnOpCode op_code)
+      : type_name_{op_type}, name_{std::move(name)}, op_code_{op_code} {}
 
   bool operator==(const OpWrapper& other) const;
-
-  OpWrapper(OpWrapper&& other);
-
-  ~OpWrapper();
 
   void SetName(std::string name);
 


### PR DESCRIPTION
Summary:
- Remove the copy-assignment operator since a proper move-assignment operator was never implemented.
- Eliminate the move constructor without noexcept to prevent the allocator from falling back to copy.
- Move the trivial constructor into the header file for better inlining and clarity.

Test:
```
CMake Build Test PASSED
```
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 40.6s

```
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 10 tests from 7 test suites ran. (0 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 30 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 64 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 18 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 64 tests from 9 test suites ran. (0 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 18 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 30 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 64 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 18 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 30 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 18 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 15 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 15 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (11 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (340 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (454 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (446 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (451 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (873 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (308 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 4 tests from 1 test suite ran. (385 ms total)
[  PASSED  ] 4 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (350 ms total)
[  PASSED  ] 2 tests.
```