### PR TITLE
Qualcomm AI Engine Direct - Refactor data unpack for int2 and int4.

### DIFF
--- a/litert/vendors/qualcomm/core/utils/miscs.cc
+++ b/litert/vendors/qualcomm/core/utils/miscs.cc
@@ -8,6 +8,7 @@
 #include <dlfcn.h>
 #endif
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
@@ -43,46 +44,6 @@ void ConvertDataFromUInt16toInt16(absl::Span<const std::uint16_t> src,
   dst.reserve(src.size());
   for (const auto& data : src) {
     dst.emplace_back(data - kUint16ZeroPoint);
-  }
-}
-
-void ConvertDataFromInt4ToInt8(const void* src, size_t num_bytes,
-                               std::vector<std::int8_t>& dst) {
-  dst.clear();
-  dst.reserve(num_bytes * 2);
-  const std::uint8_t* byte_data = static_cast<const std::uint8_t*>(src);
-  for (size_t i = 0; i < num_bytes; i++) {
-    std::uint8_t byte = byte_data[i];
-    std::int8_t lower = byte & 0x0F;
-    std::int8_t upper = (byte >> 4) & 0x0F;
-    if (lower & 0x08) lower |= 0xF0;
-    if (upper & 0x08) upper |= 0xF0;
-    dst.emplace_back(lower);
-    dst.emplace_back(upper);
-  }
-}
-
-void ConvertDataFromInt2ToInt8(const void* src, size_t num_bytes,
-                               std::vector<std::int8_t>& dst) {
-  dst.clear();
-  dst.reserve(num_bytes * 4);
-  const std::uint8_t* byte_data = static_cast<const std::uint8_t*>(src);
-  for (size_t i = 0; i < num_bytes; i++) {
-    std::uint8_t byte = byte_data[i];
-
-    for (size_t j = 0; j < 4; j++) {
-      // Mask: 0000 0011
-      std::int8_t num = byte & 0x03;
-
-      // Perform sign extension on all four numbers
-      // The sign bit for a 2-bit number is the 2nd bit (mask 0x02)
-      // The sign extension mask is 0xFC (binary 1111 1100)
-      if (num & 0x02) num |= 0xFC;
-
-      dst.emplace_back(num);
-
-      byte >>= 2;
-    }
   }
 }
 
@@ -221,5 +182,61 @@ std::optional<::qnn::SocInfo> FindSocModel(std::string_view soc_model_name) {
     }
   }
   return soc_model;
+}
+
+namespace {
+
+constexpr std::array<int8_t, 256 * 4> MakeInt2LUT() {
+  std::array<int8_t, 256 * 4> lut{};
+  for (int b = 0; b < 256; b++) {
+    for (int i = 0; i < 4; i++) {
+      int v = (b >> (i * 2)) & 3;
+      if (v & 2) v |= ~3;
+      lut[b * 4 + i] = static_cast<int8_t>(v);
+    }
+  }
+  return lut;
+}
+alignas(64) constexpr auto kInt2LUT = MakeInt2LUT();
+
+constexpr std::array<int8_t, 256 * 2> MakeInt4LUT() {
+  std::array<int8_t, 256 * 2> lut{};
+  for (int b = 0; b < 256; b++) {
+    for (int i = 0; i < 2; i++) {
+      int v = (b >> (i * 4)) & 0xF;
+      if (v & 0x8) v |= ~0xF;
+      lut[b * 2 + i] = static_cast<int8_t>(v);
+    }
+  }
+  return lut;
+}
+alignas(64) constexpr auto kInt4LUT = MakeInt4LUT();
+
+}  // namespace
+
+std::vector<std::int8_t> UnpackInt2Data(const void* src, size_t src_bytes) {
+  std::vector<std::int8_t> dst;
+  dst.reserve(src_bytes * 4);
+  const std::uint8_t* byte_data = static_cast<const std::uint8_t*>(src);
+  for (size_t i = 0; i < src_bytes; i++) {
+    const int8_t* lut_entry = &kInt2LUT[byte_data[i] * 4];
+    for (size_t j = 0; j < 4; j++) {
+      dst.emplace_back(lut_entry[j]);
+    }
+  }
+  return dst;
+}
+
+std::vector<std::int8_t> UnpackInt4Data(const void* src, size_t src_bytes) {
+  std::vector<std::int8_t> dst;
+  dst.reserve(src_bytes * 2);
+  const std::uint8_t* byte_data = static_cast<const std::uint8_t*>(src);
+  for (size_t i = 0; i < src_bytes; i++) {
+    const int8_t* lut_entry = &kInt4LUT[byte_data[i] * 2];
+    for (size_t j = 0; j < 2; j++) {
+      dst.emplace_back(lut_entry[j]);
+    }
+  }
+  return dst;
 }
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/utils/miscs.h
+++ b/litert/vendors/qualcomm/core/utils/miscs.h
@@ -39,6 +39,7 @@ constexpr uint32_t kUint16ZeroPoint = -std::numeric_limits<std::int16_t>::min();
 constexpr uint32_t kQuantBitWidth4 = 4;
 constexpr uint32_t kQuantBitWidth2 = 2;
 
