### PR TITLE
Qualcomm AI Engine Direct - Clean up CMake build dependencies

### DIFF
--- a/litert/c/litert_environment.cc
+++ b/litert/c/litert_environment.cc
@@ -60,10 +60,14 @@ LiteRtStatus LiteRtCreateEnvironment(int num_options,
       });
 
   if (has_gpu_options) {
+#if !defined(LITERT_DISABLE_GPU)
     LITERT_ASSIGN_OR_RETURN(
         auto gpu_env,
         litert::internal::GpuEnvironment::Create(env->GetOptions()));
     LITERT_RETURN_IF_ERROR(env->SetGpuEnvironment(std::move(gpu_env)));
+#else
+    return kLiteRtStatusErrorInvalidArgument;
+#endif  // !defined(LITERT_DISABLE_GPU)
   }
 
   *environment = env.release();
@@ -114,6 +118,7 @@ LiteRtStatus LiteRtAddEnvironmentOptions(LiteRtEnvironment environment,
 LiteRtStatus LiteRtGpuEnvironmentCreate(LiteRtEnvironment environment,
                                         int num_options,
                                         const LiteRtEnvOption* options) {
+#if !defined(LITERT_DISABLE_GPU)
   LITERT_RETURN_IF_ERROR(
       environment->AddOptions(absl::MakeSpan(options, num_options)));
   LITERT_ASSIGN_OR_RETURN(
@@ -121,6 +126,9 @@ LiteRtStatus LiteRtGpuEnvironmentCreate(LiteRtEnvironment environment,
       litert::internal::GpuEnvironment::Create(environment->GetOptions()));
   LITERT_RETURN_IF_ERROR(environment->SetGpuEnvironment(std::move(gpu_env)));
   return kLiteRtStatusOk;
+#else
+  return kLiteRtStatusErrorInvalidArgument;
+#endif  // !defined(LITERT_DISABLE_GPU)
 }
 
 LiteRtStatus LiteRtEnvironmentSupportsClGlInterop(LiteRtEnvironment environment,

--- a/litert/vendors/qualcomm/CMakeLists.txt
+++ b/litert/vendors/qualcomm/CMakeLists.txt
@@ -64,7 +64,10 @@ target_link_libraries(qnn_manager
         absl::statusor
         absl::strings
         absl::str_format
+    PRIVATE
         qnn_saver_utils
+        qnn_backends
+        qnn_wrappers
 )
 
 # Context Binary Info library

--- a/litert/vendors/qualcomm/compiler/CMakeLists.txt
+++ b/litert/vendors/qualcomm/compiler/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(qnn_compiler_plugin
     PUBLIC
         qnn_core
     PRIVATE
+        qnn_wrappers
         qnn_builders
         qnn_manager
         qnn_transformation

--- a/litert/vendors/qualcomm/core/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/CMakeLists.txt
@@ -39,8 +39,6 @@ target_link_libraries(qnn_core
         absl::str_format
         absl::span
         absl::string_view
-        qnn_backends
-        qnn_wrappers
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")

--- a/litert/vendors/qualcomm/core/builders/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/builders/CMakeLists.txt
@@ -74,4 +74,6 @@ target_include_directories(qnn_builders
 target_link_libraries(qnn_builders
     PUBLIC
         qnn_core
+    PRIVATE
+        qnn_wrappers
 )

--- a/litert/vendors/qualcomm/core/wrappers/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/wrappers/CMakeLists.txt
@@ -30,4 +30,6 @@ target_link_libraries(qnn_wrappers
         absl::str_format
         absl::span
         absl::string_view
+    PRIVATE
+        qnn_core
 )

--- a/litert/vendors/qualcomm/tests/CMakeLists.txt
+++ b/litert/vendors/qualcomm/tests/CMakeLists.txt
@@ -54,7 +54,7 @@ target_sources(qnn_manager_test
 target_link_libraries(qnn_manager_test
     PRIVATE
         absl::log_internal_message
-        qnn_compiler_plugin
+        qnn_manager
         litert_test_common
         GTest::gtest_main
 )


### PR DESCRIPTION
Summary:

- Clean up the dependencies of qnn_manager_test

Test Result:

- Build pass for x86 and aarch64 platform
- Pass x86 UT and aarch64 UT

======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test               PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test                 PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test                  PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 42.7s

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (11 ms total)
[  PASSED  ] 12 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 13 tests from 3 test suites ran. (28 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (9 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (8 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (14 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 16 tests from 1 test suite ran. (4 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (4 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (27 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (11 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (885 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (5839 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (2312 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (1411 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (4176 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (718 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2181 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (176 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (22 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (415 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (486 ms total)
[  PASSED  ] 2 tests