### PR TITLE
Fix RTLD_DEEPBIND shared library test

### DIFF
--- a/litert/cc/internal/litert_shared_library_test.cc
+++ b/litert/cc/internal/litert_shared_library_test.cc
@@ -49,10 +49,12 @@ TEST(RtldFlagsTest, FlagFactoryWorks) {
               Eq(RTLD_LAZY | RTLD_NODELETE));
   EXPECT_THAT(static_cast<int>(RtldFlags::Lazy().NoLoad()),
               Eq(RTLD_LAZY | RTLD_NOLOAD));
-  #if !defined(__ANDROID__)
+#if defined(RTLD_DEEPBIND)
   EXPECT_THAT(static_cast<int>(RtldFlags::Lazy().DeepBind()),
               Eq(RTLD_LAZY | RTLD_DEEPBIND));
-  #endif  // !defined(__ANDROID__)
+#else
+  EXPECT_THAT(static_cast<int>(RtldFlags::Lazy().DeepBind()), Eq(RTLD_LAZY));
+#endif  // defined(RTLD_DEEPBIND)
 }
 
 TEST(SharedLibraryTest, LoadRtldDefaultWorks) {


### PR DESCRIPTION
Gate the `RTLD_DEEPBIND` expectation in `litert_shared_library_test` on the macro being available

macOS does not have the RTLD_DEEPBIND macro. It is a GNU-specific extension found primarily in Linux (via glibc).


