### PR TITLE
eTPU for 3p: Use linker-visible eTPU soname and add FD load fallback.

### DIFF
--- a/litert/vendors/google_tensor/dispatch/litert_dispatch_device_context.cc
+++ b/litert/vendors/google_tensor/dispatch/litert_dispatch_device_context.cc
@@ -18,6 +18,8 @@
 
 #include <cstddef>
 #include <optional>
+#include <sys/mman.h>
+#include <unistd.h>
 #include <utility>
 
 #if __ANDROID__
@@ -40,6 +42,7 @@
 #include "litert/vendors/google_tensor/dispatch/dispatch_api_config.h"
 #include "litert/vendors/google_tensor/dispatch/dispatch_api_macros.h"
 #include "litert/vendors/google_tensor/dispatch/sb_api.h"
+#include "litert/vendors/google_tensor/dispatch/sb_api_features.h"
 
 namespace gt = litert::google_tensor;
 
@@ -86,6 +89,14 @@ LiteRtStatus LiteRtDispatchDeviceContextT::Destroy() {
     LITERT_LOG(LITERT_ERROR,
                "Cannot destroy device context with %zu graphs registered",
                registered_graphs_.size());
+    return kLiteRtStatusErrorRuntimeFailure;
+  }
+
+  if (!mmap_regions_.empty()) {
+    LITERT_LOG(LITERT_ERROR,
+               "Cannot destroy device context with %zu mmap'd executable(s) "
+               "still loaded",
+               mmap_regions_.size());
     return kLiteRtStatusErrorRuntimeFailure;
   }
 
