### PR TITLE
Qualcomm AI Engine Direct - Match Gemma4 mask.

### DIFF
--- a/litert/vendors/qualcomm/core/builders/cast_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/cast_op_builder.cc
@@ -12,16 +12,18 @@
 
 namespace qnn {
 
+OpWrapper CreateCastOp(const TensorWrapper& input,
+                       const TensorWrapper& output) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_CAST), QNN_OP_CAST, QnnOpCode::kCast);
+  op.AddInputTensor(input);
+  op.AddOutputTensor(output);
+  return op;
+}
+
 std::vector<OpWrapper> BuildCastOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs) {
-  std::vector<OpWrapper> res;
-
-  auto& op = CreateOpWrapper(res, QNN_OP_CAST);
-  op.AddInputTensor(inputs[0]);
-  op.AddOutputTensor(outputs[0]);
-
-  return res;
+  return MakeVector(CreateCastOp(inputs[0], outputs[0]));
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/cast_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/cast_op_builder.h
@@ -11,6 +11,8 @@
 
 namespace qnn {
 
+OpWrapper CreateCastOp(const TensorWrapper& input, const TensorWrapper& output);
+
 std::vector<OpWrapper> BuildCastOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs);

--- a/litert/vendors/qualcomm/core/builders/elementwise_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/elementwise_op_builder.cc
@@ -13,6 +13,38 @@
 #include "QnnOpDef.h"  // from @qairt
 
 namespace qnn {
+namespace {
+OpWrapper CreateElementWiseUnaryOp(const TensorWrapper& input,
+                                   const TensorWrapper& output,
+                                   std::uint32_t param_value) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_ELEMENT_WISE_UNARY),
+               QNN_OP_ELEMENT_WISE_UNARY, QnnOpCode::kElementWiseUnary);
+  op.AddInputTensor(input);
+  op.AddOutputTensor(output);
+  op.AddScalarParam<std::uint32_t>(QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION,
+                                   param_value);
+  return op;
+}
+OpWrapper CreateElementWiseBinaryOp(const TensorWrapper& input_0,
+                                    const TensorWrapper& input_1,
+                                    const TensorWrapper& output,
+                                    std::uint32_t param_value) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_ELEMENT_WISE_BINARY),
+               QNN_OP_ELEMENT_WISE_BINARY, QnnOpCode::kElementWiseBinary);
+  op.AddInputTensor(input_0);
+  op.AddInputTensor(input_1);
+  op.AddOutputTensor(output);
+  op.AddScalarParam<std::uint32_t>(QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION,
+                                   param_value);
+  return op;
+}
+}  // namespace
+
+OpWrapper CreateElementWiseNotOp(const TensorWrapper& input,
+                                 const TensorWrapper& output) {
+  return CreateElementWiseUnaryOp(input, output,
+                                  QNN_OP_ELEMENT_WISE_UNARY_OPERATION_NOT);
+}
 
 std::vector<OpWrapper> BuildElementwiseAddOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
@@ -46,21 +78,17 @@ std::vector<OpWrapper> BuildElementwiseSubOp(
   return res;
 }
 
