### PR TITLE
fix: Use absolute paths for QNN library loading on Android

### DIFF
--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -120,9 +120,17 @@ QnnManager::~QnnManager() = default;
 LiteRtStatus QnnManager::LoadLib(absl::string_view path) {
   auto saver_output_dir = options_.GetSaverOutputDir();
   if (saver_output_dir.empty()) {
+    // On Android, dlopen with bare filenames fails when called from within a
+    // dispatch .so that was itself loaded via dlopen, due to linker namespace
+    // isolation. Use the stored shared_library_dir_ to construct absolute
+    // paths that work across namespaces.
+    std::string resolved_path(path);
+    if (shared_library_dir_.has_value() && !path.empty() && path[0] != '/') {
+      resolved_path = absl::StrCat(*shared_library_dir_, "/", path);
+    }
     LITERT_LOG(LITERT_INFO, "Loading qnn shared library from \"%s\"",
-               path.data());
-    LITERT_ASSIGN_OR_RETURN(lib_, SharedLibrary::Load(path, GetRtldFlags()));
+               resolved_path.c_str());
+    LITERT_ASSIGN_OR_RETURN(lib_, SharedLibrary::Load(resolved_path, GetRtldFlags()));
   } else {
     path = kSaverLibraryName;
     LITERT_LOG(LITERT_INFO, "Loading qnn shared library from \"%s\"",
@@ -135,7 +143,12 @@ LiteRtStatus QnnManager::LoadLib(absl::string_view path) {
 }
 
 LiteRtStatus QnnManager::LoadSystemLib(absl::string_view path) {
-  auto lib_system_or = SharedLibrary::Load(path, GetRtldFlags());
+  // Use absolute path when shared_library_dir_ is available (see LoadLib).
+  std::string resolved_path(path);
+  if (shared_library_dir_.has_value() && !path.empty() && path[0] != '/') {
+    resolved_path = absl::StrCat(*shared_library_dir_, "/", path);
+  }
+  auto lib_system_or = SharedLibrary::Load(resolved_path, GetRtldFlags());
   if (!lib_system_or) {
     LITERT_LOG(LITERT_ERROR, "%s", lib_system_or.Error().Message().data());
     return lib_system_or.Error().Status();
@@ -392,6 +405,9 @@ LiteRtStatus QnnManager::ValidateOp(::qnn::OpWrapper& op) {
 LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
                               std::optional<::qnn::SocInfo> soc_info,
                               const ::qnn::Options& options) {
+  // Store for LoadLib/LoadSystemLib to construct absolute paths for dlopen.
+  shared_library_dir_ = shared_library_dir;
+
   // If shared_library_dir is provided, add it to the path as it may contain
   // libs to be loaded.
   // TOOD: This should probably be done upstream in litert_dispatch.

--- a/litert/vendors/qualcomm/qnn_manager.h
+++ b/litert/vendors/qualcomm/qnn_manager.h
@@ -186,6 +186,12 @@ class QnnManager {
                     std::optional<::qnn::SocInfo> soc_info,
                     const ::qnn::Options& options);
 
+  // Directory containing QNN shared libraries, stored during Init() for use
+  // by LoadLib/LoadSystemLib to construct absolute paths. On Android, dlopen
+  // with bare filenames fails when called from within a dispatch .so loaded
+  // via dlopen, due to linker namespace isolation.
+  std::optional<std::string> shared_library_dir_;
+
   //
   // Manage libQnn*.so Loading
   //


### PR DESCRIPTION
## Summary

Fixes QNN dispatch initialization failure on Android when using the NPU backend via `libLiteRtDispatch_Qualcomm.so`.

## Problem

On Android, when the dispatch shared library is loaded via `dlopen` from the LiteRT runtime, subsequent `dlopen` calls within the dispatch lib for QNN libraries (`libQnnHtp.so`, `libQnnSystem.so`) fail with "library not found". This is because the dispatch `.so` runs in an isolated linker namespace that cannot resolve bare filenames against the app's native library directory.

This affects any Android app that bundles QNN libraries alongside the dispatch `.so` in `jniLibs` and attempts to use the NPU backend.

**Error observed:**
```
[dispatch_delegate.cc:114] Failed to initialize Dispatch API
```

## Root Cause

`QnnManager::LoadLib()` and `QnnManager::LoadSystemLib()` call `dlopen` with bare filenames (e.g., `"libQnnHtp.so"`). On Android, `LD_LIBRARY_PATH` modifications via `setenv` at runtime do not affect the linker's namespace resolution for libraries loaded via a secondary `dlopen`. The linker namespace is fixed at process creation time.

## Fix

- Store `shared_library_dir` as a member variable in `QnnManager` during `Init()`
- In `LoadLib()` and `LoadSystemLib()`, prepend the stored directory to construct absolute paths when the input is a bare filename
- Absolute paths bypass linker namespace isolation and resolve correctly

## Testing

Tested on Samsung Galaxy S25 Ultra (Snapdragon 8 Elite, SM8750) with:
- LiteRT-LM v0.9.0 Kotlin API
- QNN SDK v2.44.0 (Maven: `com.qualcomm.qti:qnn-runtime:2.44.0`)
- `dispatch_api_so` built from this repo via Bazel (`--config=android_arm64`)

Before: Dispatch initialization fails on every subgraph load
After: Dispatch loads successfully for all 12 subgraphs without errors