### PR TITLE
Reapply "Move TensorFlow license locally"

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,3 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+license(
+    name = "license",
+    package_name = "litert",
+)
+
+exports_files(["LICENSE"])

--- a/litert/ats/BUILD
+++ b/litert/ats/BUILD
@@ -20,7 +20,7 @@ load("//litert/integration_test:litert_device.bzl", "litert_device_test")
 load("//litert/integration_test:litert_device_script.bzl", "make_download_model_provider")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         "//visibility:public",  # copybara:comment_replace "//litert:litert_public",
     ],

--- a/litert/build_common/BUILD
+++ b/litert/build_common/BUILD
@@ -17,7 +17,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:__subpackages__"],
 )
 

--- a/litert/build_common/tensorflow/BUILD
+++ b/litert/build_common/tensorflow/BUILD
@@ -1,0 +1,1 @@
+package(default_visibility = ["//visibility:public"])

--- a/litert/c/BUILD
+++ b/litert/c/BUILD
@@ -50,7 +50,7 @@ LITERT_MIN_IOS_VERSION = "14.0"
 LITERT_MIN_MACOS_VERSION = "14.0"
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # copybara:uncomment_begin(oss litert_lm)
         # "//litert:litert_c_users",

--- a/litert/c/options/BUILD
+++ b/litert/c/options/BUILD
@@ -16,7 +16,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # copybara:uncomment_begin(oss litert_lm)
         # "//litert:litert_c_users",

--- a/litert/cc/BUILD
+++ b/litert/cc/BUILD
@@ -27,7 +27,7 @@ load("//litert/integration_test:litert_device.bzl", "litert_device_exec", "liter
 # copybara:uncomment LITERT_MIN_MACOS_VERSION = "14.0"
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # copybara:uncomment_begin(oss litert_lm)
         # "//litert:litert_public",

--- a/litert/cc/dynamic_runtime/BUILD
+++ b/litert/cc/dynamic_runtime/BUILD
@@ -18,7 +18,7 @@ load("//litert/build_common:special_rule.bzl", "gles_linkopts", "litert_android_
 load("//litert/integration_test:litert_device.bzl", "litert_device_exec")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # By default, visibility is restricted to litert_cc_users_dynamic_link. Individual targets can be
         # made public by setting their visibility to litert_public.

--- a/litert/cc/dynamic_runtime/options/BUILD
+++ b/litert/cc/dynamic_runtime/options/BUILD
@@ -16,7 +16,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # By default, visibility is restricted to litert_cc_users_dynamic_link. Individual targets can be
         # made public by setting their visibility to litert_public.

--- a/litert/cc/internal/BUILD
+++ b/litert/cc/internal/BUILD
@@ -17,7 +17,7 @@ load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # copybara:uncomment_begin(oss)
         # "//litert:litert_internal_users",

--- a/litert/cc/options/BUILD
+++ b/litert/cc/options/BUILD
@@ -16,7 +16,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # copybara:uncomment_begin(oss litert_lm)
         # "//litert:litert_cc_users_static_link",

--- a/litert/compiler/BUILD
+++ b/litert/compiler/BUILD
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )

--- a/litert/compiler/mlir/dialects/litert/BUILD
+++ b/litert/compiler/mlir/dialects/litert/BUILD
@@ -17,7 +17,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/compiler/plugin/BUILD
+++ b/litert/compiler/plugin/BUILD
@@ -17,7 +17,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//litert/build_common:special_rule.bzl", "litert_metal_linkopts", "litert_metal_opts")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/core/BUILD
+++ b/litert/core/BUILD
@@ -17,7 +17,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//litert/build_common:litert_build_defs.bzl", "cc_library_with_testonly_vis")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # copybara:uncomment_begin(oss litert_lm)
         # "//litert:litert_internal_users",

--- a/litert/core/cache/BUILD
+++ b/litert/core/cache/BUILD
@@ -16,7 +16,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         "//litert:__subpackages__",
     ],

--- a/litert/core/model/BUILD
+++ b/litert/core/model/BUILD
@@ -17,7 +17,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//litert/build_common:litert_build_defs.bzl", "cc_library_with_testonly_vis")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # copybara:uncomment_begin(oss litert)
         # "//litert:litert_internal_users",

