### PR TITLE
Qualcomm AI Engine Direct - Support P point.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -43,6 +43,7 @@ struct LrtQualcommOptionsT {
   std::optional<bool> enable_weight_sharing;
   std::optional<bool> use_conv_hmx;
   std::optional<bool> use_fold_relu;
+  std::optional<std::int32_t> htp_p_point;
   std::optional<LrtQualcommOptionsHtpPerformanceMode> htp_performance_mode;
   std::optional<LrtQualcommOptionsDspPerformanceMode> dsp_performance_mode;
   std::optional<std::vector<std::int32_t>> dump_tensor_ids;
@@ -111,6 +112,10 @@ LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
           auto v = litert::internal::ParseTomlBool(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
           status = LrtQualcommOptionsSetUseFoldReLU(parsed_options, *v);
+        } else if (key == "htp_p_point") {
+          auto v = litert::internal::ParseTomlInt(value);
+          if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
+          status = LrtQualcommOptionsSetHtpPPoint(parsed_options, *v);
         } else if (key == "htp_performance_mode") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
@@ -236,6 +241,9 @@ LiteRtStatus LrtGetOpaqueQualcommOptionsData(LrtQualcommOptions options,
   if (options->use_fold_relu.has_value()) {
     toml << "use_fold_relu = " << (*options->use_fold_relu ? "true" : "false")
          << "\n";
+  }
+  if (options->htp_p_point.has_value()) {
+    toml << "htp_p_point = " << *options->htp_p_point << "\n";
   }
   if (options->htp_performance_mode.has_value()) {
     toml << "htp_performance_mode = "
@@ -533,7 +541,6 @@ LiteRtStatus LrtQualcommOptionsSetGraphIOTensorMemType(
   }
 
   options->graph_io_tensor_mem_type = graph_io_tensor_mem_type;
-
   return kLiteRtStatusOk;
 }
 
@@ -546,6 +553,27 @@ LiteRtStatus LrtQualcommOptionsGetGraphIOTensorMemType(
 
   *graph_io_tensor_mem_type = options->graph_io_tensor_mem_type.value_or(
       kLiteRtQualcommGraphIOTensorMemTypeMemHandle);
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsSetHtpPPoint(LrtQualcommOptions options,
+                                            std::int32_t htp_p_point) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->htp_p_point = htp_p_point;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsGetHtpPPoint(LrtQualcommOptions options,
+                                            std::int32_t* htp_p_point) {
+  if (htp_p_point == nullptr || options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *htp_p_point = options->htp_p_point.value_or(0);
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -171,6 +171,15 @@ LiteRtStatus LrtQualcommOptionsGetGraphIOTensorMemType(
     LrtQualcommOptions options,
     LrtQualcommOptionsGraphIOTensorMemType* mem_type);
 
+// P points are experimental (HTP backend with O3 only) and map to predefined
+// compiler configurations affecting latency and DRAM bandwidth.
+
+LiteRtStatus LrtQualcommOptionsSetHtpPPoint(LrtQualcommOptions options,
+                                            int32_t htp_p_point);
+
+LiteRtStatus LrtQualcommOptionsGetHtpPPoint(LrtQualcommOptions options,
+                                            int32_t* htp_p_point);
+
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////
 
 // htp_performance_mode

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -247,6 +247,22 @@ class QualcommOptions {
     return val;
   }
 
+  /// @brief This option controls P point to change compiler configurations.
+  ///
+  /// P points are experimental (HTP backend with O3 only) and map to predefined
+  /// compiler configurations affecting latency and DRAM bandwidth.
+  void SetHtpPPoint(std::int32_t p_point) {
+    LrtQualcommOptionsSetHtpPPoint(options_, p_point);
+  }
+  std::int32_t GetHtpPPoint() {
+    std::int32_t val;
+    auto status = LrtQualcommOptionsGetHtpPPoint(options_, &val);
+    if (status == kLiteRtStatusErrorNotFound) {
+      return 0;
+    }
+    return val;
+  }
+
   /// @brief This option controls the profiling level.
   ///
   /// A higher level results in a more detailed report after execution.

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -475,6 +475,11 @@ ABSL_FLAG(bool, qualcomm_use_fold_relu, true,
           "optimization is correct when quantization ranges for convolution "
           "are equal to or are subset of the Relu operation.");
 
+ABSL_FLAG(
+    std::int32_t, qualcomm_htp_p_point, 0,
+    "P points are experimental (HTP backend with O3 only) and map to "
+    "predefined compiler configurations affecting latency and DRAM bandwidth.");
+
 ABSL_FLAG(litert::qualcomm::QualcommOptions::Backend, qualcomm_backend,
           litert::qualcomm::QualcommOptions::Backend::kHtp,
           "QNN backend to use.");
@@ -573,6 +578,9 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
 
   const auto use_fold_relu = absl::GetFlag(FLAGS_qualcomm_use_fold_relu);
   opts.SetUseFoldReLU(use_fold_relu);
+
+  const auto htp_p_point = absl::GetFlag(FLAGS_qualcomm_htp_p_point);
+  opts.SetHtpPPoint(htp_p_point);
 
   const auto qnn_backend = absl::GetFlag(FLAGS_qualcomm_backend);
   opts.SetBackend(qnn_backend);

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -107,6 +107,8 @@ ABSL_DECLARE_FLAG(bool, qualcomm_use_conv_hmx);
 
 ABSL_DECLARE_FLAG(bool, qualcomm_use_fold_relu);
 
+ABSL_DECLARE_FLAG(int32_t, qualcomm_htp_p_point);
+
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////
 
 ABSL_DECLARE_FLAG(litert::qualcomm::QualcommOptions::HtpPerformanceMode,

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -498,6 +498,7 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   EXPECT_FALSE(options.Value().GetEnableWeightSharing());
   EXPECT_TRUE(options.Value().GetUseConvHMX());
   EXPECT_TRUE(options.Value().GetUseFoldReLU());
+  EXPECT_EQ(options.Value().GetHtpPPoint(), 0);
   EXPECT_EQ(options.Value().GetHtpPerformanceMode(),
             QualcommOptions::HtpPerformanceMode::kDefault);
   EXPECT_TRUE(options.Value().GetDumpTensorIds().empty());

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -114,6 +114,7 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetEnableWeightSharing(qualcomm_options.GetEnableWeightSharing());
   qnn_options.SetUseConvHMX(qualcomm_options.GetUseConvHMX());
   qnn_options.SetUseFoldReLU(qualcomm_options.GetUseFoldReLU());
+  qnn_options.SetHtpPPoint(qualcomm_options.GetHtpPPoint());
   qnn_options.SetHtpPerformanceMode(static_cast<::qnn::HtpPerformanceMode>(
       qualcomm_options.GetHtpPerformanceMode()));
   qnn_options.SetDspPerformanceMode(static_cast<::qnn::DspPerformanceMode>(

--- a/litert/vendors/qualcomm/compiler/graph_mapper.cc
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.cc
@@ -73,9 +73,10 @@ Qnn_Priority_t GetGraphPriorityValue(::qnn::GraphPriority graph_priority) {
 
 inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
     const ::qnn::Options& options) {
-  static std::array<QnnHtpGraph_CustomConfig_t, 6> graph_custom_configs;
-  static std::array<QnnGraph_Config_t, 7> graph_configs;
-  static std::array<const QnnGraph_Config_t*, 8> result;
+  static std::array<QnnHtpGraph_CustomConfig_t, 7> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 8> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 9> result;
+  size_t num_config = 5;
 
   // QNN suggest always enable relax precision.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
@@ -106,16 +107,33 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
       QNN_HTP_GRAPH_CONFIG_OPTION_SHORT_DEPTH_CONV_ON_HMX_OFF;
   graph_custom_configs[4].shortDepthConvOnHmxOff = !options.GetUseConvHMX();
 
-  // Hvx Thread
-  bool has_hvx = options.GetNumHvxThreads() != 0;
-  if (has_hvx) {
-    graph_custom_configs[5] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
-    graph_custom_configs[5].option =
-        QNN_HTP_GRAPH_CONFIG_OPTION_NUM_HVX_THREADS;
-    graph_custom_configs[5].numHvxThreads = options.GetNumHvxThreads();
+  // P Point
+  const std::int32_t htp_p_point = options.GetHtpPPoint();
+  if (htp_p_point > 0) {
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_FINALIZE_CONFIG;
+    graph_custom_configs[num_config].finalizeConfig.key = "P";
+    graph_custom_configs[num_config].finalizeConfig.value = {
+        QNN_DATATYPE_INT_32, {.int32Value = htp_p_point}};
+    num_config++;
+  } else if (htp_p_point < 0) {
+    LITERT_LOG(LITERT_WARNING,
+               "Invalid P point (%d): negative values not supported, skipping "
+               "P point config.",
+               htp_p_point);
   }
 
-  size_t num_config = has_hvx ? 6 : 5;
+  // Hvx Thread
+  const std::uint32_t num_hvx_threads = options.GetNumHvxThreads();
+  if (num_hvx_threads > 0) {
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_NUM_HVX_THREADS;
+    graph_custom_configs[num_config].numHvxThreads = num_hvx_threads;
+    num_config++;
+  }
+
   for (size_t i = 0; i < num_config; ++i) {
     graph_configs[i] = QNN_GRAPH_CONFIG_INIT;
     graph_configs[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -122,6 +122,12 @@ void Options::SetUseFoldReLU(bool use_fold_relu) {
 
 bool Options::GetUseFoldReLU() const { return use_fold_relu_; }
 
+void Options::SetHtpPPoint(std::int32_t htp_p_point) {
+  htp_p_point_ = htp_p_point;
+}
+
+std::int32_t Options::GetHtpPPoint() const { return htp_p_point_; }
+
 void Options::SetHtpPerformanceMode(HtpPerformanceMode htp_performance_mode) {
   htp_performance_mode_ = htp_performance_mode;
 }
@@ -207,6 +213,7 @@ UseInt64BiasAsInt32: %v\n\
 EnableWeightSharing: %v\n\
 UseConvHMX: %v\n\
 UseFoldReLU: %v\n\
+HtpPPoint: %d\n\
 HtpPerformanceMode: %d\n\
 DspPerformanceMode: %d\n\
 DumpTensorIds: %s\n\
@@ -224,7 +231,7 @@ GraphIOTensorMemType: %d\n";  // NOLINT
   return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, backend_type_,
                          profiling_, use_int64_bias_as_int32_,
                          enable_weight_sharing_, use_conv_hmx_, use_fold_relu_,
-                         htp_performance_mode_, dsp_performance_mode_,
+                         htp_p_point_, htp_performance_mode_, dsp_performance_mode_,
                          dump_tensor_ids, ir_json_dir_, dlc_dir_, vtcm_size_,
                          num_hvx_threads_, optimization_level_, graph_priority_,
                          saver_output_dir_, graph_io_tensor_mem_type_);

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -108,6 +108,9 @@ class Options {
   void SetUseFoldReLU(bool use_fold_relu);
   bool GetUseFoldReLU() const;
 
+  void SetHtpPPoint(std::int32_t htp_p_point);
+  std::int32_t GetHtpPPoint() const;
+
   void SetHtpPerformanceMode(HtpPerformanceMode htp_performance_mode);
   HtpPerformanceMode GetHtpPerformanceMode() const;
 
@@ -152,6 +155,7 @@ class Options {
   bool enable_weight_sharing_ = false;
   bool use_conv_hmx_ = true;
   bool use_fold_relu_ = true;
+  std::int32_t htp_p_point_ = 0;
   HtpPerformanceMode htp_performance_mode_ = HtpPerformanceMode::kDefault;
   DspPerformanceMode dsp_performance_mode_ = DspPerformanceMode::kDefault;
   std::vector<std::int32_t> dump_tensor_ids_;

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -187,6 +187,15 @@ TEST(QnnOptionTest, UseFoldReLU) {
   EXPECT_EQ(options.GetUseFoldReLU(), false);
 }
 
+TEST(QnnOptionTest, HtpPPoint) {
+  Options options;
+  EXPECT_EQ(options.GetHtpPPoint(), 0);
+  options.SetHtpPPoint(2);
+  EXPECT_EQ(options.GetHtpPPoint(), 2);
+  options.SetHtpPPoint(0);
+  EXPECT_EQ(options.GetHtpPPoint(), 0);
+}
+
 TEST(QnnOptionTest, SetIrJsonDir) {
   Options options;
   options.SetIrJsonDir("tmp/");
@@ -253,6 +262,7 @@ TEST(QnnOptionTest, Default) {
   EXPECT_FALSE(options.GetEnableWeightSharing());
   EXPECT_TRUE(options.GetUseConvHMX());
   EXPECT_TRUE(options.GetUseFoldReLU());
+  EXPECT_EQ(options.GetHtpPPoint(), 0);
   EXPECT_EQ(options.GetHtpPerformanceMode(), HtpPerformanceMode::kDefault);
   EXPECT_EQ(options.GetDspPerformanceMode(), DspPerformanceMode::kDefault);
   EXPECT_TRUE(options.GetIrJsonDir().empty());


### PR DESCRIPTION
Summary:
- Add support for P points to adjust compiler configurations on HTP.
- Add tests for P point configurations.

Test:
x86
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test       PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.8s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.8s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test               PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test                 PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test                  PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 38.4s
```
on-device
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 21 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 17 tests from 3 test suites ran. (7 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (5 ms total)
[  PASSED  ] 33 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (10 ms total)
[  PASSED  ] 8 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (319 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (422 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (414 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1078 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1071 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (568 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2050 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (20 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (5 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (459 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (413 ms total)
[  PASSED  ] 2 tests.
```