### PR TITLE
Add missing absl::die_if_null dependency to CMake builds.

### DIFF
--- a/litert/c/CMakeLists.txt
+++ b/litert/c/CMakeLists.txt
@@ -159,6 +159,7 @@ set(_litert_runtime_c_api_public_deps
     absl::log_internal_globals
     absl::log_internal_message
     absl::log_sink
+    absl::die_if_null
     absl::span
     absl::flat_hash_map
     flatbuffers::flatbuffers

--- a/litert/cc/CMakeLists.txt
+++ b/litert/cc/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(litert_cc_api
         absl::span
         absl::strings
         absl::log
+        absl::die_if_null
     PRIVATE
         litert_c_api
 )


### PR DESCRIPTION
**Problem**

The cc/internal/litert_runtime_proxy.h file includes absl/log/die_if_null.h and uses the ABSL_DIE_IF_NULL macro in the RuntimeProxy
```
  class constructor (line 58):
  explicit RuntimeProxy(const LiteRtRuntimeCApiStruct* runtime_c_api)
      : runtime_c_api_(ABSL_DIE_IF_NULL(runtime_c_api)) {};
```
  However, the CMake build was missing the absl::die_if_null library dependency in both c/CMakeLists.txt and cc/CMakeLists.txt. This causes linker errors when building with CMake:
```
  undefined reference to `absl::log_internal::DieBecauseNull(char const*, int, char const*)'
```

**Solution**
  Add absl::die_if_null to the target link libraries in both:
```
  - litert/c/CMakeLists.txt - for _litert_runtime_c_api_public_deps
  - litert/cc/CMakeLists.txt - for litert_cc_api
```
This ensures the ABSL_DIE_IF_NULL macro's implementation symbols are properly linked.