+OpWrapper CreateElementWiseMulOp(const TensorWrapper& input_0,
+                                 const TensorWrapper& input_1,
+                                 const TensorWrapper& output) {
+  return CreateElementWiseBinaryOp(
+      input_0, input_1, output, QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY);
+}
+
 std::vector<OpWrapper> BuildElementwiseMulOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs) {
-  std::vector<OpWrapper> res;
-
-  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_BINARY);
-  for (const auto& input : inputs) {
-    elementwise_op.AddInputTensor(input);
-  }
-  elementwise_op.AddOutputTensor(outputs[0]);
-  elementwise_op.AddScalarParam<std::uint32_t>(
-      QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION,
-      QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY);
-
-  return res;
+  return MakeVector(CreateElementWiseMulOp(inputs[0], inputs[1], outputs[0]));
 }
 
 std::vector<OpWrapper> BuildElementwiseDivOp(
@@ -403,16 +431,7 @@ std::vector<OpWrapper> BuildElementwiseLessEqualOp(
 std::vector<OpWrapper> BuildElementwiseNotOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs) {
-  std::vector<OpWrapper> res;
-
-  auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_UNARY);
-  elementwise_op.AddInputTensor(inputs[0]);
-  elementwise_op.AddOutputTensor(outputs[0]);
-  elementwise_op.AddScalarParam<std::uint32_t>(
-      QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION,
-      QNN_OP_ELEMENT_WISE_UNARY_OPERATION_NOT);
-
-  return res;
+  return MakeVector(CreateElementWiseNotOp(inputs[0], outputs[0]));
 }
 
 std::vector<OpWrapper> BuildElementwiseGreaterEqualOp(

--- a/litert/vendors/qualcomm/core/builders/elementwise_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/elementwise_op_builder.h
@@ -12,6 +12,13 @@
 
 namespace qnn {
 
+OpWrapper CreateElementWiseNotOp(const TensorWrapper& input,
+                                 const TensorWrapper& output);
+
+OpWrapper CreateElementWiseMulOp(const TensorWrapper& input_0,
+                                 const TensorWrapper& input_1,
+                                 const TensorWrapper& output);
+
 std::vector<OpWrapper> BuildElementwiseAddOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs);

--- a/litert/vendors/qualcomm/core/builders/quantize_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/quantize_op_builder.cc
@@ -13,6 +13,15 @@
 
 namespace qnn {
 
+OpWrapper CreateQuantizeOp(const TensorWrapper& input,
+                           const TensorWrapper& output) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_QUANTIZE), QNN_OP_QUANTIZE,
+               QnnOpCode::kQuantize);
+  op.AddInputTensor(input);
+  op.AddOutputTensor(output);
+  return op;
+}
+
 std::vector<OpWrapper> BuildQuantizeOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs) {
@@ -27,7 +36,7 @@ std::vector<OpWrapper> BuildQuantizeOp(
               outputs[0].get().IsQuantI16() || outputs[0].get().IsQuantU16())) {
     qnn_op = QNN_OP_CONVERT;
   } else {
-    qnn_op = QNN_OP_QUANTIZE;
+    return MakeVector(CreateQuantizeOp(inputs[0], outputs[0]));
   }
 
   auto& quantize_op = CreateOpWrapper(res, qnn_op);

--- a/litert/vendors/qualcomm/core/builders/quantize_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/quantize_op_builder.h
@@ -12,6 +12,9 @@
 
 namespace qnn {
 
+OpWrapper CreateQuantizeOp(const TensorWrapper& input,
+                           const TensorWrapper& output);
+
 std::vector<OpWrapper> BuildQuantizeOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs);

