### PR TITLE
Qualcomm AI Engine Direct - Support HTP input/output memory types.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -53,6 +53,8 @@ struct LrtQualcommOptionsT {
   std::optional<LrtQualcommOptionsOptimizationLevel> optimization_level;
   std::optional<LrtQualcommOptionsGraphPriority> graph_priority;
   std::optional<std::string> saver_output_dir;
+  std::optional<LrtQualcommOptionsGraphIOTensorMemType>
+      graph_io_tensor_mem_type;
 };
 
 LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
@@ -69,55 +71,56 @@ LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
       toml_payload,
       [&parsed_options](absl::string_view key,
                         absl::string_view value) -> LiteRtStatus {
+        LiteRtStatus status = kLiteRtStatusOk;
         if (key == "log_level") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetLogLevel(
+          status = LrtQualcommOptionsSetLogLevel(
               parsed_options, static_cast<LrtQualcommOptionsLogLevel>(*v));
         } else if (key == "profiling") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetProfiling(
+          status = LrtQualcommOptionsSetProfiling(
               parsed_options, static_cast<LrtQualcommOptionsProfiling>(*v));
         } else if (key == "use_htp_preference") {
           auto v = litert::internal::ParseTomlBool(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetUseHtpPreference(parsed_options, *v);
+          status = LrtQualcommOptionsSetUseHtpPreference(parsed_options, *v);
         } else if (key == "use_qint16_as_quint16") {
           auto v = litert::internal::ParseTomlBool(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetUseQint16AsQuint16(parsed_options, *v);
+          status = LrtQualcommOptionsSetUseQint16AsQuint16(parsed_options, *v);
         } else if (key == "use_int64_bias_as_int32") {
           auto v = litert::internal::ParseTomlBool(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetUseInt64BiasAsInt32(parsed_options, *v);
+          status = LrtQualcommOptionsSetUseInt64BiasAsInt32(parsed_options, *v);
         } else if (key == "qnn_backend") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetBackend(
+          status = LrtQualcommOptionsSetBackend(
               parsed_options, static_cast<LrtQualcommOptionsBackend>(*v));
         } else if (key == "enable_weight_sharing") {
           auto v = litert::internal::ParseTomlBool(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetEnableWeightSharing(parsed_options, *v);
+          status = LrtQualcommOptionsSetEnableWeightSharing(parsed_options, *v);
         } else if (key == "use_conv_hmx") {
           auto v = litert::internal::ParseTomlBool(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetUseConvHMX(parsed_options, *v);
+          status = LrtQualcommOptionsSetUseConvHMX(parsed_options, *v);
         } else if (key == "use_fold_relu") {
           auto v = litert::internal::ParseTomlBool(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetUseFoldReLU(parsed_options, *v);
+          status = LrtQualcommOptionsSetUseFoldReLU(parsed_options, *v);
         } else if (key == "htp_performance_mode") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetHtpPerformanceMode(
+          status = LrtQualcommOptionsSetHtpPerformanceMode(
               parsed_options,
               static_cast<LrtQualcommOptionsHtpPerformanceMode>(*v));
         } else if (key == "dsp_performance_mode") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetDspPerformanceMode(
+          status = LrtQualcommOptionsSetDspPerformanceMode(
               parsed_options,
               static_cast<LrtQualcommOptionsDspPerformanceMode>(*v));
         } else if (key == "dump_tensor_ids") {
@@ -129,41 +132,47 @@ LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
             if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
             ids.push_back(*v);
           }
-          LrtQualcommOptionsSetDumpTensorIds(parsed_options, ids.data(),
-                                             ids.size());
+          status = LrtQualcommOptionsSetDumpTensorIds(parsed_options,
+                                                      ids.data(), ids.size());
         } else if (key == "ir_json_dir") {
-          LrtQualcommOptionsSetIrJsonDir(parsed_options,
-                                         std::string(value).c_str());
+          status = LrtQualcommOptionsSetIrJsonDir(parsed_options,
+                                                  std::string(value).c_str());
         } else if (key == "dlc_dir") {
-          LrtQualcommOptionsSetDlcDir(parsed_options,
-                                      std::string(value).c_str());
+          status = LrtQualcommOptionsSetDlcDir(parsed_options,
+                                               std::string(value).c_str());
         } else if (key == "vtcm_size") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetVtcmSize(parsed_options,
-                                        static_cast<uint32_t>(*v));
+          status = LrtQualcommOptionsSetVtcmSize(parsed_options,
+                                                 static_cast<uint32_t>(*v));
         } else if (key == "num_hvx_threads") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetNumHvxThreads(parsed_options,
-                                             static_cast<uint32_t>(*v));
+          status = LrtQualcommOptionsSetNumHvxThreads(
+              parsed_options, static_cast<uint32_t>(*v));
         } else if (key == "optimization_level") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetOptimizationLevel(
+          status = LrtQualcommOptionsSetOptimizationLevel(
               parsed_options,
               static_cast<LrtQualcommOptionsOptimizationLevel>(*v));
         } else if (key == "graph_priority") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
-          LrtQualcommOptionsSetGraphPriority(
+          status = LrtQualcommOptionsSetGraphPriority(
               parsed_options, static_cast<LrtQualcommOptionsGraphPriority>(*v));
         } else if (key == "saver_output_dir") {
-          LrtQualcommOptionsSetSaverOutputDir(parsed_options,
-                                              std::string(value).c_str());
+          status = LrtQualcommOptionsSetSaverOutputDir(
+              parsed_options, std::string(value).c_str());
+        } else if (key == "graph_io_tensor_mem_type") {
+          auto v = litert::internal::ParseTomlInt(value);
+          if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
+          status = LrtQualcommOptionsSetGraphIOTensorMemType(
+              parsed_options,
+              static_cast<LrtQualcommOptionsGraphIOTensorMemType>(*v));
         }
 
-        return kLiteRtStatusOk;
+        return status;
       });
 
   if (status != kLiteRtStatusOk) {
@@ -267,7 +276,11 @@ LiteRtStatus LrtGetOpaqueQualcommOptionsData(LrtQualcommOptions options,
   if (options->saver_output_dir.has_value()) {
     toml << "saver_output_dir = \"" << *options->saver_output_dir << "\"\n";
   }
-
+  if (options->graph_io_tensor_mem_type.has_value()) {
+    toml << "graph_io_tensor_mem_type = "
+         << static_cast<int>(*options->graph_io_tensor_mem_type)
+         << "\n";
+  }
   *identifier = LrtQualcommOptionsGetIdentifier();
   std::string toml_str = toml.str();
   litert::internal::MakeCStringPayload(toml_str, payload, payload_deleter);
@@ -507,6 +520,33 @@ LiteRtStatus LrtQualcommOptionsGetUseFoldReLU(LrtQualcommOptions options,
   }
 
   *use_fold_relu = options->use_fold_relu.value_or(true);
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsSetGraphIOTensorMemType(
+    LrtQualcommOptions options, LrtQualcommOptionsGraphIOTensorMemType
+                                    graph_io_tensor_mem_type) {
+  if (options == nullptr ||
+      graph_io_tensor_mem_type > kLiteRtQualcommGraphIOTensorMemTypeMemHandle ||
+      graph_io_tensor_mem_type < kLiteRtQualcommGraphIOTensorMemTypeRaw) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->graph_io_tensor_mem_type = graph_io_tensor_mem_type;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsGetGraphIOTensorMemType(
+    LrtQualcommOptions options,
+    LrtQualcommOptionsGraphIOTensorMemType* graph_io_tensor_mem_type) {
+  if (options == nullptr || graph_io_tensor_mem_type == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *graph_io_tensor_mem_type = options->graph_io_tensor_mem_type.value_or(
+      kLiteRtQualcommGraphIOTensorMemTypeMemHandle);
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -153,6 +153,24 @@ LiteRtStatus LrtQualcommOptionsSetUseFoldReLU(LrtQualcommOptions options,
 LiteRtStatus LrtQualcommOptionsGetUseFoldReLU(LrtQualcommOptions options,
                                               bool* use_fold_relu);
 
+// graph_io_tensor_mem_type
+
+// This controls whether graph inputs and outputs use MemHandle or Raw buffers
+// during compilation.
+
+typedef enum LrtQualcommOptionsGraphIOTensorMemType {
+  kLiteRtQualcommGraphIOTensorMemTypeRaw = 0,
+  kLiteRtQualcommGraphIOTensorMemTypeMemHandle,
+} LrtQualcommOptionsGraphIOTensorMemType;
+
+LiteRtStatus LrtQualcommOptionsSetGraphIOTensorMemType(
+    LrtQualcommOptions options,
+    LrtQualcommOptionsGraphIOTensorMemType mem_type);
+
+LiteRtStatus LrtQualcommOptionsGetGraphIOTensorMemType(
+    LrtQualcommOptions options,
+    LrtQualcommOptionsGraphIOTensorMemType* mem_type);
+
 // DISPATCH OPTIONS ////////////////////////////////////////////////////////////
 
 // htp_performance_mode

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -273,6 +273,20 @@ TEST(LiteRtQualcommOptionsTest, SaverOutputDir) {
   LrtDestroyQualcommOptions(qualcomm_options);
 }
 
+TEST(LiteRtQualcommOptionsTest, GraphIOTensorMemType) {
+  LrtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
+
+  LITERT_ASSERT_OK(LrtQualcommOptionsSetGraphIOTensorMemType(
+      qualcomm_options, kLiteRtQualcommGraphIOTensorMemTypeRaw));
+
+  auto parsed = SerializeAndParse(qualcomm_options);
+  EXPECT_EQ(parsed.GetGraphIOTensorMemType(),
+            QualcommOptions::GraphIOTensorMemType::kRaw);
+
+  LrtDestroyQualcommOptions(qualcomm_options);
+}
+
 TEST(LiteRtQualcommOptionsTest, Profiling) {
   LrtQualcommOptions qualcomm_options;
   LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
@@ -388,6 +402,17 @@ TEST(QualcommOptionsTest, CppWrapper) {
   EXPECT_EQ(options->GetSaverOutputDir(), "");
   options->SetSaverOutputDir("tmp");
   EXPECT_EQ(options->GetSaverOutputDir(), "tmp");
+
+  EXPECT_EQ(options->GetGraphIOTensorMemType(),
+            QualcommOptions::GraphIOTensorMemType::kMemHandle);
+  options->SetGraphIOTensorMemType(
+      QualcommOptions::GraphIOTensorMemType::kRaw);
+  EXPECT_EQ(options->GetGraphIOTensorMemType(),
+            QualcommOptions::GraphIOTensorMemType::kRaw);
+  options->SetGraphIOTensorMemType(
+      QualcommOptions::GraphIOTensorMemType::kMemHandle);
+  EXPECT_EQ(options->GetGraphIOTensorMemType(),
+            QualcommOptions::GraphIOTensorMemType::kMemHandle);
 }
 
 }  // namespace

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -408,6 +408,26 @@ class QualcommOptions {
     return val;
   }
 
+  enum class GraphIOTensorMemType : int {
+    kRaw = kLiteRtQualcommGraphIOTensorMemTypeRaw,
+    kMemHandle = kLiteRtQualcommGraphIOTensorMemTypeMemHandle,
+  };
+
+  void SetGraphIOTensorMemType(GraphIOTensorMemType mem_type) {
+    LrtQualcommOptionsSetGraphIOTensorMemType(
+        options_,
+        static_cast<LrtQualcommOptionsGraphIOTensorMemType>(mem_type));
+  }
+
+  GraphIOTensorMemType GetGraphIOTensorMemType() const {
+    LrtQualcommOptionsGraphIOTensorMemType val;
+    auto status = LrtQualcommOptionsGetGraphIOTensorMemType(options_, &val);
+    if (status != kLiteRtStatusOk) {
+      return GraphIOTensorMemType::kMemHandle;
+    }
+    return static_cast<GraphIOTensorMemType>(val);
+  }
+
  private:
   LrtQualcommOptions options_;
 };

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -84,6 +84,7 @@ std::string AbslUnparseFlag(QualcommOptions::LogLevel options) {
       return "debug";
   }
 }
+
 }  // namespace litert::qualcomm
 
 ABSL_FLAG(bool, qualcomm_enable_weight_sharing, false,
@@ -118,7 +119,6 @@ ABSL_FLAG(litert::qualcomm::QualcommOptions::DspPerformanceMode,
 ABSL_FLAG(::litert::tools::IntList, qualcomm_dump_tensor_ids, {},
           "Debug Feature. Ids to dump as outputs. Comma-separated list of "
           "string. Use -1 to dump all op outputs.");
-
 namespace litert::qualcomm {
 
 bool AbslParseFlag(absl::string_view text,
@@ -259,6 +259,43 @@ std::string AbslUnparseFlag(QualcommOptions::DspPerformanceMode options) {
   }
 }
 
+}  // namespace litert::qualcomm
+
+ABSL_FLAG(litert::qualcomm::QualcommOptions::GraphIOTensorMemType,
+          qualcomm_graph_io_tensor_mem_type,
+          litert::qualcomm::QualcommOptions::GraphIOTensorMemType::kMemHandle,
+          "Specifies mem type to be used for input and output tensors during "
+          "graph creation. Valid settings:\"raw\" and \"memhandle\"");
+
+namespace litert::qualcomm {
+
+bool AbslParseFlag(absl::string_view text,
+                   QualcommOptions::GraphIOTensorMemType* options,
+                   std::string* error) {
+  if (text == "raw") {
+    *options = QualcommOptions::GraphIOTensorMemType::kRaw;
+    return true;
+  }
+  if (text == "memhandle") {
+    *options = QualcommOptions::GraphIOTensorMemType::kMemHandle;
+    return true;
+  }
+  *error = "Unknown graph input output tensor mem type";
+  return false;
+}
+
+std::string AbslUnparseFlag(
+    QualcommOptions::GraphIOTensorMemType options) {
+  switch (options) {
+    case QualcommOptions::GraphIOTensorMemType::kRaw:
+      return "raw";
+    case QualcommOptions::GraphIOTensorMemType::kMemHandle:
+      return "memhandle";
+    default:
+      ABSL_CHECK(false) << "Unknown GraphIOTensorMemType: "
+                        << static_cast<int>(options);
+  }
+}
 }  // namespace litert::qualcomm
 
 ABSL_FLAG(litert::qualcomm::QualcommOptions::Profiling, qualcomm_profiling,
@@ -542,6 +579,11 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
   const std::string saver_output_dir =
       absl::GetFlag(FLAGS_qualcomm_saver_output_dir);
   opts.SetSaverOutputDir(saver_output_dir);
+
+  const auto graph_io_tensor_mem_type =
+      absl::GetFlag(FLAGS_qualcomm_graph_io_tensor_mem_type);
+  opts.SetGraphIOTensorMemType(graph_io_tensor_mem_type);
+
   return {};
 }
 

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -77,6 +77,8 @@ ABSL_DECLARE_FLAG(litert::qualcomm::QualcommOptions::OptimizationLevel,
                   qualcomm_optimization_level);
 ABSL_DECLARE_FLAG(litert::qualcomm::QualcommOptions::GraphPriority,
                   qualcomm_graph_priority);
+ABSL_DECLARE_FLAG(litert::qualcomm::QualcommOptions::GraphIOTensorMemType,
+                  qualcomm_graph_io_tensor_mem_type);
 
 namespace litert::qualcomm {
 
@@ -92,6 +94,12 @@ bool AbslParseFlag(absl::string_view text,
                    std::string* error);
 
 std::string AbslUnparseFlag(QualcommOptions::GraphPriority graph_priority);
+
+bool AbslParseFlag(absl::string_view text,
+                   QualcommOptions::GraphIOTensorMemType* memory_type,
+                   std::string* error);
+
+std::string AbslUnparseFlag(QualcommOptions::GraphIOTensorMemType memory_type);
 
 }  // namespace litert::qualcomm
 

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -466,6 +466,29 @@ TEST(BackendTest, Parse) {
   }
 }
 
+TEST(GraphIOTensorMemTypeTest, Parse) {
+  std::string error;
+  QualcommOptions::GraphIOTensorMemType value;
+
+  {
+    static constexpr absl::string_view kRaw = "raw";
+    static constexpr QualcommOptions::GraphIOTensorMemType kRawEnum =
+        QualcommOptions::GraphIOTensorMemType::kRaw;
+    EXPECT_TRUE(AbslParseFlag(kRaw, &value, &error));
+    EXPECT_EQ(value, kRawEnum);
+    EXPECT_EQ(kRaw, AbslUnparseFlag(value));
+  }
+
+  {
+    static constexpr absl::string_view kMemHandle = "memhandle";
+    static constexpr QualcommOptions::GraphIOTensorMemType kMemHandleEnum =
+        QualcommOptions::GraphIOTensorMemType::kMemHandle;
+    EXPECT_TRUE(AbslParseFlag(kMemHandle, &value, &error));
+    EXPECT_EQ(value, kMemHandleEnum);
+    EXPECT_EQ(kMemHandle, AbslUnparseFlag(value));
+  }
+}
+
 TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   Expected<QualcommOptions> options = QualcommOptions::Create();
   ASSERT_TRUE(options.HasValue());
@@ -485,6 +508,8 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   EXPECT_EQ(options.Value().GetGraphPriority(),
             QualcommOptions::GraphPriority::kDefault);
   EXPECT_EQ(options.Value().GetBackend(), QualcommOptions::Backend::kHtp);
+  EXPECT_EQ(options.Value().GetGraphIOTensorMemType(),
+            QualcommOptions::GraphIOTensorMemType::kMemHandle);
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -128,6 +128,8 @@ inline LiteRtStatus InitQnnOptions(
       static_cast<::qnn::GraphPriority>(qualcomm_options.GetGraphPriority()));
   qnn_options.SetDumpTensorIds(qualcomm_options.GetDumpTensorIds());
   qnn_options.SetSaverOutputDir(qualcomm_options.GetSaverOutputDir());
+  qnn_options.SetGraphIOTensorMemType(static_cast<::qnn::GraphIOTensorMemType>(
+      qualcomm_options.GetGraphIOTensorMemType()));
 
   LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
   return kLiteRtStatusOk;

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -214,7 +214,7 @@ LiteRtStatus ConvertTensor(const litert::Tensor& litert_tensor,
                            ::qnn::TensorPool& tensor_pool,
                            ::qnn::TensorWrapper*& tensor_wrapper,
                            const absl::flat_hash_set<std::int32_t>& ids_to_dump,
-                           bool is_tensor_read_and_write) {
+                           bool is_tensor_output) {
   tensor_wrapper = nullptr;
 
   if (litert_tensor.TypeId() != kLiteRtRankedTensorType) {
@@ -320,7 +320,7 @@ LiteRtStatus ConvertTensor(const litert::Tensor& litert_tensor,
         SanitizeName(litert_tensor.Name()), qnn_data_type, quantize_params,
         dimensions);
     tensor_wrapper = &res;
-  } else if (litert_tensor.Uses().empty() || is_tensor_read_and_write) {
+  } else if (litert_tensor.Uses().empty() || is_tensor_output) {
     auto& res = tensor_pool.CreateOutputTensorWithName(
         SanitizeName(litert_tensor.Name()), qnn_data_type, quantize_params,
         dimensions);
@@ -1396,6 +1396,10 @@ LiteRtStatus MapGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
     ::qnn::TensorWrapper* tensor_wrapper{nullptr};
     LITERT_RETURN_IF_ERROR(ConvertTensor(subgraph_input, tensor_pool,
                                          tensor_wrapper, ids_to_dump));
+    if (options.GetGraphIOTensorMemType() ==
+        ::qnn::GraphIOTensorMemType::kMemHandle) {
+      tensor_wrapper->SetMemHandle(nullptr);
+    }
     litert_tensor_to_wrapper.emplace(subgraph_input.Get(), tensor_wrapper);
     LITERT_RETURN_IF_ERROR(AddTensorToQnn(qnn.Api(), graph_mapper.QnnGraph(),
                                           *tensor_wrapper, created_tensors));
@@ -1431,11 +1435,15 @@ LiteRtStatus MapGraph(QnnManager& qnn, Qnn_ContextHandle_t context_handle,
 
     std::vector<::qnn::TensorWrapperRef> output_tensors;
     for (const auto& output : op.Outputs()) {
-      bool is_tensor_read_and_write = graph_mapper.IsTensorOutput(output.Get());
+      const bool is_tensor_output = graph_mapper.IsTensorOutput(output.Get());
       ::qnn::TensorWrapper* tensor_wrapper{nullptr};
       LITERT_RETURN_IF_ERROR(ConvertTensor(output, tensor_pool, tensor_wrapper,
                                            ids_to_dump,
-                                           is_tensor_read_and_write));
+                                           is_tensor_output));
+      if (is_tensor_output && options.GetGraphIOTensorMemType() ==
+                                  ::qnn::GraphIOTensorMemType::kMemHandle) {
+        tensor_wrapper->SetMemHandle(nullptr);
+      }
       litert_tensor_to_wrapper.emplace(output.Get(), tensor_wrapper);
       output_tensors.emplace_back(*tensor_wrapper);
     }

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
@@ -40,7 +40,7 @@ LiteRtStatus ConvertTensor(
     const litert::Tensor& litert_tensor, ::qnn::TensorPool& tensor_pool,
     ::qnn::TensorWrapper*& tensor_wrapper,
     const absl::flat_hash_set<std::int32_t>& ids_to_dump = {},
-    bool is_tensor_read_and_write = false);
+    bool is_tensor_output = false);
 
 LiteRtStatus ConvertOp(bool use_int64_bias_as_int32,
                        const litert::Op& litert_op,

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -188,6 +188,14 @@ void Options::SetSaverOutputDir(absl::string_view saver_output_dir) {
   saver_output_dir_ = saver_output_dir;
 }
 
+void Options::SetGraphIOTensorMemType(GraphIOTensorMemType mem_type) {
+  graph_io_tensor_mem_type_ = mem_type;
+}
+
+GraphIOTensorMemType Options::GetGraphIOTensorMemType() const {
+  return graph_io_tensor_mem_type_;
+}
+
 std::string Options::Dump() const {
   static constexpr absl::string_view kQnnOptionsDumpFormat =
       "\
@@ -208,16 +216,18 @@ VtcmSize: %d\n\
 HvxThread: %d\n\
 OptimizationLevel: %d\n\
 GraphPriority: %d\n\
-SaverOutputDir: %s\n";  // NOLINT
+SaverOutputDir: %s\n\
+GraphIOTensorMemType: %d\n";  // NOLINT
 
   std::string dump_tensor_ids = absl::StrJoin(dump_tensor_ids_, ",");
 
-  return absl::StrFormat(
-      kQnnOptionsDumpFormat, log_level_, backend_type_, profiling_,
-      use_int64_bias_as_int32_, enable_weight_sharing_, use_conv_hmx_,
-      use_fold_relu_, htp_performance_mode_, dsp_performance_mode_,
-      dump_tensor_ids, ir_json_dir_, dlc_dir_, vtcm_size_, num_hvx_threads_,
-      optimization_level_, graph_priority_, saver_output_dir_);
+  return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, backend_type_,
+                         profiling_, use_int64_bias_as_int32_,
+                         enable_weight_sharing_, use_conv_hmx_, use_fold_relu_,
+                         htp_performance_mode_, dsp_performance_mode_,
+                         dump_tensor_ids, ir_json_dir_, dlc_dir_, vtcm_size_,
+                         num_hvx_threads_, optimization_level_, graph_priority_,
+                         saver_output_dir_, graph_io_tensor_mem_type_);
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -52,6 +52,11 @@ enum class HtpPerformanceMode {
   kExtremePowerSaver = 9,
 };
 
+enum class GraphIOTensorMemType {
+  kRaw = 0,
+  kMemHandle = 1,
+};
+
 enum class DspPerformanceMode {
   kDefault = 0,
   kSustainedHighPerformance = 1,
@@ -136,6 +141,9 @@ class Options {
   absl::string_view GetSaverOutputDir() const;
   void SetSaverOutputDir(absl::string_view saver_output_dir);
 
+  void SetGraphIOTensorMemType(GraphIOTensorMemType mem_type);
+  GraphIOTensorMemType GetGraphIOTensorMemType() const;
+
  private:
   LogLevel log_level_ = LogLevel::kInfo;
   BackendType backend_type_ = BackendType::kHtpBackend;
@@ -155,6 +163,8 @@ class Options {
       OptimizationLevel::kHtpOptimizeForInferenceO3;
   GraphPriority graph_priority_ = GraphPriority::kDefault;
   std::string saver_output_dir_;
+  GraphIOTensorMemType graph_io_tensor_mem_type_ =
+      GraphIOTensorMemType::kMemHandle;
 };
 
 // Gets a default logger implementation to stdout.

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -262,6 +262,22 @@ TEST(QnnOptionTest, Default) {
   EXPECT_EQ(options.GetOptimizationLevel(),
             OptimizationLevel::kHtpOptimizeForInferenceO3);
   EXPECT_EQ(options.GetGraphPriority(), GraphPriority::kDefault);
+  EXPECT_EQ(options.GetGraphIOTensorMemType(),
+            GraphIOTensorMemType::kMemHandle);
+}
+
+TEST(QnnOptionTest, SetGraphIOTensorMemType) {
+  Options options;
+  EXPECT_EQ(options.GetGraphIOTensorMemType(),
+            GraphIOTensorMemType::kMemHandle);
+
+  options.SetGraphIOTensorMemType(GraphIOTensorMemType::kRaw);
+  EXPECT_EQ(options.GetGraphIOTensorMemType(),
+            GraphIOTensorMemType::kRaw);
+
+  options.SetGraphIOTensorMemType(GraphIOTensorMemType::kMemHandle);
+  EXPECT_EQ(options.GetGraphIOTensorMemType(),
+            GraphIOTensorMemType::kMemHandle);
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -171,6 +171,11 @@ class TensorWrapper final {
 
   void SetQuantBitwidth(std::uint32_t bitwidth);
 
+  void SetMemHandle(Qnn_MemHandle_t memory_handle) {
+    qnn_tensor_.v2.memType = QNN_TENSORMEMTYPE_MEMHANDLE;
+    qnn_tensor_.v2.memHandle = memory_handle;
+  }
+
  private:
   void SetDataBy(std::uint32_t bytes, const void* data, bool copy_data);
 

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -682,5 +682,17 @@ INSTANTIATE_TEST_SUITE_P(TensorWrapperTest_Combinations, TensorWrapperEqualTest,
                                                {1, 1, 3},
                                                {1, 1, 3},
                                                false}));
+
+TEST(TensorWrapperTest, SetMemHandle) {
+  TensorWrapper tensor_wrapper{};
+  const auto& qnn_tensor = tensor_wrapper.GetQnnTensor();
+  int mem_handle{};
+  tensor_wrapper.SetMemHandle(&mem_handle);
+  EXPECT_EQ(qnn_tensor.v2.memType, QNN_TENSORMEMTYPE_MEMHANDLE);
+  EXPECT_EQ(qnn_tensor.v2.memHandle, &mem_handle);
+  tensor_wrapper.SetMemHandle(nullptr);
+  EXPECT_EQ(qnn_tensor.v2.memType, QNN_TENSORMEMTYPE_MEMHANDLE);
+  EXPECT_FALSE(qnn_tensor.v2.memHandle);
+}
 }  // namespace
 }  // namespace qnn


### PR DESCRIPTION
Summary:
- Add --qualcomm_graph_io_tensor_mem_type compile flag to align with qnn-context-binary-generator behavior.
- Change the default compile configuration to memhandle, as LiteRt dispatch always uses memhandle.

Test:
x86:
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.8s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.9s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 39.6s
```

on-device
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 22 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 12 tests from 8 test suites ran. (0 ms total)
[  PASSED  ] 12 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 17 tests from 3 test suites ran. (11 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 33 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 8 tests from 4 test suites ran. (10 ms total)
[  PASSED  ] 8 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (365 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (421 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (406 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1116 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1148 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (605 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1996 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (16 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (443 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (422 ms total)
[  PASSED  ] 2 tests.
```