### PR TITLE
Add host CMake CI policy

### DIFF
--- a/.github/workflows/cmake_linux_x86_64.yml
+++ b/.github/workflows/cmake_linux_x86_64.yml
@@ -1,0 +1,107 @@
+name: "cmake-linux-x86_64"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  presubmit:
+    name: "Presubmit-CMake-Linux"
+    runs-on: LiteRT_Linux_x64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup CMake 3.28.3
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.28.3"
+
+      - name: Install host build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang \
+            libc++-dev \
+            libc++abi-dev
+
+      - name: Show toolchain versions
+        run: |
+          clang --version
+          clang++ --version
+          cmake --version
+
+      - name: Configure host release build
+        run: cmake --preset default -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        working-directory: litert
+
+      - name: Build host release artifacts
+        run: cmake --build cmake_build --parallel
+        working-directory: litert
+
+      - name: Configure host debug build
+        run: cmake --preset default-debug -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        working-directory: litert
+
+      - name: Build host debug artifacts
+        run: cmake --build cmake_build_debug --parallel
+        working-directory: litert
+
+  codeql:
+    name: "CodeQL-CMake-Linux"
+    runs-on: LiteRT_Linux_x64
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup CMake 3.28.3
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.28.3"
+
+      - name: Install host build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang \
+            libc++-dev \
+            libc++abi-dev
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: cpp
+          build-mode: manual
+
+      - name: Configure host release build for CodeQL
+        run: cmake --preset default -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        working-directory: litert
+
+      - name: Build host release artifacts for CodeQL
+        run: cmake --build cmake_build --parallel
+        working-directory: litert
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4

--- a/g3doc/instructions/CMAKE_BUILD_INSTRUCTIONS.md
+++ b/g3doc/instructions/CMAKE_BUILD_INSTRUCTIONS.md
@@ -31,6 +31,11 @@ LiteRT supports both **Release** and **Debug** build flavors:
 **Release** builds use `-O3 -DNDEBUG` for optimized production binaries.
 **Debug** builds use `-O0 -g` for debugging with full symbol information.
 
+Host presets are intentionally configured to use `clang`/`clang++` with
+`libc++`. This is the repository policy for host CMake builds so the generated
+artifacts remain ABI-compatible with prebuilt LiteRT binaries that also use
+`libc++`.
+
 ## Android (arm64) Cross-Compilation
 
 1. Install the Android NDK and export the path so CMake can find it:
@@ -73,6 +78,14 @@ build directory (`cmake_build_android_arm64` or `cmake_build_android_arm64_debug
 
 ## Host Build from Mac OS and Linux
 
+1. Install `clang` and the `libc++` development packages on Linux before using
+   the host presets:
+
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y clang libc++-dev libc++abi-dev
+   ```
+
 1. Configure the default host preset:
 
    ```bash
@@ -114,6 +127,8 @@ cmake --build build-release --target dispatch_api_Qualcomm_so -j8
 
 - `LITERT_HOST_C_COMPILER` / `LITERT_HOST_CXX_COMPILER` let you point the helper
   host tools at any Clang/GCC installation without editing `CMakeLists.txt`.
+- The default host presets already select `clang + libc++`; only override those
+  toolchains if you intentionally need a different local setup.
 - `LITERT_DISABLE_KLEIDIAI` keeps x86 host builds reproducible by skipping
   KleidiAI; set it to `OFF` whenever you want to bundle the delegate.
 - Always pass `-DCMAKE_BUILD_TYPE=Release` (or the equivalent preset) when you

--- a/litert/CMakePresets.json
+++ b/litert/CMakePresets.json
@@ -7,8 +7,13 @@
       "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/cmake_build",
       "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_CXX_FLAGS": "-fpermissive",
+        "CMAKE_CXX_FLAGS": "-fpermissive -stdlib=libc++",
+        "CMAKE_EXE_LINKER_FLAGS": "-stdlib=libc++",
+        "CMAKE_SHARED_LINKER_FLAGS": "-stdlib=libc++",
+        "CMAKE_MODULE_LINKER_FLAGS": "-stdlib=libc++",
         "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
       }
     },
@@ -18,8 +23,13 @@
       "generator": "Unix Makefiles",
       "binaryDir": "${sourceDir}/cmake_build_debug",
       "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_FLAGS": "-fpermissive",
+        "CMAKE_CXX_FLAGS": "-fpermissive -stdlib=libc++",
+        "CMAKE_EXE_LINKER_FLAGS": "-stdlib=libc++",
+        "CMAKE_SHARED_LINKER_FLAGS": "-stdlib=libc++",
+        "CMAKE_MODULE_LINKER_FLAGS": "-stdlib=libc++",
         "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
       }
     },


### PR DESCRIPTION
Adds a Linux host CMake presubmit with explicit clang/libc++ toolchain policy and CodeQL analysis.

Changes:
- Set host CMake presets to clang/clang++ with libc++
- Document the host CMake policy and Linux prerequisites
- Add `.github/workflows/cmake_linux_x86_64.yml` for presubmit and CodeQL