--- a/litert/core/util/BUILD
+++ b/litert/core/util/BUILD
@@ -17,7 +17,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//litert/build_common:litert_build_defs.bzl", "cc_library_with_testonly_vis")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # copybara:uncomment "@mediapipe//mediapipe/calculators/tensor:__subpackages__",
         "//litert:litert_internal_users",

--- a/litert/experimental/BUILD
+++ b/litert/experimental/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # By default, this package is private to avoid mistaken under-restricted visibility. Each target
         # is explicitly given visibility individually.

--- a/litert/experimental/mlir/BUILD
+++ b/litert/experimental/mlir/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # By default, this package is private to avoid mistaken under-restricted visibility. Each target
         # is explicitly given visibility individually.

--- a/litert/integration_test/BUILD
+++ b/litert/integration_test/BUILD
@@ -24,7 +24,7 @@ load("//litert/integration_test:litert_device_script.bzl", "litert_device_script
 # copybara:uncomment load("//litert/integration_test/google:litert_device_guitar.bzl", "litert_intel_openvino_mh_guitar_test", "litert_mediatek_mh_guitar_test", "litert_mh_guitar_test", "litert_pixel_9_mh_guitar_test", "litert_qualcomm_mh_guitar_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_public"],
 )
 

--- a/litert/integration_test/models/BUILD
+++ b/litert/integration_test/models/BUILD
@@ -15,7 +15,7 @@
 load("//litert/build_common:tfl_model_gen.bzl", "tfl_model_gen")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert/integration_test:__subpackages__"],
 )
 

--- a/litert/kotlin/BUILD
+++ b/litert/kotlin/BUILD
@@ -25,7 +25,7 @@ load(
 load("//tflite/java:aar_with_jni.bzl", "aar_with_jni")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         "//third_party/odml/litert:__subpackages__",
     ],

--- a/litert/python/BUILD
+++ b/litert/python/BUILD
@@ -25,7 +25,7 @@ WINDOWS_PYBIND_UNDEFS = select({
 })
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_python_users"],
 )
 

--- a/litert/python/aot/BUILD
+++ b/litert/python/aot/BUILD
@@ -15,7 +15,7 @@
 load("@org_tensorflow//tensorflow:pytype.default.bzl", "pytype_strict_contrib_test", "pytype_strict_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_python_internal_users"],
 )
 

--- a/litert/python/aot/ai_pack/BUILD
+++ b/litert/python/aot/ai_pack/BUILD
@@ -15,7 +15,7 @@
 load("@org_tensorflow//tensorflow:pytype.default.bzl", "pytype_strict_contrib_test", "pytype_strict_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_python_users"],
 )
 

--- a/litert/python/aot/core/BUILD
+++ b/litert/python/aot/core/BUILD
@@ -17,7 +17,7 @@ load("@org_tensorflow//tensorflow:pytype.default.bzl", "pytype_strict_contrib_te
 load("//litert/python/aot/core:build_defs.bzl", "tflxx_deps_if_enabled")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_python_internal_users"],
 )
 

--- a/litert/python/aot/vendors/BUILD
+++ b/litert/python/aot/vendors/BUILD
@@ -15,7 +15,7 @@
 load("@org_tensorflow//tensorflow:pytype.default.bzl", "pytype_strict_contrib_test", "pytype_strict_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_python_internal_users"],
 )
 

--- a/litert/python/aot/vendors/example/BUILD
+++ b/litert/python/aot/vendors/example/BUILD
@@ -15,7 +15,7 @@
 load("@org_tensorflow//tensorflow:pytype.default.bzl", "pytype_strict_contrib_test", "pytype_strict_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
 )
 

--- a/litert/python/aot/vendors/google_tensor/BUILD
+++ b/litert/python/aot/vendors/google_tensor/BUILD
@@ -15,7 +15,7 @@
 load("@org_tensorflow//tensorflow:pytype.default.bzl", "pytype_strict_contrib_test", "pytype_strict_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
 )
 

