### PR TITLE
Fix Windows MSVC build for //litert/tools:benchmark_model

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,10 +52,14 @@ build:clang_local --repo_env USE_HERMETIC_CC_TOOLCHAIN=1
 
 build --repo_env=USE_PYWRAP_RULES=True
 build --copt=-DGRPC_BAZEL_BUILD
-build --cxxopt=-std=gnu++17
-build --cxxopt=-fpermissive
 build --host_copt=-DGRPC_BAZEL_BUILD
-build --host_cxxopt=-fpermissive
+# GCC/Clang-specific flags: only apply on non-Windows platforms.
+# Each platform already specifies its own C++ standard (see below).
+build:linux --cxxopt=-std=gnu++17
+build:linux --cxxopt=-fpermissive
+build:linux --host_cxxopt=-fpermissive
+build:macos --cxxopt=-fpermissive
+build:macos --host_cxxopt=-fpermissive
 build --action_env=GRPC_BAZEL_RUNTIME=1
 build --repo_env=PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb
 build --action_env=PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=upb
@@ -272,6 +276,12 @@ build:macos --copt=-w
 build:windows --copt=/W0
 build:windows --host_copt=/W0
 
+# Ensure the CPU is set explicitly for Windows so that XLA/TSL config_settings
+# (which match on cpu=x64_windows) resolve correctly. Without this,
+# if_not_windows() selects may fall through to the default branch and pass
+# GCC/Clang flags (e.g. -Wno-sign-compare) to MSVC.
+build:windows --cpu=x64_windows
+
 # Suppress most C++ compiler warnings to reduce log size but allow
 # for specific warnings to still be present.
 build:linux --copt="-Wno-all"
@@ -381,6 +391,13 @@ build:macos_arm64 --cxxopt=-std=c++17
 build:macos_arm64 --host_cxxopt=-std=c++17
 build:windows --cxxopt=/std:c++20
 build:windows --host_cxxopt=/std:c++20
+# Protobuf v6.31.1 uses incomplete (forward-declared) types as value types in
+# absl::flat_hash_map. Under MSVC C++20, std::pair requires complete types for
+# conditionally-trivial special members (P0848R3), causing compilation failures.
+# Compile protobuf with C++17 to work around this; the rest of the project
+# stays at C++20.
+build:windows --per_file_copt=external/com_google_protobuf/.*\.cc$@/std:c++17
+build:windows --host_per_file_copt=external/com_google_protobuf/.*\.cc$@/std:c++17
 
 # On windows, we still link everything into a single DLL.
 build:windows --config=monolithic

--- a/BUILD
+++ b/BUILD
@@ -11,3 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+exports_files([
+    "PATCH.tf_xla_tsl_win_copts",
+    "PATCH.protobuf_port_msvc_compat",
+])

--- a/PATCH.protobuf_port_msvc_compat
+++ b/PATCH.protobuf_port_msvc_compat
@@ -1,0 +1,21 @@
+diff --git a/src/google/protobuf/port.h b/src/google/protobuf/port.h
+--- a/src/google/protobuf/port.h
++++ b/src/google/protobuf/port.h
+@@ -544,7 +544,13 @@
+   alignas(std::string) char buffer_[sizeof(std::string)];
+ };
+ 
+-using GlobalEmptyString = std::conditional_t<
+-    GlobalEmptyStringConstexpr::HasConstexprDefaultConstructor(0),
+-    const GlobalEmptyStringConstexpr, GlobalEmptyStringDynamicInit>;
++#ifdef _MSC_VER
++// MSVC: force DynamicInit to maintain ABI compatibility when protobuf sources
++// compile with /std:c++17 while the rest of the project uses /std:c++20.
++using GlobalEmptyString = GlobalEmptyStringDynamicInit;
++#else
++using GlobalEmptyString = std::conditional_t<
++    GlobalEmptyStringConstexpr::HasConstexprDefaultConstructor(0),
++    const GlobalEmptyStringConstexpr, GlobalEmptyStringDynamicInit>;
++#endif
+ 
+ PROTOBUF_EXPORT extern GlobalEmptyString fixed_address_empty_string;

