### PR TITLE
Qualcomm AI Engine Direct - Change to RVO-style QNN OP builder.

### DIFF
--- a/litert/vendors/qualcomm/core/builders/op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/op_builder.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <utility>
 #include <vector>
+#include <type_traits>
 
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
@@ -57,6 +58,16 @@ void AddFusedActivationNode(std::vector<OpWrapper>& res,
                             const uint32_t fused_activation_function,
                             const TensorWrapper& input_tensor,
                             const TensorWrapper& output_tensor);
+
+template <typename... Args>
+auto MakeVector(Args&&... args) {
+  using T = std::decay_t<std::common_type_t<Args...>>;
+  std::vector<T> v;
+  v.reserve(sizeof...(args));
+  (v.emplace_back(std::forward<Args>(args)), ...);
+  return v;
+}
+
 }  // namespace qnn
 
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/core/builders/slice_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/slice_op_builder.h
@@ -15,8 +15,8 @@ std::vector<OpWrapper> BuildSliceOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs);
 
-bool BuildSliceOp(OpWrapper& op, const TensorWrapper& input,
-                  const TensorWrapper& output, const TensorWrapper& ranges);
+OpWrapper CreateSliceOp(const TensorWrapper& input, const TensorWrapper& output,
+                        const TensorWrapper& ranges);
 
 }  // namespace qnn
 

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
@@ -120,7 +120,7 @@ TensorWrapper& BuildSingleSHA(
   EmplaceOpWithIO(new_ops, softmax, {add_1_output}, {softmax_output});
 
   // Slice 1
-  auto slice_1_ranges = slice_1.GetTensorPararm(0).GetTensor();
+  auto slice_1_ranges = slice_1.GetTensorParam(0).GetTensor();
   auto slice_1_rangs_data = slice_1_ranges.GetTensorData<int32_t>();
   std::vector<int32_t> sha_slice_1_ranges_data(
       slice_1_rangs_data.value().begin(), slice_1_rangs_data.value().end());
@@ -133,11 +133,11 @@ TensorWrapper& BuildSingleSHA(
   slice_1_output_dims[2] /= num_heads;
   auto& slice_1_output = tensor_pool.CloneNativeTensorFrom(
       slice_1.GetOutputTensor(0), slice_1_output_dims);
-  BuildSliceOp(new_ops.emplace_back(), softmax_output, slice_1_output,
-               sha_slice_1_ranges);
+  new_ops.emplace_back(
+      CreateSliceOp(softmax_output, slice_1_output, sha_slice_1_ranges));
 
   // Slice 2
-  auto slice_2_ranges = slice_2.GetTensorPararm(0).GetTensor();
+  auto slice_2_ranges = slice_2.GetTensorParam(0).GetTensor();
   auto slice_2_ranges_data = slice_2_ranges.GetTensorData<int32_t>();
   std::vector<int32_t> sha_slice_2_ranges_data(
       slice_2_ranges_data.value().begin(), slice_2_ranges_data.value().end());
@@ -150,8 +150,8 @@ TensorWrapper& BuildSingleSHA(
   slice_2_output_dims[2] /= num_heads;
   auto& slice_2_output = tensor_pool.CloneNativeTensorFrom(
       slice_2.GetOutputTensor(0), slice_2_output_dims);
-  BuildSliceOp(new_ops.emplace_back(), softmax_output, slice_2_output,
-               sha_slice_2_ranges);
+  new_ops.emplace_back(
+      CreateSliceOp(softmax_output, slice_2_output, sha_slice_2_ranges));
 
   // MatMul 1
   std::vector<uint32_t> matmul_v1_output_dims =
@@ -260,7 +260,7 @@ TensorWrapper& BuildSingleSHA(
   EmplaceOpWithIO(new_ops, softmax, {reshape_3_output}, {softmax_output});
 
   // Slice 1
-  auto slice_1_param = slice_1.GetTensorPararm(0).GetTensor();
+  auto slice_1_param = slice_1.GetTensorParam(0).GetTensor();
   auto slice_1_param_data = slice_1_param.GetTensorData<int32_t>();
   std::vector<int32_t> slice_1_ranges(slice_1_param_data.value().begin(),
                                       slice_1_param_data.value().end());
@@ -277,11 +277,11 @@ TensorWrapper& BuildSingleSHA(
   slice_1_output_dims[1] /= num_attn_per_kv_heads;
   auto& slice_1_output = tensor_pool.CloneNativeTensorFrom(
       slice_1.GetOutputTensor(0), slice_1_output_dims);
-  BuildSliceOp(new_ops.emplace_back(), softmax_output, slice_1_output,
-               slice_1_param_tensor);
+  new_ops.emplace_back(
+      CreateSliceOp(softmax_output, slice_1_output, slice_1_param_tensor));
 
   // Slice 2
-  auto slice_2_param = slice_2.GetTensorPararm(0).GetTensor();
+  auto slice_2_param = slice_2.GetTensorParam(0).GetTensor();
   auto slice_2_param_data = slice_2_param.GetTensorData<int32_t>();
   std::vector<int32_t> slice_2_ranges(slice_2_param_data.value().begin(),
                                       slice_2_param_data.value().end());
@@ -298,8 +298,8 @@ TensorWrapper& BuildSingleSHA(
   slice_2_output_dims[1] /= num_attn_per_kv_heads;
   auto& slice_2_output = tensor_pool.CloneNativeTensorFrom(
       slice_2.GetOutputTensor(0), slice_2_output_dims);
-  BuildSliceOp(new_ops.emplace_back(), softmax_output, slice_2_output,
-               slice_2_param_tensor);
+  new_ops.emplace_back(
+      CreateSliceOp(softmax_output, slice_2_output, slice_2_param_tensor));
 
   // Matmul v1
   auto matmul_v1_output_dims = matmul_v1.GetOutputTensor(0).GetDimensions();
@@ -1196,7 +1196,7 @@ size_t OptimizeMHAAttn(std::function<bool(OpWrapper&)> validate_op_config,
     const auto& transpose_v_in =
         ops[select_index + kAttnTransposeIn].GetInputTensor(0);
     auto transpose_v_perm =
-        ops[select_index + kAttnTransposeIn].GetTensorPararm(0).GetTensor();
+        ops[select_index + kAttnTransposeIn].GetTensorParam(0).GetTensor();
     std::vector<uint32_t> perm_data = {0, 2, 1};
     auto perm_tensor = tensor_pool.CreateStaticTensor(
         transpose_v_perm.GetDataType(), transpose_v_perm.GetQuantParams(), {3},

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -123,7 +123,7 @@ const qnn::TensorWrapper& OpWrapper::GetOutputTensor(size_t i) const {
   return output_tensors_[i].get();
 }
 
-const qnn::TensorParamWrapper& OpWrapper::GetTensorPararm(size_t i) const {
+const qnn::TensorParamWrapper& OpWrapper::GetTensorParam(size_t i) const {
   return tensor_params_[i];
 }
 

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -55,7 +55,7 @@ class OpWrapper final {
 
   const qnn::TensorWrapper& GetOutputTensor(size_t i) const;
 
-  const qnn::TensorParamWrapper& GetTensorPararm(size_t i) const;
+  const qnn::TensorParamWrapper& GetTensorParam(size_t i) const;
 
   std::optional<ScalarParamWrapper> GetScalarParam(size_t i) const;
 


### PR DESCRIPTION
Summary:
- Update the BuildSliceOp function to return OpWrapper for constructing Slice operation.
- Introduce the make_vector template to simplify maintenance of operation numbers.
- Correct a typo in GetTensorParam.

Test:
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 13 tests from 3 test suites ran. (8 ms total)
[  PASSED  ] 13 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 30 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 64 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (8 ms total)
[  PASSED  ] 8 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (332 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (411 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (407 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (411 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (734 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (579 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1971 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (18 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (453 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (398 ms total)
[  PASSED  ] 2 tests.

```

```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all


//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 36.7s
```