### PR TITLE
Qualcomm AI Engine Direct - Clean up TensorWrapper

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -210,19 +210,19 @@ LiteRtStatus ConvertTensor(const litert::Tensor& litert_tensor,
                                          litert_tensor.HasQuantization(),
                                          qnn_data_type));
 
-  std::vector<std::uint32_t> dimentions;
+  std::vector<std::uint32_t> dimensions;
   const auto litert_layout = ranked_tensor_type->Layout();
   if (litert_layout.Rank() == 0) {
-    dimentions.resize(1, 1);
+    dimensions.resize(1, 1);
   } else {
-    dimentions.resize(litert_layout.Rank());
-    for (size_t i = 0; i < dimentions.size(); ++i) {
+    dimensions.resize(litert_layout.Rank());
+    for (size_t i = 0; i < dimensions.size(); ++i) {
       // TODO(jiunkaiy): Integrate QNN dynamic dimension.
       // If any dimension sizes are unknown, they are indicated with -1.
       if (litert_layout.Dimensions()[i] == -1) {
-        dimentions[i] = 1;
+        dimensions[i] = 1;
       } else {
-        dimentions[i] = litert_layout.Dimensions()[i];
+        dimensions[i] = litert_layout.Dimensions()[i];
       }
     }
   }
@@ -295,11 +295,11 @@ LiteRtStatus ConvertTensor(const litert::Tensor& litert_tensor,
       "_" + std::string(kLiteRtStr) + "_" + std::to_string(tensor_index);
   if (litert_tensor.IsSubgraphInput()) {
     auto& res = tensor_pool.CreateInputTensorWithSuffix(
-        qnn_data_type, quantize_params, dimentions, litert_suffix);
+        qnn_data_type, quantize_params, dimensions, litert_suffix);
     tensor_wrapper = &res;
   } else if (litert_tensor.Uses().empty() || is_tensor_read_and_write) {
     auto& res = tensor_pool.CreateOutpuTensorWithSuffix(
-        qnn_data_type, quantize_params, dimentions, litert_suffix);
+        qnn_data_type, quantize_params, dimensions, litert_suffix);
     tensor_wrapper = &res;
   } else if (litert_tensor.IsConstant()) {
     LITERT_RETURN_IF_ERROR(
@@ -307,14 +307,14 @@ LiteRtStatus ConvertTensor(const litert::Tensor& litert_tensor,
         ErrorStatusBuilder(kLiteRtStatusErrorInvalidLegalization))
         << "Empty weights for constant tensor.";
     auto& res = tensor_pool.CreateStaticTensorWithSuffix(
-        qnn_data_type, quantize_params, dimentions, litert_suffix,
+        qnn_data_type, quantize_params, dimensions, litert_suffix,
         litert_tensor.Weights().Bytes().size(),
         reinterpret_cast<const void*>(litert_tensor.Weights().Bytes().data()),
         false);
     tensor_wrapper = &res;
   } else {
     auto& res = tensor_pool.CreateNativeTensorWithSuffix(
-        qnn_data_type, quantize_params, dimentions, litert_suffix);
+        qnn_data_type, quantize_params, dimensions, litert_suffix);
     // -1 in ids_to_dump will dump all tensors
     if (ids_to_dump.count(-1) > 0 || ids_to_dump.count(tensor_index) > 0) {
       LITERT_LOG(LITERT_INFO, "LiteRT tensor index: %d is dumped",

--- a/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.cc
@@ -24,7 +24,7 @@ namespace {
 constexpr std::size_t kInputIndex = 0;
 constexpr std::size_t kOutputIndex = 0;
 
-std::vector<std::uint32_t> GetStaticTensorDimention(
+std::vector<std::uint32_t> GetStaticTensorDimension(
     const std::vector<std::uint32_t>& input_dimensions,
     const std::vector<std::uint32_t>& output_dimensions) {
   std::uint32_t input_size = input_dimensions.size();
@@ -100,8 +100,8 @@ std::vector<OpWrapper> BuildBroadcastToOp(
   auto& broadcast_op = CreateOpWrapper(res, qnn_op);
   broadcast_op.AddInputTensor(input_tensor);
 
-  auto static_dims =
-      GetStaticTensorDimention(input_tensor.GetDims(), output_tensor.GetDims());
+  auto static_dims = GetStaticTensorDimension(input_tensor.GetDimensions(),
+                                              output_tensor.GetDimensions());
 
   TensorWrapper* static_tensor = nullptr;
   switch (data_type) {

--- a/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
@@ -41,7 +41,7 @@ std::vector<OpWrapper> BuildConv2dOp(
 
   // transpose filter
   TensorWrapper& filter_tensor = inputs[kFilterIndex];
-  const std::vector<uint32_t>& filters_dims = filter_tensor.GetDims();
+  const std::vector<uint32_t>& filters_dims = filter_tensor.GetDimensions();
   auto& filter_quant_params = filter_tensor.GetQuantParams();
   std::vector<std::uint32_t> permute_dims{filters_dims[1], filters_dims[2],
                                           filters_dims[3], filters_dims[0]};
@@ -128,13 +128,13 @@ std::vector<OpWrapper> BuildConv2dOp(
 
   // padding param
   const auto [padding_before_height, padding_after_height] =
-      ComputePaddingBeforeAfter(input_tensor.GetDim(kHeightIndex),
-                                filter_tensor.GetDim(kHeightIndex), stride_h,
-                                dilation_h, padding_type);
+      ComputePaddingBeforeAfter(input_tensor.GetDimension(kHeightIndex),
+                                filter_tensor.GetDimension(kHeightIndex),
+                                stride_h, dilation_h, padding_type);
   const auto [padding_before_width, padding_after_width] =
-      ComputePaddingBeforeAfter(input_tensor.GetDim(kWidthIndex),
-                                filter_tensor.GetDim(kWidthIndex), stride_w,
-                                dilation_w, padding_type);
+      ComputePaddingBeforeAfter(input_tensor.GetDimension(kWidthIndex),
+                                filter_tensor.GetDimension(kWidthIndex),
+                                stride_w, dilation_w, padding_type);
   const std::array<std::uint32_t, 4> padding_data = {
       padding_before_height, padding_after_height, padding_before_width,
       padding_after_width};
@@ -146,14 +146,14 @@ std::vector<OpWrapper> BuildConv2dOp(
   conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_PAD_AMOUNT, padding_tensor);
 
   // group param
-  if ((input_tensor.GetDim(kChannelIndex) %
-       filter_tensor.GetDim(kChannelIndex)) != 0) {
+  if ((input_tensor.GetDimension(kChannelIndex) %
+       filter_tensor.GetDimension(kChannelIndex)) != 0) {
     QNN_LOG_WARNING(
         "The channels of the input tensor cannot be evenly divided by the "
         "channels of the filter tensor.");
   }
-  if (const std::uint32_t groups = input_tensor.GetDim(kChannelIndex) /
-                                   filter_tensor.GetDim(kChannelIndex);
+  if (const std::uint32_t groups = input_tensor.GetDimension(kChannelIndex) /
+                                   filter_tensor.GetDimension(kChannelIndex);
       groups > 1) {
     conv_op.AddScalarParam<std::uint32_t>(QNN_OP_CONV_2D_PARAM_GROUP, groups);
   }

--- a/litert/vendors/qualcomm/core/builders/conv3d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/conv3d_op_builder.cc
@@ -72,16 +72,16 @@ std::vector<OpWrapper> BuildConv3dOp(
 
   // padding param
   const auto [padding_before_depth, padding_after_depth] =
-      ComputePaddingBeforeAfter(input_tensor.GetDim(kDepthIndex),
-                                filter_tensor.GetDim(kFilterDepthIndex),
+      ComputePaddingBeforeAfter(input_tensor.GetDimension(kDepthIndex),
+                                filter_tensor.GetDimension(kFilterDepthIndex),
                                 stride_d, dilation_d, padding_type);
   const auto [padding_before_height, padding_after_height] =
-      ComputePaddingBeforeAfter(input_tensor.GetDim(kHeightIndex),
-                                filter_tensor.GetDim(kFilterHeightIndex),
+      ComputePaddingBeforeAfter(input_tensor.GetDimension(kHeightIndex),
+                                filter_tensor.GetDimension(kFilterHeightIndex),
                                 stride_h, dilation_h, padding_type);
   const auto [padding_before_width, padding_after_width] =
-      ComputePaddingBeforeAfter(input_tensor.GetDim(kWidthIndex),
-                                filter_tensor.GetDim(kFilterWidthIndex),
+      ComputePaddingBeforeAfter(input_tensor.GetDimension(kWidthIndex),
+                                filter_tensor.GetDimension(kFilterWidthIndex),
                                 stride_w, dilation_w, padding_type);
   const std::array<std::uint32_t, 6> padding_data = {
       padding_before_depth, padding_after_depth,  padding_before_height,
@@ -92,8 +92,8 @@ std::vector<OpWrapper> BuildConv3dOp(
       sizeof(padding_data[0]) * padding_data.size(), padding_data.data());
   conv_op.AddTensorParam(QNN_OP_CONV_3D_PARAM_PAD_AMOUNT, padding_tensor);
 
-  const std::vector<uint32_t>& input_dims = input_tensor.GetDims();
-  const std::vector<uint32_t>& filters_dims = filter_tensor.GetDims();
+  const std::vector<uint32_t>& input_dims = input_tensor.GetDimensions();
+  const std::vector<uint32_t>& filters_dims = filter_tensor.GetDimensions();
 
   // group param
   const std::uint32_t input_channel = input_dims[4];

--- a/litert/vendors/qualcomm/core/builders/depthwise_conv2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/depthwise_conv2d_op_builder.cc
@@ -42,8 +42,10 @@ std::vector<OpWrapper> BuildDepthwiseConv2dOp(
 
   // 1HWC to HW1C, only need reshape instead of transpose.
   const std::vector<std::uint32_t> reshape_dims{
-      filter_tensor.GetDim(kHeightIndex), filter_tensor.GetDim(kWidthIndex),
-      filter_tensor.GetDim(kBatchIndex), filter_tensor.GetDim(kChannelIndex)};
+      filter_tensor.GetDimension(kHeightIndex),
+      filter_tensor.GetDimension(kWidthIndex),
+      filter_tensor.GetDimension(kBatchIndex),
+      filter_tensor.GetDimension(kChannelIndex)};
   TensorWrapper* reshaped_filter_tensor = nullptr;
   if (filter_tensor.IsTensorStatic()) {
     reshaped_filter_tensor =
@@ -93,13 +95,13 @@ std::vector<OpWrapper> BuildDepthwiseConv2dOp(
 
   // padding param
   const auto [padding_before_height, padding_after_height] =
-      ComputePaddingBeforeAfter(input_tensor.GetDim(kHeightIndex),
-                                filter_tensor.GetDim(kHeightIndex), stride_h,
-                                dilation_h, padding_type);
+      ComputePaddingBeforeAfter(input_tensor.GetDimension(kHeightIndex),
+                                filter_tensor.GetDimension(kHeightIndex),
+                                stride_h, dilation_h, padding_type);
   const auto [padding_before_width, padding_after_width] =
-      ComputePaddingBeforeAfter(input_tensor.GetDim(kWidthIndex),
-                                filter_tensor.GetDim(kWidthIndex), stride_w,
-                                dilation_w, padding_type);
+      ComputePaddingBeforeAfter(input_tensor.GetDimension(kWidthIndex),
+                                filter_tensor.GetDimension(kWidthIndex),
+                                stride_w, dilation_w, padding_type);
   const std::array<std::uint32_t, 4> padding_data = {
       padding_before_height, padding_after_height, padding_before_width,
       padding_after_width};

--- a/litert/vendors/qualcomm/core/builders/dynamic_update_slice_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/dynamic_update_slice_op_builder.cc
@@ -96,7 +96,7 @@ std::vector<OpWrapper> BuildDynamicUpdateSliceOp(
         "%s", "Dynamic Update Slice only supports operand tensor rank >= 2");
     return {};
   }
-  uint32_t table_size = input_tensor.GetDim(1);
+  uint32_t table_size = input_tensor.GetDimension(1);
   std::vector<uint32_t> static_table_dims = {table_size};
   std::vector<int32_t> table_data(table_size);
   std::iota(table_data.begin(), table_data.end(), 0);

--- a/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
@@ -32,7 +32,7 @@ std::vector<OpWrapper> BuildEmbeddingLookupOp(
 
   auto& gather_op = CreateOpWrapper(res, QNN_OP_GATHER);
   // Case: QInt8 table with QInt16 output
-  if (table_tensor.IsQuant8() && output_tensor.IsQuant16()) {
+  if (table_tensor.IsQuantI8() && output_tensor.IsQuantI16()) {
     QNN_LOG_WARNING(
         "The data type of embedding lookup table is int8, but output data type "
         "is int16. Int8 table will be cast to int16.");
@@ -50,7 +50,7 @@ std::vector<OpWrapper> BuildEmbeddingLookupOp(
 
     TensorWrapper& int16_table_tensor = tensor_pool.CreateStaticTensor(
         output_tensor.GetDataType(), table_tensor.GetQuantParams(),
-        table_tensor.GetDims(),
+        table_tensor.GetDimensions(),
         sizeof(decltype(int16_data)::value_type) * int16_data.size(),
         reinterpret_cast<void*>(int16_data.data()));
 

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
@@ -51,7 +51,7 @@ std::vector<OpWrapper> BuildFullyConnectedOp(
       }
       auto& converted_bias_tensor = tensor_pool.CreateStaticTensor(
           QNN_DATATYPE_SFIXED_POINT_32, bias_tensor.GetQuantParams(),
-          bias_tensor.GetDims(),
+          bias_tensor.GetDimensions(),
           num_elements * sizeof(decltype(converted_data)::value_type),
           converted_data.data());
 
@@ -65,11 +65,11 @@ std::vector<OpWrapper> BuildFullyConnectedOp(
 
   TensorWrapper& output_tensor = outputs[0];
   if (keep_num_dims) {
-    auto& input_dims = input_tensor.GetDims();
+    auto& input_dims = input_tensor.GetDimensions();
     std::uint32_t input_size = std::accumulate(
         input_dims.begin(), input_dims.end(), 1, std::multiplies<>());
-    const std::uint32_t num_units = weight_tensor.GetDim(0);
-    const std::uint32_t num_input_elem = weight_tensor.GetDim(1);
+    const std::uint32_t num_units = weight_tensor.GetDimension(0);
+    const std::uint32_t num_input_elem = weight_tensor.GetDimension(1);
 
     // input_size must be divisible by num_input_elem. This should be validated
     // by QNN.

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder_htp.cc
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder_htp.cc
@@ -48,7 +48,7 @@ std::vector<OpWrapper> BuildFullyConnectedOpHtp(
   // Reshape
   qnn::OpWrapper& reshape_op_1 = CreateOpWrapper(res, QNN_OP_RESHAPE);
   reshape_op_1.AddInputTensor(input_tensor);
-  std::vector<uint32_t> conv_input_dims = input_tensor.GetDims();
+  std::vector<uint32_t> conv_input_dims = input_tensor.GetDimensions();
   conv_input_dims.insert(conv_input_dims.begin() + 1, 1);
   qnn::TensorWrapper& conv_input_tensor =
       tensor_pool.CloneNativeTensorFrom(input_tensor, conv_input_dims);
@@ -64,11 +64,11 @@ std::vector<OpWrapper> BuildFullyConnectedOpHtp(
                  quant_params)) {
     std::get<BwAxisScaleOffsetQuantizeParamsWrapper>(quant_params).SetAxis(3);
   }
-  std::vector<uint32_t> weight_dims{1, 1, weight_tensor.GetDim(1),
-                                    weight_tensor.GetDim(0)};
+  std::vector<uint32_t> weight_dims{1, 1, weight_tensor.GetDimension(1),
+                                    weight_tensor.GetDimension(0)};
   size_t weight_bytes = weight_tensor.GetTensorBytes();
-  const std::vector<std::uint32_t> transpose_dim{weight_tensor.GetDim(0), 1, 1,
-                                                 weight_tensor.GetDim(1)};
+  const std::vector<std::uint32_t> transpose_dim{
+      weight_tensor.GetDimension(0), 1, 1, weight_tensor.GetDimension(1)};
   TensorWrapper* weight;
   if (weight_tensor.GetDataType() == QNN_DATATYPE_SFIXED_POINT_8) {
     std::vector<std::int8_t> conv_weight;

--- a/litert/vendors/qualcomm/core/builders/pad_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/pad_op_builder.cc
@@ -53,7 +53,8 @@ std::vector<OpWrapper> BuildPadOp(TensorPool& tensor_pool,
   pad_op.AddScalarParam<std::uint32_t>(QNN_OP_PAD_PARAM_SCHEME, scheme_value);
   pad_op.AddTensorParam(QNN_OP_PAD_PARAM_PAD_AMOUNT, *converted_pad_tensor);
 
-  if (input_tensor.IsQuant8() || input_tensor.IsQuant16()) {
+  if (input_tensor.IsQuantI8() || input_tensor.IsQuantU8() ||
+      input_tensor.IsQuantI16() || input_tensor.IsQuantU16()) {
     std::int32_t pad_const_value = 0;
     if (inputs.size() >= kPadConstValueIndex + 1) {
       const auto pad_const_data =

--- a/litert/vendors/qualcomm/core/builders/pool2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/pool2d_op_builder.cc
@@ -60,11 +60,11 @@ std::vector<OpWrapper> BuildPool2dOp(
 
   // padding
   const auto [padding_before_height, padding_after_height] =
-      ComputePaddingBeforeAfter(input_tensor.GetDim(kHeightIndex),
+      ComputePaddingBeforeAfter(input_tensor.GetDimension(kHeightIndex),
                                 filter_height, stride_height, 1, padding_type);
   const auto [padding_before_width, padding_after_width] =
-      ComputePaddingBeforeAfter(input_tensor.GetDim(kWidthIndex), filter_width,
-                                stride_width, 1, padding_type);
+      ComputePaddingBeforeAfter(input_tensor.GetDimension(kWidthIndex),
+                                filter_width, stride_width, 1, padding_type);
   const std::vector<std::uint32_t> padding_shape{2, 2};
   const std::array<std::uint32_t, 4> padding_data{
       padding_before_height, padding_after_height, padding_before_width,

--- a/litert/vendors/qualcomm/core/builders/quantize_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/quantize_op_builder.cc
@@ -21,8 +21,10 @@ std::vector<OpWrapper> BuildQuantizeOp(
   const char* qnn_op = nullptr;
   if (inputs[0].get().IsPerTensorQuantWithOffsetDiff(outputs[0].get())) {
     qnn_op = QNN_OP_CAST;
-  } else if ((inputs[0].get().IsQuant8() || inputs[0].get().IsQuant16()) &&
-             (outputs[0].get().IsQuant8() || outputs[0].get().IsQuant16())) {
+  } else if ((inputs[0].get().IsQuantI8() || inputs[0].get().IsQuantU8() ||
+              inputs[0].get().IsQuantI16() || inputs[0].get().IsQuantU16()) &&
+             (outputs[0].get().IsQuantI8() || outputs[0].get().IsQuantU8() ||
+              outputs[0].get().IsQuantI16() || outputs[0].get().IsQuantU16())) {
     qnn_op = QNN_OP_CONVERT;
   } else {
     qnn_op = QNN_OP_QUANTIZE;

--- a/litert/vendors/qualcomm/core/builders/reduce_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/reduce_op_builder.cc
@@ -42,7 +42,7 @@ std::vector<OpWrapper> BuildReduceOp(
     return {};
   }
   std::vector<std::uint32_t> adjusted_axis_data;
-  for (size_t i = 0; i < axis_tensor.GetDim(0); ++i) {
+  for (size_t i = 0; i < axis_tensor.GetDimension(0); ++i) {
     std::uint32_t adjusted_axis =
         (*axis_data)[i] >= 0 ? (*axis_data)[i]
                              : (*axis_data)[i] + input_tensor.GetRank();
@@ -105,10 +105,10 @@ std::vector<OpWrapper> BuildReduceAnyOp(
 
   auto& reduce_max_input = tensor_pool.CreateNativeTensor(
       QNN_DATATYPE_UFIXED_POINT_8, QuantizeParamsWrapperVariant{},
-      inputs[0].get().GetDims());
+      inputs[0].get().GetDimensions());
   auto& reduce_max_output = tensor_pool.CreateNativeTensor(
       QNN_DATATYPE_UFIXED_POINT_8, QuantizeParamsWrapperVariant{},
-      outputs[0].get().GetDims());
+      outputs[0].get().GetDimensions());
 
   auto& cast_to_uint8_op = CreateOpWrapper(res, QNN_OP_CAST);
   cast_to_uint8_op.AddInputTensor(inputs[0]);
@@ -134,10 +134,10 @@ std::vector<OpWrapper> BuildReduceAllOp(
 
   auto& reduce_min_input = tensor_pool.CreateNativeTensor(
       QNN_DATATYPE_UFIXED_POINT_8, QuantizeParamsWrapperVariant{},
-      inputs[0].get().GetDims());
+      inputs[0].get().GetDimensions());
   auto& reduce_min_output = tensor_pool.CreateNativeTensor(
       QNN_DATATYPE_UFIXED_POINT_8, QuantizeParamsWrapperVariant{},
-      outputs[0].get().GetDims());
+      outputs[0].get().GetDimensions());
 
   auto& cast_to_uint8_op = CreateOpWrapper(res, QNN_OP_CAST);
   cast_to_uint8_op.AddInputTensor(inputs[0]);

--- a/litert/vendors/qualcomm/core/builders/reverse_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/reverse_op_builder.cc
@@ -36,7 +36,7 @@ std::vector<OpWrapper> BuildReverseOp(
   }
 
   // TODO: Support more axis and remove this check
-  if (axis_tensor.GetRank() != 1 || axis_tensor.GetDims()[0] != 1) {
+  if (axis_tensor.GetRank() != 1 || axis_tensor.GetDimensions()[0] != 1) {
     QNN_LOG_ERROR("Qnn supports ReverseV2 with a single axis for now.");
     return {};
   }
@@ -66,7 +66,7 @@ std::vector<OpWrapper> BuildReverseOp(
 
   // For the axis which is reversed, use (begin, end, stride) = (dim[axis]-1,
   // -1, -1) Otherwise, use (0, dim[axis], 1)
-  auto& input_dims = input_tensor.GetDims();
+  auto& input_dims = input_tensor.GetDimensions();
   std::vector<std::int32_t> ranges(
       static_cast<uint32_t>(input_rank * range_num_elements));
   for (size_t i = 0; i < input_rank; ++i) {

--- a/litert/vendors/qualcomm/core/builders/rms_norm_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/rms_norm_op_builder.cc
@@ -57,8 +57,8 @@ std::vector<OpWrapper> BuildRmsNormOp(
     TensorWrapper& beta_tensor = tensor_pool.CreateStaticTensor(
         inputs[kGammaIndex].get().GetDataType(),
         inputs[kGammaIndex].get().GetQuantParams(),
-        inputs[kGammaIndex].get().GetDims(), sizeof(float) * beta_data.size(),
-        beta_data.data());
+        inputs[kGammaIndex].get().GetDimensions(),
+        sizeof(float) * beta_data.size(), beta_data.data());
     rms_norm_op.AddInputTensor(beta_tensor);
   } else {
     // Construct uint8_t beta static all 0 tensor.
@@ -70,8 +70,8 @@ std::vector<OpWrapper> BuildRmsNormOp(
 
     TensorWrapper& beta_tensor = tensor_pool.CreateStaticTensor(
         QNN_DATATYPE_UFIXED_POINT_8, q_param,
-        inputs[kGammaIndex].get().GetDims(), sizeof(uint8_t) * beta_data.size(),
-        beta_data.data());
+        inputs[kGammaIndex].get().GetDimensions(),
+        sizeof(uint8_t) * beta_data.size(), beta_data.data());
     rms_norm_op.AddInputTensor(beta_tensor);
   }
 

--- a/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/slice_op_builder.cc
@@ -55,7 +55,7 @@ std::vector<OpWrapper> BuildSliceOp(
   for (size_t i = 0; i < input_rank; ++i) {
     range_data.emplace_back((*begin_data)[i]);
     if ((*size_data)[i] == kSizeNegative) {
-      range_data.emplace_back(input_tensor.GetDim(i));
+      range_data.emplace_back(input_tensor.GetDimension(i));
     } else {
       range_data.emplace_back((*begin_data)[i] + (*size_data)[i]);
     }

--- a/litert/vendors/qualcomm/core/builders/split_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/split_op_builder.cc
@@ -42,7 +42,7 @@ std::vector<OpWrapper> BuildSplitOp(
                            ? (*axis_data)[0]
                            : (*axis_data)[0] + input_tensor.GetRank();
 
-  const std::uint32_t slice_size = input_tensor.GetDim(axis) / num_splits;
+  const std::uint32_t slice_size = input_tensor.GetDimension(axis) / num_splits;
   // The split_indice will do N cuts, split the dimension into N+1 clips
   // so 0 will not be included in the split_indice
   // for example, when we split 12 into 4 clip, the split index will be {3,6,9}

--- a/litert/vendors/qualcomm/core/builders/strided_slice_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/strided_slice_op_builder.cc
@@ -67,7 +67,7 @@ std::vector<OpWrapper> BuildStridedSliceOp(
   for (size_t i = 0; i < input_rank; ++i) {
     std::int32_t begin = begin_data[i];
     if (begin < 0) {
-      begin += input_tensor.GetDim(i);
+      begin += input_tensor.GetDimension(i);
     }
 
     std::int32_t stride = strides_data[i];
@@ -78,7 +78,7 @@ std::vector<OpWrapper> BuildStridedSliceOp(
       // for stride > 0, end should be in [0, dimensions[i]]
       // for stride < 0, end should be in [-1, dimensions[i] - 1]
       if ((stride > 0 && end < 0) || (stride < 0 && end < -1)) {
-        end += input_tensor.GetDim(i);
+        end += input_tensor.GetDimension(i);
       }
     }
 

--- a/litert/vendors/qualcomm/core/builders/tile_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/tile_op_builder.cc
@@ -46,7 +46,7 @@ std::vector<OpWrapper> BuildTileOp(
     }
     TensorWrapper& uint32_multiples_tensor = tensor_pool.CreateStaticTensor(
         QNN_DATATYPE_UINT_32, multiples_tensor.GetQuantParams(),
-        multiples_tensor.GetDims(),
+        multiples_tensor.GetDimensions(),
         sizeof(decltype(uint32_data)::value_type) * uint32_data.size(),
         reinterpret_cast<void*>(uint32_data.data()));
 

--- a/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.cc
@@ -40,7 +40,7 @@ std::vector<OpWrapper> BuildTransposeConvOp(
 
   // reshape filter
   TensorWrapper& filter_tensor = inputs[kFilterIndex];
-  const std::vector<uint32_t>& filters_dims = filter_tensor.GetDims();
+  const std::vector<uint32_t>& filters_dims = filter_tensor.GetDimensions();
   auto& filter_quant_params = filter_tensor.GetQuantParams();
   std::vector<std::uint32_t> permute_dims{filters_dims[1], filters_dims[2],
                                           filters_dims[3], filters_dims[0]};
@@ -120,12 +120,12 @@ std::vector<OpWrapper> BuildTransposeConvOp(
 
   // padding param
   const auto [padding_before_height, padding_after_height] =
-      ComputePaddingBeforeAfter(input_tensor.GetDim(kHeightIndex),
-                                filter_tensor.GetDim(kFilterHeightIndex),
+      ComputePaddingBeforeAfter(input_tensor.GetDimension(kHeightIndex),
+                                filter_tensor.GetDimension(kFilterHeightIndex),
                                 stride_h, 1, padding_type);
   const auto [padding_before_width, padding_after_width] =
-      ComputePaddingBeforeAfter(input_tensor.GetDim(kWidthIndex),
-                                filter_tensor.GetDim(kFilterWidthIndex),
+      ComputePaddingBeforeAfter(input_tensor.GetDimension(kWidthIndex),
+                                filter_tensor.GetDimension(kFilterWidthIndex),
                                 stride_w, 1, padding_type);
   const std::array<std::uint32_t, 4> padding_data = {
       padding_before_height, padding_after_height, padding_before_width,

--- a/litert/vendors/qualcomm/core/tensor_pool.cc
+++ b/litert/vendors/qualcomm/core/tensor_pool.cc
@@ -25,63 +25,63 @@ TensorPool::TensorPool() = default;
 
 TensorWrapper& TensorPool::CreateInputTensorWithSuffix(
     Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
-    const std::vector<std::uint32_t>& dimentions, std::string_view suffix) {
+    const std::vector<std::uint32_t>& dimensions, std::string_view suffix) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + std::string(suffix);
   return tensor_wrappers_.emplace_back(std::move(tensor_name),
                                        QNN_TENSOR_TYPE_APP_WRITE, data_type,
-                                       quant_params, dimentions);
+                                       quant_params, dimensions);
 }
 
 TensorWrapper& TensorPool::CreateOutpuTensorWithSuffix(
     Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
-    const std::vector<std::uint32_t>& dimentions, std::string_view suffix) {
+    const std::vector<std::uint32_t>& dimensions, std::string_view suffix) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + std::string(suffix);
   return tensor_wrappers_.emplace_back(std::move(tensor_name),
                                        QNN_TENSOR_TYPE_APP_READ, data_type,
-                                       quant_params, dimentions);
+                                       quant_params, dimensions);
 }
 
 TensorWrapper& TensorPool::CreateNativeTensor(
     Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
-    const std::vector<std::uint32_t>& dimentions) {
+    const std::vector<std::uint32_t>& dimensions) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + kQnnSuffix;
   return tensor_wrappers_.emplace_back(std::move(tensor_name),
                                        QNN_TENSOR_TYPE_NATIVE, data_type,
-                                       quant_params, dimentions);
+                                       quant_params, dimensions);
 }
 
 TensorWrapper& TensorPool::CreateNativeTensorWithSuffix(
     Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
-    const std::vector<std::uint32_t>& dimentions, std::string_view suffix) {
+    const std::vector<std::uint32_t>& dimensions, std::string_view suffix) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + std::string(suffix);
   return tensor_wrappers_.emplace_back(std::move(tensor_name),
                                        QNN_TENSOR_TYPE_NATIVE, data_type,
-                                       quant_params, dimentions);
+                                       quant_params, dimensions);
 }
 
 TensorWrapper& TensorPool::CreateStaticTensor(
     Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
-    const std::vector<std::uint32_t>& dimentions, std::uint32_t bytes,
+    const std::vector<std::uint32_t>& dimensions, std::uint32_t bytes,
     const void* data) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + kQnnSuffix;
   return tensor_wrappers_.emplace_back(
       std::move(tensor_name), QNN_TENSOR_TYPE_STATIC, data_type, quant_params,
-      dimentions, bytes, data, true);
+      dimensions, bytes, data, true);
 }
 
 TensorWrapper* TensorPool::CreateStaticTensorWithValue(
     Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
-    const std::vector<std::uint32_t>& dimentions, float fill_value) {
+    const std::vector<std::uint32_t>& dimensions, float fill_value) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + kQnnSuffix;
 
   std::uint32_t num_data_element = std::accumulate(
-      dimentions.begin(), dimentions.end(), 1, std::multiplies<>());
+      dimensions.begin(), dimensions.end(), 1, std::multiplies<>());
   const std::uint32_t data_bytes =
       num_data_element * GetDataTypeSize(data_type);
 
@@ -195,18 +195,18 @@ TensorWrapper* TensorPool::CreateStaticTensorWithValue(
 
   return &tensor_wrappers_.emplace_back(
       std::move(tensor_name), QNN_TENSOR_TYPE_STATIC, data_type, quant_params,
-      dimentions, data_bytes, data_ptr, true);
+      dimensions, data_bytes, data_ptr, true);
 }
 
 TensorWrapper& TensorPool::CreateStaticTensorWithSuffix(
     Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
-    const std::vector<std::uint32_t>& dimentions, std::string_view suffix,
+    const std::vector<std::uint32_t>& dimensions, std::string_view suffix,
     std::uint32_t bytes, const void* data, bool copy_data) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + std::string(suffix);
   return tensor_wrappers_.emplace_back(
       std::move(tensor_name), QNN_TENSOR_TYPE_STATIC, data_type, quant_params,
-      dimentions, bytes, data, copy_data);
+      dimensions, bytes, data, copy_data);
 }
 
 TensorWrapper& TensorPool::CloneNativeTensorFrom(const TensorWrapper& src) {
@@ -214,16 +214,16 @@ TensorWrapper& TensorPool::CloneNativeTensorFrom(const TensorWrapper& src) {
   auto tensor_name = std::to_string(id) + kQnnSuffix;
   return tensor_wrappers_.emplace_back(
       std::move(tensor_name), QNN_TENSOR_TYPE_NATIVE, src.GetDataType(),
-      src.quantize_params_, src.dimentions_);
+      src.quantize_params_, src.dimensions_);
 }
 
 TensorWrapper& TensorPool::CloneNativeTensorFrom(
-    const TensorWrapper& src, const std::vector<std::uint32_t>& dimentions) {
+    const TensorWrapper& src, const std::vector<std::uint32_t>& dimensions) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + kQnnSuffix;
   return tensor_wrappers_.emplace_back(
       std::move(tensor_name), QNN_TENSOR_TYPE_NATIVE, src.GetDataType(),
-      src.quantize_params_, dimentions);
+      src.quantize_params_, dimensions);
 }
 
 TensorWrapper& TensorPool::CloneStaticTensorFrom(const TensorWrapper& src,
@@ -232,18 +232,18 @@ TensorWrapper& TensorPool::CloneStaticTensorFrom(const TensorWrapper& src,
   auto tensor_name = std::to_string(id) + kQnnSuffix;
   return tensor_wrappers_.emplace_back(std::move(tensor_name),
                                        QNN_TENSOR_TYPE_STATIC, data_type,
-                                       src.quantize_params_, src.dimentions_,
+                                       src.quantize_params_, src.dimensions_,
                                        src.qnn_tensor_.v2.clientBuf.dataSize,
                                        src.qnn_tensor_.v2.clientBuf.data, true);
 }
 
 TensorWrapper& TensorPool::CloneStaticTensorFrom(
-    const TensorWrapper& src, const std::vector<std::uint32_t>& dimentions) {
+    const TensorWrapper& src, const std::vector<std::uint32_t>& dimensions) {
   const auto id = tensor_wrappers_.size();
   auto tensor_name = std::to_string(id) + kQnnSuffix;
   return tensor_wrappers_.emplace_back(
       std::move(tensor_name), QNN_TENSOR_TYPE_STATIC,
-      src.qnn_tensor_.v2.dataType, src.quantize_params_, dimentions,
+      src.qnn_tensor_.v2.dataType, src.quantize_params_, dimensions,
       src.qnn_tensor_.v2.clientBuf.dataSize, src.qnn_tensor_.v2.clientBuf.data,
       true);
 }

--- a/litert/vendors/qualcomm/core/tensor_pool.h
+++ b/litert/vendors/qualcomm/core/tensor_pool.h
@@ -29,50 +29,50 @@ class TensorPool {
   TensorWrapper& CreateInputTensorWithSuffix(
       Qnn_DataType_t data_type,
       const QuantizeParamsWrapperVariant& quant_params,
-      const std::vector<std::uint32_t>& dimentions, std::string_view suffix);
+      const std::vector<std::uint32_t>& dimensions, std::string_view suffix);
 
   TensorWrapper& CreateOutpuTensorWithSuffix(
       Qnn_DataType_t data_type,
       const QuantizeParamsWrapperVariant& quant_params,
-      const std::vector<std::uint32_t>& dimentions, std::string_view suffix);
+      const std::vector<std::uint32_t>& dimensions, std::string_view suffix);
 
   TensorWrapper& CreateNativeTensor(
       Qnn_DataType_t data_type,
       const QuantizeParamsWrapperVariant& quant_params,
-      const std::vector<std::uint32_t>& dimentions);
+      const std::vector<std::uint32_t>& dimensions);
 
   TensorWrapper& CreateNativeTensorWithSuffix(
       Qnn_DataType_t data_type,
       const QuantizeParamsWrapperVariant& quant_params,
-      const std::vector<std::uint32_t>& dimentions, std::string_view suffix);
+      const std::vector<std::uint32_t>& dimensions, std::string_view suffix);
 
   TensorWrapper& CreateStaticTensor(
       Qnn_DataType_t data_type,
       const QuantizeParamsWrapperVariant& quant_params,
-      const std::vector<std::uint32_t>& dimentions, std::uint32_t bytes,
+      const std::vector<std::uint32_t>& dimensions, std::uint32_t bytes,
       const void* data);
 
   TensorWrapper* CreateStaticTensorWithValue(
       Qnn_DataType_t data_type,
       const QuantizeParamsWrapperVariant& quant_params,
-      const std::vector<std::uint32_t>& dimentions, float fill_value);
+      const std::vector<std::uint32_t>& dimensions, float fill_value);
 
   TensorWrapper& CreateStaticTensorWithSuffix(
       Qnn_DataType_t data_type,
       const QuantizeParamsWrapperVariant& quant_params,
-      const std::vector<std::uint32_t>& dimentions, std::string_view suffix,
+      const std::vector<std::uint32_t>& dimensions, std::string_view suffix,
       std::uint32_t bytes, const void* data, bool copy_data);
 
   TensorWrapper& CloneNativeTensorFrom(const TensorWrapper& src);
 
   TensorWrapper& CloneNativeTensorFrom(
-      const TensorWrapper& src, const std::vector<std::uint32_t>& dimentions);
+      const TensorWrapper& src, const std::vector<std::uint32_t>& dimensions);
 
   TensorWrapper& CloneStaticTensorFrom(const TensorWrapper& src,
                                        Qnn_DataType_t data_type);
 
   TensorWrapper& CloneStaticTensorFrom(
-      const TensorWrapper& src, const std::vector<std::uint32_t>& dimentions);
+      const TensorWrapper& src, const std::vector<std::uint32_t>& dimensions);
 
   template <typename T>
   TensorWrapper* ConvertStaticTensorFrom(const TensorWrapper& src_tensor);
@@ -168,7 +168,8 @@ TensorWrapper* TensorPool::ConvertStaticTensorFrom(
   auto& back = tensor_wrappers_.emplace_back(
       std::move(tensor_name), QNN_TENSOR_TYPE_STATIC,
       GetQnnDataType<T>(src_tensor.IsQuant()), src_tensor.GetQuantParams(),
-      src_tensor.GetDims(), sizeof(T) * dst_data.size(), dst_data.data(), true);
+      src_tensor.GetDimensions(), sizeof(T) * dst_data.size(), dst_data.data(),
+      true);
   return &back;
 }
 

--- a/litert/vendors/qualcomm/core/transformation/embedding_gemma.cc
+++ b/litert/vendors/qualcomm/core/transformation/embedding_gemma.cc
@@ -55,13 +55,14 @@ TensorWrapper& BuildSingleSHA(std::vector<OpWrapper>& new_ops,
                               const OpWrapper& matmul_op2, size_t num_heads) {
   // Mul
   auto& mul_output = tensor_pool.CloneNativeTensorFrom(
-      mul_op.GetOutputTensor(0), sha_input.GetDims());
+      mul_op.GetOutputTensor(0), sha_input.GetDimensions());
 
   EmplaceOpWithIO(new_ops, mul_op, {sha_input, std::nullopt}, {mul_output});
 
   // MatMul 1
   const auto& matmul_op1_output = matmul_op1.GetOutputTensor(0);
-  std::vector<uint32_t> new_matmul1_output_dim = matmul_op1_output.GetDims();
+  std::vector<uint32_t> new_matmul1_output_dim =
+      matmul_op1_output.GetDimensions();
   new_matmul1_output_dim[2] /= num_heads;
   auto& new_matmul1_output = tensor_pool.CloneNativeTensorFrom(
       matmul_op1_output, new_matmul1_output_dim);
@@ -76,11 +77,11 @@ TensorWrapper& BuildSingleSHA(std::vector<OpWrapper>& new_ops,
 
   // Softmax
   auto& softmax_output = tensor_pool.CloneNativeTensorFrom(
-      softmax_op.GetOutputTensor(0), new_add_output.GetDims());
+      softmax_op.GetOutputTensor(0), new_add_output.GetDimensions());
   EmplaceOpWithIO(new_ops, softmax_op, {new_add_output}, {softmax_output});
 
   // MatMul 2
-  auto matmul_op2_out_dim = matmul_op2.GetOutputTensor(0).GetDims();
+  auto matmul_op2_out_dim = matmul_op2.GetOutputTensor(0).GetDimensions();
   matmul_op2_out_dim[2] /= num_heads;
   auto& new_matmul2_output = tensor_pool.CloneNativeTensorFrom(
       matmul_op2.GetOutputTensor(0), matmul_op2_out_dim);
@@ -101,20 +102,20 @@ std::vector<OpWrapper> MHA2SHA(TensorPool& tensor_pool, const OpWrapper& mul_op,
   std::vector<OpWrapper> new_ops;
 
   // Transpose
-  auto transpose_out_dims = tranpose_op1.GetOutputTensor(0).GetDims();
+  auto transpose_out_dims = tranpose_op1.GetOutputTensor(0).GetDimensions();
   auto& transpose_output =
       tensor_pool.CloneNativeTensorFrom(pattern_input, transpose_out_dims);
   auto& new_transpose1 = EmplaceOpWithIO(
       new_ops, tranpose_op1, {const_cast<::qnn::TensorWrapper&>(pattern_input)},
       {transpose_output});
 
-  const uint32_t num_heads = pattern_input.GetDim(2);
+  const uint32_t num_heads = pattern_input.GetDimension(2);
   const auto& mha_input = new_transpose1.GetOutputTensor(0);  // split_in
 
   std::vector<::qnn::TensorWrapperRef> sha_inputs;
   sha_inputs.reserve(num_heads);
   for (size_t i = 0; i < num_heads; i++) {
-    auto sha_input_dims = mha_input.GetDims();  // split_out_dims
+    auto sha_input_dims = mha_input.GetDimensions();  // split_out_dims
     sha_input_dims[1] /= num_heads;
     auto& split_output =
         tensor_pool.CloneNativeTensorFrom(mha_input, sha_input_dims);
@@ -138,7 +139,7 @@ std::vector<OpWrapper> MHA2SHA(TensorPool& tensor_pool, const OpWrapper& mul_op,
   std::vector<::qnn::TensorWrapperRef> new_mask_inputs;
   new_mask_inputs.reserve(num_heads);
   for (size_t i = 0; i < num_heads; i++) {
-    auto new_mask_input_dims = mask_input.GetDims();
+    auto new_mask_input_dims = mask_input.GetDimensions();
     new_mask_input_dims[2] /= num_heads;
     auto& mask_split_output =
         tensor_pool.CloneNativeTensorFrom(mask_input, new_mask_input_dims);
@@ -167,7 +168,7 @@ std::vector<OpWrapper> MHA2SHA(TensorPool& tensor_pool, const OpWrapper& mul_op,
   }
 
   // Concat
-  auto concat_dims = pattern_output.GetDims();
+  auto concat_dims = pattern_output.GetDimensions();
   concat_dims.insert(concat_dims.begin(), 1);
   auto& concat_output =
       tensor_pool.CloneNativeTensorFrom(pattern_output, concat_dims);

--- a/litert/vendors/qualcomm/core/transformation/mask.cc
+++ b/litert/vendors/qualcomm/core/transformation/mask.cc
@@ -25,7 +25,7 @@ std::vector<OpWrapper> TransformToSelectOp(
   auto& pattern_output = const_cast<TensorWrapper&>(
       original_ops[start_index + pattern_size - 1].GetOutputTensor(0));
   const auto& quant_param = pattern_output.GetQuantParams();
-  const auto& tensor_dims = pattern_input.GetDims();
+  const auto& tensor_dims = pattern_input.GetDimensions();
   const std::uint32_t num_element = pattern_input.GetTensorNumElements();
 
   std::vector<std::int16_t> all_zero_data(num_element, 0);

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
@@ -85,19 +85,19 @@ TensorWrapper& BuildSingleSHA(
     const OpWrapper& slice_2, const OpWrapper& matmul_v1,
     const OpWrapper& matmul_v2, const OpWrapper& add_2) {
   // Mul
-  auto& mul_output = tensor_pool.CloneNativeTensorFrom(mul.GetOutputTensor(0),
-                                                       sha_input.GetDims());
+  auto& mul_output = tensor_pool.CloneNativeTensorFrom(
+      mul.GetOutputTensor(0), sha_input.GetDimensions());
   EmplaceOpWithIO(new_ops, mul, {sha_input, std::nullopt}, {mul_output});
 
   // MatMul 1
-  auto matmul_k1_output_dims = matmul_k1.GetOutputTensor(0).GetDims();
+  auto matmul_k1_output_dims = matmul_k1.GetOutputTensor(0).GetDimensions();
   matmul_k1_output_dims[2] /= num_heads;
   auto& matmul_k1_output = tensor_pool.CloneNativeTensorFrom(
       matmul_k1.GetOutputTensor(0), matmul_k1_output_dims);
   EmplaceOpWithIO(new_ops, matmul_k1, {mul_output, std::nullopt},
                   {matmul_k1_output});
   // MatMul 2
-  auto matmul_k2_output_dims = matmul_k2.GetOutputTensor(0).GetDims();
+  auto matmul_k2_output_dims = matmul_k2.GetOutputTensor(0).GetDimensions();
   matmul_k2_output_dims[2] /= num_heads;
   auto& matmul_k2_output = tensor_pool.CloneNativeTensorFrom(
       matmul_k2.GetOutputTensor(0), matmul_k2_output_dims);
@@ -112,11 +112,11 @@ TensorWrapper& BuildSingleSHA(
                   {concat_output});
   // Add
   auto& add_1_output = tensor_pool.CloneNativeTensorFrom(
-      add_1.GetOutputTensor(0), concat_output.GetDims());
+      add_1.GetOutputTensor(0), concat_output.GetDimensions());
   EmplaceOpWithIO(new_ops, add_1, {concat_output, mask}, {add_1_output});
   // Softmax
   auto& softmax_output = tensor_pool.CloneNativeTensorFrom(
-      softmax.GetOutputTensor(0), add_1_output.GetDims());
+      softmax.GetOutputTensor(0), add_1_output.GetDimensions());
   EmplaceOpWithIO(new_ops, softmax, {add_1_output}, {softmax_output});
 
   // Slice 1
@@ -127,9 +127,9 @@ TensorWrapper& BuildSingleSHA(
   sha_slice_1_ranges_data[kSlice3rdAxisEndIndex] /= num_heads;
   auto& sha_slice_1_ranges = tensor_pool.CreateStaticTensor(
       slice_1_ranges.GetDataType(), slice_1_ranges.GetQuantParams(),
-      slice_1_ranges.GetDims(), slice_1_ranges.GetTensorBytes(),
+      slice_1_ranges.GetDimensions(), slice_1_ranges.GetTensorBytes(),
       sha_slice_1_ranges_data.data());
-  auto slice_1_output_dims = slice_1.GetOutputTensor(0).GetDims();
+  auto slice_1_output_dims = slice_1.GetOutputTensor(0).GetDimensions();
   slice_1_output_dims[2] /= num_heads;
   auto& slice_1_output = tensor_pool.CloneNativeTensorFrom(
       slice_1.GetOutputTensor(0), slice_1_output_dims);
@@ -144,9 +144,9 @@ TensorWrapper& BuildSingleSHA(
   sha_slice_2_ranges_data[kSlice3rdAxisEndIndex] /= num_heads;
   auto& sha_slice_2_ranges = tensor_pool.CreateStaticTensor(
       slice_2_ranges.GetDataType(), slice_2_ranges.GetQuantParams(),
-      slice_2_ranges.GetDims(), slice_2_ranges.GetTensorBytes(),
+      slice_2_ranges.GetDimensions(), slice_2_ranges.GetTensorBytes(),
       sha_slice_2_ranges_data.data());
-  auto slice_2_output_dims = slice_2.GetOutputTensor(0).GetDims();
+  auto slice_2_output_dims = slice_2.GetOutputTensor(0).GetDimensions();
   slice_2_output_dims[2] /= num_heads;
   auto& slice_2_output = tensor_pool.CloneNativeTensorFrom(
       slice_2.GetOutputTensor(0), slice_2_output_dims);
@@ -155,7 +155,7 @@ TensorWrapper& BuildSingleSHA(
 
   // MatMul 1
   std::vector<uint32_t> matmul_v1_output_dims =
-      matmul_v1.GetOutputTensor(0).GetDims();
+      matmul_v1.GetOutputTensor(0).GetDimensions();
   matmul_v1_output_dims[2] = matmul_v1_output_dims[2] / num_heads;
   auto& matmul_v1_output = tensor_pool.CloneNativeTensorFrom(
       matmul_v1.GetOutputTensor(0), matmul_v1_output_dims);
@@ -164,7 +164,7 @@ TensorWrapper& BuildSingleSHA(
 
   // MatMul 2
   std::vector<uint32_t> matmul_v2_output_dims =
-      matmul_v2.GetOutputTensor(0).GetDims();
+      matmul_v2.GetOutputTensor(0).GetDimensions();
   matmul_v2_output_dims[2] = matmul_v2_output_dims[2] / num_heads;
   auto& matmul_v2_output = tensor_pool.CloneNativeTensorFrom(
       matmul_v2.GetOutputTensor(0), matmul_v2_output_dims);
@@ -172,7 +172,7 @@ TensorWrapper& BuildSingleSHA(
                   {matmul_v2_output});
   // Add 2
   auto& add_2_output = tensor_pool.CloneNativeTensorFrom(
-      add_2.GetOutputTensor(0), matmul_v1_output.GetDims());
+      add_2.GetOutputTensor(0), matmul_v1_output.GetDimensions());
   EmplaceOpWithIO(new_ops, add_2, {matmul_v1_output, matmul_v2_output},
                   {add_2_output});
   return add_2_output;
@@ -191,14 +191,14 @@ TensorWrapper& BuildSingleSHA(
     const OpWrapper& matmul_v1, const OpWrapper& matmul_v2,
     const OpWrapper& add_3) {
   // Mul
-  auto mul_output_dims = mul.GetOutputTensor(0).GetDims();
+  auto mul_output_dims = mul.GetOutputTensor(0).GetDimensions();
   mul_output_dims.erase(mul_output_dims.begin() + 1);
   auto& mul_output = tensor_pool.CloneNativeTensorFrom(mul.GetOutputTensor(0),
                                                        mul_output_dims);
   EmplaceOpWithIO(new_ops, mul, {sha_mul_input, std::nullopt}, {mul_output});
 
   // Matmul q
-  auto matmul_q_output_dims = matmul_k1.GetOutputTensor(0).GetDims();
+  auto matmul_q_output_dims = matmul_k1.GetOutputTensor(0).GetDimensions();
   matmul_q_output_dims.erase(matmul_q_output_dims.begin() + 1);
   matmul_q_output_dims[1] /= num_attn_per_kv_heads;
   auto& matmul_q_output = tensor_pool.CloneNativeTensorFrom(
@@ -206,7 +206,7 @@ TensorWrapper& BuildSingleSHA(
   EmplaceOpWithIO(new_ops, matmul_k1, {mul_output, q_slice}, {matmul_q_output});
 
   // Add
-  auto add_1_output_dims = add_1.GetOutputTensor(0).GetDims();
+  auto add_1_output_dims = add_1.GetOutputTensor(0).GetDimensions();
   add_1_output_dims.erase(add_1_output_dims.begin() + 1);
   auto& add_1_output = tensor_pool.CloneNativeTensorFrom(
       add_1.GetOutputTensor(0), add_1_output_dims);
@@ -214,7 +214,7 @@ TensorWrapper& BuildSingleSHA(
                   {add_1_output});
 
   // Matmul k
-  auto matmul_qk_output_dims = matmul_k2.GetOutputTensor(0).GetDims();
+  auto matmul_qk_output_dims = matmul_k2.GetOutputTensor(0).GetDimensions();
   matmul_qk_output_dims.erase(matmul_qk_output_dims.begin() + 1);
   matmul_qk_output_dims[1] /= num_attn_per_kv_heads;
   auto& matmul_qk_output = tensor_pool.CloneNativeTensorFrom(
@@ -224,7 +224,7 @@ TensorWrapper& BuildSingleSHA(
 
   // Concat
   std::uint32_t adjusted_axis = 2;
-  auto concat_output_dims = concat.GetOutputTensor(0).GetDims();
+  auto concat_output_dims = concat.GetOutputTensor(0).GetDimensions();
   concat_output_dims.erase(concat_output_dims.begin() + 1);
   concat_output_dims[1] /= num_attn_per_kv_heads;
   auto& concat_output = tensor_pool.CloneNativeTensorFrom(
@@ -235,7 +235,7 @@ TensorWrapper& BuildSingleSHA(
   std::move(concat_op.begin(), concat_op.end(), std::back_inserter(new_ops));
 
   // Add 2
-  auto add_2_output_dims = add_2.GetOutputTensor(0).GetDims();
+  auto add_2_output_dims = add_2.GetOutputTensor(0).GetDimensions();
   add_2_output_dims[0] = 1;
   add_2_output_dims[1] = 1;
   auto& add_2_output = tensor_pool.CloneNativeTensorFrom(
@@ -244,7 +244,7 @@ TensorWrapper& BuildSingleSHA(
                   {add_2_output});
 
   // Reshape 3
-  auto reshape_3_output_dims = reshape_3.GetOutputTensor(0).GetDims();
+  auto reshape_3_output_dims = reshape_3.GetOutputTensor(0).GetDimensions();
   reshape_3_output_dims.erase(reshape_3_output_dims.begin() + 1);
   reshape_3_output_dims[1] /= num_attn_per_kv_heads;
   auto& reshape_3_output = tensor_pool.CloneNativeTensorFrom(
@@ -252,7 +252,7 @@ TensorWrapper& BuildSingleSHA(
   EmplaceOpWithIO(new_ops, reshape_3, {add_2_output}, {reshape_3_output});
 
   // Softmax
-  auto softmax_output_dims = softmax.GetOutputTensor(0).GetDims();
+  auto softmax_output_dims = softmax.GetOutputTensor(0).GetDimensions();
   softmax_output_dims.erase(softmax_output_dims.begin() + 1);
   softmax_output_dims[1] /= num_attn_per_kv_heads;
   auto& softmax_output = tensor_pool.CloneNativeTensorFrom(
@@ -272,7 +272,7 @@ TensorWrapper& BuildSingleSHA(
       slice_1_param.GetDataType(), slice_1_param.GetQuantParams(),
       slice_1_param_dims, sizeof(int32_t) * slice_1_ranges.size(),
       slice_1_ranges.data());
-  auto slice_1_output_dims = slice_1.GetOutputTensor(0).GetDims();
+  auto slice_1_output_dims = slice_1.GetOutputTensor(0).GetDimensions();
   slice_1_output_dims.erase(slice_1_output_dims.begin() + 1);
   slice_1_output_dims[1] /= num_attn_per_kv_heads;
   auto& slice_1_output = tensor_pool.CloneNativeTensorFrom(
@@ -293,7 +293,7 @@ TensorWrapper& BuildSingleSHA(
       slice_2_param.GetDataType(), slice_2_param.GetQuantParams(),
       slice_2_param_dims, sizeof(int32_t) * slice_2_ranges.size(),
       slice_2_ranges.data());
-  auto slice_2_output_dims = slice_2.GetOutputTensor(0).GetDims();
+  auto slice_2_output_dims = slice_2.GetOutputTensor(0).GetDimensions();
   slice_2_output_dims.erase(slice_2_output_dims.begin() + 1);
   slice_2_output_dims[1] /= num_attn_per_kv_heads;
   auto& slice_2_output = tensor_pool.CloneNativeTensorFrom(
@@ -302,7 +302,7 @@ TensorWrapper& BuildSingleSHA(
                slice_2_param_tensor);
 
   // Matmul v1
-  auto matmul_v1_output_dims = matmul_v1.GetOutputTensor(0).GetDims();
+  auto matmul_v1_output_dims = matmul_v1.GetOutputTensor(0).GetDimensions();
   matmul_v1_output_dims.erase(matmul_v1_output_dims.begin() + 1);
   matmul_v1_output_dims[1] /= num_attn_per_kv_heads;
   auto& matmul_v1_output = tensor_pool.CloneNativeTensorFrom(
@@ -311,7 +311,7 @@ TensorWrapper& BuildSingleSHA(
                   {matmul_v1_output});
 
   // Matmul v2
-  auto matmul_v2_output_dims = matmul_v2.GetOutputTensor(0).GetDims();
+  auto matmul_v2_output_dims = matmul_v2.GetOutputTensor(0).GetDimensions();
   matmul_v2_output_dims.erase(matmul_v2_output_dims.begin() + 1);
   matmul_v2_output_dims[1] /= num_attn_per_kv_heads;
   auto& matmul_v2_output = tensor_pool.CloneNativeTensorFrom(
@@ -320,7 +320,7 @@ TensorWrapper& BuildSingleSHA(
                   {matmul_v2_output});
 
   // Add 3
-  auto add_3_output_dims = add_3.GetOutputTensor(0).GetDims();
+  auto add_3_output_dims = add_3.GetOutputTensor(0).GetDimensions();
   add_3_output_dims.erase(add_3_output_dims.begin() + 1);
   add_3_output_dims[1] /= num_attn_per_kv_heads;
   auto& add_3_output = tensor_pool.CloneNativeTensorFrom(
@@ -352,7 +352,7 @@ std::vector<OpWrapper> TransformToSHA(
   std::vector<::qnn::TensorWrapperRef> sha_inputs;
   sha_inputs.reserve(num_heads);
   for (int i = 0; i < num_heads; ++i) {
-    auto head_input_dims = ops[start_index].GetOutputTensor(0).GetDims();
+    auto head_input_dims = ops[start_index].GetOutputTensor(0).GetDimensions();
     head_input_dims[2] /= num_heads;
     auto& split_output =
         tensor_pool.CloneNativeTensorFrom(mha_input, head_input_dims);
@@ -385,7 +385,7 @@ std::vector<OpWrapper> TransformToSHA(
         ops[start_index + kMatMulV2Index], ops[start_index + kAdd2Index]));
   }
   // Concat
-  auto concat_dims = mha_output.GetDims();
+  auto concat_dims = mha_output.GetDimensions();
   concat_dims.insert(concat_dims.begin(), 1);
   auto& concat_output =
       tensor_pool.CloneNativeTensorFrom(mha_output, concat_dims);
@@ -439,8 +439,9 @@ size_t OptimizeMHAPrefill(std::function<bool(OpWrapper&)> validate_op_config,
       ops[start_index + pattern_size - 1].GetOutputTensor(0);
 
   // Transpose
-  auto transpose_output_dims =
-      ops[start_index + kTransposePrefillIndex].GetOutputTensor(0).GetDims();
+  auto transpose_output_dims = ops[start_index + kTransposePrefillIndex]
+                                   .GetOutputTensor(0)
+                                   .GetDimensions();
   auto& transpose_output =
       tensor_pool.CloneNativeTensorFrom(pattern_input, transpose_output_dims);
   EmplaceOpWithIO(new_ops, ops[start_index + kTransposePrefillIndex],
@@ -456,7 +457,7 @@ size_t OptimizeMHAPrefill(std::function<bool(OpWrapper&)> validate_op_config,
                   {transpose_output}, {reshape_output});
 
   // Process MHA to SHA transformation.
-  const int num_heads = pattern_input.GetDim(2);
+  const int num_heads = pattern_input.GetDimension(2);
   const auto& mha_input = new_ops.back().GetOutputTensor(0);
   auto sha_ops =
       TransformToSHA(ops, start_index + new_ops.size(), tensor_pool, mha_input,
@@ -520,7 +521,7 @@ size_t OptimizeMHADecode(std::function<bool(OpWrapper&)> validate_op_config,
       ops[start_index + pattern_size - 1].GetOutputTensor(0);
 
   // Process MHA to SHA transformation.
-  const int num_heads = pattern_input.GetDim(2);
+  const int num_heads = pattern_input.GetDimension(2);
   auto sha_ops =
       TransformToSHA(ops, start_index + new_ops.size(), tensor_pool,
                      pattern_input, pattern_output, scaling_mul, num_heads);
@@ -611,24 +612,24 @@ size_t OptimizeMHAFastVlmPrefill(
   const auto& matmul_v1_in =
       ops[start_index + matmul_v1_index].GetInputTensor(1);
   auto unpack_1_dims =
-      ops[start_index + matmul_v1_index].GetInputTensor(1).GetDims();
+      ops[start_index + matmul_v1_index].GetInputTensor(1).GetDimensions();
   uint32_t num_kv_heads = unpack_1_dims[1];
   const auto& matmul_q_in = ops[start_index + matmul_q_index].GetInputTensor(1);
-  auto unpack_2_dims = matmul_q_in.GetDims();
+  auto unpack_2_dims = matmul_q_in.GetDimensions();
   const auto& mul_in = ops[start_index + mul_index].GetInputTensor(0);
-  auto unpack_3_dims = mul_in.GetDims();
+  auto unpack_3_dims = mul_in.GetDimensions();
   uint32_t num_attn_heads = unpack_3_dims[1];
   uint32_t num_attn_per_kv_heads = num_attn_heads / num_kv_heads;
   const auto& add_1_in_1 = ops[start_index + add_1_index].GetInputTensor(0);
-  auto unpack_4_dims = add_1_in_1.GetDims();
+  auto unpack_4_dims = add_1_in_1.GetDimensions();
   const auto& add_1_in_2 = ops[start_index + add_1_index].GetInputTensor(1);
-  auto unpack_5_dims = add_1_in_2.GetDims();
+  auto unpack_5_dims = add_1_in_2.GetDimensions();
   const auto& matmul_v2_in =
       ops[start_index + matmul_v2_index].GetInputTensor(1);
-  auto unpack_6_dims = matmul_v2_in.GetDims();
+  auto unpack_6_dims = matmul_v2_in.GetDimensions();
   const auto& pattern_output =
       ops[start_index + pattern_size - 1].GetOutputTensor(0);
-  auto mha_output_dims = pattern_output.GetDims();
+  auto mha_output_dims = pattern_output.GetDimensions();
   if (!(num_kv_heads == unpack_2_dims[1] &&
         num_kv_heads == (unpack_3_dims[1] / 7) &&
         num_kv_heads == unpack_4_dims[1] && num_kv_heads == unpack_5_dims[1] &&
@@ -814,7 +815,7 @@ bool OptimizeMHATinyGemmaPrefill(
   const auto& pattern_output = reshape_2.GetOutputTensor(0);
 
   // Transpose
-  auto transpose_output_dims = transpoe_0.GetOutputTensor(0).GetDims();
+  auto transpose_output_dims = transpoe_0.GetOutputTensor(0).GetDimensions();
   auto& transpose_output =
       tensor_pool.CloneNativeTensorFrom(pattern_input, transpose_output_dims);
   auto& new_transpose_0 = EmplaceOpWithIO(
@@ -822,13 +823,13 @@ bool OptimizeMHATinyGemmaPrefill(
       {transpose_output});
 
   // Process MHA to SHA transformation.
-  const int num_heads = pattern_input.GetDim(2);
+  const int num_heads = pattern_input.GetDimension(2);
   const auto& mha_input = new_transpose_0.GetOutputTensor(0);
 
   // Prepare inputs for num_heads SHAs.
   std::vector<TensorWrapperRef> sha_inputs;
   sha_inputs.reserve(num_heads);
-  auto sha_input_dims = new_transpose_0.GetOutputTensor(0).GetDims();
+  auto sha_input_dims = new_transpose_0.GetOutputTensor(0).GetDimensions();
   sha_input_dims[1] /= num_heads;
   for (size_t i = 0; i < num_heads; ++i) {
     auto& sha_input =
@@ -853,7 +854,7 @@ bool OptimizeMHATinyGemmaPrefill(
   std::vector<TensorWrapperRef> splited_masks;
   splited_masks.reserve(num_heads);
   const auto& concated_mask = add_0.GetInputTensor(1);
-  auto splited_mask_dims = concated_mask.GetDims();
+  auto splited_mask_dims = concated_mask.GetDimensions();
   splited_mask_dims[2] /= num_heads;
   for (size_t i = 0; i < num_heads; ++i) {
     splited_masks.emplace_back(
@@ -877,7 +878,7 @@ bool OptimizeMHATinyGemmaPrefill(
   }
 
   // Concat
-  auto concat_output_dims = sha_outputs[0].get().GetDims();
+  auto concat_output_dims = sha_outputs[0].get().GetDimensions();
   concat_output_dims[3] *= num_heads;
   auto& concat_output =
       tensor_pool.CloneNativeTensorFrom(sha_outputs[0], concat_output_dims);
@@ -1097,7 +1098,7 @@ size_t OptimizeMHAAttn(std::function<bool(OpWrapper&)> validate_op_config,
   QNN_LOG_INFO("[G2G] MHA optimization (Attn)");
   // Handle masking.
   std::vector<OpWrapper> new_ops;
-  auto not_equal_out_dims = not_equal_out.GetDims();
+  auto not_equal_out_dims = not_equal_out.GetDimensions();
   not_equal_out_dims.erase(not_equal_out_dims.begin() + 1);
   auto& select_mask =
       tensor_pool.CloneNativeTensorFrom(not_equal_out, not_equal_out_dims);
@@ -1111,7 +1112,7 @@ size_t OptimizeMHAAttn(std::function<bool(OpWrapper&)> validate_op_config,
   std::move(equal_op.begin(), equal_op.end(), std::back_inserter(new_ops));
   const auto& select_out =
       ops[attn_start_index + kAttnSelect].GetOutputTensor(0);
-  auto select_out_dims = select_out.GetDims();
+  auto select_out_dims = select_out.GetDimensions();
   select_out_dims.erase(select_out_dims.begin() + 1);
 
   auto& mul_in = tensor_pool.CloneNativeTensorFrom(select_out, select_out_dims);
@@ -1127,7 +1128,8 @@ size_t OptimizeMHAAttn(std::function<bool(OpWrapper&)> validate_op_config,
       std::max(select_const.GetTensorData<float>().value()[0], -65472.f);
   auto& mul_const = tensor_pool.CreateStaticTensor(
       select_const.GetDataType(), select_const.GetQuantParams(),
-      select_const.GetDims(), select_const.GetTensorBytes(), &mul_const_value);
+      select_const.GetDimensions(), select_const.GetTensorBytes(),
+      &mul_const_value);
   auto& add_in = tensor_pool.CloneNativeTensorFrom(select_out, select_out_dims);
   auto mul_select =
       BuildElementwiseMulOp(tensor_pool, {mul_in, mul_const}, {add_in});
@@ -1180,10 +1182,10 @@ size_t OptimizeMHAAttn(std::function<bool(OpWrapper&)> validate_op_config,
     }
     // QKV Unpack
     const auto& mul_q_in = ops[matmul_qk_index + kAttnMulQ].GetInputTensor(0);
-    auto q_unpack_dims = mul_q_in.GetDims();
+    auto q_unpack_dims = mul_q_in.GetDimensions();
     uint32_t num_heads = q_unpack_dims[2];
     const auto& mul_k_in = ops[matmul_qk_index + kAttnMulK].GetInputTensor(0);
-    auto k_unpack_dims = mul_k_in.GetDims();
+    auto k_unpack_dims = mul_k_in.GetDimensions();
     const auto& transpose_v_in =
         ops[select_index + kAttnTransposeIn].GetInputTensor(0);
     auto transpose_v_perm =
@@ -1192,10 +1194,10 @@ size_t OptimizeMHAAttn(std::function<bool(OpWrapper&)> validate_op_config,
     auto perm_tensor = tensor_pool.CreateStaticTensor(
         transpose_v_perm.GetDataType(), transpose_v_perm.GetQuantParams(), {3},
         perm_data.size() * sizeof(perm_data[0]), perm_data.data());
-    auto v_unpack_dims = transpose_v_in.GetDims();
+    auto v_unpack_dims = transpose_v_in.GetDimensions();
     const auto& mha_out =
         ops[select_index + kAttnTransposeOut].GetOutputTensor(0);
-    auto mha_out_dims = mha_out.GetDims();
+    auto mha_out_dims = mha_out.GetDimensions();
     if (!(num_heads == k_unpack_dims[2] && num_heads == v_unpack_dims[2] &&
           num_heads == mha_out_dims[2])) {
       QNN_LOG_ERROR("[G2G] Num heads mismatches.");
@@ -1263,8 +1265,9 @@ size_t OptimizeMHAAttn(std::function<bool(OpWrapper&)> validate_op_config,
       // MatMul
       const auto& matmul_qk_out = ops[matmul_qk_index].GetOutputTensor(0);
       auto& select_in = tensor_pool.CloneNativeTensorFrom(
-          matmul_qk_out, {q_matmul_in.GetDim(0), q_matmul_in.GetDim(1),
-                          k_matmul_in.GetDim(2)});
+          matmul_qk_out,
+          {q_matmul_in.GetDimension(0), q_matmul_in.GetDimension(1),
+           k_matmul_in.GetDimension(2)});
       EmplaceOpWithIO(new_ops, ops[matmul_qk_index], {q_matmul_in, k_matmul_in},
                       {select_in});
 
@@ -1284,7 +1287,7 @@ size_t OptimizeMHAAttn(std::function<bool(OpWrapper&)> validate_op_config,
       // MatMul
       const auto& matmul_out =
           ops[select_index + kAttnMatMul].GetOutputTensor(0);
-      auto matmul_out_dims = matmul_out.GetDims();
+      auto matmul_out_dims = matmul_out.GetDimensions();
       matmul_out_dims.erase(matmul_out_dims.begin() + 1);
       EmplaceOpWithIO(new_ops, ops[matmul_qk_index],
                       {qk_softmax, v_sha_inputs[i]}, {sha_outputs[i]});

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -27,12 +27,14 @@ TEST(TensorWrapperTest, SanityTest) {
   TensorWrapper tensor_wrapper{};
 
   EXPECT_EQ(tensor_wrapper.GetRank(), 0);
-  EXPECT_TRUE(tensor_wrapper.GetDims().empty());
+  EXPECT_TRUE(tensor_wrapper.GetDimensions().empty());
   EXPECT_TRUE(std::holds_alternative<UndefinedQuantizeParamsWrapper>(
       tensor_wrapper.GetQuantParams()));
   EXPECT_FALSE(tensor_wrapper.IsPerTensorQuantWithOffsetDiff(tensor_wrapper));
-  EXPECT_FALSE(tensor_wrapper.IsQuant8());
-  EXPECT_FALSE(tensor_wrapper.IsQuant16());
+  EXPECT_FALSE(tensor_wrapper.IsQuantU8());
+  EXPECT_FALSE(tensor_wrapper.IsQuantI8());
+  EXPECT_FALSE(tensor_wrapper.IsQuantU16());
+  EXPECT_FALSE(tensor_wrapper.IsQuantI16());
   EXPECT_EQ(tensor_wrapper.GetDataType(), QNN_DATATYPE_UNDEFINED);
   EXPECT_FALSE(tensor_wrapper.IsSubgraphInput());
   EXPECT_FALSE(tensor_wrapper.IsSubgraphOutput());
@@ -54,12 +56,14 @@ TEST(TensorWrapperTest, CopyTensorTest) {
   TensorWrapper copied{tensor_wrapper};
 
   EXPECT_EQ(copied.GetRank(), 3);
-  EXPECT_EQ(copied.GetDims(), dummy_dims);
+  EXPECT_EQ(copied.GetDimensions(), dummy_dims);
   EXPECT_TRUE(std::holds_alternative<ScaleOffsetQuantizeParamsWrapper>(
       copied.GetQuantParams()));
   EXPECT_FALSE(copied.IsPerTensorQuantWithOffsetDiff(copied));
-  EXPECT_TRUE(copied.IsQuant8());
-  EXPECT_FALSE(copied.IsQuant16());
+  EXPECT_TRUE(copied.IsQuantU8());
+  EXPECT_FALSE(copied.IsQuantI8());
+  EXPECT_FALSE(copied.IsQuantU16());
+  EXPECT_FALSE(copied.IsQuantI16());
   EXPECT_EQ(copied.GetDataType(), QNN_DATATYPE_UFIXED_POINT_8);
   EXPECT_FALSE(copied.IsSubgraphInput());
   EXPECT_FALSE(copied.IsSubgraphOutput());
@@ -91,12 +95,14 @@ TEST(TensorWrapperTest, MoveTensorTest) {
   TensorWrapper moved{tensor_wrapper};
 
   EXPECT_EQ(moved.GetRank(), 3);
-  EXPECT_EQ(moved.GetDims(), dummy_dims);
+  EXPECT_EQ(moved.GetDimensions(), dummy_dims);
   EXPECT_TRUE(std::holds_alternative<ScaleOffsetQuantizeParamsWrapper>(
       moved.GetQuantParams()));
   EXPECT_FALSE(moved.IsPerTensorQuantWithOffsetDiff(moved));
-  EXPECT_TRUE(moved.IsQuant8());
-  EXPECT_FALSE(moved.IsQuant16());
+  EXPECT_TRUE(moved.IsQuantU8());
+  EXPECT_FALSE(moved.IsQuantI8());
+  EXPECT_FALSE(moved.IsQuantU16());
+  EXPECT_FALSE(moved.IsQuantI16());
   EXPECT_EQ(moved.GetDataType(), QNN_DATATYPE_UFIXED_POINT_8);
   EXPECT_FALSE(moved.IsSubgraphInput());
   EXPECT_FALSE(moved.IsSubgraphOutput());


### PR DESCRIPTION
Summary:
- Clean up functions order
- Clean Up naming and typo

Test Result:
- Pass UT on x86_64 and device
- Pass E2E model execution

======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.9s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.5s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.3s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 57.8s

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 20 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 10 tests from 7 test suites ran. (0 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (10 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 30 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 64 tests from 9 test suites ran. (4 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 18 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 64 tests from 9 test suites ran. (4 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 18 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 31 tests from 17 test suites ran. (4 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 30 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 64 tests from 9 test suites ran. (4 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 18 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (3 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 30 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (3 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 18 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 15 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 15 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (15 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (677 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (773 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (680 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (1264 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (627 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (4 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (442 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 4 tests from 1 test suite ran. (475 ms total)
[  PASSED  ] 4 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (423 ms total)
[  PASSED  ] 2 tests