--- a/PATCH.tf_xla_tsl_win_copts
+++ b/PATCH.tf_xla_tsl_win_copts
@@ -1,0 +1,11 @@
+--- a/third_party/xla/xla/tsl/tsl.bzl
++++ b/third_party/xla/xla/tsl/tsl.bzl
+@@ -364,7 +364,7 @@
+             clean_dep("//xla/tsl:android"): android_copts,
+             clean_dep("//xla/tsl:emscripten"): [],
+             clean_dep("//xla/tsl:macos"): [],
+-            clean_dep("//xla/tsl:windows"): get_win_copts(is_external, is_msvc = False),
++            clean_dep("//xla/tsl:windows"): get_win_copts(is_external, is_msvc = True),
+             clean_dep("//xla/tsl:ios"): [],
+             clean_dep("//xla/tsl:no_lgpl_deps"): ["-D__TENSORFLOW_NO_LGPL_DEPS__", "-pthread"],
+             "//conditions:default": ["-pthread"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,6 +49,8 @@ tensorflow_source_repo(
     sha256 = "3a26196b1a9cee6e56a17f2334b0be32c23c4a7367648cae942b217091728a98",
     strip_prefix = "tensorflow-f2d8e35dc5369fb4002f57d95303eb551e85f138",
     urls = ["https://github.com/tensorflow/tensorflow/archive/f2d8e35dc5369fb4002f57d95303eb551e85f138.tar.gz"],
+    patches = ["//:PATCH.tf_xla_tsl_win_copts"],
+    protobuf_patches = ["//:PATCH.protobuf_port_msvc_compat"],
 )
 
 # Initialize the TensorFlow repository and all dependencies.

--- a/litert/tensorflow_source_rules.bzl
+++ b/litert/tensorflow_source_rules.bzl
@@ -36,6 +36,23 @@ def _tensorflow_source_repo_impl(ctx):
             stripPrefix = ctx.attr.strip_prefix,
         )
 
+    # Apply patches after extraction/symlinking.
+    for patch in ctx.attr.patches:
+        ctx.patch(ctx.path(patch), strip = 1)
+
+    # Append protobuf-specific patches to XLA's protobuf.patch so that
+    # tf_workspace2()'s protobuf fetch applies them automatically.
+    if ctx.attr.protobuf_patches:
+        pb_patch_path = ctx.path("third_party/xla/third_party/protobuf/protobuf.patch")
+        existing = ctx.read(pb_patch_path)
+        extras = []
+        for pb_patch in ctx.attr.protobuf_patches:
+            extras.append(ctx.read(ctx.path(pb_patch)))
+        ctx.file(
+            "third_party/xla/third_party/protobuf/protobuf.patch",
+            content = existing + "\n" + "\n".join(extras),
+        )
+
 tensorflow_source_repo = repository_rule(
     implementation = _tensorflow_source_repo_impl,
     local = False,
@@ -43,6 +60,8 @@ tensorflow_source_repo = repository_rule(
         "sha256": attr.string(mandatory = False),
         "strip_prefix": attr.string(mandatory = True),
         "urls": attr.string_list(mandatory = True),
+        "patches": attr.label_list(default = []),
+        "protobuf_patches": attr.label_list(default = []),
     },
     doc = """
     A custom repository rule to select between a local TensorFlow source or a remote http_archive


### PR DESCRIPTION
Address multiple issues preventing the Bazel build from succeeding on Windows with MSVC (cl.exe) and C++20:

1. Move GCC/Clang-only flags (-std=gnu++17, -fpermissive) from unconditional 'build' to platform-specific 'build:linux'/'build:macos' sections in .bazelrc so they don't get passed to cl.exe.

2. Add 'build:windows --cpu=x64_windows' so that XLA/TSL config_settings (which match on cpu=x64_windows) resolve correctly. Without this, if_not_windows() selects fall through to the default branch and emit GCC flags like -Wno-sign-compare to MSVC.

3. Patch XLA's tsl.bzl (via PATCH.tf_xla_tsl_win_copts) to fix get_win_copts(is_msvc=False) -> is_msvc=True, so TSL emits MSVC-style compiler flags on Windows.

4. Add per_file_copt to compile protobuf sources with /std:c++17 on Windows. Protobuf v6.31.1 uses incomplete (forward-declared) types as flat_hash_map value types, which fails under MSVC C++20 due to P0848R3 requiring complete types for conditionally-trivial special members.

5. Patch protobuf's port.h (via PATCH.protobuf_port_msvc_compat) to force GlobalEmptyString to use GlobalEmptyStringDynamicInit on MSVC. This prevents an ABI mismatch where protobuf .cc files compiled at C++17 define a different mangled symbol than .pb.cc files compiled at C++20.

6. Extend tensorflow_source_repo rule to support 'patches' and 'protobuf_patches' attributes, allowing patches to be applied to the TensorFlow source and appended to XLA's protobuf.patch respectively.