### PR TITLE
Qualcomm AI Engine Direct - Enable GPU backend.

### DIFF
--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -516,6 +516,8 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   EXPECT_EQ(options.Value().GetHtpPPoint(), 0);
   EXPECT_EQ(options.Value().GetHtpPerformanceMode(),
             QualcommOptions::HtpPerformanceMode::kDefault);
+  EXPECT_EQ(options.Value().GetDspPerformanceMode(),
+            QualcommOptions::DspPerformanceMode::kDefault);
   EXPECT_TRUE(options.Value().GetDumpTensorIds().empty());
   EXPECT_EQ(options.Value().GetVtcmSize(), 0);
   EXPECT_EQ(options.Value().GetNumHvxThreads(), 0);

--- a/litert/vendors/qualcomm/BUILD
+++ b/litert/vendors/qualcomm/BUILD
@@ -87,6 +87,7 @@ litert_cc_lib_with_qnn(
         "//litert/vendors/qualcomm/core:common",
         "//litert/vendors/qualcomm/core:op_code",
         "//litert/vendors/qualcomm/core/backends:dsp_backend",
+        "//litert/vendors/qualcomm/core/backends:gpu_backend",
         "//litert/vendors/qualcomm/core/backends:htp_backend",
         "//litert/vendors/qualcomm/core/backends:ir_backend",
         "//litert/vendors/qualcomm/core/backends:qnn_backend",

--- a/litert/vendors/qualcomm/compiler/graph_mapper.cc
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.cc
@@ -33,6 +33,7 @@
 #include "litert/vendors/qualcomm/common.h"
 #include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/qnn_manager.h"
+#include "GPU/QnnGpuGraph.h"  // from @qairt
 #include "HTP/QnnHtpGraph.h"  // from @qairt
 #include "QnnCommon.h"  // from @qairt
 #include "QnnGraph.h"  // from @qairt
@@ -69,6 +70,21 @@ Qnn_Priority_t GetGraphPriorityValue(::qnn::GraphPriority graph_priority) {
       return QNN_PRIORITY_HIGH;
     default:
       return QNN_PRIORITY_UNDEFINED;
+  }
+}
+
+QnnGpu_Precision_t GetGpuPrecisionValue(::qnn::GpuPrecision precision) {
+  switch (precision) {
+    case ::qnn::GpuPrecision::kUserProvided:
+      return QNN_GPU_PRECISION_USER_PROVIDED;
+    case ::qnn::GpuPrecision::kFp32:
+      return QNN_GPU_PRECISION_FP32;
+    case ::qnn::GpuPrecision::kFp16:
+      return QNN_GPU_PRECISION_FP16;
+    case ::qnn::GpuPrecision::kHybrid:
+      return QNN_GPU_PRECISION_HYBRID;
+    default:
+      return QNN_GPU_PRECISION_FP16;
   }
 }
 
@@ -214,6 +230,26 @@ inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
   return absl::MakeSpan(result.data(), num_config + 1);
 }
 
