### PR TITLE
Qualcomm AI Engine Direct - Improve safety of quant params wrapper.

### DIFF
--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
@@ -14,14 +14,6 @@
 
 namespace qnn {
 
-UndefinedQuantizeParamsWrapper::UndefinedQuantizeParamsWrapper() = default;
-
-UndefinedQuantizeParamsWrapper::UndefinedQuantizeParamsWrapper(
-    const UndefinedQuantizeParamsWrapper&) = default;
-
-UndefinedQuantizeParamsWrapper::UndefinedQuantizeParamsWrapper(
-    UndefinedQuantizeParamsWrapper&&) = default;
-
 bool UndefinedQuantizeParamsWrapper::operator==(
     const UndefinedQuantizeParamsWrapper& other) const {
   return qnn_quantize_param_.encodingDefinition ==
@@ -51,12 +43,6 @@ ScaleOffsetQuantizeParamsWrapper::ScaleOffsetQuantizeParamsWrapper(
   qnn_quantize_param_.scaleOffsetEncoding = scale_offset;
 }
 
-ScaleOffsetQuantizeParamsWrapper::ScaleOffsetQuantizeParamsWrapper(
-    const ScaleOffsetQuantizeParamsWrapper&) = default;
-
-ScaleOffsetQuantizeParamsWrapper::ScaleOffsetQuantizeParamsWrapper(
-    ScaleOffsetQuantizeParamsWrapper&&) = default;
-
 bool ScaleOffsetQuantizeParamsWrapper::operator==(
     const ScaleOffsetQuantizeParamsWrapper& other) const {
   return qnn_quantize_param_.encodingDefinition ==
@@ -68,6 +54,7 @@ bool ScaleOffsetQuantizeParamsWrapper::operator==(
          qnn_quantize_param_.scaleOffsetEncoding.offset ==
              other.qnn_quantize_param_.scaleOffsetEncoding.offset;
 }
+
 void ScaleOffsetQuantizeParamsWrapper::CloneTo(Qnn_QuantizeParams_t& dst) {
   dst = qnn_quantize_param_;
 }
@@ -117,12 +104,25 @@ AxisScaleOffsetQuantizeParamsWrapper::AxisScaleOffsetQuantizeParamsWrapper(
       scale_offsets_.data();
 }
 
+AxisScaleOffsetQuantizeParamsWrapper&
+AxisScaleOffsetQuantizeParamsWrapper::operator=(
+    const AxisScaleOffsetQuantizeParamsWrapper& rhs) {
+  if (this != &rhs) {
+    scale_offsets_ = rhs.scale_offsets_;
+    qnn_quantize_param_ = rhs.qnn_quantize_param_;
+    qnn_quantize_param_.axisScaleOffsetEncoding.scaleOffset =
+        scale_offsets_.data();
+  }
+  return *this;
+}
+
 AxisScaleOffsetQuantizeParamsWrapper::AxisScaleOffsetQuantizeParamsWrapper(
-    AxisScaleOffsetQuantizeParamsWrapper&& rhs)
+    AxisScaleOffsetQuantizeParamsWrapper&& rhs) noexcept
     : qnn_quantize_param_{rhs.qnn_quantize_param_},
       scale_offsets_{std::move(rhs.scale_offsets_)} {
   qnn_quantize_param_.axisScaleOffsetEncoding.scaleOffset =
       scale_offsets_.data();
+  rhs.qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
 }
 
 bool AxisScaleOffsetQuantizeParamsWrapper::operator==(
@@ -149,6 +149,20 @@ bool AxisScaleOffsetQuantizeParamsWrapper::operator==(
         return a.scale == b.scale && a.offset == b.offset;
       });
 }
+
+AxisScaleOffsetQuantizeParamsWrapper&
+AxisScaleOffsetQuantizeParamsWrapper::operator=(
+    AxisScaleOffsetQuantizeParamsWrapper&& rhs) noexcept {
+  if (this != &rhs) {
+    qnn_quantize_param_ = rhs.qnn_quantize_param_;
+    scale_offsets_ = std::move(rhs.scale_offsets_);
+    qnn_quantize_param_.axisScaleOffsetEncoding.scaleOffset =
+        scale_offsets_.data();
+    rhs.qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
+  }
+  return *this;
+}
+
 void AxisScaleOffsetQuantizeParamsWrapper::CloneTo(Qnn_QuantizeParams_t& dst) {
   dst = qnn_quantize_param_;
 }
@@ -189,12 +203,6 @@ BwScaleOffsetQuantizeParamsWrapper::BwScaleOffsetQuantizeParamsWrapper(
   qnn_quantize_param_.bwScaleOffsetEncoding.scale = scale;
   qnn_quantize_param_.bwScaleOffsetEncoding.offset = -1 * zero_point;
 }
-
-BwScaleOffsetQuantizeParamsWrapper::BwScaleOffsetQuantizeParamsWrapper(
-    const BwScaleOffsetQuantizeParamsWrapper& rhs) = default;
-
-BwScaleOffsetQuantizeParamsWrapper::BwScaleOffsetQuantizeParamsWrapper(
-    BwScaleOffsetQuantizeParamsWrapper&& rhs) = default;
 
 bool BwScaleOffsetQuantizeParamsWrapper::operator==(
     const BwScaleOffsetQuantizeParamsWrapper& other) const {
@@ -243,13 +251,41 @@ BwAxisScaleOffsetQuantizeParamsWrapper::BwAxisScaleOffsetQuantizeParamsWrapper(
   qnn_quantize_param_.bwAxisScaleOffsetEncoding.offsets = offsets_.data();
 }
 
+BwAxisScaleOffsetQuantizeParamsWrapper&
+BwAxisScaleOffsetQuantizeParamsWrapper::operator=(
+    const BwAxisScaleOffsetQuantizeParamsWrapper& rhs) {
+  if (this != &rhs) {
+    scales_ = rhs.scales_;
+    offsets_ = rhs.offsets_;
+    qnn_quantize_param_ = rhs.qnn_quantize_param_;
+    qnn_quantize_param_.bwAxisScaleOffsetEncoding.scales = scales_.data();
+    qnn_quantize_param_.bwAxisScaleOffsetEncoding.offsets = offsets_.data();
+  }
+  return *this;
+}
+
 BwAxisScaleOffsetQuantizeParamsWrapper::BwAxisScaleOffsetQuantizeParamsWrapper(
-    BwAxisScaleOffsetQuantizeParamsWrapper&& rhs)
+    BwAxisScaleOffsetQuantizeParamsWrapper&& rhs) noexcept
     : qnn_quantize_param_{rhs.qnn_quantize_param_},
       scales_{std::move(rhs.scales_)},
       offsets_{std::move(rhs.offsets_)} {
   qnn_quantize_param_.bwAxisScaleOffsetEncoding.scales = scales_.data();
   qnn_quantize_param_.bwAxisScaleOffsetEncoding.offsets = offsets_.data();
+  rhs.qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
+}
+
+BwAxisScaleOffsetQuantizeParamsWrapper&
+BwAxisScaleOffsetQuantizeParamsWrapper::operator=(
+    BwAxisScaleOffsetQuantizeParamsWrapper&& rhs) noexcept {
+  if (this != &rhs) {
+    qnn_quantize_param_ = rhs.qnn_quantize_param_;
+    scales_ = std::move(rhs.scales_);
+    offsets_ = std::move(rhs.offsets_);
+    qnn_quantize_param_.bwAxisScaleOffsetEncoding.scales = scales_.data();
+    qnn_quantize_param_.bwAxisScaleOffsetEncoding.offsets = offsets_.data();
+    rhs.qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
+  }
+  return *this;
 }
 
 bool BwAxisScaleOffsetQuantizeParamsWrapper::operator==(

--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
@@ -15,12 +15,6 @@ namespace qnn {
 
 class UndefinedQuantizeParamsWrapper final {
  public:
-  UndefinedQuantizeParamsWrapper();
-
-  UndefinedQuantizeParamsWrapper(const UndefinedQuantizeParamsWrapper&);
-
-  UndefinedQuantizeParamsWrapper(UndefinedQuantizeParamsWrapper&&);
-
   bool operator==(const UndefinedQuantizeParamsWrapper& other) const;
 
   void CloneTo(Qnn_QuantizeParams_t& dst);
@@ -35,10 +29,6 @@ class ScaleOffsetQuantizeParamsWrapper final {
                                             const std::int32_t zero_point);
   explicit ScaleOffsetQuantizeParamsWrapper(
       const Qnn_ScaleOffset_t& scale_offset);
-
-  ScaleOffsetQuantizeParamsWrapper(const ScaleOffsetQuantizeParamsWrapper&);
-
-  ScaleOffsetQuantizeParamsWrapper(ScaleOffsetQuantizeParamsWrapper&&);
 
   bool operator==(const ScaleOffsetQuantizeParamsWrapper& other) const;
 
@@ -72,8 +62,16 @@ class AxisScaleOffsetQuantizeParamsWrapper final {
   AxisScaleOffsetQuantizeParamsWrapper(
       const AxisScaleOffsetQuantizeParamsWrapper& rhs);
 
+  AxisScaleOffsetQuantizeParamsWrapper& operator=(
+      const AxisScaleOffsetQuantizeParamsWrapper& rhs);
+
   AxisScaleOffsetQuantizeParamsWrapper(
-      AxisScaleOffsetQuantizeParamsWrapper&& rhs);
+      AxisScaleOffsetQuantizeParamsWrapper&& rhs) noexcept;
+
+  AxisScaleOffsetQuantizeParamsWrapper& operator=(
+      AxisScaleOffsetQuantizeParamsWrapper&& rhs) noexcept;
+
+  ~AxisScaleOffsetQuantizeParamsWrapper() = default;
 
   bool operator==(const AxisScaleOffsetQuantizeParamsWrapper& other) const;
 
@@ -88,8 +86,8 @@ class AxisScaleOffsetQuantizeParamsWrapper final {
   void GetZeroPoints(std::vector<std::int32_t>& zero_points) const;
 
  private:
-  Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
   std::vector<Qnn_ScaleOffset_t> scale_offsets_;
+  Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
 };
 
 class BwScaleOffsetQuantizeParamsWrapper final {
@@ -97,11 +95,6 @@ class BwScaleOffsetQuantizeParamsWrapper final {
   explicit BwScaleOffsetQuantizeParamsWrapper(const std::uint32_t bitwidth,
                                               const float scale,
                                               const std::int32_t zero_point);
-
-  BwScaleOffsetQuantizeParamsWrapper(
-      const BwScaleOffsetQuantizeParamsWrapper& rhs);
-
-  BwScaleOffsetQuantizeParamsWrapper(BwScaleOffsetQuantizeParamsWrapper&& rhs);
 
   bool operator==(const BwScaleOffsetQuantizeParamsWrapper& other) const;
 
@@ -125,8 +118,16 @@ class BwAxisScaleOffsetQuantizeParamsWrapper final {
   BwAxisScaleOffsetQuantizeParamsWrapper(
       const BwAxisScaleOffsetQuantizeParamsWrapper& rhs);
 
+  BwAxisScaleOffsetQuantizeParamsWrapper& operator=(
+      const BwAxisScaleOffsetQuantizeParamsWrapper& rhs);
+
   BwAxisScaleOffsetQuantizeParamsWrapper(
-      BwAxisScaleOffsetQuantizeParamsWrapper&& rhs);
+      BwAxisScaleOffsetQuantizeParamsWrapper&& rhs) noexcept;
+
+  BwAxisScaleOffsetQuantizeParamsWrapper& operator=(
+      BwAxisScaleOffsetQuantizeParamsWrapper&& rhs) noexcept;
+
+  ~BwAxisScaleOffsetQuantizeParamsWrapper() = default;
 
   bool operator==(const BwAxisScaleOffsetQuantizeParamsWrapper& other) const;
 
@@ -139,9 +140,9 @@ class BwAxisScaleOffsetQuantizeParamsWrapper final {
   }
 
  private:
-  Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
   std::vector<float> scales_;
   std::vector<int32_t> offsets_;
+  Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
 };
 
 using QuantizeParamsWrapperVariant = std::variant<


### PR DESCRIPTION
Summary:
- Implement Rule of Five for AxisScaleOffset/BwAxisScaleOffset quantization since it owns a raw pointer.
- Apply Rule of Zero for ScaleOffset/BwScaleOffset quantization to simplify management.

Test:
```
CMake Build Test PASSED
```
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 10 tests from 7 test suites ran. (0 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 30 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 64 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 18 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 64 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 18 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 30 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 64 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 18 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 30 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 18 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 15 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 15 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (6 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (178 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (457 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (461 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (451 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (795 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (284 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 4 tests from 1 test suite ran. (387 ms total)
[  PASSED  ] 4 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (353 ms total)
[  PASSED  ] 2 tests.
```
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 40.4s

```