### PR TITLE
Qualcomm AI Engine Direct - Convert int64 bias to int32.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -33,6 +33,7 @@ struct LiteRtQualcommOptionsT {
   LiteRtQualcommOptionsProfiling profiling = kLiteRtQualcommProfilingOff;
   bool use_htp_preference = false;
   bool use_qint16_as_quint16 = false;
+  bool use_int64_bias_as_int32 = true;
   LiteRtQualcommOptionsBackend qnn_backend = kLiteRtQualcommBackendHtp;
   bool enable_weight_sharing = false;
   bool use_conv_hmx = true;
@@ -74,8 +75,9 @@ LiteRtStatus LiteRtQualcommOptionsCreate(LiteRtOpaqueOptions* options) {
     litert::HashCombine(
         ans, options->log_level, options->profiling,
         options->use_htp_preference, options->use_qint16_as_quint16,
-        options->qnn_backend, options->enable_weight_sharing,
-        options->htp_performance_mode, options->dsp_performance_mode,
+        options->use_int64_bias_as_int32, options->qnn_backend,
+        options->enable_weight_sharing, options->htp_performance_mode,
+        options->dsp_performance_mode,
         options->ir_json_dir, options->dlc_dir, options->vtcm_size,
         options->num_hvx_threads, options->optimization_level);
     return ans;
@@ -224,6 +226,28 @@ LiteRtStatus LiteRtQualcommOptionsGetUseQint16AsQuint16(
   }
 
   *use_qint16_as_quint16 = options->use_qint16_as_quint16;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsSetUseInt64BiasAsInt32(
+    LiteRtQualcommOptions options, bool use_int64_bias_as_int32) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->use_int64_bias_as_int32 = use_int64_bias_as_int32;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LiteRtQualcommOptionsGetUseInt64BiasAsInt32(
+    LiteRtQualcommOptions options, bool* use_int64_bias_as_int32) {
+  if (use_int64_bias_as_int32 == nullptr || options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *use_int64_bias_as_int32 = options->use_int64_bias_as_int32;
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -92,6 +92,17 @@ LiteRtStatus LiteRtQualcommOptionsSetUseQint16AsQuint16(
 LiteRtStatus LiteRtQualcommOptionsGetUseQint16AsQuint16(
     LiteRtQualcommOptions options, bool* use_qint16_as_quint16);
 
+// use_int64_bias_as_int32
+
+// This option controls whether to convert bias tensors of FullyConnected
+// and Conv2D Ops from int64 to int32 . Defaults to true.
+
+LiteRtStatus LiteRtQualcommOptionsSetUseInt64BiasAsInt32(
+    LiteRtQualcommOptions options, bool use_int64_bias_as_int32);
+
+LiteRtStatus LiteRtQualcommOptionsGetUseInt64BiasAsInt32(
+    LiteRtQualcommOptions options, bool* use_int64_bias_as_int32);
+
 // enable_weight_sharing
 
 // Weight sharing indicates whether different subgraphs may share weight

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -100,6 +100,24 @@ TEST(LiteRtQualcommOptionsTest, UseQint16AsQuint16) {
   LiteRtDestroyOpaqueOptions(options);
 }
 
+TEST(LiteRtQualcommOptionsTest, UseInt64BiasAsInt32) {
+  LiteRtOpaqueOptions options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
+
+  LiteRtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGet(options, &qualcomm_options));
+
+  LITERT_ASSERT_OK(
+      LiteRtQualcommOptionsSetUseInt64BiasAsInt32(qualcomm_options, false));
+
+  bool use_int64_bias_as_int32;
+  LITERT_ASSERT_OK(LiteRtQualcommOptionsGetUseInt64BiasAsInt32(
+      qualcomm_options, &use_int64_bias_as_int32));
+  EXPECT_FALSE(use_int64_bias_as_int32);
+
+  LiteRtDestroyOpaqueOptions(options);
+}
+
 TEST(LiteRtQualcommOptionsTest, EnableWeightSharing) {
   LiteRtOpaqueOptions options;
   LITERT_ASSERT_OK(LiteRtQualcommOptionsCreate(&options));
@@ -369,6 +387,10 @@ TEST(QualcommOptionsTest, CppApi) {
   EXPECT_FALSE(options->GetUseQint16AsQuint16());
   options->SetUseQint16AsQuint16(true);
   EXPECT_TRUE(options->GetUseQint16AsQuint16());
+
+  EXPECT_TRUE(options->GetUseInt64BiasAsInt32());
+  options->SetUseInt64BiasAsInt32(false);
+  EXPECT_FALSE(options->GetUseInt64BiasAsInt32());
 
   EXPECT_EQ(options->GetHtpPerformanceMode(),
             QualcommOptions::HtpPerformanceMode::kDefault);

--- a/litert/c/windows_exported_symbols.def
+++ b/litert/c/windows_exported_symbols.def
@@ -287,6 +287,7 @@ EXPORTS
   LiteRtQualcommOptionsGetUseFoldReLU
   LiteRtQualcommOptionsGetUseHtpPreference
   LiteRtQualcommOptionsGetUseQint16AsQuint16
+  LiteRtQualcommOptionsGetUseInt64BiasAsInt32
   LiteRtQualcommOptionsGetVtcmSize
   LiteRtQualcommOptionsSetBackend
   LiteRtQualcommOptionsSetDlcDir
@@ -305,6 +306,7 @@ EXPORTS
   LiteRtQualcommOptionsSetUseFoldReLU
   LiteRtQualcommOptionsSetUseHtpPreference
   LiteRtQualcommOptionsSetUseQint16AsQuint16
+  LiteRtQualcommOptionsSetUseInt64BiasAsInt32
   LiteRtQualcommOptionsSetVtcmSize
   LiteRtRegisterAccelerator
   LiteRtRegisterTensorBufferHandlers

--- a/litert/cc/options/litert_qualcomm_options.cc
+++ b/litert/cc/options/litert_qualcomm_options.cc
@@ -121,6 +121,18 @@ bool QualcommOptions::GetUseQint16AsQuint16() {
   return use_qin16_as_quint16;
 }
 
+void QualcommOptions::SetUseInt64BiasAsInt32(bool use_int64_bias_as_int32) {
+  internal::AssertOk(LiteRtQualcommOptionsSetUseInt64BiasAsInt32, Data(),
+                     use_int64_bias_as_int32);
+}
+
+bool QualcommOptions::GetUseInt64BiasAsInt32() {
+  bool use_int64_bias_as_int32;
+  internal::AssertOk(LiteRtQualcommOptionsGetUseInt64BiasAsInt32, Data(),
+                     &use_int64_bias_as_int32);
+  return use_int64_bias_as_int32;
+}
+
 void QualcommOptions::SetProfiling(QualcommOptions::Profiling profiling) {
   internal::AssertOk(LiteRtQualcommOptionsSetProfiling, Data(),
                      static_cast<LiteRtQualcommOptionsProfiling>(profiling));

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -100,6 +100,11 @@ class QualcommOptions : public OpaqueOptions {
   void SetUseQint16AsQuint16(bool use_qin16_as_quint16);
   bool GetUseQint16AsQuint16();
 
+  /// @brief This option controls whether to convert bias tensors of
+  /// FullyConnected and Conv2D Ops from int64 to int32. Defaults to `true`.
+  void SetUseInt64BiasAsInt32(bool use_int64_bias_as_int32);
+  bool GetUseInt64BiasAsInt32();
+
   /// @brief Indicates whether different subgraphs may share weight tensors.
   ///
   /// This is only supported on x86 AOT. Defaults to `false`.

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -94,6 +94,10 @@ ABSL_FLAG(bool, qualcomm_use_qint16_as_quint16, false,
           "Whether to automatically convert a quantized int16 model into a "
           "quantized uin16 model.");
 
+ABSL_FLAG(bool, qualcomm_use_int64_bias_as_int32, true,
+          "Whether to convert bias tensors of FullyConnected "
+          "and Conv2D Ops from int64 to int32. Defaults to true.");
+
 // Default should be
 // litert::qualcomm::QualcommOptions::HtpPerformanceMode::kDefault since we need
 // default performance model during compilation.
@@ -491,6 +495,10 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
   const auto use_qint16_as_quint16 =
       absl::GetFlag(FLAGS_qualcomm_use_qint16_as_quint16);
   opts.SetUseQint16AsQuint16(use_qint16_as_quint16);
+
+  const auto use_int64_bias_as_int32 =
+      absl::GetFlag(FLAGS_qualcomm_use_int64_bias_as_int32);
+  opts.SetUseInt64BiasAsInt32(use_int64_bias_as_int32);
 
   const auto htp_performance_mode =
       absl::GetFlag(FLAGS_qualcomm_htp_performance_mode);

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -64,6 +64,8 @@ ABSL_DECLARE_FLAG(bool, qualcomm_use_htp_preference);
 
 ABSL_DECLARE_FLAG(bool, qualcomm_use_qint16_as_quint16);
 
+ABSL_DECLARE_FLAG(bool, qualcomm_use_int64_bias_as_int32);
+
 ABSL_DECLARE_FLAG(::litert::tools::IntList, qualcomm_dump_tensor_ids);
 
 ABSL_DECLARE_FLAG(std::string, qualcomm_ir_json_dir);

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -110,6 +110,7 @@ inline LiteRtStatus InitQnnOptions(
       static_cast<::qnn::Profiling>(qualcomm_options.GetProfiling()));
   qnn_options.SetUseHtpPreference(qualcomm_options.GetUseHtpPreference());
   qnn_options.SetUseQint16AsQuint16(qualcomm_options.GetUseQint16AsQuint16());
+  qnn_options.SetUseInt64BiasAsInt32(qualcomm_options.GetUseInt64BiasAsInt32());
   qnn_options.SetBackendType(
       static_cast<::qnn::BackendType>(qualcomm_options.GetBackend()));
   qnn_options.SetEnableWeightSharing(qualcomm_options.GetEnableWeightSharing());

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -283,7 +283,8 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
 
     std::vector<::qnn::OpWrapper> op_wrappers;
     LITERT_RETURN_IF_ERROR(litert::qnn::ConvertOp(
-        compiler_plugin->Options().GetUseHtpPreference(), op, tensor_pool,
+        compiler_plugin->Options().GetUseHtpPreference(),
+        compiler_plugin->Options().GetUseInt64BiasAsInt32(), op, tensor_pool,
         input_tensors, output_tensors, op_wrappers));
 
     if (compiler_plugin->Options().GetUseQint16AsQuint16()) {

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
@@ -42,7 +42,7 @@ LiteRtStatus ConvertTensor(
     const absl::flat_hash_set<std::int32_t>& ids_to_dump = {},
     bool is_tensor_read_and_write = false);
 
-LiteRtStatus ConvertOp(const bool use_htp_preferences,
+LiteRtStatus ConvertOp(bool use_htp_preferences, bool use_int64_bias_as_int32,
                        const litert::Op& litert_op,
                        ::qnn::TensorPool& tensor_pool,
                        std::vector<::qnn::TensorWrapperRef>& input_tensors,

--- a/litert/vendors/qualcomm/core/builders/conv2d_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/conv2d_op_builder.h
@@ -18,7 +18,8 @@ std::vector<OpWrapper> BuildConv2dOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs, const std::uint32_t stride_h,
     const std::uint32_t stride_w, const std::uint32_t dilation_h,
-    const std::uint32_t dilation_w, const PaddingType padding_type);
+    const std::uint32_t dilation_w, const PaddingType padding_type,
+    bool use_int64_bias_as_int32);
 
 }  // namespace qnn
 

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
@@ -25,7 +25,8 @@ constexpr int kBiasIdx = 2;
 
 std::vector<OpWrapper> BuildFullyConnectedOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
-    const std::vector<TensorWrapperRef>& outputs, const bool keep_num_dims) {
+    const std::vector<TensorWrapperRef>& outputs, const bool keep_num_dims,
+    bool use_int64_bias_as_int32) {
   std::vector<OpWrapper> res;
   OpWrapper& fully_connected_op = CreateOpWrapper(res, QNN_OP_FULLY_CONNECTED);
 
@@ -35,27 +36,14 @@ std::vector<OpWrapper> BuildFullyConnectedOp(
   fully_connected_op.AddInputTensor(weight_tensor);
   if (inputs.size() - 1 >= kBiasIdx) {
     TensorWrapper& bias_tensor = inputs[kBiasIdx];
-    if (bias_tensor.IsTensorStatic() &&
+    if (use_int64_bias_as_int32 && bias_tensor.IsTensorStatic() &&
         bias_tensor.GetDataType() == QNN_DATATYPE_INT_64) {
-      const auto original_data = bias_tensor.GetTensorData<int64_t>();
-      if (!original_data.has_value()) {
-        QNN_LOG_ERROR(
-            "Failed to get static tensor data when convert bias tensor from "
-            "int64 to int32.");
+      auto* converted_bias_tensor =
+          tensor_pool.ConvertStaticTensorFrom<std::int32_t>(bias_tensor);
+      if (converted_bias_tensor == nullptr) {
         return {};
       }
-      const auto num_elements = bias_tensor.GetTensorNumElements();
-      std::vector<int32_t> converted_data(num_elements);
-      for (size_t i = 0; i < num_elements; ++i) {
-        converted_data[i] = static_cast<int32_t>((*original_data)[i]);
-      }
-      auto& converted_bias_tensor = tensor_pool.CreateStaticTensor(
-          QNN_DATATYPE_SFIXED_POINT_32, bias_tensor.GetQuantParams(),
-          bias_tensor.GetDimensions(),
-          num_elements * sizeof(decltype(converted_data)::value_type),
-          converted_data.data());
-
-      fully_connected_op.AddInputTensor(converted_bias_tensor);
+      fully_connected_op.AddInputTensor(*converted_bias_tensor);
       QNN_LOG_WARNING(
           "Convert bias tensor in fully connected op from int64 to int32.");
     } else {

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h
@@ -15,7 +15,8 @@ namespace qnn {
 
 std::vector<OpWrapper> BuildFullyConnectedOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
-    const std::vector<TensorWrapperRef>& outputs, const bool keep_num_dims);
+    const std::vector<TensorWrapperRef>& outputs, const bool keep_num_dims,
+    bool use_int64_bias_as_int32);
 
 }  // namespace qnn
 

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -77,6 +77,12 @@ void Options::SetUseQint16AsQuint16(bool use_qint16_as_quint16) {
 
 bool Options::GetUseQint16AsQuint16() const { return use_qint16_as_quint16_; }
 
+void Options::SetUseInt64BiasAsInt32(bool use_int64_bias_as_int32) {
+  use_int64_bias_as_int32_ = use_int64_bias_as_int32;
+}
+
+bool Options::GetUseInt64BiasAsInt32() const { return use_int64_bias_as_int32_; }
+
 void Options::SetEnableWeightSharing(bool enable_weight_sharing) {
   enable_weight_sharing_ = enable_weight_sharing;
 }
@@ -168,6 +174,7 @@ BackendType: %d\n\
 Profiling: %d\n\
 UseHtpPreference: %v\n\
 UseQint16AsQuint16: %v\n\
+UseInt64BiasAsInt32: %v\n\
 EnableWeightSharing: %v\n\
 UseConvHMX: %v\n\
 UseFoldReLU: %v\n\
@@ -186,11 +193,11 @@ SaverOutputDir: %s\n";  // NOLINT
 
   return absl::StrFormat(
       kQnnOptionsDumpFormat, log_level_, backend_type_, profiling_,
-      use_htp_preference_, use_qint16_as_quint16_, enable_weight_sharing_,
-      use_conv_hmx_, use_fold_relu_, htp_performance_mode_,
-      dsp_performance_mode_, dump_tensor_ids, ir_json_dir_, dlc_dir_,
-      vtcm_size_, num_hvx_threads_, optimization_level_, graph_priority_,
-      saver_output_dir_);
+      use_htp_preference_, use_qint16_as_quint16_, use_int64_bias_as_int32_,
+      enable_weight_sharing_, use_conv_hmx_, use_fold_relu_,
+      htp_performance_mode_, dsp_performance_mode_, dump_tensor_ids,
+      ir_json_dir_, dlc_dir_, vtcm_size_, num_hvx_threads_, optimization_level_,
+      graph_priority_, saver_output_dir_);
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -97,6 +97,9 @@ class Options {
   void SetUseQint16AsQuint16(bool use_qint16_as_quint16);
   bool GetUseQint16AsQuint16() const;
 
+  void SetUseInt64BiasAsInt32(bool use_int64_bias_as_int32);
+  bool GetUseInt64BiasAsInt32() const;
+
   void SetEnableWeightSharing(bool enable_weight_sharing);
   bool GetEnableWeightSharing() const;
 
@@ -145,6 +148,7 @@ class Options {
   Profiling profiling_ = Profiling::kOff;
   bool use_htp_preference_ = false;
   bool use_qint16_as_quint16_ = false;
+  bool use_int64_bias_as_int32_ = true;
   bool enable_weight_sharing_ = false;
   bool use_conv_hmx_ = true;
   bool use_fold_relu_ = true;

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -171,6 +171,14 @@ TEST(QnnOptionTest, UseQint16AsQuint16) {
   EXPECT_EQ(options.GetUseQint16AsQuint16(), false);
 }
 
+TEST(QnnOptionTest, UseInt64BiasAsInt32) {
+  Options options;
+  options.SetUseInt64BiasAsInt32(true);
+  EXPECT_EQ(options.GetUseInt64BiasAsInt32(), true);
+  options.SetUseInt64BiasAsInt32(false);
+  EXPECT_EQ(options.GetUseInt64BiasAsInt32(), false);
+}
+
 TEST(QnnOptionTest, EnableWeightSharing) {
   Options options;
   options.SetEnableWeightSharing(true);
@@ -259,6 +267,7 @@ TEST(QnnOptionTest, Default) {
   EXPECT_EQ(options.GetProfiling(), Profiling::kOff);
   EXPECT_FALSE(options.GetUseHtpPreference());
   EXPECT_FALSE(options.GetUseQint16AsQuint16());
+  EXPECT_TRUE(options.GetUseInt64BiasAsInt32());
   EXPECT_FALSE(options.GetEnableWeightSharing());
   EXPECT_TRUE(options.GetUseConvHMX());
   EXPECT_TRUE(options.GetUseFoldReLU());

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/fully_connected_int2_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/fully_connected_int2_test.cc
@@ -44,7 +44,7 @@ TEST_P(QnnModelTest, FullyConnectedInt2Sanity) {
       int2_weight_data.size(), int2_weight_data.data());
 
   auto ops = ::qnn::BuildFullyConnectedOp(
-      tensor_pool_, {input_0, weight_tensor}, {output_0}, true);
+      tensor_pool_, {input_0, weight_tensor}, {output_0}, true, false);
   ASSERT_FALSE(ops.empty());
 
   qnn_model_.MoveOpsToGraph(std::move(ops));


### PR DESCRIPTION
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.5s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.3s
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 42.1s

======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 23 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 23 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 13 tests from 3 test suites ran. (8 ms total)
[  PASSED  ] 13 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 30 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (6 ms total)
[  PASSED  ] 64 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (12 ms total)
[  PASSED  ] 8 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (337 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (363 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (800 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (365 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (401 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (605 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2017 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (16 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (440 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (406 ms total)
[  PASSED  ] 2 tests.
```