--- a/litert/vendors/qualcomm/core/builders/select_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/select_op_builder.cc
@@ -13,18 +13,24 @@
 
 namespace qnn {
 
+OpWrapper CreateSelectOp(const TensorWrapper& condition,
+                         const TensorWrapper& input_1,
+                         const TensorWrapper& input_2,
+                         const TensorWrapper& output) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_ELEMENT_WISE_SELECT),
+               QNN_OP_ELEMENT_WISE_SELECT, QnnOpCode::kElementWiseSelect);
+  op.AddInputTensor(condition);
+  op.AddInputTensor(input_1);
+  op.AddInputTensor(input_2);
+  op.AddOutputTensor(output);
+  return op;
+}
+
 std::vector<OpWrapper> BuildSelectOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs) {
-  std::vector<OpWrapper> res;
-
-  auto& select_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_SELECT);
-  for (const auto& input : inputs) {
-    select_op.AddInputTensor(input);
-  }
-  select_op.AddOutputTensor(outputs[0]);
-
-  return res;
+  return MakeVector(
+      CreateSelectOp(inputs[0], inputs[1], inputs[2], outputs[0]));
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/select_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/select_op_builder.h
@@ -11,6 +11,11 @@
 
 namespace qnn {
 
+OpWrapper CreateSelectOp(const TensorWrapper& condition,
+                         const TensorWrapper& input_1,
+                         const TensorWrapper& input_2,
+                         const TensorWrapper& output);
+
 std::vector<OpWrapper> BuildSelectOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs);

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
@@ -207,12 +207,20 @@ void GraphToGraphTransform(G2GConfig g2g_option, std::vector<OpWrapper>& ops,
 
   // Mask Gemma Optimization
   const std::vector<QnnOpCode> gemma3_mask = {
-      QnnOpCode::kElementWiseUnary,
+      QnnOpCode::kElementWiseUnary,  // Not
       QnnOpCode::kCast,
       QnnOpCode::kQuantize,
-      QnnOpCode::kElementWiseBinary,
+      QnnOpCode::kElementWiseBinary,  // Mul
   };
   Transform(validate_op_config, ops, tensor_pool, gemma3_mask,
+            TransformQuantizeInMask);
+  const std::vector<QnnOpCode> gemma4_mask = {
+      QnnOpCode::kElementWiseUnary,  // Not
+      QnnOpCode::kCast,
+      QnnOpCode::kElementWiseBinary,  // Mul
+      QnnOpCode::kQuantize,
+  };
+  Transform(validate_op_config, ops, tensor_pool, gemma4_mask,
             TransformQuantizeInMask);
 
   // Embedding Gemma Optimization

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
@@ -698,7 +698,7 @@ TEST(MHAOptimization, Gemma3Decode) {
   ASSERT_EQ(op_wrappers[46].GetOpCode(), QnnOpCode::kReshape);
 }
 
-TEST(MaskTransformTest, Gemma3) {
+TEST(MaskTransformTest, Gemma3Mask) {
   // G2G Test case:
   //
   // ----- Before -----
@@ -767,7 +767,7 @@ TEST(MaskTransformTest, Gemma3) {
   auto& mul_const = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_SFIXED_POINT_16, mul_quant_param, {mul_val.size()},
       mul_val.size() * sizeof(mul_val[0]), mul_val.data());
-  auto mul_ops = BuildElementwiseMulOp(tensor_pool, {cast_output, mul_const},
+  auto mul_ops = BuildElementwiseMulOp(tensor_pool, {quant_output, mul_const},
                                        {pattern_output});
   std::move(mul_ops.begin(), mul_ops.end(), std::back_inserter(op_wrappers));
 
@@ -790,6 +790,63 @@ TEST(MaskTransformTest, Gemma3) {
       std::get<ScaleOffsetQuantizeParamsWrapper>(in_2.GetQuantParams());
   ASSERT_EQ(quant_param_2.GetScale(), mul_scale);
   ASSERT_EQ(quant_param_2.GetZeroPoint(), mul_zero_point);
+}
+
+TEST(MaskTransformTest, Gemma4Mask) {
+  // G2G Test case:
+  //
+  // ----- Before -----
+  //       In0
+  //        |
+  //     E-wise Not
+  //        |
+  //       Cast
+  //        |
+  //       Mul
+  //        |
+  //      Quant
+  //        |
+  //       Out0
+  //
+  // ----- After -----
+  //       In0
+  //        |
+  //     E-wise Select
+  //        |
+  //       Out0
+  //
+
+  // Prepare all tensors.
+  const std::vector<uint32_t> kDims{1, 1, 128, 4224};
+  TensorPool tensor_pool;
+  const auto& condition =
+      tensor_pool.CreateNativeTensor(QNN_DATATYPE_BOOL_8, {}, kDims);
+  const auto& logic_not_output = tensor_pool.CloneNativeTensorFrom(condition);
+  const auto& cast_output =
+      tensor_pool.CreateNativeTensor(QNN_DATATYPE_FLOAT_32, {}, kDims);
+  static constexpr float kMulVal{-100};
+  const auto& mul_const = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_FLOAT_32, {}, {1u}, sizeof(kMulVal), &kMulVal);
+  const auto& mul_output = tensor_pool.CloneNativeTensorFrom(cast_output);
+  const auto& pattern_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8,
+      ScaleOffsetQuantizeParamsWrapper{0.392156869f, 127}, kDims);
+
+  // Construct the masking graph.
+  std::vector<OpWrapper> op_wrappers =
+      MakeVector(CreateElementWiseNotOp(condition, logic_not_output),
+                 CreateCastOp(logic_not_output, cast_output),
+                 CreateElementWiseMulOp(cast_output, mul_const, mul_output),
+                 CreateQuantizeOp(mul_output, pattern_output));
+
+  GraphToGraphTransform(::qnn::G2GConfig::kMHAOpt, op_wrappers, tensor_pool,
+                        [](OpWrapper& op) { return true; });
+  ASSERT_EQ(op_wrappers.size(), 1);
+  ASSERT_TRUE(op_wrappers[0].IsOpCode(QnnOpCode::kElementWiseSelect));
+  ASSERT_EQ(pattern_output.GetQuantParams(),
+            op_wrappers[0].GetInputTensor(1).GetQuantParams());
+  ASSERT_EQ(pattern_output.GetQuantParams(),
+            op_wrappers[0].GetInputTensor(2).GetQuantParams());
 }
 
 TEST(MHASHATest, FastVlm) {

--- a/litert/vendors/qualcomm/core/transformation/mask.cc
+++ b/litert/vendors/qualcomm/core/transformation/mask.cc
@@ -7,6 +7,8 @@
 #include <cstdint>
 #include <functional>
 #include <vector>
+#include <limits>
+#include <optional>
 
 #include "litert/vendors/qualcomm/core/builders/select_op_builder.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
@@ -15,40 +17,86 @@
 #include "QnnTypes.h"  // from @qairt
 
 namespace qnn {
-
-std::vector<OpWrapper> TransformToSelectOp(
+namespace {
+std::optional<OpWrapper> CreateGemma3SelectOp(
     const std::vector<OpWrapper>& original_ops, size_t start_index,
     TensorPool& tensor_pool, size_t pattern_size) {
-  // const_cast for BuildSelectOp, can be removed if builders are refined
-  auto& pattern_input =
-      const_cast<TensorWrapper&>(original_ops[start_index].GetInputTensor(0));
-  auto& pattern_output = const_cast<TensorWrapper&>(
-      original_ops[start_index + pattern_size - 1].GetOutputTensor(0));
+  const auto& pattern_input = original_ops[start_index].GetInputTensor(0);
+  const auto& pattern_output =
+      original_ops[start_index + pattern_size - 1].GetOutputTensor(0);
   const auto& quant_param = pattern_output.GetQuantParams();
   const auto& tensor_dims = pattern_input.GetDimensions();
   const std::uint32_t num_element = pattern_input.GetTensorNumElements();
 
   std::vector<std::int16_t> all_zero_data(num_element, 0);
-  auto& input_1 = tensor_pool.CreateStaticTensor(
+  const auto& input_1 = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_SFIXED_POINT_16, quant_param, tensor_dims,
       all_zero_data.size() * sizeof(all_zero_data[0]), all_zero_data.data());
 
-  auto& mul_static_tensor =
+  const auto& mul_static_tensor =
       original_ops[start_index + pattern_size - 1].GetInputTensor(1);
   auto static_tensor_data = mul_static_tensor.GetTensorData<std::int16_t>();
   if (!static_tensor_data) {
     QNN_LOG_ERROR("[G2G] Get tensor data failed when transforming mask model.");
-    return {};
+    return std::nullopt;
   }
   std::vector<std::int16_t> mask_data(num_element,
                                       static_tensor_data.value()[0]);
-  auto& input_2 = tensor_pool.CreateStaticTensor(
+  const auto& input_2 = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_SFIXED_POINT_16, quant_param, tensor_dims,
       mask_data.size() * sizeof(mask_data[0]), mask_data.data());
-
-  return BuildSelectOp(tensor_pool, {pattern_input, input_1, input_2},
-                       {pattern_output});
+  return CreateSelectOp(pattern_input, input_1, input_2, pattern_output);
 }
+
+std::optional<OpWrapper> CreateGemma4SelectOp(
+    const std::vector<OpWrapper>& original_ops, size_t start_index,
+    TensorPool& tensor_pool, size_t pattern_size) {
+  const auto& pattern_input = original_ops[start_index].GetInputTensor(0);
+  const auto& tensor_dims = pattern_input.GetDimensions();
+  const std::uint32_t num_element = pattern_input.GetTensorNumElements();
+
+  const auto& pattern_output =
+      original_ops[start_index + pattern_size - 1].GetOutputTensor(0);
+  const auto& quant_param = pattern_output.GetQuantParams();
+
+  // Verify the static tensor for the Mul op.
+  const auto& mul_static_tensor =
+      original_ops[start_index + pattern_size - 2].GetInputTensor(1);
+  auto static_tensor_data = mul_static_tensor.GetTensorData<float>();
+  if (!static_tensor_data || static_tensor_data->empty()) {
+    QNN_LOG_ERROR("[G2G] Get tensor data failed when transforming mask model.");
+    return std::nullopt;
+  }
+
+  if (auto scale_offset =
+          std::get_if<ScaleOffsetQuantizeParamsWrapper>(&quant_param)) {
+    const float actual_min = (*static_tensor_data)[0];
+    const float expected_min =
+        scale_offset->GetScale() * (std::numeric_limits<std::int8_t>::min() -
+                                    scale_offset->GetZeroPoint());
+    if (expected_min != actual_min) {
+      QNN_LOG_WARNING(
+          "[G2G] Static min value in Mul (%f) does not match expected value "
+          "(%f)",
+          actual_min, expected_min)
+      return std::nullopt;
+    }
+  }
+
+  std::vector<std::int8_t> all_max_data(
+      num_element, std::numeric_limits<std::int8_t>::max());
+  const auto& input_1 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, tensor_dims,
+      all_max_data.size() * sizeof(all_max_data[0]), all_max_data.data());
+
+  const std::vector<std::int8_t> all_min_data(
+      num_element, std::numeric_limits<std::int8_t>::min());
+  const auto& input_2 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, tensor_dims,
+      all_min_data.size() * sizeof(all_min_data[0]), all_min_data.data());
+  return CreateSelectOp(pattern_input, input_1, input_2, pattern_output);
+}
+}  // namespace
 
 size_t TransformQuantizeInMask(
     std::function<bool(OpWrapper&)> validate_op_config,
@@ -58,41 +106,37 @@ size_t TransformQuantizeInMask(
   bool is_connected = ops[start_index + 0].GetOutputTensor(0) ==
                           ops[start_index + 1].GetInputTensor(0) &&
                       ops[start_index + 1].GetOutputTensor(0) ==
-                          ops[start_index + 2].GetInputTensor(0);
+                          ops[start_index + 2].GetInputTensor(0) &&
+                      ops[start_index + 2].GetOutputTensor(0) ==
+                          ops[start_index + 3].GetInputTensor(0);
   if (!is_connected) {
     return 1;
   }
 
-  if (!IsElementWiseNot(ops[start_index + 0]) ||
-      !IsElementWiseMultiply(ops[start_index + 3])) {
+  if (!IsElementWiseNot(ops[start_index + 0])) {
     return 1;
   }
 
-  // Graph transform
-  QNN_LOG_INFO("[G2G] Transform quant ops in Gemma3 mask models");
-  // Construct the new subgraph
-  auto new_ops =
-      TransformToSelectOp(ops, start_index, tensor_pool, pattern_size);
-  if (new_ops.empty()) {
-    QNN_LOG_WARNING(
-        "[G2G] Transformation failed. Rolling back to the original graph.");
+  // Construct the new subgraph.
+  QNN_LOG_INFO("[G2G] Transform quant ops in Gemma mask models");
+  std::optional<OpWrapper> select{};
+  if (IsElementWiseMultiply(ops[start_index + 2])) {
+    select = CreateGemma4SelectOp(ops, start_index, tensor_pool, pattern_size);
+  } else if (IsElementWiseMultiply(ops[start_index + 3])) {
+    select = CreateGemma3SelectOp(ops, start_index, tensor_pool, pattern_size);
+  }
+  if (!select) {
+    QNN_LOG_WARNING("[G2G] Failed to construct transformed Select op.");
     return 1;
   }
+
   // Validate new graph.
-  bool is_valid =
-      std::all_of(new_ops.begin(), new_ops.end(),
-                  [validate_op_config](::qnn::OpWrapper& op_wrapper) -> bool {
-                    return validate_op_config(op_wrapper);
-                  });
-  if (is_valid) {
+  if (validate_op_config(select.value())) {
     // Replace the matched pattern with a newly generated subgraph.
-    size_t step_size = new_ops.size();
-    ops.insert(ops.begin() + start_index + pattern_size,
-               std::make_move_iterator(new_ops.begin()),
-               std::make_move_iterator(new_ops.end()));
+    ops.insert(ops.begin() + start_index + pattern_size, std::move(*select));
     ops.erase(ops.begin() + start_index,
               ops.begin() + start_index + pattern_size);
-    return step_size;
+    return 1;
   }
   QNN_LOG_WARNING(
       "[G2G] Validation failed. Rolling back to the original graph.");


### PR DESCRIPTION
Summary:
- Transform Gemma4 auxiliary mask into a QNN Select operation.
- Improve connection validation checks.
- Fix and extend mask graph‑to‑graph transformation tests.

Test:
x86:
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.8s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.8s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test


//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 39.5s
```
on-device:
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 21 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 17 tests from 3 test suites ran. (8 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 33 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (13 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (354 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (381 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (421 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1136 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1128 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (606 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1984 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (18 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (5 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (452 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (399 ms total)
[  PASSED  ] 2 tests.
```
