### PR TITLE
Add INT16 support to SPACE_TO_DEPTH kernel

### DIFF
--- a/tflite/kernels/space_to_depth.cc
+++ b/tflite/kernels/space_to_depth.cc
@@ -56,8 +56,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   auto data_type = output->type;
   TF_LITE_ENSURE(context,
                  data_type == kTfLiteFloat32 || data_type == kTfLiteUInt8 ||
-                     data_type == kTfLiteInt8 || data_type == kTfLiteInt32 ||
-                     data_type == kTfLiteInt64);
+                     data_type == kTfLiteInt8 || data_type == kTfLiteInt16 ||
+                     data_type == kTfLiteInt32 || data_type == kTfLiteInt64);
   TF_LITE_ENSURE_TYPES_EQ(context, input->type, output->type);
 
   const int block_size = params->block_size;

--- a/tflite/kernels/space_to_depth_test.cc
+++ b/tflite/kernels/space_to_depth_test.cc
@@ -88,6 +88,14 @@ TEST(SpaceToDepthOpModel, int8) {
   EXPECT_THAT(m.GetOutputShape(), ElementsAre(1, 1, 1, 4));
 }
 
+TEST(SpaceToDepthOpModel, Int16) {
+  SpaceToDepthOpModel m({TensorType_INT16, {1, 2, 2, 1}}, 2);
+  m.SetInput<int16_t>({1, 2, 3, 4});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutput<int16_t>(), ElementsAreArray({1, 2, 3, 4}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAre(1, 1, 1, 4));
+}
+
 TEST(SpaceToDepthOpModel, Int32) {
   SpaceToDepthOpModel m({TensorType_INT32, {1, 2, 2, 3}}, 2);
   m.SetInput<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});


### PR DESCRIPTION
## Summary
- Add `kTfLiteInt16` to the type check in `Prepare()` in `tflite/kernels/space_to_depth.cc`
- The `Eval()` function already handles 16-bit data via its `TfLiteTypeGetSizeBits` `case 16` branch, so no execution logic changes are needed
- Add INT16 test case to `space_to_depth_test.cc`

This enables INT16 quantized models (e.g. STATIC_WI8_AI16 from ai-edge-quantizer) to run on the LiteRT runtime.

Related PR: https://github.com/google-ai-edge/ai-edge-quantizer/pull/445

## Test plan
- [x] Add `Int16` test case following the same pattern as existing `int8` test