--- a/litert/python/aot/vendors/mediatek/BUILD
+++ b/litert/python/aot/vendors/mediatek/BUILD
@@ -15,7 +15,7 @@
 load("@org_tensorflow//tensorflow:pytype.default.bzl", "pytype_strict_contrib_test", "pytype_strict_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
 )
 

--- a/litert/python/aot/vendors/qualcomm/BUILD
+++ b/litert/python/aot/vendors/qualcomm/BUILD
@@ -15,7 +15,7 @@
 load("@org_tensorflow//tensorflow:pytype.default.bzl", "pytype_strict_contrib_test", "pytype_strict_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
 )
 

--- a/litert/python/internal/BUILD
+++ b/litert/python/internal/BUILD
@@ -20,7 +20,7 @@ load("@flatbuffers//:build_defs.bzl", "flatbuffer_py_library")
 load("@org_tensorflow//tensorflow:pytype.default.bzl", "pytype_strict_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
 )
 

--- a/litert/python/litert_wrapper/BUILD
+++ b/litert/python/litert_wrapper/BUILD
@@ -15,7 +15,7 @@
 # copybara:uncomment load("@org_tensorflow//tensorflow:strict.default.bzl", "py_strict_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
 )

--- a/litert/python/litert_wrapper/common/BUILD
+++ b/litert/python/litert_wrapper/common/BUILD
@@ -17,7 +17,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 # copybara:uncomment load("@org_tensorflow//tensorflow:tensorflow.default.bzl", "pybind_extension")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
 )

--- a/litert/python/litert_wrapper/compiled_model_wrapper/BUILD
+++ b/litert/python/litert_wrapper/compiled_model_wrapper/BUILD
@@ -30,7 +30,7 @@ WINDOWS_PYBIND_UNDEFS = select({
 })
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
 )

--- a/litert/python/litert_wrapper/tensor_buffer_wrapper/BUILD
+++ b/litert/python/litert_wrapper/tensor_buffer_wrapper/BUILD
@@ -27,7 +27,7 @@ WINDOWS_PYBIND_UNDEFS = select({
 })
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],
 )

--- a/litert/python/tools/BUILD
+++ b/litert/python/tools/BUILD
@@ -15,7 +15,7 @@ load("@org_tensorflow//tensorflow:pytype.default.bzl", "pytype_strict_library")
 load("@org_tensorflow//tensorflow:strict.default.bzl", "py_strict_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
 )
 

--- a/litert/python/tools/model_utils/BUILD
+++ b/litert/python/tools/model_utils/BUILD
@@ -16,7 +16,7 @@ load("@rules_python//python:py_library.bzl", "py_library")
 load("//litert/build_common:litert_build_defs.bzl", "if_google")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         # copybara:uncomment "//visibility:private",
         "//visibility:public",  # copybara:comment

--- a/litert/python/tools/model_utils/test/BUILD
+++ b/litert/python/tools/model_utils/test/BUILD
@@ -14,7 +14,7 @@
 load("@org_tensorflow//tensorflow:pytype.default.bzl", "pytype_strict_contrib_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
     licenses = ["notice"],
 )

--- a/litert/runtime/accelerators/BUILD
+++ b/litert/runtime/accelerators/BUILD
@@ -15,7 +15,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/runtime/accelerators/dispatch/BUILD
+++ b/litert/runtime/accelerators/dispatch/BUILD
@@ -15,7 +15,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/runtime/accelerators/xnnpack/BUILD
+++ b/litert/runtime/accelerators/xnnpack/BUILD
@@ -15,7 +15,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/runtime/compiler/BUILD
+++ b/litert/runtime/compiler/BUILD
@@ -15,7 +15,7 @@
 load("//litert/integration_test:litert_device.bzl", "litert_device_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/runtime/dispatch/BUILD
+++ b/litert/runtime/dispatch/BUILD
@@ -18,7 +18,7 @@ load("//litert/build_common:special_rule.bzl", "gles_linkopts", "litert_metal_op
 load("//litert/integration_test:litert_device.bzl", "litert_device_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/samples/semantic_similarity/BUILD
+++ b/litert/samples/semantic_similarity/BUILD
@@ -15,7 +15,7 @@
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
 )
 

--- a/litert/test/BUILD
+++ b/litert/test/BUILD
@@ -20,7 +20,7 @@ load("//litert/build_common:symlink_files.bzl", "symlink_files")  # @unused
 load("//litert/build_common:tfl_model_gen.bzl", "tfl_model_gen")  # @unused
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         "//visibility:public",  # copybara:comment_replace "//litert:litert_public",
     ],

--- a/litert/test/generators/BUILD
+++ b/litert/test/generators/BUILD
@@ -16,7 +16,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         "//visibility:public",  # copybara:comment_replace "//litert:litert_public",
     ],

