### PR TITLE
fix: multiple memcpy operations in tensor buffer han... in litert_ten...

### DIFF
--- a/litert/cc/litert_buffer_ref.h
+++ b/litert/cc/litert_buffer_ref.h
@@ -234,7 +234,8 @@ class MutableBufferRef : public BufferRef<ByteT> {
   /// @return `true` if the entire string fits and is written, `false`
   /// otherwise.
   bool WriteInto(absl::string_view str, size_t offset = 0) {
-    if (str.size() > this->Size() - offset) {
+    // Check for integer underflow when offset > Size()
+    if (offset > this->Size() || str.size() > this->Size() - offset) {
       return false;
     }
     std::memcpy(Data() + offset, str.data(), str.size());

--- a/litert/cc/litert_tensor_buffer.h
+++ b/litert/cc/litert_tensor_buffer.h
@@ -381,15 +381,24 @@ class TensorBuffer : public internal::BaseHandle<LiteRtTensorBuffer> {
     LITERT_ASSIGN_OR_RETURN(void* host_mem_addr, Lock(LockMode::kWrite));
     absl::Cleanup unlock = [this] { Unlock(); };
     LITERT_ASSIGN_OR_RETURN(size_t size, PackedSize());
-    if (size < data.size() * sizeof(T)) {
+    // Check for potential integer overflow in size calculation
+    if (data.size() > SIZE_MAX / sizeof(T)) {
+      return Unexpected(
+          kLiteRtStatusErrorRuntimeFailure,
+          "Data size would cause integer overflow");
+    }
+    // Calculate byte size safely after overflow check
+    const size_t byte_size = data.size() * sizeof(T);
+    // Validate destination buffer has sufficient capacity
+    if (size < byte_size) {
       return Unexpected(
           kLiteRtStatusErrorRuntimeFailure,
           absl::StrFormat(
               "TensorBuffer host memory buffer size is smaller than the "
               "given data size, %zu vs %zu",
-              size, data.size() * sizeof(T)));
+              size, byte_size));
     }
-    std::memcpy(host_mem_addr, data.data(), data.size() * sizeof(T));
+    std::memcpy(host_mem_addr, data.data(), byte_size);
     return {};
   }
 
@@ -404,7 +413,15 @@ class TensorBuffer : public internal::BaseHandle<LiteRtTensorBuffer> {
     LITERT_ASSIGN_OR_RETURN(void* host_mem_addr, Lock(LockMode::kRead));
     absl::Cleanup unlock = [this] { Unlock(); };
     LITERT_ASSIGN_OR_RETURN(size_t size, PackedSize());
-    size_t total_read_size = data.size() * sizeof(T);
+    // Check for potential integer overflow in size calculation
+    if (data.size() > SIZE_MAX / sizeof(T)) {
+      return Unexpected(
+          kLiteRtStatusErrorRuntimeFailure,
+          "Data size would cause integer overflow");
+    }
+    // Calculate byte size safely after overflow check
+    const size_t total_read_size = data.size() * sizeof(T);
+    // Validate source buffer has sufficient data
     if (size < total_read_size) {
       return Unexpected(
           kLiteRtStatusErrorRuntimeFailure,


### PR DESCRIPTION
## Summary
Fix high severity security issue in `litert/cc/litert_tensor_buffer.h`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `litert/cc/litert_tensor_buffer.h:392` |

**Description**: Multiple memcpy operations in tensor buffer handling code copy data without validating that the source size fits within the destination buffer bounds. In litert_tensor_buffer.h:392, data is copied ...

## Changes
- `litert/cc/litert_tensor_buffer.h`
- `litert/cc/litert_buffer_ref.h`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] Code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisai.dev)*