+inline absl::Span<const QnnGraph_Config_t*> GetGpuGraphConfigs(
+    const ::qnn::Options& options) {
+  static std::array<QnnGpuGraph_CustomConfig_t, 1> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 1> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 2> result;
+
+  // Precision
+  graph_custom_configs[0] = QNN_GPU_GRAPH_CUSTOM_CONFIG_INIT;
+  graph_custom_configs[0].precision =
+      GetGpuPrecisionValue(options.GetGpuPrecision());
+
+  graph_configs[0] = QNN_GRAPH_CONFIG_INIT;
+  graph_configs[0].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
+  graph_configs[0].customConfig = &graph_custom_configs[0];
+  result[0] = &graph_configs[0];
+
+  result[1] = nullptr;
+  return absl::MakeSpan(result.data(), 2);
+}
+
 absl::Span<const QnnGraph_Config_t*> GetDefaultIrGraphConfigs(
     const ::qnn::Options& options, absl::string_view qnn_graph_name) {
   static std::array<QnnIrGraph_CustomConfig_t, 1> graph_custom_configs;
@@ -262,6 +298,9 @@ LiteRtStatus GraphMapper::InitQnnGraph(absl::string_view qnn_graph_name,
   switch (options.GetBackendType()) {
     case ::qnn::BackendType::kHtpBackend:
       graph_configs = PickGraphConfigHeuristic(options);
+      break;
+    case ::qnn::BackendType::kGpuBackend:
+      graph_configs = GetGpuGraphConfigs(options);
       break;
     case ::qnn::BackendType::kIrBackend:
       graph_configs = GetDefaultIrGraphConfigs(options, qnn_graph_name);

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -562,11 +562,18 @@ LiteRtStatus LiteRtCompilerPluginCompile(
             break;
           }
           default: {
-            LITERT_LOG(LITERT_WARNING,
-                       "Only support weight sharing feature in Htp Backend, "
-                       "disable weight sharing feature");
-            break;
+            LITERT_LOG(LITERT_ERROR,
+                       "Weight sharing is only supported in HTP backend.");
+            return kLiteRtStatusErrorInvalidArgument;
           }
+        }
+      } else if (options.GetBackendType() == ::qnn::BackendType::kGpuBackend) {
+        if (options.GetGpuPerformanceMode() !=
+            ::qnn::GpuPerformanceMode::kDefault) {
+          context_configs = QnnManager::GpuPerformanceContextConfigs(
+              options.GetGpuPerformanceMode());
+          LITERT_LOG(LITERT_INFO, "Enable GPU performance mode: %d",
+                     static_cast<int>(options.GetGpuPerformanceMode()));
         }
       }
       auto context_handle = qnn_manager->CreateContextHandle(

--- a/litert/vendors/qualcomm/core/backends/BUILD
+++ b/litert/vendors/qualcomm/core/backends/BUILD
@@ -49,6 +49,21 @@ cc_library(
 )
 
 cc_library(
+    name = "gpu_backend",
+    srcs = ["gpu_backend.cc"],
+    hdrs = ["gpu_backend.h"],
+    deps = [
+        ":backend_utils",
+        ":qnn_backend",
+        "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core/schema:soc_table",
+        "//litert/vendors/qualcomm/core/utils:log",
+        "@com_google_absl//absl/types:span",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+cc_library(
     name = "htp_backend",
     srcs = ["htp_backend.cc"],
     hdrs = ["htp_backend.h"],
@@ -77,6 +92,20 @@ cc_library(
         "//litert/vendors/qualcomm/core/utils:log",
         "@com_google_absl//absl/types:span",
         "@qairt//:qnn_lib_headers",
+    ],
+)
+
+cc_test(
+    name = "gpu_backend_test",
+    srcs = [
+        "gpu_backend_test.cc",
+    ],
+    deps = [
+        ":gpu_backend",
+        "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core/schema:soc_table",
+        "//litert/vendors/qualcomm/core/utils:miscs",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/litert/vendors/qualcomm/core/backends/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/backends/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(qnn_backends STATIC)
 
 target_sources(qnn_backends
     PRIVATE
+        gpu_backend.cc
         dsp_backend.cc
         htp_backend.cc
         ir_backend.cc

--- a/litert/vendors/qualcomm/core/backends/dsp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/dsp_backend.cc
@@ -9,7 +9,6 @@
 #include <memory>
 #include <optional>
 #include <utility>
-#include <vector>
 
 #include "absl/types/span.h"  // from @com_google_absl
 #include "litert/vendors/qualcomm/core/backends/backend_utils.h"
@@ -223,8 +222,7 @@ bool DspBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
   }
 
   // Backend Handle
-  std::vector<const QnnBackend_Config_t*> backend_configs;
-  backend_configs.emplace_back(nullptr);
+  std::array<const QnnBackend_Config_t*, 1> backend_configs = {nullptr};
 
   auto local_backend_handle = CreateBackendHandle(
       local_log_handle.get(), absl::MakeSpan(backend_configs));

--- a/litert/vendors/qualcomm/core/backends/gpu_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/gpu_backend.cc
@@ -1,31 +1,35 @@
 // Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "litert/vendors/qualcomm/core/backends/ir_backend.h"
-
 #include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <utility>
 
-#include "absl/types/span.h"  // from @com_google_absl
+#include "QnnBackend.h"                    // from @qairt
+#include "QnnCommon.h"                     // from @qairt
+#include "QnnDevice.h"                     // from @qairt
+#include "QnnInterface.h"                  // from @qairt
+#include "absl/types/span.h"               // from @com_google_absl
+#include "litert/vendors/qualcomm/core/backends/backend_utils.h"
+#include "litert/vendors/qualcomm/core/backends/gpu_backend.h"
 #include "litert/vendors/qualcomm/core/backends/qnn_backend.h"
 #include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/core/schema/soc_table.h"
 #include "litert/vendors/qualcomm/core/utils/log.h"
-#include "QnnBackend.h"  // from @qairt
-#include "QnnInterface.h"  // from @qairt
 
 namespace qnn {
 
-IrBackend::IrBackend(const QNN_INTERFACE_VER_TYPE* qnn_api)
+GpuBackend::GpuBackend(const QNN_INTERFACE_VER_TYPE* qnn_api)
     : QnnBackend(qnn_api) {}
 
-bool IrBackend::Init(const Options& options,
-                     std::optional<::qnn::SocInfo> soc_info) {
+bool GpuBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
   // Log Handle
   auto local_log_handle = CreateLogHandle(options.GetLogLevel());
-  if (!local_log_handle && options.GetLogLevel() != ::qnn::LogLevel::kOff) {
-    QNN_LOG_ERROR("Failed to create log handle!");
+  if (!local_log_handle && options.GetLogLevel() != LogLevel::kOff) {
+    QNN_LOG_ERROR("Failed to create log handle.");
     return false;
   }
 
@@ -35,12 +39,15 @@ bool IrBackend::Init(const Options& options,
   auto local_backend_handle = CreateBackendHandle(
       local_log_handle.get(), absl::MakeSpan(backend_configs));
   if (!local_backend_handle) {
-    QNN_LOG_ERROR("Failed to create backend handle!");
+    QNN_LOG_ERROR("Failed to create backend handle.");
     return false;
   }
 
+  // Follow RAII pattern to manage handles.
   log_handle_ = std::move(local_log_handle);
   backend_handle_ = std::move(local_backend_handle);
+
   return true;
 }
+
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/backends/gpu_backend.h
+++ b/litert/vendors/qualcomm/core/backends/gpu_backend.h
@@ -1,0 +1,45 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BACKENDS_GPU_BACKEND_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BACKENDS_GPU_BACKEND_H_
+
+#include <memory>
+#include <optional>
+
+#include "GPU/QnnGpuCommon.h"  // from @qairt
+#include "QnnInterface.h"      // from @qairt
+#include "QnnTypes.h"          // from @qairt
+#include "litert/vendors/qualcomm/core/backends/qnn_backend.h"
+#include "litert/vendors/qualcomm/core/common.h"
+#include "litert/vendors/qualcomm/core/schema/soc_table.h"
+
+namespace qnn {
+
+class GpuBackend : public QnnBackend {
+ public:
+  static const char* GetLibraryName() { return "libQnnGpu.so"; }
+
+  static Qnn_Version_t GetExpectedBackendVersion() {
+    Qnn_Version_t backend_version;
+    backend_version.major = QNN_GPU_API_VERSION_MAJOR;
+    backend_version.minor = QNN_GPU_API_VERSION_MINOR;
+    backend_version.patch = QNN_GPU_API_VERSION_PATCH;
+    return backend_version;
+  }
+
+  explicit GpuBackend(const QNN_INTERFACE_VER_TYPE* qnn_api);
+
+  ~GpuBackend() = default;
+
+  GpuBackend(const GpuBackend&) = delete;
+  GpuBackend& operator=(const GpuBackend&) = delete;
+  GpuBackend(GpuBackend&&) = delete;
+  GpuBackend& operator=(GpuBackend&&) = delete;
+
+  bool Init(const Options& options, std::optional<SocInfo> soc_info) override;
+};
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BACKENDS_GPU_BACKEND_H_

--- a/litert/vendors/qualcomm/core/backends/gpu_backend_test.cc
+++ b/litert/vendors/qualcomm/core/backends/gpu_backend_test.cc
@@ -1,0 +1,61 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/backends/gpu_backend.h"
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "QnnCommon.h"
+#include "QnnInterface.h"
+#include <gtest/gtest.h>
+#include "litert/vendors/qualcomm/core/backends/backend_utils.h"
+#include "litert/vendors/qualcomm/core/common.h"
+#include "litert/vendors/qualcomm/core/utils/miscs.h"
+#include "QnnDevice.h"  // from @qairt
+
+namespace qnn {
+namespace {
+class GpuBackendTest : public testing::Test {
+ public:
+  void SetUp() override {
+    handle_ = CreateDLHandle(GpuBackend::GetLibraryName());
+    if (!handle_) GTEST_SKIP();
+
+    auto* qnn_api =
+        ResolveQnnApi(handle_.get(), GpuBackend::GetExpectedBackendVersion());
+    ASSERT_TRUE(qnn_api);
+    backend_ = std::make_unique<GpuBackend>(qnn_api);
+  }
+
+  DLHandle handle_;
+  std::unique_ptr<GpuBackend> backend_;
+};
+
+TEST_F(GpuBackendTest, DISABLED_InitializeWithLogLevelOffTest) {
+  Options options;
+  options.SetLogLevel(LogLevel::kOff);
+
+  ASSERT_TRUE(backend_->Init(options, std::nullopt));
+  ASSERT_FALSE(backend_->GetDeviceHandle());
+
+  ASSERT_TRUE(backend_->GetBackendHandle());
+  ASSERT_FALSE(backend_->GetLogHandle());
+}
+
+TEST_F(GpuBackendTest, DISABLED_InitializeWithLogLevelVerboseTest) {
+  Options options;
+  options.SetLogLevel(LogLevel::kVerbose);
+
+  ASSERT_TRUE(backend_->Init(options, std::nullopt));
+  ASSERT_FALSE(backend_->GetDeviceHandle());
+
+  ASSERT_TRUE(backend_->GetBackendHandle());
+  ASSERT_TRUE(backend_->GetLogHandle());
+}
+
+}  // namespace
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/backends/htp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.cc
@@ -384,8 +384,7 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
   }
 
   // Backend Handle
-  std::vector<const QnnBackend_Config_t*> backend_configs;
-  backend_configs.emplace_back(nullptr);
+  std::array<const QnnBackend_Config_t*, 1> backend_configs = {nullptr};
 
   auto local_backend_handle = CreateBackendHandle(
       local_log_handle.get(), absl::MakeSpan(backend_configs));

--- a/litert/vendors/qualcomm/core/backends/ir_backend.h
+++ b/litert/vendors/qualcomm/core/backends/ir_backend.h
@@ -35,7 +35,7 @@ class IrBackend : public QnnBackend {
 
   explicit IrBackend(const QNN_INTERFACE_VER_TYPE* qnn_api);
 
-  ~IrBackend();
+  ~IrBackend() = default;
 
   bool Init(const Options& options,
             std::optional<::qnn::SocInfo> soc_info) override;

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -192,6 +192,20 @@ void Options::SetGraphPriority(GraphPriority graph_priority) {
   graph_priority_ = graph_priority;
 }
 
+void Options::SetGpuPrecision(GpuPrecision gpu_precision) {
+  gpu_precision_ = gpu_precision;
+}
+
+GpuPrecision Options::GetGpuPrecision() const { return gpu_precision_; }
+
+void Options::SetGpuPerformanceMode(GpuPerformanceMode gpu_performance_mode) {
+  gpu_performance_mode_ = gpu_performance_mode;
+}
+
+GpuPerformanceMode Options::GetGpuPerformanceMode() const {
+  return gpu_performance_mode_;
+}
+
 absl::string_view Options::GetSaverOutputDir() const {
   return saver_output_dir_;
 }
@@ -239,6 +253,8 @@ UseFoldReLU: %v\n\
 HtpPPoint: %d\n\
 HtpPerformanceMode: %d\n\
 DspPerformanceMode: %d\n\
+GpuPerformanceMode: %d\n\
+GpuPrecision: %d\n\
 DumpTensorIds: %s\n\
 IrJsonDir: %s\n\
 DlcDir: %s\n\
@@ -262,9 +278,10 @@ CustomOpPackage: {\n\
       kQnnOptionsDumpFormat, log_level_, backend_type_, profiling_,
       use_int64_bias_as_int32_, enable_weight_sharing_, enable_just_in_time_,
       use_conv_hmx_, use_fold_relu_, htp_p_point_, htp_performance_mode_,
-      dsp_performance_mode_, dump_tensor_ids, ir_json_dir_, dlc_dir_,
-      vtcm_size_, num_hvx_threads_, optimization_level_, graph_priority_,
-      saver_output_dir_, graph_io_tensor_mem_type_, custom_op_package_.name,
+      dsp_performance_mode_, gpu_performance_mode_, gpu_precision_,
+      dump_tensor_ids, ir_json_dir_, dlc_dir_, vtcm_size_, num_hvx_threads_,
+      optimization_level_, graph_priority_, saver_output_dir_,
+      graph_io_tensor_mem_type_, custom_op_package_.name,
       custom_op_package_.interface_provider,
       custom_op_package_.compile_package_path,
       custom_op_package_.dispatch_package_path, custom_op_package_.target);

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -92,6 +92,20 @@ struct CustomOpPackage {
   std::string target;
 };
 
+enum class GpuPrecision {
+  kUserProvided = 0,
+  kFp32 = 1,
+  kFp16 = 2,
+  kHybrid = 3,
+};
+
+enum class GpuPerformanceMode {
+  kDefault = 0,
+  kHigh = 1,
+  kNormal = 2,
+  kLow = 3,
+};
+
 class Options {
  public:
   Options() = default;
@@ -151,6 +165,12 @@ class Options {
   void SetGraphPriority(GraphPriority graph_priority);
   GraphPriority GetGraphPriority() const;
 
+  void SetGpuPrecision(GpuPrecision gpu_precision);
+  GpuPrecision GetGpuPrecision() const;
+
+  void SetGpuPerformanceMode(GpuPerformanceMode gpu_performance_mode);
+  GpuPerformanceMode GetGpuPerformanceMode() const;
+
   std::string Dump() const;
 
   absl::string_view GetSaverOutputDir() const;
@@ -186,6 +206,8 @@ class Options {
   OptimizationLevel optimization_level_ =
       OptimizationLevel::kHtpOptimizeForInferenceO3;
   GraphPriority graph_priority_ = GraphPriority::kDefault;
+  GpuPrecision gpu_precision_ = GpuPrecision::kFp16;
+  GpuPerformanceMode gpu_performance_mode_ = GpuPerformanceMode::kHigh;
   std::string saver_output_dir_;
   GraphIOTensorMemType graph_io_tensor_mem_type_ =
       GraphIOTensorMemType::kMemHandle;

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -272,6 +272,37 @@ TEST(QnnOptionTest, SetCustomOpPackage) {
   EXPECT_EQ(package.target, target);
 }
 
+TEST(QnnOptionTest, SetGpuPrecision) {
+  Options options;
+  options.SetGpuPrecision(GpuPrecision::kHybrid);
+  EXPECT_NE(options.GetGpuPrecision(), GpuPrecision::kFp16);
+  EXPECT_EQ(options.GetGpuPrecision(), GpuPrecision::kHybrid);
+  options.SetGpuPrecision(GpuPrecision::kFp16);
+  EXPECT_EQ(options.GetGpuPrecision(), GpuPrecision::kFp16);
+}
+
+TEST(QnnOptionTest, SetGpuPerformanceMode) {
+  Options options;
+  options.SetGpuPerformanceMode(GpuPerformanceMode::kHigh);
+  EXPECT_NE(options.GetGpuPerformanceMode(), GpuPerformanceMode::kDefault);
+  EXPECT_EQ(options.GetGpuPerformanceMode(), GpuPerformanceMode::kHigh);
+  options.SetGpuPerformanceMode(GpuPerformanceMode::kDefault);
+  EXPECT_EQ(options.GetGpuPerformanceMode(), GpuPerformanceMode::kDefault);
+}
+
+TEST(QnnOptionTest, SetGraphIOTensorMemType) {
+  Options options;
+  EXPECT_EQ(options.GetGraphIOTensorMemType(),
+            GraphIOTensorMemType::kMemHandle);
+
+  options.SetGraphIOTensorMemType(GraphIOTensorMemType::kRaw);
+  EXPECT_EQ(options.GetGraphIOTensorMemType(), GraphIOTensorMemType::kRaw);
+
+  options.SetGraphIOTensorMemType(GraphIOTensorMemType::kMemHandle);
+  EXPECT_EQ(options.GetGraphIOTensorMemType(),
+            GraphIOTensorMemType::kMemHandle);
+}
+
 TEST(QnnOptionTest, Default) {
   Options options;
   EXPECT_EQ(options.GetLogLevel(), LogLevel::kInfo);
@@ -299,19 +330,8 @@ TEST(QnnOptionTest, Default) {
   EXPECT_TRUE(custom_op_package.compile_package_path.empty());
   EXPECT_TRUE(custom_op_package.dispatch_package_path.empty());
   EXPECT_TRUE(custom_op_package.target.empty());
-}
-
-TEST(QnnOptionTest, SetGraphIOTensorMemType) {
-  Options options;
-  EXPECT_EQ(options.GetGraphIOTensorMemType(),
-            GraphIOTensorMemType::kMemHandle);
-
-  options.SetGraphIOTensorMemType(GraphIOTensorMemType::kRaw);
-  EXPECT_EQ(options.GetGraphIOTensorMemType(), GraphIOTensorMemType::kRaw);
-
-  options.SetGraphIOTensorMemType(GraphIOTensorMemType::kMemHandle);
-  EXPECT_EQ(options.GetGraphIOTensorMemType(),
-            GraphIOTensorMemType::kMemHandle);
+  EXPECT_EQ(options.GetGpuPrecision(), GpuPrecision::kFp16);
+  EXPECT_EQ(options.GetGpuPerformanceMode(), GpuPerformanceMode::kHigh);
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/core/utils/test_main.cc
+++ b/litert/vendors/qualcomm/core/utils/test_main.cc
@@ -29,6 +29,8 @@ bool ParseArgs(int argc, char** argv) {
         qnn::SetTestBackend(qnn::BackendType::kHtpBackend);
       } else if (backend_str == "dsp") {
         qnn::SetTestBackend(qnn::BackendType::kDspBackend);
+      } else if (backend_str == "gpu") {
+        qnn::SetTestBackend(qnn::BackendType::kGpuBackend);
       } else {
         std::cerr << "Unknown backend: " << backend_str << std::endl;
         return false;

--- a/litert/vendors/qualcomm/core/utils/test_utils.cc
+++ b/litert/vendors/qualcomm/core/utils/test_utils.cc
@@ -19,6 +19,8 @@ bool IsTestHtpBackend() { return GetTestBackend() == BackendType::kHtpBackend; }
 
 bool IsTestDspBackend() { return GetTestBackend() == BackendType::kDspBackend; }
 
+bool IsTestGpuBackend() { return GetTestBackend() == BackendType::kGpuBackend; }
+
 void SetTestBackend(BackendType backend_type) {
   GetTestBackend() = backend_type;
 }

--- a/litert/vendors/qualcomm/core/utils/test_utils.h
+++ b/litert/vendors/qualcomm/core/utils/test_utils.h
@@ -15,6 +15,8 @@ bool IsTestHtpBackend();
 
 bool IsTestDspBackend();
 
+bool IsTestGpuBackend();
+
 // Sets the target backend for testing.
 // This should be called by the test main.
 void SetTestBackend(BackendType backend_type);

--- a/litert/vendors/qualcomm/core/utils/utils_test.cc
+++ b/litert/vendors/qualcomm/core/utils/utils_test.cc
@@ -158,6 +158,11 @@ TEST(MiscTests, IsTestDspBackendTest) {
   EXPECT_TRUE(qnn::IsTestDspBackend());
 }
 
+TEST(MiscTests, IsTestGpuBackendTest) {
+  qnn::SetTestBackend(BackendType::kGpuBackend);
+  EXPECT_TRUE(qnn::IsTestGpuBackend());
+}
+
 TEST(MiscTests, UnpackInt2Data) {
   // Single byte: 0xE4 (binary: 11 10 01 00), LSB-first unpacking.
   // bits 0-1: 00 -> 0

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_device_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_device_context.cc
@@ -115,7 +115,6 @@ Expected<Qnn_MemHandle_t> LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
 
   void* buffer_host_addr;
   int buffer_fd;
-  (void)buffer_host_addr;
 
   switch (tensor_buffer_type) {
     case kLiteRtTensorBufferTypeFastRpc:
@@ -161,6 +160,17 @@ Expected<Qnn_MemHandle_t> LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
 
   QnnMemHtp_Descriptor_t mem_htp_descriptor = {};
   switch (qnn_manager_.GetOptions().GetBackendType()) {
+    case ::qnn::BackendType::kGpuBackend:
+      // QnnGpu imports the DMA-BUF fd as OpenCL memory; it does not accept
+      // QNN_MEM_TYPE_ION (returns QNN_MEM_ERROR_UNSUPPORTED_MEMTYPE, 8005).
+      if (tensor_buffer_type != kLiteRtTensorBufferTypeDmaBuf) {
+        return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                          "GPU backend only supports DMA-BUF tensor buffers");
+      }
+      mem_descriptor.memType = QNN_MEM_TYPE_DMA_BUF;
+      mem_descriptor.dmaBufInfo =
+          Qnn_MemDmaBufInfo_t{buffer_fd, buffer_host_addr};
+      break;
     // DSP Backend only supports QNN_MEM_TYPE_ION.
     case ::qnn::BackendType::kDspBackend:
       mem_descriptor.memType = QNN_MEM_TYPE_ION;

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
@@ -266,11 +266,23 @@ LiteRtDispatchInvocationContextT::GetTensorBufferRequirements(
           kLiteRtTensorBufferTypeFastRpc,
           kLiteRtTensorBufferTypeDmaBuf,
       };
+  // QnnGpu imports the DMA-BUF fd as OpenCL memory and rejects
+  // QNN_MEM_TYPE_ION (i.e. FastRPC-backed buffers), so advertise only
+  // DMA-BUF for the GPU backend.
+  static constexpr std::array<const LiteRtTensorBufferType, 1>
+      kGpuSupportedTensorBufferTypes = {
+          kLiteRtTensorBufferTypeDmaBuf,
+      };
+
   const LiteRtTensorBufferType* supported_tensor_buffer_types =
       kMemHandleTensorBufferTypes.data();
   size_t num_supported_tensor_buffer_types = kMemHandleTensorBufferTypes.size();
-  if (qnn_manager_.GetOptions().GetGraphIOTensorMemType() ==
-      ::qnn::GraphIOTensorMemType::kRaw) {
+  if (qnn_manager_.GetOptions().GetBackendType() ==
+      ::qnn::BackendType::kGpuBackend) {
+    supported_tensor_buffer_types = kGpuSupportedTensorBufferTypes.data();
+    num_supported_tensor_buffer_types = kGpuSupportedTensorBufferTypes.size();
+  } else if (qnn_manager_.GetOptions().GetGraphIOTensorMemType() ==
+             ::qnn::GraphIOTensorMemType::kRaw) {
     supported_tensor_buffer_types = kRawTensorBufferTypes.data();
     num_supported_tensor_buffer_types = kRawTensorBufferTypes.size();
   }

--- a/litert/vendors/qualcomm/qnn_backend_test/test_utils.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/test_utils.cc
@@ -28,6 +28,9 @@ std::string QnnTestPrinter(
 
   // TODO (chunhsue-qti): Add more backend once it expands.
   switch (options.GetBackendType()) {
+    case ::qnn::BackendType::kGpuBackend:
+      ss << "Gpu";
+      break;
     case ::qnn::BackendType::kHtpBackend:
       ss << "Htp";
       break;

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -29,6 +29,7 @@
 #include <utility>
 #include <vector>
 
+#include "GPU/QnnGpuContext.h"  // from @qairt
 #include "HTP/QnnHtpContext.h"  // from @qairt
 #include "HTP/QnnHtpProfile.h"  // from @qairt
 #include "QnnCommon.h"  // from @qairt
@@ -52,6 +53,7 @@
 #include "litert/core/filesystem.h"
 #include "litert/vendors/qualcomm/common.h"
 #include "litert/vendors/qualcomm/core/backends/dsp_backend.h"
+#include "litert/vendors/qualcomm/core/backends/gpu_backend.h"
 #include "litert/vendors/qualcomm/core/backends/htp_backend.h"
 #include "litert/vendors/qualcomm/core/backends/ir_backend.h"
 #include "litert/vendors/qualcomm/core/common.h"
@@ -535,6 +537,16 @@ LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
   LITERT_RETURN_IF_ERROR(ResolveSystemApi());
 
   switch (backend_type) {
+    case ::qnn::BackendType::kGpuBackend: {
+      LITERT_RETURN_IF_ERROR(LoadLib(::qnn::GpuBackend::GetLibraryName()));
+      LITERT_RETURN_IF_ERROR(
+          ResolveApi(::qnn::GpuBackend::GetExpectedBackendVersion()));
+
+      backend_ = std::make_unique<::qnn::GpuBackend>(Api());
+      LITERT_RETURN_IF_ERROR(backend_->Init(options_, std::nullopt));
+
+      break;
+    }
     case ::qnn::BackendType::kHtpBackend: {
       LITERT_RETURN_IF_ERROR(LoadLib(::qnn::HtpBackend::GetLibraryName()));
       LITERT_RETURN_IF_ERROR(
@@ -733,6 +745,33 @@ Expected<SdkVersion> QnnManager::ParseSdkVersion(const char* build_id) {
   if (!parse_component(version.patch)) return parsing_error;
 
   return version;
+}
+
+absl::Span<const QnnContext_Config_t*> QnnManager::GpuPerformanceContextConfigs(
+    ::qnn::GpuPerformanceMode performance_mode) {
+  static QnnGpuContext_CustomConfig_t customConfig =
+      QNN_GPU_CONTEXT_CUSTOM_CONFIG_INIT;
+  customConfig.option = QNN_GPU_CONTEXT_CONFIG_OPTION_PERF_HINT;
+  switch (performance_mode) {
+    case ::qnn::GpuPerformanceMode::kHigh:
+      customConfig.perfHint = QNN_GPU_CONTEXT_PERF_HINT_HIGH;
+      break;
+    case ::qnn::GpuPerformanceMode::kNormal:
+      customConfig.perfHint = QNN_GPU_CONTEXT_PERF_HINT_NORMAL;
+      break;
+    case ::qnn::GpuPerformanceMode::kLow:
+      customConfig.perfHint = QNN_GPU_CONTEXT_PERF_HINT_LOW;
+      break;
+    case ::qnn::GpuPerformanceMode::kDefault:
+    default:
+      return DefaultContextConfigs();
+  }
+
+  static QnnContext_Config_t contextConfig = QNN_CONTEXT_CONFIG_INIT;
+  contextConfig.option = QNN_CONTEXT_CONFIG_OPTION_CUSTOM;
+  contextConfig.customConfig = &customConfig;
+  static const QnnContext_Config_t* configs[2] = {&contextConfig, nullptr};
+  return absl::MakeSpan(configs);
 }
 
 };  // namespace litert::qnn

--- a/litert/vendors/qualcomm/qnn_manager.h
+++ b/litert/vendors/qualcomm/qnn_manager.h
@@ -125,6 +125,8 @@ class QnnManager {
 
   static absl::Span<const QnnContext_Config_t*> DefaultContextConfigs();
   static absl::Span<const QnnContext_Config_t*> WeightSharingContextConfigs();
+  static absl::Span<const QnnContext_Config_t*> GpuPerformanceContextConfigs(
+      ::qnn::GpuPerformanceMode performance_mode);
   // Get resolved function pointers for qnn sdk calls. Nullptr if functions
   // have not been resolved yet.
   const QnnApi* Api() const;

--- a/litert/vendors/qualcomm/qnn_manager_test.cc
+++ b/litert/vendors/qualcomm/qnn_manager_test.cc
@@ -52,6 +52,10 @@ std::optional<::qnn::Options> GetOptionsForTarget() {
     options.SetBackendType(::qnn::BackendType::kDspBackend);
     return options;
   }
+  if (::qnn::IsTestGpuBackend()) {
+    options.SetBackendType(::qnn::BackendType::kGpuBackend);
+    return options;
+  }
   return std::nullopt;
 }
 


### PR DESCRIPTION
# What
Enable QNN GPU backend for real JIT flow. For example, using ` ` to execute.

## Verification

- Developer-Verified
- Passed float model with QNN GPU backend


# Test

- Passed x86 unit test. (1 failure is known issue, reported to ODML)
- Passed android unit test, both GPU & HTP backend.
- Passed CMake build.

======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all


//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 0.2s

Using GPU Backend:
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 23 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 23 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 16 tests from 10 test suites ran. (1 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 18 tests from 3 test suites ran. (10 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 33 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (6 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 19 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (5 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (21 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (7 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (121 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (9 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (42 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (9 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (146 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

Using HTP backend:
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 21 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 16 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (16 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 32 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 32 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (3 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (5 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (20 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (646 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (618 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1621 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1609 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (634 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2095 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (27 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (8 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (498 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (464 ms total)
[  PASSED  ] 2 tests.