### PR TITLE
Add Bool support in npu_numerics_check output comparison

### DIFF
--- a/litert/tools/npu_numerics_check.cc
+++ b/litert/tools/npu_numerics_check.cc
@@ -323,6 +323,11 @@ Expected<void> CompareSingleOutputBuffer(TensorBuffer& cpu_buffer,
       LITERT_RETURN_IF_ERROR(buffer.Read<uint8_t>(absl::MakeSpan(data)));
       copy_data_and_return(buffer_data, data, total_elements);
     }
+    if (element_type == ElementType::Bool) {
+      std::vector<uint8_t> data(total_elements);
+      LITERT_RETURN_IF_ERROR(buffer.Read<uint8_t>(absl::MakeSpan(data)));
+      copy_data_and_return(buffer_data, data, total_elements);
+    }
     return Error(kLiteRtStatusErrorInvalidArgument,
                  "Unsupported element type for reading tensor.");
   };


### PR DESCRIPTION
Previously, the get_val lambda had no handler for ElementType::Bool, this caused Bool-typed output tensors to remain as zero-initialized, producing misleading all-zero comparison results. Add a Bool handler that reads the data as uint8_t and converts to float for comparison.