--- a/litert/tools/BUILD
+++ b/litert/tools/BUILD
@@ -23,7 +23,7 @@ load("//litert/integration_test:litert_device_common.bzl", "dispatch_device_rloc
 load("//litert/tools:tool_test.bzl", "runfile_path", "tool_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/tools/flags/BUILD
+++ b/litert/tools/flags/BUILD
@@ -16,7 +16,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/tools/flags/vendors/BUILD
+++ b/litert/tools/flags/vendors/BUILD
@@ -17,7 +17,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//litert/build_common:litert_build_defs.bzl", "commandline_flag_copts")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/vendors/c/BUILD
+++ b/litert/vendors/c/BUILD
@@ -16,7 +16,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:__subpackages__"],
 )
 

--- a/litert/vendors/cc/BUILD
+++ b/litert/vendors/cc/BUILD
@@ -16,7 +16,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_public"],
 )
 

--- a/litert/vendors/examples/BUILD
+++ b/litert/vendors/examples/BUILD
@@ -17,7 +17,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//litert/build_common:litert_build_defs.bzl", "litert_bin", "litert_dynamic_lib", "litert_lib", "litert_test", "make_rpaths")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
 )
 

--- a/litert/vendors/google_tensor/BUILD
+++ b/litert/vendors/google_tensor/BUILD
@@ -19,7 +19,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//litert/build_common:litert_build_defs.bzl", "litert_lib", "make_rpaths")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:__subpackages__"],
 )
 

--- a/litert/vendors/google_tensor/compiler/BUILD
+++ b/litert/vendors/google_tensor/compiler/BUILD
@@ -18,7 +18,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//litert/build_common:litert_build_defs.bzl", "litert_dynamic_lib", "make_rpaths")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
 )
 

--- a/litert/vendors/google_tensor/dispatch/BUILD
+++ b/litert/vendors/google_tensor/dispatch/BUILD
@@ -19,7 +19,7 @@ load("//litert/build_common:special_rule.bzl", "litert_android_linkopts")
 load("//litert/integration_test:litert_device.bzl", "litert_device_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/vendors/intel_openvino/compiler/BUILD
+++ b/litert/vendors/intel_openvino/compiler/BUILD
@@ -15,7 +15,7 @@
 load("//litert/build_common:litert_build_defs.bzl", "litert_bin", "litert_dynamic_lib", "litert_lib", "litert_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:__subpackages__"],
 )
 

--- a/litert/vendors/intel_openvino/dispatch/BUILD
+++ b/litert/vendors/intel_openvino/dispatch/BUILD
@@ -17,7 +17,7 @@ load("//litert/build_common:litert_build_defs.bzl", "litert_bin", "litert_dynami
 load("//litert/build_common:special_rule.bzl", "litert_android_linkopts")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/vendors/mediatek/BUILD
+++ b/litert/vendors/mediatek/BUILD
@@ -16,7 +16,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//litert/vendors/mediatek:mediatek_build_defs.bzl", "litert_cc_lib_with_mtk")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:__subpackages__"],
 )
 

--- a/litert/vendors/mediatek/compiler/BUILD
+++ b/litert/vendors/mediatek/compiler/BUILD
@@ -16,7 +16,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//litert/build_common:litert_build_defs.bzl", "litert_dynamic_lib", "litert_test", "make_rpaths")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert/vendors/mediatek/compiler:__subpackages__"],
 )
 

--- a/litert/vendors/mediatek/compiler/legalizations/BUILD
+++ b/litert/vendors/mediatek/compiler/legalizations/BUILD
@@ -15,7 +15,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert/vendors/mediatek/compiler:__subpackages__"],
 )
 

