### PR TITLE
docs: fix #TODO links in COMPILER_PLUGIN.md

### DIFF
--- a/litert/COMPILER_PLUGIN.md
+++ b/litert/COMPILER_PLUGIN.md
@@ -49,7 +49,7 @@ the hardware driver, passing along the compiled bytecode created by the plugin.
 
 **LiteRt Dispatch** is the runtime analog for compiler plugin. They provide the
 means of calling into the HAL given compiler output. See the dispatch
-documentation here #TODO.
+documentation [here](DISPATCH_API.md).
 
 ### AOT vs On-Device
 
@@ -300,4 +300,4 @@ LiteRtStatus LiteRtGetCompiledResultByteCode(
 
 LiteRt provides various toolings for applying compiler plugins to model files,
 executing the result, and validating/benchmarking. Please refer to the
-documentation for the LiteRt's tooling: #TODO.
+[TESTING.md](TESTING.md) for the Accelerator Test Suite (ats) documentation.


### PR DESCRIPTION
## Summary
Replace placeholder #TODO links with actual documentation references.

## Changes
- Line 52: Link to DISPATCH_API.md for dispatch documentation
- Line 303: Link to TESTING.md for tooling/validation documentation

## Why
Broken #TODO placeholders reduce documentation usability. These docs exist
but were not linked.

## Testing
- [x] Verified DISPATCH_API.md exists
- [x] Verified TESTING.md exists and covers tooling
- [x] Links are relative and will resolve correctly