### PR TITLE
Qualcomm AI Engine Direct - Support a8w2 FC by a8w4.

### DIFF
--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -99,6 +99,7 @@ cc_library(
         ":op_builder",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/utils:log",
+        "//litert/vendors/qualcomm/core/utils:miscs",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
         "@qairt//:qnn_lib_headers",

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
@@ -12,6 +12,7 @@
 #include "litert/vendors/qualcomm/core/builders/op_builder.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/utils/log.h"
+#include "litert/vendors/qualcomm/core/utils/miscs.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 #include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
 #include "QnnOpDef.h"  // from @qairt
@@ -32,8 +33,22 @@ std::vector<OpWrapper> BuildFullyConnectedOp(
 
   TensorWrapper& input_tensor = inputs[0];
   fully_connected_op.AddInputTensor(input_tensor);
+
   TensorWrapper& weight_tensor = inputs[1];
+  // TODO (chunhsue-qti): Treat a8w2 as a8w4, 2-bit quant weight tensor is
+  // QNN_DATATYPE_SFIXED_POINT_8 with bitwidth 2. Remove this after a8w2 is
+  // supported.
+
+  // Check input tensor is QNN_DATATYPE_SFIXED_POINT_8 so that a16w2 will be
+  // intact.
+  if (input_tensor.IsQuantI8() && weight_tensor.IsQuantI8() &&
+      weight_tensor.IsQuantBitwidth(kQuantBitWidth2)) {
+    QNN_LOG_WARNING(
+        "Aggressively convert the a8w2 Fully Connected Op to a8w4.");
+    weight_tensor.SetQuantBitwidth(kQuantBitWidth4);
+  }
   fully_connected_op.AddInputTensor(weight_tensor);
+
   if (inputs.size() - 1 >= kBiasIdx) {
     TensorWrapper& bias_tensor = inputs[kBiasIdx];
     if (use_int64_bias_as_int32 && bias_tensor.IsTensorStatic() &&

--- a/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h
@@ -104,6 +104,10 @@ class BwScaleOffsetQuantizeParamsWrapper final {
     return qnn_quantize_param_.bwScaleOffsetEncoding.bitwidth;
   }
 
+  void SetBitwidth(std::uint32_t bitwidth) {
+    qnn_quantize_param_.bwScaleOffsetEncoding.bitwidth = bitwidth;
+  }
+
  private:
   Qnn_QuantizeParams_t qnn_quantize_param_ = QNN_QUANTIZE_PARAMS_INIT;
 };
@@ -137,6 +141,10 @@ class BwAxisScaleOffsetQuantizeParamsWrapper final {
 
   std::uint32_t GetBitwidth() const {
     return qnn_quantize_param_.bwAxisScaleOffsetEncoding.bitwidth;
+  }
+
+  void SetBitwidth(std::uint32_t bitwidth) {
+    qnn_quantize_param_.bwAxisScaleOffsetEncoding.bitwidth = bitwidth;
   }
 
  private:

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -24,26 +24,6 @@
 #include "QnnTypes.h"  // from @qairt
 
 namespace qnn {
-namespace {
-
-bool IsNBitQuant(const QuantizeParamsWrapperVariant& quantize_params,
-                 uint32_t bitwidth) {
-  if (std::holds_alternative<BwScaleOffsetQuantizeParamsWrapper>(
-          quantize_params)) {
-    const auto& wrapper =
-        std::get<BwScaleOffsetQuantizeParamsWrapper>(quantize_params);
-    return wrapper.GetBitwidth() == bitwidth;
-
-  } else if (std::holds_alternative<BwAxisScaleOffsetQuantizeParamsWrapper>(
-                 quantize_params)) {
-    const auto& wrapper =
-        std::get<BwAxisScaleOffsetQuantizeParamsWrapper>(quantize_params);
-    return wrapper.GetBitwidth() == bitwidth;
-  }
-  return false;
-}
-}  // namespace
-
 std::size_t GetDataTypeSize(const Qnn_DataType_t data_type) {
   std::size_t bytes = 0;
   switch (data_type) {
@@ -120,13 +100,13 @@ TensorWrapper::TensorWrapper(
                     dimensions) {
   // Already map to QNN_DATATYPE_SFIXED_POINT_8 for 4-bit and 2-bit
   // quantization
-  if (IsNBitQuant(quantize_params, kQuantBitWidth4)) {
+  if (IsQuantBitwidth(kQuantBitWidth4)) {
     std::vector<std::int8_t> int8_data;
     QNN_LOG_DEBUG("4-bit Qunat, converting data to 8-bit for QNN.");
     ConvertDataFromInt4ToInt8(data, bytes, int8_data);
     // Set copy_data to true to prevent loss of int8_data.
     SetDataBy(GetTensorBytes(), int8_data.data(), true);
-  } else if (IsNBitQuant(quantize_params, kQuantBitWidth2)) {
+  } else if (IsQuantBitwidth(kQuantBitWidth2)) {
     std::vector<std::int8_t> int8_data;
     QNN_LOG_DEBUG("2-bit Qunat, converting data to 8-bit for QNN.");
     ConvertDataFromInt2ToInt8(data, bytes, int8_data);
@@ -407,4 +387,34 @@ TensorWrapper::TensorWrapper(const Qnn_Tensor_t& qnn_tensor)
   }
 }
 
+bool TensorWrapper::IsQuantBitwidth(std::uint32_t bitwidth) const {
+  if (const auto* wrapper =
+          std::get_if<BwScaleOffsetQuantizeParamsWrapper>(&quantize_params_)) {
+    return wrapper->GetBitwidth() == bitwidth;
+
+  } else if (const auto* wrapper =
+                 std::get_if<BwAxisScaleOffsetQuantizeParamsWrapper>(
+                     &quantize_params_)) {
+    return wrapper->GetBitwidth() == bitwidth;
+  }
+  return false;
+}
+
+void TensorWrapper::SetQuantBitwidth(std::uint32_t bitwidth) {
+  if (auto* wrapper =
+          std::get_if<BwScaleOffsetQuantizeParamsWrapper>(&quantize_params_)) {
+    wrapper->SetBitwidth(bitwidth);
+
+  } else if (auto* wrapper =
+                 std::get_if<BwAxisScaleOffsetQuantizeParamsWrapper>(
+                     &quantize_params_)) {
+    wrapper->SetBitwidth(bitwidth);
+  } else {
+    QNN_LOG_WARNING(
+        "Cannot update bitwidth for non bitwidth-based quantization.");
+    return;
+  }
+
+  UpdateQnnQuantParams();
+}
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -148,6 +148,8 @@ class TensorWrapper final {
            qnn_tensor_.v2.type == QNN_TENSOR_TYPE_APP_READ;
   }
 
+  bool IsQuantBitwidth(std::uint32_t bitwidth) const;
+
   // Utilities /////////////////////////////////////////////////////////
 
   // Allocate memory on owned_data_ for output tensors
@@ -168,6 +170,8 @@ class TensorWrapper final {
     }
     SetTensorType(QNN_TENSOR_TYPE_APP_READ);
   }
+
+  void SetQuantBitwidth(std::uint32_t bitwidth);
 
  private:
   void SetDataBy(std::uint32_t bytes, const void* data, bool copy_data);

--- a/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/quantize_params_wrapper_test.cc
@@ -268,6 +268,16 @@ TEST(BwScaleOffsetQuantizeParamsWrapperTest, GetBitwidthTest) {
   ASSERT_EQ(wrapper.GetBitwidth(), 4);
 }
 
+TEST(BwScaleOffsetQuantizeParamsWrapperTest, SetBitwidthTest) {
+  BwScaleOffsetQuantizeParamsWrapper wrapper(4, 1.5f, 10);
+  wrapper.SetBitwidth(2);
+  EXPECT_EQ(wrapper.GetBitwidth(), 2);
+  wrapper.SetBitwidth(4);
+  EXPECT_EQ(wrapper.GetBitwidth(), 4);
+  wrapper.SetBitwidth(8);
+  EXPECT_EQ(wrapper.GetBitwidth(), 8);
+}
+
 TEST(BwAxisScaleOffsetQuantizeParamsWrapperTest, CopyConstructorTest) {
   std::uint32_t bw = 4;
   std::int32_t axis = 1;
@@ -319,6 +329,20 @@ TEST(BwAxisScaleOffsetQuantizeParamsWrapperTest, GetBitwidthTest) {
   std::vector<std::int32_t> zero_points = {10, 20};
   BwAxisScaleOffsetQuantizeParamsWrapper wrapper(bw, axis, scales, zero_points);
   ASSERT_EQ(wrapper.GetBitwidth(), 4);
+}
+
+TEST(BwAxisScaleOffsetQuantizeParamsWrapperTest, SetBitwidthTest) {
+  std::uint32_t bw = 4;
+  std::int32_t axis = 1;
+  std::vector<float> scales = {1.5f, 2.5f};
+  std::vector<std::int32_t> zero_points = {10, 20};
+  BwAxisScaleOffsetQuantizeParamsWrapper wrapper(bw, axis, scales, zero_points);
+  wrapper.SetBitwidth(2);
+  EXPECT_EQ(wrapper.GetBitwidth(), 2);
+  wrapper.SetBitwidth(4);
+  EXPECT_EQ(wrapper.GetBitwidth(), 4);
+  wrapper.SetBitwidth(8);
+  EXPECT_EQ(wrapper.GetBitwidth(), 8);
 }
 using AxisScaleOffsetParamsWithType =
     std::tuple<int32_t, std::vector<float>, std::vector<int32_t>, int32_t,

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -327,6 +327,40 @@ TEST(TensorWrapperTest, ConvertQint16ToQuint16Test) {
     EXPECT_NEAR(data[i], deq_data[i], 1e-3);
   }
 }
+
+TEST(TensorWrapperTest, UpdateBitWidthTest) {
+  BwScaleOffsetQuantizeParamsWrapper q_param(2, 0.0001f, 0);
+  TensorWrapper tensor_wrapper{"",
+                               QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_SFIXED_POINT_8,
+                               q_param,
+                               {1, 1, 4}};
+  EXPECT_TRUE(tensor_wrapper.IsQuantBitwidth(2));
+
+  tensor_wrapper.SetQuantBitwidth(4);
+  EXPECT_TRUE(tensor_wrapper.IsQuantBitwidth(4));
+  EXPECT_EQ(tensor_wrapper.GetQnnTensor()
+                .v2.quantizeParams.bwScaleOffsetEncoding.bitwidth,
+            4);
+
+  tensor_wrapper.SetQuantBitwidth(8);
+  EXPECT_TRUE(tensor_wrapper.IsQuantBitwidth(8));
+  EXPECT_EQ(tensor_wrapper.GetQnnTensor()
+                .v2.quantizeParams.bwScaleOffsetEncoding.bitwidth,
+            8);
+}
+
+TEST(TensorWrapperTest, UpdateBitWidthOnUnsupportedQuantTypeTest) {
+  ScaleOffsetQuantizeParamsWrapper q_param(0.0001f, 0);
+  TensorWrapper tensor_wrapper{"",
+                               QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_SFIXED_POINT_8,
+                               q_param,
+                               {1, 1, 4}};
+  tensor_wrapper.SetQuantBitwidth(4);
+  EXPECT_FALSE(tensor_wrapper.IsQuantBitwidth(4));
+}
+
 TEST(TensorWrapperTest, QnnTensorPerTensorQuantConstructTest) {
   ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
   TensorWrapper tensor_wrapper{"",

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/fully_connected_int2_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/fully_connected_int2_test.cc
@@ -19,7 +19,7 @@ namespace {
 INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
                          QnnTestPrinter);
 
-TEST_P(QnnModelTest, FullyConnectedInt2Sanity) {
+TEST_P(QnnModelTest, FullyConnectedA16W2Sanity) {
   constexpr float kScale = 0.001;
 
   auto input_quant = ::qnn::ScaleOffsetQuantizeParamsWrapper(kScale, 0);
@@ -74,5 +74,116 @@ TEST_P(QnnModelTest, FullyConnectedInt2Sanity) {
                                 ::qnn::Quantize<int16_t>(-0.001, kScale, 0)}));
 }
 
+TEST_P(QnnModelTest, FullyConnectedA8W2Sanity) {
+  constexpr float kScale = 0.01;
+
+  auto input_quant = ::qnn::ScaleOffsetQuantizeParamsWrapper(kScale, 0);
+  auto output_quant = ::qnn::ScaleOffsetQuantizeParamsWrapper(kScale, 0);
+  const std::vector<std::uint32_t> kInDims{1, 2};
+  const std::vector<std::uint32_t> kOutDims{1, 2};
+
+  auto& input_0 = tensor_pool_.CreateInputTensorWithSuffix(
+      QNN_DATATYPE_SFIXED_POINT_8, input_quant, kInDims, "");
+  auto& output_0 = tensor_pool_.CreateOutpuTensorWithSuffix(
+      QNN_DATATYPE_SFIXED_POINT_8, output_quant, kOutDims, "");
+
+  const std::vector<std::uint32_t> kFilterDims{2, 2};
+  auto weight_quant_param =
+      ::qnn::BwScaleOffsetQuantizeParamsWrapper(2, kScale, 0);
+
+  std::vector<int8_t> weight_data = {1, -1, -1, 1};
+  std::vector<int8_t> int2_weight_data;
+  ::qnn::ConvertDataFromInt8ToInt2(weight_data, int2_weight_data);
+  auto& weight_tensor = tensor_pool_.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, kFilterDims,
+      int2_weight_data.size(), int2_weight_data.data());
+
+  auto ops = ::qnn::BuildFullyConnectedOp(
+      tensor_pool_, {input_0, weight_tensor}, {output_0}, true, false);
+  ASSERT_FALSE(ops.empty());
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_0);
+  auto output_idx = qnn_model_.AddOutputTensor(output_0);
+
+  std::vector<int8_t> in_data = {100, 0};
+  qnn_model_.SetInputData<int8_t>(input_idx, in_data);
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<int8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_EQ(output_data->size(), 2);
+  ASSERT_THAT(
+      output_data.value(),
+      Pointwise(testing::Eq(), {::qnn::Quantize<int8_t>(0.01, kScale, 0),
+                                ::qnn::Quantize<int8_t>(-0.01, kScale, 0)}));
+}
+
+TEST_P(QnnModelTest, FullyConnectedA8W2BwAxisScaleOffsetSanity) {
+  constexpr float kScale = 0.01;
+
+  auto input_quant = ::qnn::ScaleOffsetQuantizeParamsWrapper(kScale, 0);
+  auto output_quant = ::qnn::ScaleOffsetQuantizeParamsWrapper(kScale, 0);
+  const std::vector<std::uint32_t> kInDims{1, 2};
+  const std::vector<std::uint32_t> kOutDims{1, 2};
+
+  auto& input_0 = tensor_pool_.CreateInputTensorWithSuffix(
+      QNN_DATATYPE_SFIXED_POINT_8, input_quant, kInDims, "");
+  auto& output_0 = tensor_pool_.CreateOutpuTensorWithSuffix(
+      QNN_DATATYPE_SFIXED_POINT_8, output_quant, kOutDims, "");
+
+  const std::vector<std::uint32_t> kFilterDims{2, 2};
+  std::vector<float> weight_scales = {kScale, 2 * kScale};
+  std::vector<int32_t> weight_offsets = {0, 0};
+  auto weight_quant_param = ::qnn::BwAxisScaleOffsetQuantizeParamsWrapper(
+      2, 0, weight_scales, weight_offsets);
+
+  std::vector<int8_t> weight_data = {1, -1, -1, 1};
+  std::vector<int8_t> int2_weight_data;
+  ::qnn::ConvertDataFromInt8ToInt2(weight_data, int2_weight_data);
+  auto& weight_tensor = tensor_pool_.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, kFilterDims,
+      int2_weight_data.size(), int2_weight_data.data());
+
+  auto ops = ::qnn::BuildFullyConnectedOp(
+      tensor_pool_, {input_0, weight_tensor}, {output_0}, true, false);
+  ASSERT_FALSE(ops.empty());
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_0);
+  auto output_idx = qnn_model_.AddOutputTensor(output_0);
+
+  std::vector<int8_t> in_data = {100, 0};
+  qnn_model_.SetInputData<int8_t>(input_idx, in_data);
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<int8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_EQ(output_data->size(), 2);
+  ASSERT_THAT(
+      output_data.value(),
+      Pointwise(testing::Eq(), {::qnn::Quantize<int8_t>(0.01, kScale, 0),
+                                ::qnn::Quantize<int8_t>(-0.02, kScale, 0)}));
+}
 }  // namespace
 }  // namespace litert::qnn


### PR DESCRIPTION
Updates Qualcomm FC handling for A8W2 by converting the weight quant bitwidth to A8W4 when needed.
- `fully_connected_op_builder.cc`: detects `input=i8`, `weight=i8`, `weight bitwidth=2`, logs warning, and sets weight bitwidth to 4 before building FC op.
- `quantize_params_wrapper.h`: adds `SetBitwidth(uint32_t)` for `BwScaleOffsetQuantizeParamsWrapper` and `BwAxisScaleOffsetQuantizeParamsWrapper`.
- `tensor_wrapper.h/.cc`: adds `IsQuantBitwidth(uint32_t)` and `SetQuantBitwidth(uint32_t)`; updates internal quant param sync flow.
- `core/builders/BUILD`: adds dependency on `//litert/vendors/qualcomm/core/utils:miscs`.
- Unit tests added/updated in commit:
  - `quantize_params_wrapper_test.cc`: `SetBitwidthTest` for bw-scale-offset and bw-axis-scale-offset wrappers.
  - `tensor_wrapper_test.cc`: bitwidth update behavior tests, including unsupported quant-type case.
  - `fully_connected_int2_test.cc`: expands with `FullyConnectedA8W2Sanity` and `FullyConnectedA8W2BwAxisScaleOffsetSanity`; existing test renamed to `FullyConnectedA16W2Sanity`.
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 21 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 13 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 32 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 32 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (12 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (678 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (1387 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (2066 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (725 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (753 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (579 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1896 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (26 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (459 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (477 ms total)
[  PASSED  ] 2 tests.
```

```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.8s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test               PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test                 PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test                  PASSED in 0.1s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 42.1s
```