@@ -199,13 +210,56 @@ LiteRtStatus LiteRtDispatchDeviceContextT::LoadExecutable(
   }
 
   if (bytecode_buffer.fd >= 0) {
+    if (GoogleTensorSouthBoundFeatureSupported(
+            GoogleTensorSouthBoundFeature::kSqContainerFdWithOffset)) {
+      GT_LOG_RETURN_IF_SB_ERROR(
+          thrLoadSqContainerFdWithOffset(
+              thr_context_, thr_type, bytecode_buffer.fd, bytecode_buffer.size,
+              bytecode_buffer.offset, /*lazy_loading=*/false, &exec_handle),
+          "Failed to load SQ container from FD with offset");
+      return kLiteRtStatusOk;
+    }
+
+    // Old SouthBound, offset == 0: legacy FD entry point handles it directly.
+    if (bytecode_buffer.offset == 0) {
+      GT_LOG_RETURN_IF_SB_ERROR(
+          thrLoadSqContainerFd(thr_context_, thr_type, bytecode_buffer.fd,
+                               bytecode_buffer.size, /*lazy_loading=*/false,
+                               &exec_handle),
+          "Failed to load SQ container from FD");
+      return kLiteRtStatusOk;
+    }
+
+    // Old SouthBound, offset > 0 (e.g. AOT .tflite with embedded DISPATCH_OP):
+    // mmap a page-aligned region and load via the pointer-based API.
+    const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    const size_t aligned_offset = bytecode_buffer.offset & ~(page_size - 1);
+    const size_t offset_delta = bytecode_buffer.offset - aligned_offset;
+    const size_t map_length = bytecode_buffer.size + offset_delta;
+    void* mapped = mmap(nullptr, map_length, PROT_READ, MAP_PRIVATE,
+                        bytecode_buffer.fd,
+                        static_cast<off_t>(aligned_offset));
+    if (mapped == MAP_FAILED) {
+      LITERT_LOG(LITERT_ERROR,
+                 "Failed to mmap SQ bytecode (fd=%d, size=%zu, offset=%zu)",
+                 bytecode_buffer.fd, bytecode_buffer.size,
+                 bytecode_buffer.offset);
+      return kLiteRtStatusErrorRuntimeFailure;
+    }
+    absl::Cleanup mmap_cleanup = [mapped, map_length] {
+      munmap(mapped, map_length);
+    };
+
+    const void* bytecode_ptr =
+        static_cast<const std::byte*>(mapped) + offset_delta;
     GT_LOG_RETURN_IF_SB_ERROR(
-        thrLoadSqContainerFdWithOffset(thr_context_, thr_type,
-                                       bytecode_buffer.fd, bytecode_buffer.size,
-                                       bytecode_buffer.offset,
-                                       /*lazy_loading=*/false, &exec_handle),
-        "Failed to load SQ container from fd %d with size %zu and offset %zu",
-        bytecode_buffer.fd, bytecode_buffer.size, bytecode_buffer.offset);
+        thrLoadSqContainer(thr_context_, thr_type, bytecode_ptr,
+                           bytecode_buffer.size, &exec_handle),
+        "Failed to load SQ container from mmap'd buffer");
+
+    mmap_regions_.push_back({exec_handle, mapped, map_length});
+    std::move(mmap_cleanup).Cancel();
+    return kLiteRtStatusOk;
   } else {
     const auto* sq_bytecode =
         static_cast<const std::byte*>(bytecode_buffer.base_addr) +
@@ -226,6 +280,15 @@ LiteRtStatus LiteRtDispatchDeviceContextT::UnloadExecutable(
   GT_LOG_RETURN_IF_SB_ERROR(thrUnloadSqContainer(thr_context_, exec_handle),
                             "Failed to unload SQ container %" PRIu64,
                             exec_handle);
+
+  // Release any mmap'd region associated with this executable.
+  for (auto it = mmap_regions_.begin(); it != mmap_regions_.end(); ++it) {
+    if (it->exec_handle == exec_handle) {
+      munmap(it->addr, it->length);
+      mmap_regions_.erase(it);
+      break;
+    }
+  }
 
   return kLiteRtStatusOk;
 }

--- a/litert/vendors/google_tensor/dispatch/litert_dispatch_device_context.h
+++ b/litert/vendors/google_tensor/dispatch/litert_dispatch_device_context.h
@@ -79,6 +79,12 @@ class LiteRtDispatchDeviceContextT {
                                        const char* absl_nonnull value);
 
  private:
+  struct MmapRegion {
+    LiteRtDispatchExecutableHandle exec_handle;
+    void* addr;
+    size_t length;
+  };
+
   explicit LiteRtDispatchDeviceContextT(
       const LiteRtRuntimeContext* runtime_context,
       ThrContext* absl_nonnull thr_context)
@@ -86,12 +92,6 @@ class LiteRtDispatchDeviceContextT {
 
   // Consumers of this class must use `Destroy` to delete the instance.
   ~LiteRtDispatchDeviceContextT() = default;
-
-  struct MmapRegion {
-    LiteRtDispatchExecutableHandle exec_handle;
-    void* addr;
-    size_t length;
-  };
 
   const LiteRtRuntimeContext* runtime_context_;
   ThrContext* absl_nonnull thr_context_;

--- a/litert/vendors/google_tensor/dispatch/litert_dispatch_device_context.h
+++ b/litert/vendors/google_tensor/dispatch/litert_dispatch_device_context.h
@@ -17,6 +17,9 @@
 
 #include <optional>
 
+#include <utility>
+#include <vector>
+
 #include "absl/base/nullability.h"  // from @com_google_absl
 #include "absl/container/flat_hash_set.h"  // from @com_google_absl
 #include "litert/c/internal/litert_runtime_context.h"
@@ -84,6 +87,12 @@ class LiteRtDispatchDeviceContextT {
   // Consumers of this class must use `Destroy` to delete the instance.
   ~LiteRtDispatchDeviceContextT() = default;
 
+  struct MmapRegion {
+    LiteRtDispatchExecutableHandle exec_handle;
+    void* addr;
+    size_t length;
+  };
+
   const LiteRtRuntimeContext* runtime_context_;
   ThrContext* absl_nonnull thr_context_;
 #if LITERT_HAS_DARWINN_OPTIONS_SUPPORT
@@ -91,6 +100,11 @@ class LiteRtDispatchDeviceContextT {
 #endif  // LITERT_HAS_DARWINN_OPTIONS_SUPPORT
   // A device context cannot be destroyed with any registered graphs.
   absl::flat_hash_set<LiteRtDispatchGraph> registered_graphs_;
+  // Each region backs an executable's bytecode and must outlive any graph
+  // referencing that executable via AssignNodeFunction. Destroy refuses
+  // when non-empty; release order is graphs, then executables, then Destroy.
+  // std::vector (not hash set): expected N=1.
+  std::vector<MmapRegion> mmap_regions_;
 };
 
 #endif  // ODML_LITERT_LITERT_VENDORS_GOOGLE_TENSOR_DISPATCH_LITERT_DISPATCH_DEVICE_CONTEXT_H_

--- a/litert/vendors/google_tensor/dispatch/sb_api_features.h
+++ b/litert/vendors/google_tensor/dispatch/sb_api_features.h
@@ -61,6 +61,8 @@ enum class GoogleTensorSouthBoundFeature {
   kOriginalUidDispatchDirective = 7,
   // BufferDirectiveAnnotations::kRequestFence
   kRequestFence = 8,
+  // thrLoadSqContainerFdWithOffset
+  kSqContainerFdWithOffset = 9,
 };
 
 // Returns `true` if `feature` is supported by the available Google Tensor
@@ -93,6 +95,10 @@ inline bool GoogleTensorSouthBoundFeatureSupported(
     case GoogleTensorSouthBoundFeature::kRequestFence:
       return GoogleTensorSouthBoundMajorVersion() > 0 ||
              GoogleTensorSouthBoundMinorVersion() >= 17;
+    case GoogleTensorSouthBoundFeature::kSqContainerFdWithOffset:
+      // TODO(google-tensor): confirm minor version.
+      return GoogleTensorSouthBoundMajorVersion() > 0 ||
+             GoogleTensorSouthBoundMinorVersion() >= 18;
   }
 }
 

--- a/litert/vendors/google_tensor/dispatch/sb_api_late_binding.cc
+++ b/litert/vendors/google_tensor/dispatch/sb_api_late_binding.cc
@@ -185,6 +185,9 @@ T GetValForSymUnavailable() {
 
 constexpr char kDefaultSouthBoundLibPath[] =
 #ifdef __ANDROID__
+    // Use bare soname instead of absolute vendor path so that Android's linker
+    // namespace resolves the library via public.libraries.txt. The absolute
+    // path is blocked for untrusted_app contexts on Android 12+.
     "libedgetpu_litert.so";
 #else
     "third_party/darwinn/litert/dispatch/libedgetpu_litert.so";


### PR DESCRIPTION
Switch Android Southbound loading to `libedgetpu_litert.so` and add an mmap-based fallback when `thrLoadSqContainerFdWithOffset` is unavailable so eTPU dispatch works on older runtimes.
