### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LiteRT
 
+[![gitcgr](https://gitcgr.com/badge/google-ai-edge/LiteRT.svg)](https://gitcgr.com/google-ai-edge/LiteRT)
+
 <p align="center">
   <img src="./g3doc/sources/litert_logo.png" alt="LiteRT Logo"/>
 </p>


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/google-ai-edge/LiteRT.svg)](https://gitcgr.com/google-ai-edge/LiteRT)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).