### PR TITLE
Qualcomm AI Engine Direct - Support more SoC

### DIFF
--- a/litert/vendors/qualcomm/core/schema/soc_table.cc
+++ b/litert/vendors/qualcomm/core/schema/soc_table.cc
@@ -51,6 +51,9 @@ constexpr SocInfo kSocInfos[] = {
     {SocInfo("SXR2230P", SnapdragonModel::SXR2230P, DspArch::V69,
              8  // vtcm_size_in_mb
              )},
+    {SocInfo("SSG2125P", SnapdragonModel::SSG2125P, DspArch::V73,
+             2  // vtcm_size_in_mb
+             )},
 };
 constexpr uint64_t kNumSocInfos = sizeof(kSocInfos) / sizeof(kSocInfos[0]);
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/schema/soc_table.h
+++ b/litert/vendors/qualcomm/core/schema/soc_table.h
@@ -18,6 +18,7 @@ enum class SnapdragonModel {
   SA8255 = 52,
   SXR2230P = 53,
   SM8650 = 57,
+  SSG2125P = 58,
   SC8380XP = 60,
   SM8750 = 69,
   SM8850 = 87,


### PR DESCRIPTION
Summary:
- Add SSG2125P support

Test Result:
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all


//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 41.2s

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (6 ms total)
[  PASSED  ] 12 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 13 tests from 3 test suites ran. (29 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (6 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (7 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (14 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 16 tests from 1 test suite ran. (9 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (6 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (22 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (905 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (762 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (742 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (1376 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (763 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (8 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (600 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2070 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (56 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (23 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (744 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (441 ms total)
[  PASSED  ] 2 tests.