### PR TITLE
Qualcomm AI Engine Direct - Rename I/O tensors to align with QNN converter.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -29,6 +29,7 @@
 
 #include "absl/container/flat_hash_map.h"  // from @com_google_absl
 #include "absl/container/flat_hash_set.h"  // from @com_google_absl
+#include "absl/strings/ascii.h"  // from @com_google_absl
 #include "absl/strings/str_cat.h"  // from @com_google_absl
 #include "absl/strings/str_split.h"  // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
@@ -109,7 +110,25 @@
 namespace litert::qnn {
 namespace {
 static const char* kLiteRtStr = "litert";
+
+std::string SanitizeName(std::string_view name) {
+  std::string out;
+  out.reserve(name.size());
+  bool underscore_added = false;
+
+  // This does the same as python re.sub(r"[^a-zA-Z0-9_]+", "_", name).
+  for (char c : name) {
+    if (absl::ascii_isalnum(c) || c == '_') {
+      out.push_back(c);
+      underscore_added = false;
+    } else if (!underscore_added) {
+      out.push_back('_');
+      underscore_added = true;
+    }
+  }
+  return out;
 }
+}  // namespace
 
 LiteRtStatus ConvertPaddingType(const uint32_t litert_padding,
                                 ::qnn::PaddingType& qnn_padding) {
@@ -296,12 +315,14 @@ LiteRtStatus ConvertTensor(const litert::Tensor& litert_tensor,
   auto litert_suffix =
       "_" + std::string(kLiteRtStr) + "_" + std::to_string(tensor_index);
   if (litert_tensor.IsSubgraphInput()) {
-    auto& res = tensor_pool.CreateInputTensorWithSuffix(
-        qnn_data_type, quantize_params, dimensions, litert_suffix);
+    auto& res = tensor_pool.CreateInputTensorWithName(
+        SanitizeName(litert_tensor.Name()), qnn_data_type, quantize_params,
+        dimensions);
     tensor_wrapper = &res;
   } else if (litert_tensor.Uses().empty() || is_tensor_read_and_write) {
-    auto& res = tensor_pool.CreateOutpuTensorWithSuffix(
-        qnn_data_type, quantize_params, dimensions, litert_suffix);
+    auto& res = tensor_pool.CreateOutputTensorWithName(
+        SanitizeName(litert_tensor.Name()), qnn_data_type, quantize_params,
+        dimensions);
     tensor_wrapper = &res;
   } else if (litert_tensor.IsConstant()) {
     LITERT_RETURN_IF_ERROR(

--- a/litert/vendors/qualcomm/core/tensor_pool.cc
+++ b/litert/vendors/qualcomm/core/tensor_pool.cc
@@ -21,24 +21,23 @@
 
 namespace qnn {
 
+
 TensorPool::TensorPool() = default;
 
-TensorWrapper& TensorPool::CreateInputTensorWithSuffix(
-    Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
-    const std::vector<std::uint32_t>& dimensions, std::string_view suffix) {
-  const auto id = tensor_wrappers_.size();
-  auto tensor_name = std::to_string(id) + std::string(suffix);
-  return tensor_wrappers_.emplace_back(std::move(tensor_name),
+TensorWrapper& TensorPool::CreateInputTensorWithName(
+    std::string_view name, Qnn_DataType_t data_type,
+    const QuantizeParamsWrapperVariant& quant_params,
+    const std::vector<std::uint32_t>& dimensions) {
+  return tensor_wrappers_.emplace_back(std::string{name},
                                        QNN_TENSOR_TYPE_APP_WRITE, data_type,
                                        quant_params, dimensions);
 }
 
-TensorWrapper& TensorPool::CreateOutpuTensorWithSuffix(
-    Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
-    const std::vector<std::uint32_t>& dimensions, std::string_view suffix) {
-  const auto id = tensor_wrappers_.size();
-  auto tensor_name = std::to_string(id) + std::string(suffix);
-  return tensor_wrappers_.emplace_back(std::move(tensor_name),
+TensorWrapper& TensorPool::CreateOutputTensorWithName(
+    std::string_view name, Qnn_DataType_t data_type,
+    const QuantizeParamsWrapperVariant& quant_params,
+    const std::vector<std::uint32_t>& dimensions) {
+  return tensor_wrappers_.emplace_back(std::string{name},
                                        QNN_TENSOR_TYPE_APP_READ, data_type,
                                        quant_params, dimensions);
 }

--- a/litert/vendors/qualcomm/core/tensor_pool.h
+++ b/litert/vendors/qualcomm/core/tensor_pool.h
@@ -22,19 +22,22 @@ namespace qnn {
 static const char* kQnnSuffix = "_qnn";
 class TensorPool {
  public:
-  TensorPool();
   // id: Number of tensors in TensorPool, used for ensure uniqueness of tensor
-  // name Tensors directly converted from framework: <id>_suffix_from_framework
-  // Tensors created by builder: <id>_qnn
-  TensorWrapper& CreateInputTensorWithSuffix(
-      Qnn_DataType_t data_type,
-      const QuantizeParamsWrapperVariant& quant_params,
-      const std::vector<std::uint32_t>& dimensions, std::string_view suffix);
+  // name. I/O tensors will use the exact same name as provided. Tensors
+  // directly converted from framework: `<id>_suffix_from_framework`. Tensors
+  // created by QNN: `<id>_qnn`.
 
-  TensorWrapper& CreateOutpuTensorWithSuffix(
-      Qnn_DataType_t data_type,
+  TensorPool();
+
+  TensorWrapper& CreateInputTensorWithName(
+      std::string_view name, Qnn_DataType_t data_type,
       const QuantizeParamsWrapperVariant& quant_params,
-      const std::vector<std::uint32_t>& dimensions, std::string_view suffix);
+      const std::vector<std::uint32_t>& dimensions);
+
+  TensorWrapper& CreateOutputTensorWithName(
+      std::string_view name, Qnn_DataType_t data_type,
+      const QuantizeParamsWrapperVariant& quant_params,
+      const std::vector<std::uint32_t>& dimensions);
 
   TensorWrapper& CreateNativeTensor(
       Qnn_DataType_t data_type,

--- a/litert/vendors/qualcomm/core/tensor_pool_test.cc
+++ b/litert/vendors/qualcomm/core/tensor_pool_test.cc
@@ -388,6 +388,32 @@ TEST(TensorPoolConvertStaticTensorTest, CreateStatictensorByValueUInt32) {
   EXPECT_EQ(tensor_data, golden_data);
 }
 
+TEST(TensorPoolCreateTensorWithNameTest, CreateInputTensorWithName) {
+  TensorPool tensor_pool;
+  const char* input_name = "test_input_name";
+
+  auto& tensor_wrapper = tensor_pool.CreateInputTensorWithName(
+      input_name, QNN_DATATYPE_FLOAT_32, QuantizeParamsWrapperVariant{},
+      {1, 2, 3});
+
+  EXPECT_STREQ(tensor_wrapper.GetQnnTensor().v1.name, input_name);
+  EXPECT_EQ(tensor_wrapper.GetQnnTensor().v1.dataType, QNN_DATATYPE_FLOAT_32);
+  EXPECT_EQ(tensor_wrapper.GetQnnTensor().v1.type, QNN_TENSOR_TYPE_APP_WRITE);
+}
+
+TEST(TensorPoolCreateTensorWithNameTest, CreateOutputTensorWithName) {
+  TensorPool tensor_pool;
+  const char* output_name = "test_output_name";
+
+  auto& tensor_wrapper = tensor_pool.CreateOutputTensorWithName(
+      output_name, QNN_DATATYPE_FLOAT_32, QuantizeParamsWrapperVariant{},
+      {1, 2, 3});
+
+  EXPECT_STREQ(tensor_wrapper.GetQnnTensor().v1.name, output_name);
+  EXPECT_EQ(tensor_wrapper.GetQnnTensor().v1.dataType, QNN_DATATYPE_FLOAT_32);
+  EXPECT_EQ(tensor_wrapper.GetQnnTensor().v1.type, QNN_TENSOR_TYPE_APP_READ);
+}
+
 }  // namespace
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/elementwise_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/elementwise_test.cc
@@ -34,12 +34,12 @@ TEST_P(QnnModelTest, SingleElementWiseDivide) {
       std::in_place_type<::qnn::ScaleOffsetQuantizeParamsWrapper>, 0.000030f,
       0};
 
-  auto& input_0 = tensor_pool_.CreateInputTensorWithSuffix(
-      QNN_DATATYPE_SFIXED_POINT_16, quant_param_0, kDims, "");
-  auto& input_1 = tensor_pool_.CreateInputTensorWithSuffix(
-      QNN_DATATYPE_SFIXED_POINT_16, quant_param_1, kDims, "");
-  auto& output_0 = tensor_pool_.CreateOutpuTensorWithSuffix(
-      QNN_DATATYPE_SFIXED_POINT_16, quant_param_2, kDims, "");
+  auto& input_0 = tensor_pool_.CreateInputTensorWithName(
+      "in_0", QNN_DATATYPE_SFIXED_POINT_16, quant_param_0, kDims);
+  auto& input_1 = tensor_pool_.CreateInputTensorWithName(
+      "in_1", QNN_DATATYPE_SFIXED_POINT_16, quant_param_1, kDims);
+  auto& output_0 = tensor_pool_.CreateOutputTensorWithName(
+      "out_0", QNN_DATATYPE_SFIXED_POINT_16, quant_param_2, kDims);
   auto ops = ::qnn::BuildElementwiseDivOp(tensor_pool_, {input_0, input_1},
                                           {output_0});
   ASSERT_FALSE(ops.empty());
@@ -85,12 +85,12 @@ TEST_P(QnnModelTest, SingleElementWiseMax) {
       std::in_place_type<::qnn::ScaleOffsetQuantizeParamsWrapper>, 0.00015f, 0};
 
   const std::vector<std::uint32_t> kDims{1, 2, 2, 1};
-  auto& input_0 = tensor_pool_.CreateInputTensorWithSuffix(
-      QNN_DATATYPE_SFIXED_POINT_16, quant_param, kDims, "");
-  auto& input_1 = tensor_pool_.CreateInputTensorWithSuffix(
-      QNN_DATATYPE_SFIXED_POINT_16, quant_param, kDims, "");
-  auto& output_0 = tensor_pool_.CreateOutpuTensorWithSuffix(
-      QNN_DATATYPE_SFIXED_POINT_16, quant_param, kDims, "");
+  auto& input_0 = tensor_pool_.CreateInputTensorWithName(
+      "in_0", QNN_DATATYPE_SFIXED_POINT_16, quant_param, kDims);
+  auto& input_1 = tensor_pool_.CreateInputTensorWithName(
+      "in_1", QNN_DATATYPE_SFIXED_POINT_16, quant_param, kDims);
+  auto& output_0 = tensor_pool_.CreateOutputTensorWithName(
+      "out_0", QNN_DATATYPE_SFIXED_POINT_16, quant_param, kDims);
   auto ops = ::qnn::BuildElementwiseMaximumOp(tensor_pool_, {input_0, input_1},
                                               {output_0});
   ASSERT_FALSE(ops.empty());

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/fully_connected_int2_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/fully_connected_int2_test.cc
@@ -27,10 +27,10 @@ TEST_P(QnnModelTest, FullyConnectedInt2Sanity) {
   const std::vector<std::uint32_t> kInDims{1, 2};
   const std::vector<std::uint32_t> kOutDims{1, 2};
 
-  auto& input_0 = tensor_pool_.CreateInputTensorWithSuffix(
-      QNN_DATATYPE_SFIXED_POINT_16, input_quant, kInDims, "");
-  auto& output_0 = tensor_pool_.CreateOutpuTensorWithSuffix(
-      QNN_DATATYPE_SFIXED_POINT_16, output_quant, kOutDims, "");
+  auto& input_0 = tensor_pool_.CreateInputTensorWithName(
+      "in_0", QNN_DATATYPE_SFIXED_POINT_16, input_quant, kInDims);
+  auto& output_0 = tensor_pool_.CreateOutputTensorWithName(
+      "out_0", QNN_DATATYPE_SFIXED_POINT_16, output_quant, kOutDims);
 
   const std::vector<std::uint32_t> kFilterDims{2, 2};
   auto weight_quant_param =

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/relu_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/relu_test.cc
@@ -18,10 +18,10 @@ INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
 
 TEST_P(QnnModelTest, SingleRelu) {
   const std::vector<std::uint32_t> kDims{1, 2, 2, 1};
-  auto& input_0 = tensor_pool_.CreateInputTensorWithSuffix(
-      QNN_DATATYPE_FLOAT_32, {}, kDims, "");
-  auto& output_0 = tensor_pool_.CreateOutpuTensorWithSuffix(
-      QNN_DATATYPE_FLOAT_32, {}, kDims, "");
+  auto& input_0 = tensor_pool_.CreateInputTensorWithName(
+      "in_0", QNN_DATATYPE_FLOAT_32, {}, kDims);
+  auto& output_0 = tensor_pool_.CreateOutputTensorWithName(
+      "out_0", QNN_DATATYPE_FLOAT_32, {}, kDims);
   auto ops = ::qnn::BuildReluOp(tensor_pool_, {input_0}, {output_0});
   ASSERT_FALSE(ops.empty());
 

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/topk_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/topk_test.cc
@@ -25,12 +25,12 @@ TEST_P(QnnModelTest, SingleTopK) {
   const uint32_t k_value = 3;
   const std::vector<std::uint32_t> outputDims{1, 3};
 
-  auto& input_tensor = tensor_pool_.CreateInputTensorWithSuffix(
-      QNN_DATATYPE_FLOAT_32, {}, inputDims, "");
-  auto& values_tensor = tensor_pool_.CreateOutpuTensorWithSuffix(
-      QNN_DATATYPE_FLOAT_32, {}, outputDims, "");
-  auto& indices_tensor = tensor_pool_.CreateOutpuTensorWithSuffix(
-      QNN_DATATYPE_UINT_32, {}, outputDims, "");
+  auto& input_tensor = tensor_pool_.CreateInputTensorWithName(
+      "in_0", QNN_DATATYPE_FLOAT_32, {}, inputDims);
+  auto& values_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "out_0", QNN_DATATYPE_FLOAT_32, {}, outputDims);
+  auto& indices_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "out_1", QNN_DATATYPE_UINT_32, {}, outputDims);
 
   auto ops = ::qnn::BuildTopKOp(tensor_pool_, {input_tensor},
                                 {values_tensor, indices_tensor}, k_value);


### PR DESCRIPTION
# Test

```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.1s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.1s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 42.4s
```

```
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 13 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 16 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (13 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (656 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (1429 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (740 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (692 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (726 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (541 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1986 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (34 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (5 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (820 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (468 ms total)
[  PASSED  ] 2 tests.
```
