### PR TITLE
Convert weight from i2 to u2 since OV does not support i2

### DIFF
--- a/litert/vendors/intel_openvino/compiler/graph_iterator.cc
+++ b/litert/vendors/intel_openvino/compiler/graph_iterator.cc
@@ -15,9 +15,13 @@
 
 #include "litert/vendors/intel_openvino/compiler/graph_iterator.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
+#include <vector>
 
 #include "litert/c/internal/litert_logging.h"
+#include "litert/c/litert_op_code.h"
 #include "litert/vendors/intel_openvino/utils.h"
 
 namespace litert {
@@ -90,6 +94,7 @@ bool fill_tensor_meta(
 
 std::shared_ptr<ov::frontend::tensorflow_lite::DecoderBase>
 GraphIteratorDelegate::get_decoder() const {
+  converted_weight_buffers_.clear();
   ov::frontend::tensorflow_lite::TensorMetaInfo tensor_meta_info;
   if (node_index_ < iterator_indices_.input_index_) {
     const auto& input_vec = subgraph_ptr_->Inputs();
@@ -130,6 +135,44 @@ GraphIteratorDelegate::get_decoder() const {
         LITERT_LOG(LITERT_VERBOSE, "Data is static or constant for op %d",
                    op.Code());
         tensor_meta_info.m_tensor_data = input.Weights().Bytes().data();
+
+        // Convert signed i2 weights to unsigned u2 for NPU friendliness.
+        // XOR flips each sub-byte element's MSB, which is equivalent to
+        // adding 2^(bits-1) mod 2^bits. The zero points are adjusted by the
+        // same offset to keep dequantized values unchanged.
+        // i2 → u2: for all ops, since MapLiteTypeToOV maps i2 to u2
+        //   globally and OpenVINO never sees ov::element::i2.
+        if (tensor_meta_info.m_quantization_info) {
+          const auto litert_type = static_cast<LiteRtElementType>(
+              input.ElementType());
+          if (litert_type == kLiteRtElementTypeInt2) {
+            constexpr uint8_t xor_mask = 0xAA;  // flip MSB of each 2-bit pair
+            constexpr int64_t zp_offset = 2;     // [-2..1] -> [0..3]
+
+            auto weight_bytes = input.Weights().Bytes();
+            auto& buf = converted_weight_buffers_.emplace_back(
+                weight_bytes.data(),
+                weight_bytes.data() + weight_bytes.size());
+            for (auto& byte : buf) {
+              byte ^= xor_mask;
+            }
+            tensor_meta_info.m_tensor_data = buf.data();
+            tensor_meta_info.m_element_type = ov::element::u2;
+
+            auto adjusted_qi = std::make_shared<
+                ov::frontend::tensorflow_lite::QuantizationInfo>(
+                *tensor_meta_info.m_quantization_info);
+            auto zps = adjusted_qi->get_zero_point();
+            for (auto& zp : zps) {
+              zp += zp_offset;
+            }
+            adjusted_qi->set_zero_point(zps);
+            tensor_meta_info.m_quantization_info = adjusted_qi;
+            LITERT_LOG(LITERT_INFO,
+                       "Converted i2 weights to u2 for tensor: %s",
+                       tensor_meta_info.m_tensor_name.c_str());
+          }
+        }
       }
       input_meta_info.push_back(tensor_meta_info);
     }

--- a/litert/vendors/intel_openvino/compiler/graph_iterator.h
+++ b/litert/vendors/intel_openvino/compiler/graph_iterator.h
@@ -16,6 +16,7 @@
 #ifndef ODML_LITERT_LITERT_VENDORS_OPENVINO_COMPILER_GRAPH_ITERATOR_H_
 #define ODML_LITERT_LITERT_VENDORS_OPENVINO_COMPILER_GRAPH_ITERATOR_H_
 
+#include <cstdint>
 #include <memory>
 #include <unordered_set>
 #include <vector>
@@ -96,6 +97,10 @@ class GraphIteratorDelegate
   size_t node_index_ = 0;
   const litert::Subgraph* subgraph_ptr_;
   struct OVGraphIndices iterator_indices_;
+  // Owns converted weight buffers for i2-to-u2 transformations. Each entry
+  // holds a copy of the original packed bytes with the MSB of every 2-bit
+  // pair flipped (XOR 0xAA), which shifts signed [-2,1] to unsigned [0,3].
+  mutable std::vector<std::vector<uint8_t>> converted_weight_buffers_;
 };
 
 }  // namespace openvino

--- a/litert/vendors/intel_openvino/utils.h
+++ b/litert/vendors/intel_openvino/utils.h
@@ -18,6 +18,11 @@ static const ov::element::Type MapLiteTypeToOV(
     case kLiteRtElementTypeBool:
       ov_type = ov::element::boolean;
       break;
+    case kLiteRtElementTypeInt2:
+      // i2 weights are converted to u2 in graph_iterator before reaching
+      // OpenVINO, so map directly to u2 here as well.
+      ov_type = ov::element::u2;
+      break;
     case kLiteRtElementTypeInt4:
       ov_type = ov::element::i4;
       break;


### PR DESCRIPTION
OpenVINO does not support i2 data type. Thus before model compilation, we will need to convert the quantized i2 weights to use u2 data type, and shift zero-point accordingly, so they are numerically equivalent to the original i2 values. 