### PR TITLE
Qualcomm AI Engine Direct - Refactor AxisScaleOffsetQuantizeParamsWrapper.

### DIFF
--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.cc
@@ -60,8 +60,8 @@ void ScaleOffsetQuantizeParamsWrapper::CloneTo(Qnn_QuantizeParams_t& dst) {
 }
 
 AxisScaleOffsetQuantizeParamsWrapper::AxisScaleOffsetQuantizeParamsWrapper(
-    const std::int32_t axis, const absl::Span<const float> scales,
-    const absl::Span<const std::int32_t> zero_points)
+    std::int32_t axis, absl::Span<const float> scales,
+    absl::Span<const std::int32_t> zero_points)
     : scale_offsets_(scales.size()) {
   assert(scales.size() == zero_points.size());
   for (size_t i = 0; i < scale_offsets_.size(); ++i) {
@@ -175,22 +175,23 @@ void AxisScaleOffsetQuantizeParamsWrapper::SetAxis(const std::int32_t axis) {
   qnn_quantize_param_.axisScaleOffsetEncoding.axis = axis;
 }
 
-void AxisScaleOffsetQuantizeParamsWrapper::GetScales(
-    std::vector<float>& scales) const {
-  scales.clear();
+std::vector<float> AxisScaleOffsetQuantizeParamsWrapper::GetScales() const {
+  std::vector<float> scales;
   scales.reserve(scale_offsets_.size());
   for (size_t i = 0; i < scale_offsets_.size(); ++i) {
     scales.emplace_back(scale_offsets_[i].scale);
   }
+  return scales;
 }
 
-void AxisScaleOffsetQuantizeParamsWrapper::GetZeroPoints(
-    std::vector<std::int32_t>& zero_points) const {
-  zero_points.clear();
+std::vector<std::int32_t> AxisScaleOffsetQuantizeParamsWrapper::GetZeroPoints()
+    const {
+  std::vector<std::int32_t> zero_points;
   zero_points.reserve(scale_offsets_.size());
   for (size_t i = 0; i < scale_offsets_.size(); ++i) {
     zero_points.emplace_back(-1 * scale_offsets_[i].offset);
   }
+  return zero_points;
 }
 
 BwScaleOffsetQuantizeParamsWrapper::BwScaleOffsetQuantizeParamsWrapper(

--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
@@ -53,8 +53,8 @@ class ScaleOffsetQuantizeParamsWrapper final {
 class AxisScaleOffsetQuantizeParamsWrapper final {
  public:
   explicit AxisScaleOffsetQuantizeParamsWrapper(
-      const std::int32_t axis, const absl::Span<const float> scales,
-      const absl::Span<const std::int32_t> zero_points);
+      std::int32_t axis, absl::Span<const float> scales,
+      absl::Span<const std::int32_t> zero_points);
 
   explicit AxisScaleOffsetQuantizeParamsWrapper(
       const Qnn_AxisScaleOffset_t& axis_scale_offset);
@@ -81,9 +81,9 @@ class AxisScaleOffsetQuantizeParamsWrapper final {
 
   void SetAxis(const std::int32_t axis);
 
-  void GetScales(std::vector<float>& scales) const;
+  std::vector<float> GetScales() const;
 
-  void GetZeroPoints(std::vector<std::int32_t>& zero_points) const;
+  std::vector<std::int32_t> GetZeroPoints() const;
 
  private:
   std::vector<Qnn_ScaleOffset_t> scale_offsets_;

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -325,15 +325,11 @@ void TensorWrapper::ConvertQint16ToQuint16() {
   } else if (IsPerChannelQuant()) {
     const auto& q_param =
         std::get<AxisScaleOffsetQuantizeParamsWrapper>(GetQuantParams());
-    std::int32_t axis = q_param.GetAxis();
-    std::vector<float> scales;
-    q_param.GetScales(scales);
-    std::vector<std::int32_t> zero_points;
-    q_param.GetZeroPoints(zero_points);
+    std::vector<int32_t> zero_points = q_param.GetZeroPoints();
     std::for_each(zero_points.begin(), zero_points.end(),
                   [](std::int32_t& val) { val += kUint16ZeroPoint; });
     quantize_params_.emplace<AxisScaleOffsetQuantizeParamsWrapper>(
-        axis, absl::MakeSpan(scales), absl::MakeSpan(zero_points));
+        q_param.GetAxis(), q_param.GetScales(), zero_points);
   }
 
   UpdateQnnQuantParams();

--- a/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
@@ -185,11 +185,9 @@ TEST(AxisScaleOffsetQuantizeParamsWrapperTest, GetterTest) {
   std::vector<float> scales = {1.5f, 2.5f};
   std::vector<std::int32_t> zero_points = {10, 20};
   AxisScaleOffsetQuantizeParamsWrapper wrapper(axis, scales, zero_points);
-  std::vector<float> scales_out;
-  wrapper.GetScales(scales_out);
+  const auto scales_out = wrapper.GetScales();
   EXPECT_EQ(scales, scales_out);
-  std::vector<std::int32_t> zero_points_out;
-  wrapper.GetZeroPoints(zero_points_out);
+  const auto zero_points_out = wrapper.GetZeroPoints();
   EXPECT_EQ(zero_points, zero_points_out);
 }
 


### PR DESCRIPTION
Summary:
- Remove top-level const from constructor parameters
- Use NRVO-friendly return style for GetScales() and GetZeroPoint().

Test:
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:all


//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 36.8s
```

```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (2 ms total)
[  PASSED  ] 12 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 13 tests from 3 test suites ran. (9 ms total)
[  PASSED  ] 13 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 30 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 64 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (11 ms total)
[  PASSED  ] 8 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (376 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (379 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (382 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (412 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (774 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (601 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2019 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (18 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (5 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (422 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (366 ms total)
[  PASSED  ] 2 tests.
```