--- a/litert/vendors/mediatek/dispatch/BUILD
+++ b/litert/vendors/mediatek/dispatch/BUILD
@@ -17,7 +17,7 @@ load("//litert/build_common:special_rule.bzl", "litert_android_linkopts")
 load("//litert/integration_test:litert_device.bzl", "litert_device_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:litert_internal_users"],
 )
 

--- a/litert/vendors/mediatek/schema/BUILD
+++ b/litert/vendors/mediatek/schema/BUILD
@@ -16,7 +16,7 @@ load("@flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/BUILD
+++ b/litert/vendors/qualcomm/BUILD
@@ -22,7 +22,7 @@ load("//litert/integration_test:litert_device.bzl", "litert_device_exec")
 load("//litert/vendors/qualcomm:qualcomm_build_defs.bzl", "litert_cc_lib_with_qnn")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -20,7 +20,7 @@ load("//litert/build_common:special_rule.bzl", "litert_android_linkopts")
 load("//litert/integration_test:litert_device.bzl", "litert_device_exec")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = [
         "//visibility:private",
     ],

--- a/litert/vendors/qualcomm/core/BUILD
+++ b/litert/vendors/qualcomm/core/BUILD
@@ -6,7 +6,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//litert/integration_test:litert_device.bzl", "litert_device_exec")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/core/backends/BUILD
+++ b/litert/vendors/qualcomm/core/backends/BUILD
@@ -5,7 +5,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert/vendors/qualcomm:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -4,7 +4,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert/vendors/qualcomm:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/core/dump/BUILD
+++ b/litert/vendors/qualcomm/core/dump/BUILD
@@ -7,7 +7,7 @@
 # copybara:uncomment_end
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert/vendors/qualcomm:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/core/schema/BUILD
+++ b/litert/vendors/qualcomm/core/schema/BUILD
@@ -4,7 +4,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert/vendors/qualcomm:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/core/transformation/BUILD
+++ b/litert/vendors/qualcomm/core/transformation/BUILD
@@ -5,7 +5,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert/vendors/qualcomm:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/core/utils/BUILD
+++ b/litert/vendors/qualcomm/core/utils/BUILD
@@ -6,7 +6,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//litert/integration_test:litert_device.bzl", "litert_device_exec")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert/vendors/qualcomm:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/core/wrappers/BUILD
+++ b/litert/vendors/qualcomm/core/wrappers/BUILD
@@ -4,7 +4,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert/vendors/qualcomm:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/core/wrappers/tests/BUILD
+++ b/litert/vendors/qualcomm/core/wrappers/tests/BUILD
@@ -5,7 +5,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//litert/integration_test:litert_device.bzl", "litert_device_exec")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert/vendors/qualcomm:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/dispatch/BUILD
+++ b/litert/vendors/qualcomm/dispatch/BUILD
@@ -20,7 +20,7 @@ load("//litert/build_common:special_rule.bzl", "litert_android_linkopts")
 load("//litert/integration_test:litert_device.bzl", "litert_device_test")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],
 )
 

--- a/litert/vendors/qualcomm/qnn_backend_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/BUILD
@@ -4,7 +4,7 @@
 load("//litert/build_common:litert_build_defs.bzl", "litert_test", "litert_test_lib", "make_rpaths")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -4,7 +4,7 @@
 load("//litert/build_common:litert_build_defs.bzl", "litert_test", "make_rpaths")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:__subpackages__"],
 )
 

--- a/litert/vendors/qualcomm/tools/BUILD
+++ b/litert/vendors/qualcomm/tools/BUILD
@@ -15,7 +15,7 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
-    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    # copybara:uncomment default_applicable_licenses = ["//:license"],
     default_visibility = ["//litert:__subpackages__"],
 )
 


### PR DESCRIPTION
- Created litert/build_common/tensorflow/BUILD and LICENSE.
- Updated references in litert/ from @org_tensorflow//tensorflow:license to //litert:license.
- Added analysis reports and guidelines.

This reverts commit ffbe5759932d82ee85cbe3cbc3feb0dea1ff9a24.
