### PR TITLE
Fix std::max type mismatch for size_t Rank (portable across platforms)

### DIFF
--- a/litert/cc/internal/litert_rng.h
+++ b/litert/cc/internal/litert_rng.h
@@ -359,7 +359,7 @@ class RandomTensorType {
 
   // `std::pow` is not constexpr until C++26, so this cannot be constexpr.
   static DimSize MaxDimSize() {
-    const double rank = std::max(1lu, Rank);
+    const double rank = std::max(static_cast<size_t>(1), Rank);
     const double exp = 1.0 / rank;
     const double max_flat = MaxSize;
     const double max_dim = std::pow(max_flat, exp);


### PR DESCRIPTION
… such as armv7-a in 32 bits)

Fix type mismatch in std::max for size_t Rank

The current code uses:
  std::max(1lu, Rank)

This can cause template deduction issues because:
- 1lu is unsigned long
- Rank is size_t

These types are not guaranteed to match across platforms, which may lead to compilation errors.

This change replaces it with:
  std::max(static_cast<size_t>(1), Rank)

This ensures both arguments have the same type and makes
the code portable across platforms.

No functional change intended.

More specifically, I got an error of type mismatch when build for armv7-a and I got it work with
  std::max(1u, Rank),
but then it will have problem with armv8. ChatGPT suggested static_cast to size_t. 