### PR TITLE
Expand macOS Bazel CI coverage

### DIFF
--- a/.github/workflows/macos-arm64.yml
+++ b/.github/workflows/macos-arm64.yml
@@ -92,24 +92,39 @@ jobs:
           echo "Cache Primary Key: ${{ steps.bazel-cache.outputs.cache-primary-key }}"
           echo "Cache Matched Key: ${{ steps.bazel-cache.outputs.cache-matched-key }}"
 
-      - name: Build LiteRT targets
-        run: |
-          # TODO(b/446718368): Re-enable the tests once we update our workflow with a custom runner.
-          bazel build --disk_cache=~/.cache/bazel-macos \
-            -c opt \
-            -s \
-            --cxxopt=-std=c++17 \
-            --verbose_failures \
-            //litert/core/...
-
       - name: Run LiteRT tests
+        env:
+          TEST_LANG_FILTERS: cc,py
         run: |
+          BUILD_FLAGS=(
+            "--config=bulk_test_cpu"
+            "--config=macos_arm64"
+            "--test_lang_filters=${TEST_LANG_FILTERS}"
+            "--keep_going"
+            "--repo_env=USE_PYWRAP_RULES=True"
+          )
+
+          LITERT_EXCLUDED_TARGETS=(
+            "-//litert/c:litert_compiled_model_shared_lib_test"
+            "-//litert/c:litert_compiled_model_test"
+            "-//litert/cc:litert_compiled_model_test"
+            "-//litert/cc:litert_environment_test"
+            "-//litert/python/tools/model_utils/test/..."
+            "-//litert/runtime:compiled_model_test"
+            "-//litert/tools:tool_display_test"
+            "-//litert/tools:dump_test"
+            "-//litert/tools:apply_plugin_test"
+            "-//litert/vendors/intel_openvino/compiler:decoder_test"
+            "-//litert/vendors/intel_openvino/dispatch:dispatch_api_openvino_test"
+            "-//litert/vendors/intel_openvino/compiler:openvino_compiler_plugin_test"
+          )
+
           bazel test --disk_cache=~/.cache/bazel-macos \
-            -c opt \
-            -s \
-            --cxxopt=-std=c++17 \
-            --verbose_failures \
-            //litert/core/...
+            "${BUILD_FLAGS[@]}" \
+            -- \
+            //litert/... \
+            //weight_loader/... \
+            "${LITERT_EXCLUDED_TARGETS[@]}"
 
       - name: Remove cache if cache is being refreshed.
         if: env.REFRESH_CACHE == 'true'


### PR DESCRIPTION
## Summary
Expand the macOS Bazel presubmit to use the same broad LiteRT package test selection as Linux.

This changes the macOS workflow from testing only `//litert/core/...` to testing:
- `//litert/...`
- `//weight_loader/...`

It also reuses the same explicit exclusion list that the Linux workflow already carries, while adding `--config=macos_arm64` for the Apple runner.

## Testing
- Workflow-only change; not executed locally.
- Verified the change is isolated to `.github/workflows/macos-arm64.yml`.
