### PR TITLE
Qualcomm AI Engine Direct - Enable QNN log to logcat.

### DIFF
--- a/litert/vendors/qualcomm/core/BUILD
+++ b/litert/vendors/qualcomm/core/BUILD
@@ -53,6 +53,10 @@ cc_library(
     name = "common",
     srcs = ["common.cc"],
     hdrs = ["common.h"],
+    linkopts = select({
+        "@platforms//os:android": ["-llog"],
+        "//conditions:default": [],
+    }),
     deps = [
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -9,12 +9,35 @@
 #include <string>
 #include <vector>
 
+#if defined(__ANDROID__)
+#include <android/log.h>
+#endif  // defined(__ANDROID__)
+
 #include "absl/strings/str_format.h"  // from @com_google_absl
 #include "absl/strings/str_join.h"  // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
 
 namespace qnn {
 namespace {
+
+#if defined(__ANDROID__)
+int GetAndroidLogPriority(QnnLog_Level_t level) {
+  switch (level) {
+    case QNN_LOG_LEVEL_ERROR:
+      return ANDROID_LOG_ERROR;
+    case QNN_LOG_LEVEL_WARN:
+      return ANDROID_LOG_WARN;
+    case QNN_LOG_LEVEL_INFO:
+      return ANDROID_LOG_INFO;
+    case QNN_LOG_LEVEL_VERBOSE:
+      return ANDROID_LOG_VERBOSE;
+    case QNN_LOG_LEVEL_DEBUG:
+      return ANDROID_LOG_DEBUG;
+    case QNN_LOG_LEVEL_MAX:
+      return ANDROID_LOG_UNKNOWN;
+  }
+}
+#endif  // defined(__ANDROID__)
 
 void DefaultStdOutLogger(const char* fmt, QnnLog_Level_t level,
                          uint64_t timestamp, va_list argp) {
@@ -39,6 +62,16 @@ void DefaultStdOutLogger(const char* fmt, QnnLog_Level_t level,
       levelStr = "UNKNOWN";
       break;
   }
+
+#if defined(__ANDROID__)
+  // Log to Android logcat.
+  va_list argp_copy;
+  va_copy(argp_copy, argp);
+  __android_log_vprint(GetAndroidLogPriority(level), "qnn", fmt, argp_copy);
+  va_end(argp_copy);
+#endif  // defined(__ANDROID__)
+
+  // Also print to stdout for console output.
   char buffer1[256];
   char buffer2[256];
   double ms = timestamp;

--- a/litert/vendors/qualcomm/core/utils/BUILD
+++ b/litert/vendors/qualcomm/core/utils/BUILD
@@ -13,12 +13,12 @@ package(
 cc_library(
     name = "log",
     srcs = select({
-        "@org_tensorflow//tensorflow:android": ["log_android.cc"],
+        "@platforms//os:android": ["log_android.cc"],
         "//conditions:default": ["log_default.cc"],
     }),
     hdrs = ["log.h"],
     linkopts = select({
-        "@org_tensorflow//tensorflow:android": ["-llog"],
+        "@platforms//os:android": ["-llog"],
         "//conditions:default": [],
     }),
     deps = [

--- a/litert/vendors/qualcomm/core/utils/log_android.cc
+++ b/litert/vendors/qualcomm/core/utils/log_android.cc
@@ -49,7 +49,7 @@ void QNNLogger::Log(::qnn::LogLevel severity, const char* format, ...) {
   // First log to Android's explicit log(cat) API.
   va_list args_copy;
   va_copy(args_copy, args);
-  __android_log_vprint(GetPlatformSeverity(severity), "qnn", format, args_copy);
+  __android_log_vprint(GetPlatformSeverity(severity), "lrt-qc", format, args_copy);
   va_end(args_copy);
 
   // Print to file pointer.


### PR DESCRIPTION
# What

- The qnn log handle haven't print the android log to logcat, need to pass to logcat.
- Modify the existing logcat tag to separate them.

## Verification
<img width="1495" height="403" alt="image" src="https://github.com/user-attachments/assets/1562ff14-5b62-43ef-ab8b-e0c5cdb44536" />


# Test

- Passed CMake build flow
- Passed x86 & arm64 unit test

```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 56.9s

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 23 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 23 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (1 ms total)
[  PASSED  ] 12 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 13 tests from 3 test suites ran. (14 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 30 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 30 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (3 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 64 tests from 9 test suites ran. (6 ms total)
[  PASSED  ] 64 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 17 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (5 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (20 ms total)
[  PASSED  ] 8 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (689 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (890 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (819 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 2 tests from 1 test suite ran. (1088 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 1 test from 1 test suite ran. (541 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (5 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (434 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1832 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (62 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (7 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (590 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (485 ms total)
[  PASSED  ] 2 tests.
```