### PR TITLE
Fix heap OOB read in Slice op via negative begin values

### DIFF
--- a/tflite/kernels/slice.cc
+++ b/tflite/kernels/slice.cc
@@ -59,16 +59,22 @@ TfLiteStatus CalculateOutputShapeVector(TfLiteContext* context,
                                         const TfLiteTensor* size,
                                         std::vector<int>* output_shape_vector) {
   for (int idx = 0; idx < NumDimensions(input); ++idx) {
+    T begin_value = GetTensorData<T>(begin)[idx];
+    if (begin_value < 0) {
+      TF_LITE_KERNEL_LOG(context,
+                         "Begin value at index %d must be non-negative, got %d.",
+                         idx, static_cast<int>(begin_value));
+      return kTfLiteError;
+    }
     T size_value = GetTensorData<T>(size)[idx];
     if (size_value < 0) {
       if (size_value != -1) {
         TF_LITE_KERNEL_LOG(context, "Invalid size.");
         return kTfLiteError;
       }
-      size_value = SizeOfDimension(input, idx) - GetTensorData<T>(begin)[idx];
+      size_value = SizeOfDimension(input, idx) - begin_value;
     } else {
-      if (SizeOfDimension(input, idx) <
-          GetTensorData<T>(begin)[idx] + size_value) {
+      if (SizeOfDimension(input, idx) < begin_value + size_value) {
         TF_LITE_KERNEL_LOG(context, "Invalid begin and size.");
         return kTfLiteError;
       }

--- a/tflite/kernels/slice_test.cc
+++ b/tflite/kernels/slice_test.cc
@@ -398,6 +398,22 @@ TEST_P(SliceOpTest, BeginNonZeroSizeMinus1Axis1BFloat16) {
                                 Eigen::bfloat16(8), Eigen::bfloat16(9)}));
 }
 
+TEST(SliceOpTest, NegativeBeginRejected) {
+  SliceOpModel<float, int32_t> m({4, 3}, {2}, {-1, 0}, {2}, {1, 2},
+                                 TensorType_INT32, TensorType_FLOAT32,
+                                 TestType::kDynamic);
+  m.SetInput({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+  EXPECT_EQ(m.Invoke(), kTfLiteError);
+}
+
+TEST(SliceOpTest, NegativeBeginInt64Rejected) {
+  SliceOpModel<float, int64_t> m({4, 3}, {2}, {0, -2}, {2}, {2, 1},
+                                 TensorType_INT64, TensorType_FLOAT32,
+                                 TestType::kDynamic);
+  m.SetInput({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+  EXPECT_EQ(m.Invoke(), kTfLiteError);
+}
+
 INSTANTIATE_TEST_SUITE_P(SliceOpTest, SliceOpTest,
                          ::testing::Values(TestType::kConst,
                                            TestType::kDynamic));


### PR DESCRIPTION
## Summary

- **Security fix**: `CalculateOutputShapeVector` in `tflite/kernels/slice.cc` uses signed arithmetic to validate `begin + size` against the input dimension length. A negative `begin` value (e.g. `-20`) makes the sum negative, bypassing the upper-bound check (`50 < -10` evaluates to `false`). The unchecked negative `begin` then flows into the inner Slice kernel, reading heap memory before the input tensor's buffer.
- Adds an explicit `begin >= 0` check before the bounds comparison, rejecting negative values with a descriptive error message.
- Adds unit tests for both `int32` and `int64` index types to verify negative begin is rejected.

## Reproduction

```python
import numpy as np, tensorflow as tf

converter = tf.lite.TFLiteConverter.from_concrete_functions([
    tf.function(lambda x, b, s: tf.slice(x, b, s), input_signature=[
        tf.TensorSpec([50], tf.float32),
        tf.TensorSpec([1], tf.int32),
        tf.TensorSpec([1], tf.int32),
    ]).get_concrete_function()])
open('slice_oob.tflite', 'wb').write(converter.convert())

interp = tf.lite.Interpreter(model_path='slice_oob.tflite')
interp.allocate_tensors()
inp = interp.get_input_details()
interp.set_tensor(inp[0]['index'], np.arange(50, dtype=np.float32))
interp.set_tensor(inp[1]['index'], np.array([-20], dtype=np.int32))
interp.set_tensor(inp[2]['index'], np.array([10], dtype=np.int32))
interp.invoke()
# Output contains heap data from before the input buffer
```

## Impact

Heap out-of-bounds read with attacker-controlled offset and length. Leaks heap pointers (defeating ASLR) and adjacent tensor contents. Reachable from untrusted input data to a trusted model — no malicious model required.

The same class of bug was previously fixed in other TFLite ops (Gather CVE-2021-37687, SegmentSum CVE-2020-15212) but Slice was missed.