+
 template <typename...>
 inline constexpr bool always_false = false;
 template <typename T>
@@ -69,14 +70,12 @@ void ConvertDataFromInt16toUInt16(absl::Span<const std::int16_t> src,
 void ConvertDataFromUInt16toInt16(absl::Span<const std::uint16_t> src,
                                   std::vector<std::int16_t>& dst);
 
-void ConvertDataFromInt4ToInt8(const void* src, size_t num_bytes,
-                               std::vector<std::int8_t>& dst);
-
-void ConvertDataFromInt2ToInt8(const void* src, size_t num_bytes,
-                               std::vector<std::int8_t>& dst);
-
 void ConvertDataFromInt8ToInt2(const std::vector<std::int8_t>& src,
                                std::vector<std::int8_t>& dst);
+
+std::vector<std::int8_t> UnpackInt2Data(const void* src, size_t src_bytes);
+
+std::vector<std::int8_t> UnpackInt4Data(const void* src, size_t src_bytes);
 
 bool CreateDirectoryRecursive(const std::filesystem::path& dir_name);
 

--- a/litert/vendors/qualcomm/core/utils/utils_test.cc
+++ b/litert/vendors/qualcomm/core/utils/utils_test.cc
@@ -160,4 +160,116 @@ TEST(MiscTests, DISABLED_LoadHtpBackendApiTest) {
   ASSERT_TRUE(api);
 }
 
+TEST(MiscTests, UnpackInt2Data) {
+  // Single byte: 0xE4 (binary: 11 10 01 00), LSB-first unpacking.
+  // bits 0-1: 00 -> 0
+  // bits 2-3: 01 -> 1
+  // bits 4-5: 10 -> -2
+  // bits 6-7: 11 -> -1
+  {
+    const uint8_t src[] = {0xE4};
+    auto dst = UnpackInt2Data(src, 1);
+    ASSERT_EQ(dst.size(), 4);
+    EXPECT_EQ(dst[0], 0);
+    EXPECT_EQ(dst[1], 1);
+    EXPECT_EQ(dst[2], -2);
+    EXPECT_EQ(dst[3], -1);
+  }
+
+  // All zeros: 0x00 -> {0, 0, 0, 0}
+  {
+    const uint8_t src[] = {0x00};
+    auto dst = UnpackInt2Data(src, 1);
+    ASSERT_EQ(dst.size(), 4);
+    EXPECT_EQ(dst[0], 0);
+    EXPECT_EQ(dst[1], 0);
+    EXPECT_EQ(dst[2], 0);
+    EXPECT_EQ(dst[3], 0);
+  }
+
+  // All ones: 0xFF (binary: 11 11 11 11) -> {-1, -1, -1, -1}
+  {
+    const uint8_t src[] = {0xFF};
+    auto dst = UnpackInt2Data(src, 1);
+    ASSERT_EQ(dst.size(), 4);
+    EXPECT_EQ(dst[0], -1);
+    EXPECT_EQ(dst[1], -1);
+    EXPECT_EQ(dst[2], -1);
+    EXPECT_EQ(dst[3], -1);
+  }
+
+  // Multiple bytes: {0xE4, 0x1B}
+  // 0x1B (binary: 00 01 10 11):
+  //   bits 0-1: 11 -> -1
+  //   bits 2-3: 10 -> -2
+  //   bits 4-5: 01 ->  1
+  //   bits 6-7: 00 ->  0
+  {
+    const uint8_t src[] = {0xE4, 0x1B};
+    auto dst = UnpackInt2Data(src, 2);
+    ASSERT_EQ(dst.size(), 8);
+    EXPECT_EQ(dst[0], 0);
+    EXPECT_EQ(dst[1], 1);
+    EXPECT_EQ(dst[2], -2);
+    EXPECT_EQ(dst[3], -1);
+    EXPECT_EQ(dst[4], -1);
+    EXPECT_EQ(dst[5], -2);
+    EXPECT_EQ(dst[6], 1);
+    EXPECT_EQ(dst[7], 0);
+  }
+}
+
+TEST(MiscTests, UnpackInt4Data) {
+  // Single byte: 0xE4 (binary: 1110 0100), LSB-first unpacking.
+  // lower nibble: 0100 = 4
+  // upper nibble: 1110 = -2 (sign extended)
+  {
+    const uint8_t src[] = {0xE4};
+    auto dst = UnpackInt4Data(src, 1);
+    ASSERT_EQ(dst.size(), 2);
+    EXPECT_EQ(dst[0], 4);
+    EXPECT_EQ(dst[1], -2);
+  }
+
+  // All zeros: 0x00 -> {0, 0}
+  {
+    const uint8_t src[] = {0x00};
+    auto dst = UnpackInt4Data(src, 1);
+    ASSERT_EQ(dst.size(), 2);
+    EXPECT_EQ(dst[0], 0);
+    EXPECT_EQ(dst[1], 0);
+  }
+
+  // All ones: 0xFF (binary: 1111 1111) -> {-1, -1}
+  {
+    const uint8_t src[] = {0xFF};
+    auto dst = UnpackInt4Data(src, 1);
+    ASSERT_EQ(dst.size(), 2);
+    EXPECT_EQ(dst[0], -1);
+    EXPECT_EQ(dst[1], -1);
+  }
+
+  // Min/max: 0x87 (binary: 1000 0111)
+  // lower nibble: 0111 = 7 (max positive int4)
+  // upper nibble: 1000 = -8 (min negative int4)
+  {
+    const uint8_t src[] = {0x87};
+    auto dst = UnpackInt4Data(src, 1);
+    ASSERT_EQ(dst.size(), 2);
+    EXPECT_EQ(dst[0], 7);
+    EXPECT_EQ(dst[1], -8);
+  }
+
+  // Multiple bytes: {0xE4, 0x87}
+  {
+    const uint8_t src[] = {0xE4, 0x87};
+    auto dst = UnpackInt4Data(src, 2);
+    ASSERT_EQ(dst.size(), 4);
+    EXPECT_EQ(dst[0], 4);
+    EXPECT_EQ(dst[1], -2);
+    EXPECT_EQ(dst[2], 7);
+    EXPECT_EQ(dst[3], -8);
+  }
+}
+
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -101,15 +101,13 @@ TensorWrapper::TensorWrapper(
   // Already map to QNN_DATATYPE_SFIXED_POINT_8 for 4-bit and 2-bit
   // quantization
   if (IsQuantBitwidth(kQuantBitWidth4)) {
-    std::vector<std::int8_t> int8_data;
     QNN_LOG_DEBUG("4-bit Qunat, converting data to 8-bit for QNN.");
-    ConvertDataFromInt4ToInt8(data, bytes, int8_data);
+    auto int8_data = UnpackInt4Data(data, bytes);
     // Set copy_data to true to prevent loss of int8_data.
     SetDataBy(GetTensorBytes(), int8_data.data(), true);
   } else if (IsQuantBitwidth(kQuantBitWidth2)) {
-    std::vector<std::int8_t> int8_data;
     QNN_LOG_DEBUG("2-bit Qunat, converting data to 8-bit for QNN.");
-    ConvertDataFromInt2ToInt8(data, bytes, int8_data);
+    auto int8_data = UnpackInt2Data(data, bytes);
     SetDataBy(GetTensorBytes(), int8_data.data(), true);
   } else {
     SetDataBy(bytes, data, copy_data);

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -569,15 +569,13 @@ void RunQnnTensorImplicitCopyTest(Qnn_DataType_t datatype) {
   tensor_wrapper.CloneTo(cloned_tensor);
   Qnn_Tensor_t& ref_tensor = tensor_wrapper.GetQnnTensor();
   if constexpr (bitwidth == kQuantBitWidth4) {
-    std::vector<std::int8_t> int8_data;
-    ConvertDataFromInt4ToInt8(data.data(), data.size(), int8_data);
+    auto int8_data = UnpackInt4Data(data.data(), data.size());
     ValidateTensor<int8_t, true>(cloned_tensor, QNN_DATATYPE_SFIXED_POINT_8,
                                  kDims, int8_data);
     ValidateTensor<int8_t, true>(ref_tensor, QNN_DATATYPE_SFIXED_POINT_8, kDims,
                                  int8_data);
   } else if constexpr (bitwidth == kQuantBitWidth2) {
-    std::vector<std::int8_t> int8_data;
-    ConvertDataFromInt2ToInt8(data.data(), data.size(), int8_data);
+    auto int8_data = UnpackInt2Data(data.data(), data.size());
     ValidateTensor<int8_t, true>(cloned_tensor, QNN_DATATYPE_SFIXED_POINT_8,
                                  kDims, int8_data);
     ValidateTensor<int8_t, true>(ref_tensor, QNN_DATATYPE_SFIXED_POINT_8, kDims,


### PR DESCRIPTION
# What
Make data unpack faster by refactor to function with LUT.

## Verification
 ```
[Int2 Benchmark] 1000 iterations x 4096 bytes
  ConvertDataFromInt2ToInt8 : 31.258 ms total  (0.0313 ms/iter)
  UnpackIntData<2>          : 9.582 ms total  (0.0096 ms/iter)
  Speedup (Convert/Unpack)  : 3.26x
 
[Int4 Benchmark] 1000 iterations x 4096 bytes
  ConvertDataFromInt4ToInt8 : 5.181 ms total  (0.0052 ms/iter)
  UnpackIntData<4>          : 4.216 ms total  (0.0042 ms/iter)
  Speedup (Convert/Unpack)  : 1.23x 
```
# Test
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.
 
SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (2 ms total)
[  PASSED  ] 12 tests.
 
SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 15 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 15 tests.
 
SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 20 tests.
 
SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 30 tests.
 
SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.
 
SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 64 tests.
 
SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 16 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 16 tests.
 
SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 17 tests.
 
SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.
 
SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.
 
SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (13 ms total)
[  PASSED  ] 8 tests.
 
SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (801 ms total)
[  PASSED  ] 1 test.
 
SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (770 ms total)
[  PASSED  ] 1 test.
 
SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (1438 ms total)
[  PASSED  ] 2 tests.
 
SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (729 ms total)
[  PASSED  ] 1 test.
 
SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (716 ms total)
[  PASSED  ] 1 test.
 
SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.
 
SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (560 ms total)
[  PASSED  ] 9 tests.
 
SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.
 
SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2037 ms total)
[  PASSED  ] 11 tests.
 
SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (26 ms total)
[  PASSED  ] 2 tests.
 
SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (5 ms total)
[  PASSED  ] 0 tests.
 
SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (542 ms total)
[  PASSED  ] 5 tests.
 
SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (451 ms total)
[  PASSED  ] 2 tests.
```

```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 42.0s
```