### PR TITLE
Enable converter API in Python

### DIFF
--- a/ci/tools/python/wheel/BUILD
+++ b/ci/tools/python/wheel/BUILD
@@ -71,8 +71,8 @@ ALL_PY_SRC_MODULES = select({
     "//conditions:default": [],
 }) + [
     # TODO(b/460805332): stop building converter until protobuf symbol conflict is resolved.
-    # "//litert/python/mlir",
-    # "//litert/python/tools/model_utils",
+    "//litert/python/mlir",
+    "//litert/python/tools/model_utils",
     # TODO(b/445163709): Remove the following module once litert_lm publishes a pypi package.
     "//litert/python/internal:litertlm_core",
     "//litert/python/internal:litertlm_header_schema_py",
@@ -103,7 +103,7 @@ py_wheel(
         "//litert/python/litert_wrapper/compiled_model_wrapper:compiled_model",
         "//litert/python/litert_wrapper/tensor_buffer_wrapper:tensor_buffer",
         # TODO(b/460805332): stop building converter until protobuf symbol conflict is resolved.
-        # "//litert/python/mlir/_mlir_libs:libLiteRTCompilerMLIR.so",
+        "//litert/python/mlir/_mlir_libs:libLiteRTCompilerMLIR.so",
         "//tflite/profiling/proto:profiling_info_py",
         "//tflite/python:schema_py",
         "//tflite/python/metrics:metrics_interface",

--- a/litert/python/BUILD
+++ b/litert/python/BUILD
@@ -27,7 +27,7 @@ py_strict_library(
         "//litert/python/litert_wrapper/compiled_model_wrapper:_pywrap_litert_compiled_model_wrapper",
         "//litert/python/litert_wrapper/tensor_buffer_wrapper:_pywrap_litert_tensor_buffer_wrapper",
         # TODO(b/460805332): stop building converter until protobuf symbol conflict is resolved.
-        # "//litert/python/mlir",
+        "//litert/python/mlir",
     ],
 )
 
@@ -50,7 +50,7 @@ pywrap_library(
             "//conditions:default": "//tflite/python:pywrap_tflite_common.lds",
         }),
     },
-    pywrap_count = 10,
+    pywrap_count = 12,
     visibility = ["//visibility:public"],
     deps = [
         ":litert_pywrap_deps",

--- a/litert/python/mlir/_mlir_libs/BUILD
+++ b/litert/python/mlir/_mlir_libs/BUILD
@@ -83,6 +83,11 @@ cc_library(
 cc_binary(
     name = "libLiteRTCompilerMLIR.so",
     linkshared = 1,
+    linkopts = select({
+        "@platforms//os:macos": [],
+        "@platforms//os:windows": [],
+        "//conditions:default": ["-Wl,-Bsymbolic"],
+    }),
     tags = [
         "nobuilder",
         "notap",


### PR DESCRIPTION
This pull request re-apply a previous CL , and add the following change to resolve the previous issues:
- Link LiteRTCompilerMLIR with -Bsymbolic to avoid protobuf descriptor conflicts

I tested the change locally with the a sample that I am adding to the LiteRT-samples repo: https://github.com/google-ai-edge/litert-samples/pull/75 . 

The change I made in litert/python/mlir/_mlir_libs/BUILD may need more refinement. I am not familiar with Bazel's syntax. Welcome to make your suggestions. 
