### PR TITLE
Qualcomm AI Engine Direct - Clean up unit tests for non-HTP backend.

### DIFF
--- a/litert/cc/BUILD
+++ b/litert/cc/BUILD
@@ -338,8 +338,9 @@ litert_device_test(
         "//litert/c/internal:litert_logging",
         "//litert/test:common",
         "//litert/test:matchers",
+        "//litert/vendors/qualcomm/core/utils:test_utils",
+        "//litert/vendors/qualcomm/core/utils:test_main",
         "@com_google_absl//absl/strings:string_view",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/litert/cc/litert_compiled_model_qualcomm_test.cc
+++ b/litert/cc/litert_compiled_model_qualcomm_test.cc
@@ -27,6 +27,7 @@
 #include "litert/cc/litert_tensor_buffer.h"
 #include "litert/test/common.h"
 #include "litert/test/matchers.h"
+#include "litert/vendors/qualcomm/core/utils/test_utils.h"
 
 namespace litert {
 namespace {
@@ -34,6 +35,10 @@ namespace {
 constexpr absl::string_view kDispatchLibraryDir = "vendors/qualcomm/dispatch";
 
 TEST(CompiledModelTest, RunMultipleIterationsWithSameTensorBuffers) {
+  if (!::qnn::IsTestHtpBackend()) {
+    GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+  }
+
   const std::string dispatch_library_dir =
       testing::GetLiteRtPath(kDispatchLibraryDir);
   absl::string_view dispatch_library_dir_view(dispatch_library_dir);
@@ -70,6 +75,10 @@ TEST(CompiledModelTest, RunMultipleIterationsWithSameTensorBuffers) {
 }
 
 TEST(CompiledModelTest, RunMultipleIterationsWithNewTensorBuffers) {
+  if (!::qnn::IsTestHtpBackend()) {
+    GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+  }
+
   const std::string dispatch_library_dir =
       testing::GetLiteRtPath(kDispatchLibraryDir);
   absl::string_view dispatch_library_dir_view(dispatch_library_dir);

--- a/litert/vendors/qualcomm/BUILD
+++ b/litert/vendors/qualcomm/BUILD
@@ -105,6 +105,7 @@ litert_test(
         ],
     }),
     linkstatic = True,
+    no_main = True,
     tags = [
         "no-remote-exec",
         "nosan",
@@ -124,6 +125,8 @@ litert_test(
         "//litert/test:matchers_oss",
         "//litert/vendors/qualcomm/core:common",
         "//litert/vendors/qualcomm/core/schema:soc_table",
+        "//litert/vendors/qualcomm/core/utils:test_utils",
+        "//litert/vendors/qualcomm/core/utils:test_main",
         "//litert/vendors/qualcomm/tools:dump",
     ],
 )

--- a/litert/vendors/qualcomm/core/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(qnn_core STATIC
     
     # Utils
     utils/miscs.cc
+    utils/test_utils.cc
     
     # Schema
     schema/soc_table.cc

--- a/litert/vendors/qualcomm/core/utils/BUILD
+++ b/litert/vendors/qualcomm/core/utils/BUILD
@@ -38,6 +38,27 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "test_utils",
+    srcs = ["test_utils.cc"],
+    hdrs = ["test_utils.h"],
+    deps = [
+        "//litert/vendors/qualcomm/core:common",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "test_main",
+    testonly = True,
+    srcs = ["test_main.cc"],
+    deps = [
+        ":test_utils",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
 cc_test(
     name = "utils_test",
     srcs = [
@@ -46,10 +67,12 @@ cc_test(
     deps = [
         ":log",
         ":miscs",
+        ":test_main",
+        ":test_utils",
         "//litert/vendors/qualcomm/core:common",
         "//litert/vendors/qualcomm/core/backends:htp_backend",
         "//litert/vendors/qualcomm/core/backends:ir_backend",
-        "@com_google_googletest//:gtest_main",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/litert/vendors/qualcomm/core/utils/test_main.cc
+++ b/litert/vendors/qualcomm/core/utils/test_main.cc
@@ -1,0 +1,57 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
+#include "absl/strings/string_view.h"
+#include "litert/vendors/qualcomm/core/utils/test_utils.h"
+
+namespace {
+
+// Simple argument parser for --backend flag.
+bool ParseArgs(int argc, char** argv) {
+  constexpr absl::string_view kBackendFlag = "--backend=";
+  constexpr absl::string_view kHelpFlag = "--help";
+  constexpr absl::string_view kShortHelpFlag = "-h";
+
+  for (int i = 1; i < argc; ++i) {
+    absl::string_view arg = argv[i];
+    if (absl::StartsWith(arg, kBackendFlag)) {  // Starts with --backend=
+      absl::string_view value = arg.substr(kBackendFlag.size());
+      std::string backend_str = absl::AsciiStrToLower(value);
+      if (backend_str == "htp") {
+        qnn::SetTestBackend(qnn::BackendType::kHtpBackend);
+      } else if (backend_str == "dsp") {
+        qnn::SetTestBackend(qnn::BackendType::kDspBackend);
+      } else {
+        std::cerr << "Unknown backend: " << backend_str << std::endl;
+        return false;
+      }
+    } else if (arg == kHelpFlag || arg == kShortHelpFlag) {
+      std::cout << "Test specific options:\n"
+                << "  " << kBackendFlag << "[BACKEND_NAME]\n"
+                << "      Specify the backend to run tests against. Supported "
+                   "backends: htp, dsp.\n"
+                << "      Default is htp.\n"
+                << std::endl;
+      exit(0);
+    }
+  }
+  return true;
+}
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (!ParseArgs(argc, argv)) {
+    return 1;
+  }
+
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/litert/vendors/qualcomm/core/utils/test_utils.cc
+++ b/litert/vendors/qualcomm/core/utils/test_utils.cc
@@ -1,0 +1,27 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/utils/test_utils.h"
+
+#include "absl/strings/string_view.h"
+#include "litert/vendors/qualcomm/core/common.h"
+
+namespace qnn {
+
+namespace {
+BackendType& GetTestBackend() {
+  static BackendType test_backend = BackendType::kHtpBackend;
+
+  return test_backend;
+}
+}  // namespace
+
+bool IsTestHtpBackend() { return GetTestBackend() == BackendType::kHtpBackend; }
+
+bool IsTestDspBackend() { return GetTestBackend() == BackendType::kDspBackend; }
+
+void SetTestBackend(BackendType backend_type) {
+  GetTestBackend() = backend_type;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/utils/test_utils.h
+++ b/litert/vendors/qualcomm/core/utils/test_utils.h
@@ -1,0 +1,24 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_UTILS_TEST_UTILS_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_UTILS_TEST_UTILS_H_
+
+#include "litert/vendors/qualcomm/core/common.h"
+
+namespace qnn {
+
+// Checks if the target backend for testing is HTP.
+// This relies on the global variable set by the test main.
+// Default is true (HTP).
+bool IsTestHtpBackend();
+
+bool IsTestDspBackend();
+
+// Sets the target backend for testing.
+// This should be called by the test main.
+void SetTestBackend(BackendType backend_type);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_UTILS_TEST_UTILS_H_

--- a/litert/vendors/qualcomm/core/utils/utils_test.cc
+++ b/litert/vendors/qualcomm/core/utils/utils_test.cc
@@ -15,6 +15,7 @@
 #include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/core/utils/log.h"
 #include "litert/vendors/qualcomm/core/utils/miscs.h"
+#include "litert/vendors/qualcomm/core/utils/test_utils.h"
 
 namespace qnn {
 namespace {
@@ -153,11 +154,26 @@ TEST(MiscTests, LoadHtpBackendApiWithInvalidPathTest) {
 }
 
 TEST(MiscTests, DISABLED_LoadHtpBackendApiTest) {
+  if (!::qnn::IsTestHtpBackend()) {
+    GTEST_SKIP()
+        << "Skipping test because targeted backend is not supported";
+  }
+
   DLHandle handle = ::qnn::CreateDLHandle(::qnn::HtpBackend::GetLibraryName());
   auto api = ::qnn::ResolveQnnApi(
       handle.get(), ::qnn::HtpBackend::GetExpectedBackendVersion());
 
   ASSERT_TRUE(api);
+}
+
+TEST(MiscTests, IsTestHtpBackendTest) {
+  qnn::SetTestBackend(BackendType::kHtpBackend);
+  EXPECT_TRUE(qnn::IsTestHtpBackend());
+}
+
+TEST(MiscTests, IsTestDspBackendTest) {
+  qnn::SetTestBackend(BackendType::kDspBackend);
+  EXPECT_TRUE(qnn::IsTestDspBackend());
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/dispatch/BUILD
+++ b/litert/vendors/qualcomm/dispatch/BUILD
@@ -105,10 +105,11 @@ litert_device_test(
         "//litert/test:simple_model_npu",
         "//litert/vendors/c:litert_dispatch_c_api",
         "//litert/vendors/qualcomm/core/utils:miscs",
+        "//litert/vendors/qualcomm/core/utils:test_utils",
+        "//litert/vendors/qualcomm/core/utils:test_main",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:absl_log",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
-        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/litert/vendors/qualcomm/dispatch/dispatch_api_qualcomm_test.cc
+++ b/litert/vendors/qualcomm/dispatch/dispatch_api_qualcomm_test.cc
@@ -42,6 +42,7 @@
 #include "litert/test/testdata/simple_model_test_vectors.h"
 #include "litert/vendors/c/litert_dispatch.h"
 #include "litert/vendors/qualcomm/core/utils/miscs.h"
+#include "litert/vendors/qualcomm/core/utils/test_utils.h"
 
 namespace {
 
@@ -67,6 +68,10 @@ TEST(Qualcomm, DispatchApiWithFastRpc) {
 #if !defined(__ANDROID__)
   GTEST_SKIP()
       << "This test is specific to Android devices with a Qualcomm NPU";
+#else
+  if (!::qnn::IsTestHtpBackend()) {
+    GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+  }
 #endif
 
   LITERT_ASSERT_OK_AND_ASSIGN(auto env, CreateDefaultEnvironment());
@@ -329,6 +334,10 @@ TEST(Qualcomm, DispatchApiWithDmaBuf) {
 #if !defined(__ANDROID__)
   GTEST_SKIP()
       << "This test is specific to Android devices with a Qualcomm NPU";
+#else
+  if (!::qnn::IsTestHtpBackend()) {
+    GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+  }
 #endif
 
   LITERT_ASSERT_OK_AND_ASSIGN(auto env, CreateDefaultEnvironment());
@@ -591,6 +600,10 @@ TEST(Qualcomm, DispatchApiWithFastRpcInt16Model) {
 #if !defined(__ANDROID__)
   GTEST_SKIP()
       << "This test is specific to Android devices with a Qualcomm NPU";
+#else
+  if (!::qnn::IsTestHtpBackend()) {
+    GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+  }
 #endif
   // ///////////////////////////////////////////////////////////////////////////
   // Set up data for input and output.
@@ -888,6 +901,10 @@ TEST(Qualcomm, DispatchApiWithDmaBufInt16Model) {
 #if !defined(__ANDROID__)
   GTEST_SKIP()
       << "This test is specific to Android devices with a Qualcomm NPU";
+#else
+  if (!::qnn::IsTestHtpBackend()) {
+    GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+  }
 #endif
   // ///////////////////////////////////////////////////////////////////////////
   // Set up data for input and output.
@@ -1182,6 +1199,9 @@ TEST(Qualcomm, DispatchApiWithDmaBufInt16Model) {
 }
 
 TEST(Qualcomm, DispatchApiCompatibility) {
+  if (!::qnn::IsTestHtpBackend()) {
+    GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+  }
   static constexpr LiteRtApiVersion kApiVersion{LITERT_API_VERSION_MAJOR,
                                                 LITERT_API_VERSION_MINOR,
                                                 LITERT_API_VERSION_PATCH};

--- a/litert/vendors/qualcomm/qnn_backend_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/BUILD
@@ -1,7 +1,7 @@
 # Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//litert/build_common:litert_build_defs.bzl", "litert_test", "litert_test_lib", "make_rpaths")
+load("//litert/build_common:litert_build_defs.bzl", "litert_lib", "litert_test", "make_rpaths")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
@@ -22,6 +22,7 @@ litert_test(
         ],
     }),
     linkstatic = True,
+    no_main = True,
     tags = [
         # Don't build/test in OS until qnn is available.
         "no-remote-exec",
@@ -33,20 +34,24 @@ litert_test(
     deps = [
         ":test_utils",
         "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core/utils:test_main",
     ],
 )
 
-litert_test_lib(
+litert_lib(
     name = "test_utils",
+    testonly = True,
     srcs = ["test_utils.cc"],
     hdrs = ["test_utils.h"],
     ungrte = True,
     deps = [
+        "@com_google_googletest//:gtest",
         "//litert/test:common",
         "//litert/vendors/qualcomm:qnn_manager",
         "//litert/vendors/qualcomm/core:common",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/utils:miscs",
         "//litert/vendors/qualcomm/core/utils:qnn_model",
+        "//litert/vendors/qualcomm/core/utils:test_utils",
     ],
 )

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -22,6 +22,7 @@ litert_test(
         ],
     }),
     linkstatic = True,
+    no_main = True,
     tags = [
         # Don't build/test in OS until qnn is available.
         "no-remote-exec",
@@ -35,6 +36,7 @@ litert_test(
         "//litert/vendors/qualcomm/core:common",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/builders:relu_op_builder",
+        "//litert/vendors/qualcomm/core/utils:test_main",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
         "@qairt//:qnn_lib_headers",
@@ -55,6 +57,7 @@ litert_test(
         ],
     }),
     linkstatic = True,
+    no_main = True,
     tags = [
         # Don't build/test in OS until qnn is available.
         "no-remote-exec",
@@ -68,6 +71,7 @@ litert_test(
         "//litert/vendors/qualcomm/core:common",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/builders:topk_op_builder",
+        "//litert/vendors/qualcomm/core/utils:test_main",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
         "@qairt//:qnn_lib_headers",
@@ -88,6 +92,7 @@ litert_test(
         ],
     }),
     linkstatic = True,
+    no_main = True,
     tags = [
         # Don't build/test in OS until qnn is available.
         "no-remote-exec",
@@ -101,6 +106,7 @@ litert_test(
         "//litert/vendors/qualcomm/core:common",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/builders:elementwise_op_builder",
+        "//litert/vendors/qualcomm/core/utils:test_main",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
         "@qairt//:qnn_lib_headers",
@@ -121,6 +127,7 @@ litert_test(
         ],
     }),
     linkstatic = True,
+    no_main = True,
     tags = [
         # Don't build/test in OS until qnn is available.
         "no-remote-exec",
@@ -135,6 +142,7 @@ litert_test(
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/builders:fully_connected_op_builder",
         "//litert/vendors/qualcomm/core/utils:miscs",
+        "//litert/vendors/qualcomm/core/utils:test_main",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
         "@qairt//:qnn_lib_headers",

--- a/litert/vendors/qualcomm/qnn_backend_test/test_utils.h
+++ b/litert/vendors/qualcomm/qnn_backend_test/test_utils.h
@@ -11,6 +11,7 @@
 #include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/utils/miscs.h"
+#include "litert/vendors/qualcomm/core/utils/test_utils.h"
 #include "litert/vendors/qualcomm/core/utils/qnn_model.h"
 #include "litert/vendors/qualcomm/qnn_manager.h"
 
@@ -32,6 +33,9 @@ class QnnModelTest : public testing::TestWithParam<
 
   void SetUp() override {
     const auto& [options, soc_model_name] = GetParam();
+    if (!::qnn::IsTestHtpBackend()) {
+      GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+    }
     SetUpQnnModel(options, soc_model_name);
   }
 

--- a/litert/vendors/qualcomm/qnn_manager_test.cc
+++ b/litert/vendors/qualcomm/qnn_manager_test.cc
@@ -15,8 +15,12 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include <optional>
+
 #include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/core/schema/soc_table.h"
+#include "litert/vendors/qualcomm/core/utils/test_utils.h"
 #include "litert/vendors/qualcomm/tools/dump.h"
 
 namespace {
@@ -36,13 +40,37 @@ auto CreateQnnManager(const ::qnn::Options& options) {
 #endif
 }
 
+// Helper to get options based on target
+std::optional<::qnn::Options> GetOptionsForTarget() {
+  auto options = ::qnn::Options();
+  if (::qnn::IsTestHtpBackend()) {
+    options.SetBackendType(::qnn::BackendType::kHtpBackend);
+    return options;
+  }
+  if (::qnn::IsTestDspBackend()) {
+    options.SetBackendType(::qnn::BackendType::kDspBackend);
+    return options;
+  }
+  return std::nullopt;
+}
+
 TEST(QnnManagerTest, SetupQnnManager) {
-  auto qnn = CreateQnnManager(::qnn::Options());
+  auto options = GetOptionsForTarget();
+  if (!options) {
+    GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+  }
+
+  auto qnn = CreateQnnManager(*options);
   ASSERT_TRUE(qnn);
 }
 
 TEST(QnnManagerTest, Dump) {
-  auto qnn = CreateQnnManager(::qnn::Options());
+  auto options = GetOptionsForTarget();
+  if (!options) {
+    GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+  }
+
+  auto qnn = CreateQnnManager(*options);
   ASSERT_TRUE(qnn);
 
   auto dump = Dump(**qnn);
@@ -52,30 +80,38 @@ TEST(QnnManagerTest, Dump) {
 }
 
 TEST(QnnManagerTest, GetOptions) {
-  auto options = ::qnn::Options();
-  auto qnn = CreateQnnManager(options);
+  auto options = GetOptionsForTarget();
+  if (!options) {
+    GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+  }
+
+  auto qnn = CreateQnnManager(*options);
   ASSERT_TRUE(qnn);
 
   const auto& options_ref = (*qnn)->GetOptions();
-  EXPECT_EQ(options.GetLogLevel(), options_ref.GetLogLevel());
-  EXPECT_EQ(options.GetProfiling(), options_ref.GetProfiling());
-  EXPECT_EQ(options.GetUseHtpPreference(), options_ref.GetUseHtpPreference());
-  EXPECT_EQ(options.GetUseQint16AsQuint16(),
+  EXPECT_EQ(options->GetLogLevel(), options_ref.GetLogLevel());
+  EXPECT_EQ(options->GetProfiling(), options_ref.GetProfiling());
+  EXPECT_EQ(options->GetUseHtpPreference(), options_ref.GetUseHtpPreference());
+  EXPECT_EQ(options->GetUseQint16AsQuint16(),
             options_ref.GetUseQint16AsQuint16());
-  EXPECT_EQ(options.GetEnableWeightSharing(),
+  EXPECT_EQ(options->GetEnableWeightSharing(),
             options_ref.GetEnableWeightSharing());
-  EXPECT_EQ(options.GetHtpPerformanceMode(),
+  EXPECT_EQ(options->GetHtpPerformanceMode(),
             options_ref.GetHtpPerformanceMode());
-  EXPECT_EQ(options.GetDspPerformanceMode(),
+  EXPECT_EQ(options->GetDspPerformanceMode(),
             options_ref.GetDspPerformanceMode());
-  EXPECT_EQ(options.GetDumpTensorIds(), options_ref.GetDumpTensorIds());
-  EXPECT_EQ(options.GetIrJsonDir(), options_ref.GetIrJsonDir());
-  EXPECT_EQ(options.GetDlcDir(), options_ref.GetDlcDir());
+  EXPECT_EQ(options->GetDumpTensorIds(), options_ref.GetDumpTensorIds());
+  EXPECT_EQ(options->GetIrJsonDir(), options_ref.GetIrJsonDir());
+  EXPECT_EQ(options->GetDlcDir(), options_ref.GetDlcDir());
 }
 
 TEST(QnnManagerTest, GetSdkVersion) {
-  auto options = ::qnn::Options();
-  auto qnn = CreateQnnManager(options);
+  auto options = GetOptionsForTarget();
+  if (!options) {
+    GTEST_SKIP() << "Skipping test because targeted backend is not supported";
+  }
+
+  auto qnn = CreateQnnManager(*options);
   ASSERT_TRUE(qnn);
   const auto sdk_version = qnn.Value().get()->GetSdkVersion();
   static constexpr SdkVersion kInitSdkVersion{0, 0, 0};

--- a/litert/vendors/qualcomm/tests/CMakeLists.txt
+++ b/litert/vendors/qualcomm/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(qnn_manager_test
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_manager_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../tools/dump.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/utils/test_main.cc
 )
 
 target_link_libraries(qnn_manager_test
@@ -56,7 +57,7 @@ target_link_libraries(qnn_manager_test
         absl::log_internal_message
         qnn_manager
         litert_test_common
-        GTest::gtest_main
+        GTest::gtest
 )
 
 # Core common test
@@ -154,13 +155,14 @@ add_executable(utils_test)
 target_sources(utils_test
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/../core/utils/utils_test.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/utils/test_main.cc
 )
 
 target_link_libraries(utils_test
     PRIVATE
         qnn_backends
         qnn_core
-        GTest::gtest_main
+        GTest::gtest
 )
 
 # IR backend test


### PR DESCRIPTION
Summary:
- Add qualcomm specific gtest main to check the testing target.
- Skip tests if not using targeted backend.

Test Result:
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 38.9s

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (1 ms total)
[  PASSED  ] 12 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 15 tests from 3 test suites ran. (16 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (5 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (4 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 16 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (12 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (534 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (575 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (630 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (1067 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (605 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (531 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2147 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (66 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (8 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (557 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (448 ms total)
[  PASSED  ] 2 tests.

======================== Test Summary ========================
SM8250: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8250: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

SM8250: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 15 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 14 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (9 ms total)
[  PASSED  ] 30 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 64 tests.

SM8250: //litert/vendors/qualcomm/core:common_test
[==========] 16 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 16 tests.

SM8250: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 17 tests.

SM8250: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (11 ms total)
[  PASSED  ] 8 tests.

SM8250: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

SM8250: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.

SM8250: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (2544 ms total)
[  PASSED  ] 9 tests.

SM8250: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.

SM8250: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (21 ms total)
[  PASSED  ] 2 tests.

SM8250: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (6435 ms total)
[  PASSED  ] 10 tests.

SM8250: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.