### PR TITLE
Qualcomm AI Engine Direct - Support EmbeddingLookup with different quant params.

### DIFF
--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -84,6 +84,7 @@ cc_library(
     hdrs = ["embedding_lookup_op_builder.h"],
     deps = [
         ":op_builder",
+        ":quantize_op_builder",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/utils:log",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",

--- a/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/quantize_op_builder.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/utils/log.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
@@ -19,50 +20,65 @@ namespace {
 constexpr int kTableIdx = 1;
 constexpr int kIndicesIdx = 0;
 constexpr int kOutputIdx = 0;
+constexpr std::int32_t kGatherDefaultAxis = 0;
 }  // namespace
+
+OpWrapper CreateGatherOp(const TensorWrapper& table,
+                         const TensorWrapper& indices,
+                         const TensorWrapper& output, std::int32_t axis) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_GATHER), QNN_OP_GATHER,
+               QnnOpCode::kGather);
+  op.AddInputTensor(table);
+  op.AddInputTensor(indices);
+  op.AddOutputTensor(output);
+  op.AddScalarParam<std::int32_t>(QNN_OP_GATHER_PARAM_AXIS, axis);
+  return op;
+}
 
 std::vector<OpWrapper> BuildEmbeddingLookupOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs) {
-  std::vector<OpWrapper> res;
+  const TensorWrapper* table_tensor = &(inputs[kTableIdx].get());
+  const TensorWrapper& indices_tensor = inputs[kIndicesIdx];
+  const TensorWrapper& output_tensor = outputs[kOutputIdx];
 
-  TensorWrapper& table_tensor = inputs[kTableIdx];
-  TensorWrapper& indices_tensor = inputs[kIndicesIdx];
-  TensorWrapper& output_tensor = outputs[kOutputIdx];
-
-  auto& gather_op = CreateOpWrapper(res, QNN_OP_GATHER);
   // Case: QInt8 table with QInt16 output
-  if (table_tensor.IsQuantI8() && output_tensor.IsQuantI16()) {
+  if (table_tensor->IsQuantI8() && output_tensor.IsQuantI16()) {
     QNN_LOG_WARNING(
         "The data type of embedding lookup table is int8, but output data type "
         "is int16. Int8 table will be cast to int16.");
     std::vector<std::int16_t> int16_data;
-    size_t data_len = table_tensor.GetTensorNumElements();
-    auto int8_data = table_tensor.GetTensorData<std::int8_t>();
+    size_t data_len = table_tensor->GetTensorNumElements();
+    auto int8_data = table_tensor->GetTensorData<std::int8_t>();
     if (!int8_data.has_value()) {
       QNN_LOG_ERROR("Embedding lookup get int8 table failed.");
-      return res;
+      return {};
     }
     int16_data.reserve(data_len);
-    for (int i = 0; i < data_len; ++i) {
+    for (size_t i = 0; i < data_len; ++i) {
       int16_data.emplace_back(static_cast<std::int16_t>((*int8_data)[i]));
     }
 
-    TensorWrapper& int16_table_tensor = tensor_pool.CreateStaticTensor(
-        output_tensor.GetDataType(), table_tensor.GetQuantParams(),
-        table_tensor.GetDimensions(),
+    table_tensor = &tensor_pool.CreateStaticTensor(
+        output_tensor.GetDataType(), table_tensor->GetQuantParams(),
+        table_tensor->GetDimensions(),
         sizeof(decltype(int16_data)::value_type) * int16_data.size(),
         reinterpret_cast<void*>(int16_data.data()));
-
-    gather_op.AddInputTensor(int16_table_tensor);
-  } else {
-    gather_op.AddInputTensor(table_tensor);
   }
 
-  gather_op.AddInputTensor(indices_tensor);
-  gather_op.AddOutputTensor(output_tensor);
-  gather_op.AddScalarParam<std::int32_t>(QNN_OP_GATHER_PARAM_AXIS, 0);
-  return res;
+  const auto& table_quant_params = table_tensor->GetQuantParams();
+  if (table_quant_params == output_tensor.GetQuantParams()) {
+    return MakeVector(CreateGatherOp(*table_tensor, indices_tensor,
+                                     output_tensor, kGatherDefaultAxis));
+  }
+  QNN_LOG_WARNING(
+      "Add a Convert op after the Gather op since the table's quant params do "
+      "not match the output's.");
+  const auto& gather_output =
+      tensor_pool.CloneNativeTensorFrom(output_tensor, table_quant_params);
+  return MakeVector(CreateGatherOp(*table_tensor, indices_tensor, gather_output,
+                                   kGatherDefaultAxis),
+                    CreateConvertOp(gather_output, output_tensor));
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.h
@@ -4,12 +4,19 @@
 #ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_EMBEDDING_LOOKUP_OP_BUILDER_H_
 #define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_EMBEDDING_LOOKUP_OP_BUILDER_H_
 
+#include <cstdint>
+#include <vector>
+
 #include "litert/vendors/qualcomm/core/builders/op_builder.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 #include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
 
 namespace qnn {
+
+OpWrapper CreateGatherOp(const TensorWrapper& table,
+                         const TensorWrapper& indices,
+                         const TensorWrapper& output, std::int32_t axis);
 
 std::vector<OpWrapper> BuildEmbeddingLookupOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,

--- a/litert/vendors/qualcomm/core/builders/quantize_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/quantize_op_builder.cc
@@ -13,6 +13,15 @@
 
 namespace qnn {
 
+OpWrapper CreateConvertOp(const TensorWrapper& input,
+                          const TensorWrapper& output) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_CONVERT), QNN_OP_CONVERT,
+               QnnOpCode::kConvert);
+  op.AddInputTensor(input);
+  op.AddOutputTensor(output);
+  return op;
+}
+
 std::vector<OpWrapper> BuildQuantizeOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs) {
@@ -25,7 +34,8 @@ std::vector<OpWrapper> BuildQuantizeOp(
               inputs[0].get().IsQuantI16() || inputs[0].get().IsQuantU16()) &&
              (outputs[0].get().IsQuantI8() || outputs[0].get().IsQuantU8() ||
               outputs[0].get().IsQuantI16() || outputs[0].get().IsQuantU16())) {
-    qnn_op = QNN_OP_CONVERT;
+    res.emplace_back(CreateConvertOp(inputs[0], outputs[0]));
+    return res;
   } else {
     qnn_op = QNN_OP_QUANTIZE;
   }

--- a/litert/vendors/qualcomm/core/builders/quantize_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/quantize_op_builder.h
@@ -12,6 +12,9 @@
 
 namespace qnn {
 
+OpWrapper CreateConvertOp(const TensorWrapper& input,
+                          const TensorWrapper& output);
+
 std::vector<OpWrapper> BuildQuantizeOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs);

--- a/litert/vendors/qualcomm/core/tensor_pool.cc
+++ b/litert/vendors/qualcomm/core/tensor_pool.cc
@@ -224,6 +224,15 @@ TensorWrapper& TensorPool::CloneNativeTensorFrom(
       src.quantize_params_, dimensions);
 }
 
+TensorWrapper& TensorPool::CloneNativeTensorFrom(
+    const TensorWrapper& src, const QuantizeParamsWrapperVariant& quant) {
+  const auto id = tensor_wrappers_.size();
+  auto tensor_name = std::to_string(id) + kQnnSuffix;
+  return tensor_wrappers_.emplace_back(
+      std::move(tensor_name), QNN_TENSOR_TYPE_NATIVE, src.GetDataType(), quant,
+      src.dimensions_);
+}
+
 TensorWrapper& TensorPool::CloneStaticTensorFrom(const TensorWrapper& src,
                                                  Qnn_DataType_t data_type) {
   const auto id = tensor_wrappers_.size();

--- a/litert/vendors/qualcomm/core/tensor_pool.h
+++ b/litert/vendors/qualcomm/core/tensor_pool.h
@@ -71,6 +71,9 @@ class TensorPool {
   TensorWrapper& CloneNativeTensorFrom(
       const TensorWrapper& src, const std::vector<std::uint32_t>& dimensions);
 
+  TensorWrapper& CloneNativeTensorFrom(
+      const TensorWrapper& src, const QuantizeParamsWrapperVariant& quant);
+
   TensorWrapper& CloneStaticTensorFrom(const TensorWrapper& src,
                                        Qnn_DataType_t data_type);
 

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -113,6 +113,42 @@ litert_test(
 )
 
 litert_test(
+    name = "embedding_lookup_test",
+    srcs = [
+        "embedding_lookup_test.cc",
+    ],
+    linkopts = select({
+        "@org_tensorflow//tensorflow:android": [],
+        "//conditions:default": [
+            make_rpaths([
+                "//litert/c:litert_runtime_c_api_so",
+            ]),
+        ],
+    }),
+    linkstatic = True,
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "no-remote-exec",
+        "nobuilder",
+        "notap",
+        "manual",
+    ],
+    ungrte = True,
+    use_sys_malloc = True,
+    deps = [
+        "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:embedding_lookup_op_builder",
+        "//litert/vendors/qualcomm/core/utils:miscs",
+        "//litert/vendors/qualcomm/core/utils:test_main",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+litert_test(
     name = "fully_connected_int2_test",
     srcs = [
         "fully_connected_int2_test.cc",

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/embedding_lookup_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/embedding_lookup_test.cc
@@ -1,0 +1,151 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "litert/vendors/qualcomm/core/builders/embedding_lookup_op_builder.h"
+#include "litert/vendors/qualcomm/core/utils/miscs.h"
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+#include "QnnTypes.h"  // from @qairt
+
+using testing::Pointwise;
+namespace litert::qnn {
+namespace {
+INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
+                         QnnTestPrinter);
+
+// Table shape: (2, 10), output shape: (1, 10).
+// Both table and output use ScaleOffset quant with scale=0.1 and offset=0.
+//
+// Table data (int8, row-major):
+//   row 0: [ 1,  2,  3,  4,  5, -1, -2, -3, -4, -5]
+//   row 1: [10, 20, 30, 40, 50,-10,-20,-30,-40,-50]
+//
+// Indices: [1]  →  gather row 1.
+//
+// Since table and output share the same quant params, BuildEmbeddingLookupOp
+// emits a single Gather op (no Convert op).
+//
+// Expected output (int8): [10, 20, 30, 40, 50, -10, -20, -30, -40, -50]
+TEST_P(QnnModelTest, EmbeddingLookupScaleOffsetSameQuantParams) {
+  const std::vector<std::uint32_t> kTableDims{2, 10};
+  const std::vector<std::uint32_t> kIndicesDims{1};
+  const std::vector<std::uint32_t> kOutputDims{1, 10};
+
+  // 10 per-column scales, all 0.1.
+  const constexpr float kScales = 0.1f;
+  const constexpr std::int32_t kZeroPoints = 0;
+  const auto kQuant =
+      ::qnn::ScaleOffsetQuantizeParamsWrapper{kScales, kZeroPoints};
+
+  // Table: row 0 = [1..5, -1..-5], row 1 = [10..50, -10..-50] (int8).
+  std::vector<std::int8_t> table_data = {
+      1,  2,  3,  4,  5,  -1,  -2,  -3,  -4,  -5,  // row 0
+      10, 20, 30, 40, 50, -10, -20, -30, -40, -50  // row 1
+  };
+
+  auto& table_tensor = tensor_pool_.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, kQuant, kTableDims,
+      table_data.size() * sizeof(std::int8_t), table_data.data());
+
+  auto& indices_tensor = tensor_pool_.CreateInputTensorWithName(
+      "indices", QNN_DATATYPE_UINT_32, {}, kIndicesDims);
+
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_SFIXED_POINT_8, kQuant, kOutputDims);
+
+  auto ops = ::qnn::BuildEmbeddingLookupOp(
+      tensor_pool_, {indices_tensor, table_tensor}, {output_tensor});
+  // Same quant params: expect exactly one Gather op, no Convert op.
+  ASSERT_EQ(ops.size(), 1u);
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+  const auto indices_idx = qnn_model_.AddInputTensor(indices_tensor);
+  const auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+
+  // Select row 1.
+  qnn_model_.SetInputData<std::uint32_t>(indices_idx, {1});
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  const auto output_data = qnn_model_.GetOutputData<std::int8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_EQ(output_data->size(), 10u);
+  // Row 1 int8 values pass through unchanged.
+  ASSERT_THAT(
+      output_data.value(),
+      Pointwise(testing::Eq(), std::vector<std::int8_t>{10, 20, 30, 40, 50, -10,
+                                                        -20, -30, -40, -50}));
+}
+
+// Same table as above (scale=0.1), but the output uses
+// ScaleOffset with scale=0.2.
+//
+// BuildEmbeddingLookupOp must emit Gather + Convert because the quant params
+// differ.
+//
+// Gather picks row 1 (int8): [10, 20, 30, 40, 50, -10, -20, -30, -40, -50]
+// Real values (scale 0.1):   [1.0, 2.0, 3.0, 4.0, 5.0, -1.0, -2.0, -3.0,
+//                              -4.0, -5.0]
+// Re-quantized to scale 0.2: round(real / 0.2)
+//                           = [5, 10, 15, 20, 25, -5, -10, -15, -20, -25]
+TEST_P(QnnModelTest, EmbeddingLookupScaleOffsetDifferentQuantParams) {
+  const std::vector<std::uint32_t> kTableDims{2, 10};
+  const std::vector<std::uint32_t> kIndicesDims{1};
+  const std::vector<std::uint32_t> kOutputDims{1, 10};
+
+  const auto kTableQuant = ::qnn::ScaleOffsetQuantizeParamsWrapper{0.1f, 0};
+  const auto kOutputQuant = ::qnn::ScaleOffsetQuantizeParamsWrapper{0.2f, 0};
+
+  std::vector<std::int8_t> table_data = {
+      1,  2,  3,  4,  5,  -1,  -2,  -3,  -4,  -5,  // row 0
+      10, 20, 30, 40, 50, -10, -20, -30, -40, -50  // row 1
+  };
+
+  auto& table_tensor = tensor_pool_.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, kTableQuant, kTableDims,
+      table_data.size() * sizeof(std::int8_t), table_data.data());
+
+  auto& indices_tensor = tensor_pool_.CreateInputTensorWithName(
+      "indices", QNN_DATATYPE_UINT_32, {}, kIndicesDims);
+
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_SFIXED_POINT_8, kOutputQuant, kOutputDims);
+
+  auto ops = ::qnn::BuildEmbeddingLookupOp(
+      tensor_pool_, {indices_tensor, table_tensor}, {output_tensor});
+  // Different quant params: expect Gather + Convert = 2 ops.
+  ASSERT_EQ(ops.size(), 2u);
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+  const auto indices_idx = qnn_model_.AddInputTensor(indices_tensor);
+  const auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+
+  // Select row 1.
+  qnn_model_.SetInputData<std::uint32_t>(indices_idx, {1});
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  const auto output_data = qnn_model_.GetOutputData<std::int8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_EQ(output_data->size(), 10u);
+  // Real values from row 1 (scale 0.1) re-quantized to scale 0.2:
+  //   round(v * 0.1 / 0.2) = round(v / 2)
+  //   [10, 20, 30, 40, 50, -10, -20, -30, -40, -50] / 2 =
+  //   [5, 10, 15, 20, 25, -5, -10, -15, -20, -25]
+  ASSERT_THAT(
+      output_data.value(),
+      Pointwise(testing::Eq(), std::vector<std::int8_t>{5, 10, 15, 20, 25, -5,
+                                                        -10, -15, -20, -25}));
+}
+
+}  // namespace
+}  // namespace litert::qnn


### PR DESCRIPTION
Summary:
- Add a Convert op after EmbeddingLookup when output quantization parameters do not match its table.
- Add unit tests covering both matching and mismatched quantization parameters for EmbeddingLookup.

Test:
x86:
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test       PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.8s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.7s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test               PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test                 PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test                  PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 39.3s
```

on-device:
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 21 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 17 tests from 3 test suites ran. (8 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (5 ms total)
[  PASSED  ] 33 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (10 ms total)
[  PASSED  ] 8 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (330 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (417 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (408 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1079 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1167 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
[==========] 2 tests from 1 test suite ran. (809 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (610 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1977 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (20 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (440 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (407 ms total)
[  PASSED  ] 2 tests.
```