### PR TITLE
Restrict backports.strenum to Python<3.11

### DIFF
--- a/ci/tools/python/wheel/setup_with_binary.py
+++ b/ci/tools/python/wheel/setup_with_binary.py
@@ -182,7 +182,7 @@ setuptools.setup(
         ]
     },
     install_requires=[
-        'backports.strenum',
+        'backports.strenum; python_version<"3.11"',
         'flatbuffers',
         'numpy >= 1.23.2',  # Better to keep sync with both TF ci_build
         # and OpenCV-Python requirement.


### PR DESCRIPTION
Its use is conditional on Python 3.10 or older already, so no need to try and install a package that states it doesn't support anything newer.

https://github.com/clbarnes/backports.strenum/blob/main/pyproject.toml#L20-L21