### PR TITLE
Qualcomm AI Engine Direct - Add range check for getters.

### DIFF
--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -4,6 +4,7 @@
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -115,15 +116,18 @@ bool OpWrapper::IsOpCode(QnnOpCode op_code) const {
   return op_code_ == op_code;
 }
 
-const qnn::TensorWrapper& OpWrapper::GetInputTensor(size_t i) const {
+const TensorWrapper& OpWrapper::GetInputTensor(size_t i) const {
+  assert(i < input_tensors_.size());
   return input_tensors_[i].get();
 }
 
-const qnn::TensorWrapper& OpWrapper::GetOutputTensor(size_t i) const {
+const TensorWrapper& OpWrapper::GetOutputTensor(size_t i) const {
+  assert(i < output_tensors_.size());
   return output_tensors_[i].get();
 }
 
-const qnn::TensorParamWrapper& OpWrapper::GetTensorPararm(size_t i) const {
+const TensorParamWrapper& OpWrapper::GetTensorPararm(size_t i) const {
+  assert(i < tensor_params_.size());
   return tensor_params_[i];
 }
 
@@ -139,8 +143,8 @@ void OpWrapper::SwapOutputs(OpWrapper& other) {
 }
 
 void OpWrapper::UpdateTensors(
-    const std::vector<std::optional<qnn::TensorWrapperRef>>& inputs,
-    const std::vector<std::optional<qnn::TensorWrapperRef>>& outputs) {
+    const std::vector<std::optional<TensorWrapperRef>>& inputs,
+    const std::vector<std::optional<TensorWrapperRef>>& outputs) {
   if (inputs.size() != input_tensors_.size() ||
       outputs.size() != output_tensors_.size()) {
     QNN_LOG_WARNING("UpdateTensors skipped due to incorrect tensor count.");

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -51,11 +51,11 @@ class OpWrapper final {
 
   bool IsOpCode(QnnOpCode op_code) const;
 
-  const qnn::TensorWrapper& GetInputTensor(size_t i) const;
+  const TensorWrapper& GetInputTensor(size_t i) const;
 
-  const qnn::TensorWrapper& GetOutputTensor(size_t i) const;
+  const TensorWrapper& GetOutputTensor(size_t i) const;
 
-  const qnn::TensorParamWrapper& GetTensorPararm(size_t i) const;
+  const TensorParamWrapper& GetTensorPararm(size_t i) const;
 
   std::optional<ScalarParamWrapper> GetScalarParam(size_t i) const;
 
@@ -64,8 +64,8 @@ class OpWrapper final {
   void SwapOutputs(OpWrapper& other);
 
   void UpdateTensors(
-      const std::vector<std::optional<qnn::TensorWrapperRef>>& inputs,
-      const std::vector<std::optional<qnn::TensorWrapperRef>>& outputs);
+      const std::vector<std::optional<TensorWrapperRef>>& inputs,
+      const std::vector<std::optional<TensorWrapperRef>>& outputs);
 
   void AddPrefixToName(absl::string_view prefix);
 


### PR DESCRIPTION
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 21 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 10 tests from 7 test suites ran. (1 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 12 tests from 3 test suites ran. (5 ms total)
[  PASSED  ] 12 tests.
YOU HAVE 2 DISABLED TESTS

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 15 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (13 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (631 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (753 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (1459 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (746 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (725 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 3 tests from 1 test suite ran. (403 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 4 tests from 1 test suite ran. (399 ms total)
[  PASSED  ] 4 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (468 ms total)
[  PASSED  ] 2 tests.

======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 42.0s