### PR TITLE
[Intel OV] Enable litert execution on linux

### DIFF
--- a/litert/runtime/dispatch/litert_dispatch.cc
+++ b/litert/runtime/dispatch/litert_dispatch.cc
@@ -148,10 +148,14 @@ LiteRtStatus LiteRtDispatchInitialize(
       DispatchSharedLibrary = new litert::SharedLibrary();
     }
 
-    LITERT_ASSIGN_OR_RETURN(
-        *DispatchSharedLibrary,
-        litert::SharedLibrary::Load(shared_lib_path,
-                                    litert::RtldFlags::Now().Local()));
+    auto shared_library = litert::SharedLibrary::Load(
+        shared_lib_path, litert::RtldFlags::Now().Local());
+    if (!shared_library.HasValue()) {
+      LITERT_LOG(LITERT_ERROR, "%s",
+                 shared_library.Error().Message().c_str());
+      return litert::ToLiteRtStatus(shared_library.Error().StatusCC());
+    }
+    *DispatchSharedLibrary = std::move(shared_library.Value());
 
     using LiteRtDispatchGetApi_t = LiteRtStatus (*)(LiteRtDispatchApi*);
     LITERT_ASSIGN_OR_RETURN(

--- a/litert/vendors/intel_openvino/dispatch/BUILD
+++ b/litert/vendors/intel_openvino/dispatch/BUILD
@@ -27,10 +27,14 @@ litert_dynamic_lib(
         "device_context.cc",
         "dispatch_api.cc",
         "invocation_context.cc",
+        "openvino_shared_core.cc",
+        "openvino_tensor_buffer.cc",
     ],
     hdrs = [
         "device_context.h",
         "invocation_context.h",
+        "openvino_shared_core.h",
+        "openvino_tensor_buffer.h",
     ],
     copts = [
         "-Os",

--- a/litert/vendors/intel_openvino/dispatch/device_context.cc
+++ b/litert/vendors/intel_openvino/dispatch/device_context.cc
@@ -39,9 +39,7 @@
 #include "litert/c/litert_model.h"
 #include "litert/vendors/intel_openvino/utils.h"
 
-#if defined(LITERT_WINDOWS_OS)
 #include "litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.h"
-#endif  // LITERT_WINDOWS_OS
 
 #if LITERT_HAS_AHWB_SUPPORT || LITERT_HAS_DMABUF_SUPPORT
 #include "openvino/core/type/element_type.hpp"
@@ -143,7 +141,6 @@ LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
 
   switch (tensor_buffer_type) {
     case kLiteRtTensorBufferTypeOpenVINOTensorBuffer: {
-#if defined(LITERT_WINDOWS_OS)
       HwMemoryHandle hw_memory_handle;
       LITERT_RETURN_IF_ERROR(
           LiteRtGetTensorBufferCustomTensorBufferHandle(tensor_buffer,
@@ -159,11 +156,6 @@ LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
                                  RegisteredTensor{.tensor = openvino_tensor});
 
       return next_handle_++;
-#else
-      return litert::Unexpected(
-          kLiteRtStatusErrorRuntimeFailure,
-          "OpenVINO tensor support is missing on this platform.");
-#endif  // LITERT_WINDOWS_OS
     }
     case kLiteRtTensorBufferTypeDmaBuf: {
 #if LITERT_HAS_DMABUF_SUPPORT
@@ -176,7 +168,7 @@ LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
                                             &buffer_fd),
           litert::Unexpected(kLiteRtStatusErrorRuntimeFailure,
                              "Failed to get DMA-BUF buffer"));
-      auto context = core_->get_default_context("NPU")
+      auto context = getCore()->get_default_context("NPU")
                          .as<ov::intel_npu::level_zero::ZeroContext>();
       std::vector<int32_t> ov_shape_vec(tensor_type.layout.rank);
       for (int i = 0; i < ov_shape_vec.size(); i++)
@@ -215,7 +207,7 @@ LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
       std::vector<int32_t> ov_shape_vec(tensor_type.layout.rank);
       for (int i = 0; i < ov_shape_vec.size(); i++)
         ov_shape_vec[i] = tensor_type.layout.dimensions[i];
-      auto context = core_->get_default_context("NPU")
+      auto context = getCore()->get_default_context("NPU")
                          .as<ov::intel_npu::level_zero::ZeroContext>();
       void* buffer = mmap(nullptr, tensor_buffer_size, PROT_READ | PROT_WRITE,
                           MAP_SHARED, fd, tensor_buffer_offset);

--- a/litert/vendors/intel_openvino/dispatch/device_context.h
+++ b/litert/vendors/intel_openvino/dispatch/device_context.h
@@ -36,9 +36,7 @@
 #include "litert/cc/litert_macros.h"
 #include "litert/vendors/c/litert_dispatch.h"
 
-#if defined(LITERT_WINDOWS_OS)
 #include "litert/vendors/intel_openvino/dispatch/openvino_shared_core.h"
-#endif  // LITERT_WINDOWS_OS
 
 class LiteRtDispatchDeviceContextT {
  public:
@@ -65,11 +63,7 @@ class LiteRtDispatchDeviceContextT {
 
   // Return the core shared_pointer.
   std::shared_ptr<ov::Core> getCore() const {
-#if defined(LITERT_WINDOWS_OS)
     return OpenVINOSharedCore::GetInstance()->getCore();
-#else
-    return core_;
-#endif  // LITERT_WINDOWS_OS
   }
 
  private:
@@ -109,8 +103,7 @@ class LiteRtDispatchDeviceContextT {
   };
 
   explicit LiteRtDispatchDeviceContextT()
-      : core_(std::make_shared<ov::Core>()), next_handle_(0) {}
-  std::shared_ptr<ov::Core> core_;
+      : next_handle_(0) {}
   std::unordered_map<LiteRtTensorBufferHandle, RegisteredTensor>
       tensor_handle_map_;
   uint64_t next_handle_;

--- a/litert/vendors/intel_openvino/dispatch/dispatch_api.cc
+++ b/litert/vendors/intel_openvino/dispatch/dispatch_api.cc
@@ -34,11 +34,9 @@
 #include "litert/vendors/intel_openvino/dispatch/device_context.h"
 #include "litert/vendors/intel_openvino/dispatch/invocation_context.h"
 
-#if defined(LITERT_WINDOWS_OS)
 #include "litert/c/internal/litert_tensor_buffer_registry.h"
 #include "litert/c/litert_custom_tensor_buffer.h"
 #include "litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.h"
-#endif  // LITERT_WINDOWS_OS
 
 namespace litert {
 namespace openvino {
@@ -51,7 +49,6 @@ IntelOpenVinoOptions* intel_openvino_opts = nullptr;
 
 }  // namespace
 
-#if defined(LITERT_WINDOWS_OS)
 LiteRtStatus CreateOpenVinoTensorBuffer(
     LiteRtGpuDeviceId device_id, LiteRtGpuQueueId queue_id,
     const LiteRtRankedTensorType* tensor_type,
@@ -99,7 +96,6 @@ LiteRtStatus LockOpenVinoTensorBuffer(HwMemoryInfoPtr hw_memory_info,
   *host_memory_ptr = result.Value();
   return kLiteRtStatusOk;
 }
-#endif  // LITERT_WINDOWS_OS
 
 // Initialize the Dispatch API runtime.
 // This function should be called before calling any other Dispatch API
@@ -118,14 +114,12 @@ LiteRtStatus DispatchInitialize(const LiteRtRuntimeContext* runtime_context,
     LITERT_LOG(LITERT_INFO, "[Openvino]Found device plugin for: %s",
                device.c_str());
 
-#if defined(LITERT_WINDOWS_OS)
   LITERT_RETURN_IF_ERROR(LiteRtRegisterTensorBufferHandlers(
       env, kLiteRtTensorBufferTypeOpenVINOTensorBuffer,
       CreateOpenVinoTensorBuffer, DestroyOpenVinoTensorBuffer,
       LockOpenVinoTensorBuffer, UnlockOpenVinoTensorBuffer, nullptr, nullptr,
       /*device_tag=*/kLiteRtEnvOptionTagNull,
       /*queue_tag=*/kLiteRtEnvOptionTagNull));
-#endif  // LITERT_WINDOWS_OS
 
   if (options) {
     auto cc_options = litert::Options(options, litert::OwnHandle::kNo);

--- a/litert/vendors/intel_openvino/dispatch/invocation_context.cc
+++ b/litert/vendors/intel_openvino/dispatch/invocation_context.cc
@@ -155,9 +155,7 @@ LiteRtDispatchInvocationContextT::Create(
         break;
     }
   }
-#if defined(LITERT_WINDOWS_OS)
   OpenVINOSharedCore::GetInstance()->SetDevice(device);
-#endif  // LITERT_WINDOWS_OS
 
   if (!exec_bytecode_ptr || exec_bytecode_size == 0) {
     return litert::Error(kLiteRtStatusErrorRuntimeFailure,
@@ -193,14 +191,11 @@ litert::Expected<LiteRtTensorBufferRequirements>
 LiteRtDispatchInvocationContextT::GetTensorBufferRequirements(
     const LiteRtRankedTensorType& tensor_type) {
   LiteRtTensorBufferType supported_tensor_buffer_types[] = {
-#if defined(LITERT_WINDOWS_OS)
       kLiteRtTensorBufferTypeOpenVINOTensorBuffer,
-#else
       // OpenVINO RemoteTensor doesn't support copy-free AHWB buffer. Until
       // it's supported, we use DMA-BUF.
       kLiteRtTensorBufferTypeDmaBuf,
       kLiteRtTensorBufferTypeAhwb,
-#endif
   };
 
   int num_supported_tensor_buffer_types =

--- a/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.h
+++ b/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.h
@@ -28,7 +28,7 @@ class OpenVinoTensorBuffer {
   OpenVinoTensorBuffer(OpenVinoTensorBuffer&&) = default;
   OpenVinoTensorBuffer& operator=(OpenVinoTensorBuffer&&) = default;
 
-  OpenVinoTensorBuffer() : host_tensor_({}), allocated_(false) {};
+  OpenVinoTensorBuffer() : host_tensor_(), allocated_(false) {};
   ~OpenVinoTensorBuffer() = default;
 
   litert::Expected<void> Alloc(const LiteRtRankedTensorType& tensor_type,


### PR DESCRIPTION
Enable litert execution across all OS using the Openvino buffer.

Verified the compiler plugin with the following steps :

Bazel build commands :
build litert/vendors/intel_openvino/compiler:libLiteRtCompilerPlugin_IntelOpenvino.so
build litert/vendors/intel_openvino/dispatch:libLiteRtDispatch_IntelOpenvino.so
build litert/tools:apply_plugin_main

AOT compilation step:
LD_LIBRARY_PATH=<PATH_TO_OPENVINO_LIBS> bazel-bin/litert/tools/apply_plugin_main --cmd apply --model=<PATH_TO_tflite_MODEL> -o <PATH_TO_AOT_MODEL> --libs bazel-bin/litert/vendors/intel_openvino/compiler --intel_openvino_device_type=cpu --soc_manufacturer "IntelOpenVINO" --soc_model=""