### PR TITLE
Add Python benchmark tool for LiteRT model inference

### DIFF
--- a/ci/tools/python/wheel/BUILD
+++ b/ci/tools/python/wheel/BUILD
@@ -148,6 +148,7 @@ ALL_PY_SRC_MODULES = [
     "//litert/python/internal:sampler_params_py_pb2",
     "//litert/python/internal:litertlm_builder",
     "//litert/python/tools:flatbuffer_utils",
+    "//litert/python/tools:benchmark_litert_model",
 ] + select({
     ":build_converter_enabled": [
         "//litert/python/mlir",

--- a/ci/tools/python/wheel/setup_with_binary.py
+++ b/ci/tools/python/wheel/setup_with_binary.py
@@ -213,6 +213,11 @@ setuptools.setup(
             'xdsl==0.28.0',
         ],
     },
+    entry_points={
+        'console_scripts': [
+            'litert-benchmark=ai_edge_litert.tools.benchmark_litert_model:main',
+        ],
+    },
     # Use the custom command for the build_py step
     cmdclass={
         'build_py': CustomBuildPy,

--- a/litert/python/tools/BUILD
+++ b/litert/python/tools/BUILD
@@ -60,3 +60,20 @@ py_strict_test(
         "@absl_py//absl/testing:absltest",
     ],
 )
+
+pytype_strict_library(
+    name = "benchmark_litert_model",
+    srcs = ["benchmark_litert_model.py"],
+    deps = [
+        "@org_tensorflow//third_party/py/numpy",
+    ],
+)
+
+py_strict_test(
+    name = "benchmark_litert_model_test",
+    srcs = ["benchmark_litert_model_test.py"],
+    deps = [
+        ":benchmark_litert_model",
+        "@org_tensorflow//third_party/py/numpy",
+    ],
+)

--- a/litert/python/tools/README.md
+++ b/litert/python/tools/README.md
@@ -1,0 +1,112 @@
+<!-- Copyright (C) 2026 Intel Corporation
+     SPDX-License-Identifier: Apache-2.0
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License. -->
+
+# LiteRT Python Tools
+
+This directory contains Python command-line tools for working with LiteRT
+models.
+
+## `benchmark_litert_model`
+
+Benchmark the inference performance of a LiteRT model using the Python API.
+This is the Python counterpart to the C++ `litert/tools/benchmark_model`,
+useful for validating pip wheel installations on target devices without
+compiling C++ code.
+
+Installed as the `litert-benchmark` console entry point in the pip wheel.
+
+### Basic Usage
+
+```bash
+# Run from pip wheel
+litert-benchmark --model=model.tflite
+
+# Run as module
+python -m litert.python.tools.benchmark_litert_model --model=model.tflite
+```
+
+### Hardware Acceleration Options
+
+- `--use_cpu`: Use CPU acceleration (default: true)
+- `--use_gpu`: Use GPU acceleration
+- `--use_npu`: Use NPU acceleration (requires dispatch library)
+- `--no_cpu`: Disable CPU fallback
+- `--require_full_delegation`: Fail if model is not fully accelerated
+
+```bash
+# CPU only (default)
+litert-benchmark --model=model.tflite
+
+# GPU with CPU fallback
+litert-benchmark --model=model.tflite --use_gpu
+
+# NPU with CPU fallback
+litert-benchmark --model=model.tflite --use_npu \
+    --dispatch_library_path=/path/to/libLiteRtDispatch.so
+
+# NPU only, require full acceleration
+litert-benchmark --model=model.tflite --use_npu \
+    --dispatch_library_path=/path/to/dispatch.so --require_full_delegation
+```
+
+### Benchmark Parameters
+
+- `--num_runs` (default: 50): Number of benchmark iterations
+- `--warmup_runs` (default: 5): Number of warmup iterations
+- `--num_threads` (default: 1): Number of CPU threads
+- `--signature` (default: first): Signature key to run
+
+### Environment Parameters
+
+- `--dispatch_library_path`: Path to vendor dispatch library
+- `--compiler_plugin_path`: Path to compiler plugin library directory
+- `--runtime_path`: Path to LiteRT runtime library directory
+
+### Output Options
+
+- `--result_json`: Path to save results as JSON (for CI integration)
+- `--verbose`: Enable verbose output with per-iteration timing
+
+### Output Format
+
+```
+========================================
+ BENCHMARK RESULTS
+========================================
+Model initialization:  45.32 ms
+Warmup (first):        120.45 ms
+Warmup (avg):          98.76 ms (5 runs)
+Inference (avg):       85.23 ms (50 runs)
+Inference (min):       82.10 ms
+Inference (max):       92.45 ms
+Inference (median):    84.50 ms
+Inference (std):       3.21 ms
+Inference (p5):        82.50 ms
+Inference (p95):       91.00 ms
+Throughput:            12.45 MB/s
+Fully accelerated:     True
+========================================
+```
+
+### JSON Output
+
+Use `--result_json` to save structured results:
+
+```bash
+litert-benchmark --model=model.tflite --result_json=results.json
+```
+
+Output includes model metadata, accelerator configuration, and full latency
+statistics (avg, min, max, median, std, p5, p95).

--- a/litert/python/tools/benchmark_litert_model.py
+++ b/litert/python/tools/benchmark_litert_model.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Python benchmark tool for LiteRT models with CPU, GPU, and NPU support.
+
+This script mirrors the C++ benchmark_litert_model tool, providing inference
+benchmarking via the LiteRT Python API. It supports all hardware accelerators
+(CPU, GPU, NPU) and can be used to validate pip wheel installations on target
+devices without compiling C++ code.
+
+Usage:
+  # CPU only (default)
+  python benchmark_litert_model.py --model=model.tflite
+
+  # NPU with CPU fallback (Intel OpenVINO)
+  python benchmark_litert_model.py --model=model.tflite --use_npu \
+      --dispatch_library_path=/path/to/libLiteRtDispatch_IntelOpenvino.so
+
+  # GPU with CPU fallback
+  python benchmark_litert_model.py --model=model.tflite --use_gpu
+
+  # NPU only, require full acceleration
+  python benchmark_litert_model.py --model=model.tflite --use_npu \
+      --dispatch_library_path=/path/to/dispatch.so --require_full_delegation
+"""
+
+import argparse
+import json
+import logging
+import os
+import statistics
+import sys
+import time
+
+import numpy as np
+
+logger = logging.getLogger('benchmark_litert_model')
+
+
+def _import_litert():
+  """Import LiteRT modules for both litert and ai_edge_litert."""
+  try:
+    # pylint: disable=g-import-not-at-top
+    from litert.python.litert_wrapper.compiled_model_wrapper import (
+        compiled_model as _cm,
+    )
+    from litert.python.litert_wrapper.compiled_model_wrapper import (
+        hardware_accelerator as _ha,
+    )
+    from litert.python.litert_wrapper.environment_wrapper import (
+        environment as _env,
+    )
+    # pylint: enable=g-import-not-at-top
+    return _cm.CompiledModel, _ha.HardwareAccelerator, _env.Environment
+  except ImportError:
+    pass
+  try:
+    from ai_edge_litert.compiled_model import CompiledModel
+    from ai_edge_litert.hardware_accelerator import HardwareAccelerator
+    from ai_edge_litert.environment import Environment
+    return CompiledModel, HardwareAccelerator, Environment
+  except ImportError:
+    logger.error(
+        'Could not import LiteRT. Install with:\n'
+        '  pip install ai-edge-litert\n'
+        'or run from the LiteRT source tree.'
+    )
+    sys.exit(1)
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(
+      description='Benchmark a LiteRT model on CPU, GPU, or NPU.',
+      formatter_class=argparse.RawDescriptionHelpFormatter,
+  )
+  parser.add_argument(
+      '--model', required=True, help='Path to the .tflite model file.'
+  )
+  parser.add_argument(
+      '--signature', default='', help='Signature key to run (default: first).'
+  )
+
+  parser.add_argument(
+      '--use_cpu',
+      action='store_true',
+      default=True,
+      help='Enable CPU accelerator (default: True).',
+  )
+  parser.add_argument(
+      '--no_cpu',
+      action='store_true',
+      help='Disable CPU fallback.',
+  )
+  parser.add_argument(
+      '--use_gpu', action='store_true', help='Enable GPU accelerator.'
+  )
+  parser.add_argument(
+      '--use_npu', action='store_true', help='Enable NPU accelerator.'
+  )
+  parser.add_argument(
+      '--require_full_delegation',
+      action='store_true',
+      help='Fail if model is not fully accelerated.',
+  )
+
+  parser.add_argument(
+      '--dispatch_library_path',
+      default='',
+      help='Path to vendor dispatch library (e.g., '
+      'libLiteRtDispatch_IntelOpenvino.so).',
+  )
+  parser.add_argument(
+      '--compiler_plugin_path',
+      default='',
+      help='Path to compiler plugin library directory.',
+  )
+  parser.add_argument(
+      '--runtime_path',
+      default='',
+      help='Path to LiteRT runtime library directory.',
+  )
+
+  parser.add_argument(
+      '--num_runs', type=int, default=50, help='Number of inference runs.'
+  )
+  parser.add_argument(
+      '--warmup_runs', type=int, default=5, help='Number of warmup runs.'
+  )
+  parser.add_argument(
+      '--num_threads',
+      type=int,
+      default=1,
+      help='Number of CPU threads.',
+  )
+
+  parser.add_argument(
+      '--result_json',
+      default='',
+      help='Path to save results as JSON.',
+  )
+  parser.add_argument(
+      '--verbose', action='store_true', help='Enable verbose output.'
+  )
+
+  return parser.parse_args()
+
+
+def build_hardware_accelerators(args, HardwareAccelerator):
+  """Build the HardwareAccelerator bitmask from CLI flags."""
+  accel = 0
+  if args.use_npu:
+    accel |= HardwareAccelerator.NPU
+  if args.use_gpu:
+    accel |= HardwareAccelerator.GPU
+  if not args.no_cpu and not args.require_full_delegation:
+    accel |= HardwareAccelerator.CPU
+  if accel == 0:
+    accel = HardwareAccelerator.CPU
+  return HardwareAccelerator(accel)
+
+
+def create_environment(args, Environment):
+  """Create a LiteRT Environment with the requested paths."""
+  kwargs = {}
+  if args.runtime_path:
+    kwargs['runtime_path'] = args.runtime_path
+
+  compiler_plugin_path = args.compiler_plugin_path
+  if compiler_plugin_path:
+    if os.path.isfile(compiler_plugin_path):
+      compiler_plugin_path = os.path.dirname(compiler_plugin_path)
+    kwargs['compiler_plugin_path'] = compiler_plugin_path
+
+  dispatch_path = args.dispatch_library_path
+  if dispatch_path:
+    if os.path.isfile(dispatch_path):
+      dispatch_path = os.path.dirname(dispatch_path)
+    kwargs['dispatch_library_path'] = dispatch_path
+
+  kwargs['cpu_num_threads'] = args.num_threads
+  return Environment.create(**kwargs)
+
+
+def get_numpy_dtype(dtype_str):
+  """Map LiteRT dtype string to numpy dtype."""
+  mapping = {
+      'float32': np.float32,
+      'float16': np.float16,
+      'int32': np.int32,
+      'int8': np.int8,
+      'uint8': np.uint8,
+      'int64': np.int64,
+      'bool': np.bool_,
+  }
+  return mapping.get(dtype_str, np.float32)
+
+
+def fill_random_input(tensor_buffer, details):
+  """Fill a tensor buffer with random data appropriate for its dtype."""
+  dtype = get_numpy_dtype(details.get('dtype', 'float32'))
+  shape = details.get('shape', [1])
+  if np.issubdtype(dtype, np.floating):
+    data = np.random.uniform(-1.0, 1.0, shape).astype(dtype)
+  elif np.issubdtype(dtype, np.integer):
+    info = np.iinfo(dtype)
+    low = max(info.min, -128)
+    high = min(info.max, 127)
+    data = np.random.randint(low, high + 1, shape, dtype=dtype)
+  else:
+    data = np.zeros(shape, dtype=dtype)
+  tensor_buffer.write(data)
+
+
+def percentile(sorted_data, p):
+  """Compute the p-th percentile of sorted data."""
+  if not sorted_data:
+    return 0.0
+  k = (len(sorted_data) - 1) * p / 100.0
+  f = int(k)
+  c = f + 1
+  if c >= len(sorted_data):
+    return sorted_data[-1]
+  return sorted_data[f] + (k - f) * (sorted_data[c] - sorted_data[f])
+
+
+def run_benchmark(args):
+  """Run the benchmark and return results dict."""
+  CompiledModel, HardwareAccelerator, Environment = _import_litert()
+
+  model_path = args.model
+  if not os.path.isfile(model_path):
+    logger.error('Model file not found: %s', model_path)
+    sys.exit(1)
+
+  model_size_mb = os.path.getsize(model_path) / (1024 * 1024)
+  hw_accel = build_hardware_accelerators(args, HardwareAccelerator)
+
+  accel_names = []
+  if hw_accel & HardwareAccelerator.NPU:
+    accel_names.append('NPU')
+  if hw_accel & HardwareAccelerator.GPU:
+    accel_names.append('GPU')
+  if hw_accel & HardwareAccelerator.CPU:
+    accel_names.append('CPU')
+
+  logger.info('Model:           %s', model_path)
+  logger.info('Model size:      %.2f MB', model_size_mb)
+  logger.info('Accelerators:    %s', ' | '.join(accel_names))
+  logger.info('Num threads:     %d', args.num_threads)
+  logger.info('Warmup runs:     %d', args.warmup_runs)
+  logger.info('Benchmark runs:  %d', args.num_runs)
+  if args.dispatch_library_path:
+    logger.info('Dispatch lib:    %s', args.dispatch_library_path)
+  if args.compiler_plugin_path:
+    logger.info('Compiler plugin: %s', args.compiler_plugin_path)
+  logger.info('Creating environment...')
+  t0 = time.perf_counter()
+  env = create_environment(args, Environment)
+  env_time_ms = (time.perf_counter() - t0) * 1000
+  logger.info('Environment created (%.1f ms)', env_time_ms)
+
+  logger.info('Loading model...')
+  t0 = time.perf_counter()
+  model = CompiledModel.from_file(
+      model_path,
+      hardware_accel=hw_accel,
+      environment=env,
+  )
+  init_time_ms = (time.perf_counter() - t0) * 1000
+  logger.info('Model loaded (%.1f ms)', init_time_ms)
+
+  sig_list = model.get_signature_list()
+  num_signatures = model.get_num_signatures()
+  logger.info('Signatures:      %d', num_signatures)
+
+  if args.signature:
+    sig_key = args.signature
+  else:
+    sig_key = list(sig_list.keys())[0] if sig_list else 'serving_default'
+  logger.info('Using signature: %s', sig_key)
+
+  sig_idx = model.get_signature_index(sig_key)
+  if sig_idx < 0:
+    logger.error('Signature "%s" not found.', sig_key)
+    sys.exit(1)
+
+  is_fully_accel = model.is_fully_accelerated()
+  logger.info('Fully accelerated: %s', is_fully_accel)
+  if args.require_full_delegation and not is_fully_accel:
+    logger.error(
+        'Model is not fully accelerated but '
+        '--require_full_delegation was set.'
+    )
+    sys.exit(1)
+
+  input_details = model.get_input_tensor_details(sig_key)
+  output_details = model.get_output_tensor_details(sig_key)
+
+  if args.verbose:
+    logger.debug('Input tensors:')
+    for name, detail in input_details.items():
+      logger.debug(
+          '  %s: dtype=%s, shape=%s',
+          name, detail.get('dtype'), detail.get('shape'),
+      )
+    logger.debug('Output tensors:')
+    for name, detail in output_details.items():
+      logger.debug(
+          '  %s: dtype=%s, shape=%s',
+          name, detail.get('dtype'), detail.get('shape'),
+      )
+
+  input_names = list(input_details.keys())
+  output_names = list(output_details.keys())
+
+  input_buffers = {
+      name: model.create_input_buffer_by_name(sig_key, name)
+      for name in input_names
+  }
+  output_buffers = {
+      name: model.create_output_buffer_by_name(sig_key, name)
+      for name in output_names
+  }
+
+  for name, buf in input_buffers.items():
+    fill_random_input(buf, input_details[name])
+
+  total_input_bytes = 0
+  for name, detail in input_details.items():
+    shape = detail.get('shape', [1])
+    dtype = get_numpy_dtype(detail.get('dtype', 'float32'))
+    total_input_bytes += int(np.prod(shape)) * np.dtype(dtype).itemsize
+  total_input_mb = total_input_bytes / (1024 * 1024)
+
+  logger.info('Running %d warmup iterations...', args.warmup_runs)
+  warmup_times = []
+  for i in range(args.warmup_runs):
+    t0 = time.perf_counter()
+    model.run_by_name(sig_key, input_buffers, output_buffers)
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    warmup_times.append(elapsed_ms)
+    if args.verbose:
+      logger.debug(
+          '  Warmup %d/%d: %.2f ms',
+          i + 1, args.warmup_runs, elapsed_ms,
+      )
+
+  logger.info('Running %d benchmark iterations...', args.num_runs)
+  inference_times = []
+  for i in range(args.num_runs):
+    t0 = time.perf_counter()
+    model.run_by_name(sig_key, input_buffers, output_buffers)
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    inference_times.append(elapsed_ms)
+    if args.verbose and (i + 1) % 10 == 0:
+      logger.debug('  Run %d/%d: %.2f ms', i + 1, args.num_runs, elapsed_ms)
+
+  sorted_times = sorted(inference_times)
+  avg_ms = statistics.mean(inference_times)
+  min_ms = min(inference_times)
+  max_ms = max(inference_times)
+  std_ms = statistics.stdev(inference_times) if len(inference_times) > 1 else 0
+  median_ms = statistics.median(inference_times)
+  p5_ms = percentile(sorted_times, 5)
+  p95_ms = percentile(sorted_times, 95)
+
+  warmup_avg_ms = statistics.mean(warmup_times) if warmup_times else 0
+  warmup_first_ms = warmup_times[0] if warmup_times else 0
+
+  throughput_mb_s = (total_input_mb / (avg_ms / 1000)) if avg_ms > 0 else 0
+
+  # Printed to stdout (not logger) so results are always visible and parseable.
+
+  print()
+  print('=' * 40)
+  print(' BENCHMARK RESULTS')
+  print('=' * 40)
+  print(f'Model initialization:  {init_time_ms:.2f} ms')
+  print(f'Warmup (first):        {warmup_first_ms:.2f} ms')
+  warmup_n = len(warmup_times)
+  print(f'Warmup (avg):          {warmup_avg_ms:.2f} ms ({warmup_n} runs)')
+  print(f'Inference (avg):       {avg_ms:.2f} ms ({len(inference_times)} runs)')
+  print(f'Inference (min):       {min_ms:.2f} ms')
+  print(f'Inference (max):       {max_ms:.2f} ms')
+  print(f'Inference (median):    {median_ms:.2f} ms')
+  print(f'Inference (std):       {std_ms:.2f} ms')
+  print(f'Inference (p5):        {p5_ms:.2f} ms')
+  print(f'Inference (p95):       {p95_ms:.2f} ms')
+  if throughput_mb_s > 0:
+    print(f'Throughput:            {throughput_mb_s:.2f} MB/s')
+  print(f'Fully accelerated:     {is_fully_accel}')
+  print('=' * 40)
+
+  results = {
+      'model': model_path,
+      'model_size_mb': round(model_size_mb, 2),
+      'accelerators': accel_names,
+      'signature': sig_key,
+      'fully_accelerated': is_fully_accel,
+      'num_threads': args.num_threads,
+      'latency': {
+          'init_ms': round(init_time_ms, 2),
+          'warmup_first_ms': round(warmup_first_ms, 2),
+          'warmup_avg_ms': round(warmup_avg_ms, 2),
+          'num_warmup_runs': len(warmup_times),
+          'avg_ms': round(avg_ms, 2),
+          'min_ms': round(min_ms, 2),
+          'max_ms': round(max_ms, 2),
+          'median_ms': round(median_ms, 2),
+          'std_ms': round(std_ms, 2),
+          'p5_ms': round(p5_ms, 2),
+          'p95_ms': round(p95_ms, 2),
+          'num_runs': len(inference_times),
+      },
+      'throughput_mb_s': round(throughput_mb_s, 2),
+  }
+
+  if args.result_json:
+    try:
+      with open(args.result_json, 'w') as f:
+        json.dump(results, f, indent=2)
+      logger.info('Results saved to: %s', args.result_json)
+    except OSError as e:
+      logger.error('Failed to write results to %s: %s', args.result_json, e)
+
+  return results
+
+
+def main():
+  args = parse_args()
+  logging.basicConfig(
+      level=logging.DEBUG if args.verbose else logging.INFO,
+      format='%(asctime)s %(levelname)s %(name)s: %(message)s',
+      datefmt='%Y-%m-%d %H:%M:%S',
+  )
+  run_benchmark(args)
+
+
+if __name__ == '__main__':
+  main()

--- a/litert/python/tools/benchmark_litert_model_test.py
+++ b/litert/python/tools/benchmark_litert_model_test.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for benchmark_litert_model helper functions."""
+
+import enum
+import logging
+import os
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+import numpy as np
+
+# Import the module under test.
+from litert.python.tools import benchmark_litert_model as bm
+
+# Suppress INFO/DEBUG logs from the module under test during test runs.
+# Set to logging.DEBUG to see benchmark module logs when debugging tests.
+logging.basicConfig(level=logging.WARNING)
+
+
+class PercentileTest(unittest.TestCase):
+
+  def test_empty_list(self):
+    self.assertEqual(bm.percentile([], 50), 0.0)
+
+  def test_single_element(self):
+    self.assertAlmostEqual(bm.percentile([5.0], 50), 5.0)
+
+  def test_median_odd(self):
+    data = [1.0, 2.0, 3.0, 4.0, 5.0]
+    self.assertAlmostEqual(bm.percentile(data, 50), 3.0)
+
+  def test_p0_returns_min(self):
+    data = [1.0, 2.0, 3.0]
+    self.assertAlmostEqual(bm.percentile(data, 0), 1.0)
+
+  def test_p100_returns_max(self):
+    data = [1.0, 2.0, 3.0]
+    self.assertAlmostEqual(bm.percentile(data, 100), 3.0)
+
+  def test_interpolation(self):
+    data = [10.0, 20.0]
+    self.assertAlmostEqual(bm.percentile(data, 50), 15.0)
+
+
+class GetNumpyDtypeTest(unittest.TestCase):
+
+  def test_known_dtypes(self):
+    self.assertEqual(bm.get_numpy_dtype('float32'), np.float32)
+    self.assertEqual(bm.get_numpy_dtype('float16'), np.float16)
+    self.assertEqual(bm.get_numpy_dtype('int32'), np.int32)
+    self.assertEqual(bm.get_numpy_dtype('int8'), np.int8)
+    self.assertEqual(bm.get_numpy_dtype('uint8'), np.uint8)
+    self.assertEqual(bm.get_numpy_dtype('int64'), np.int64)
+    self.assertEqual(bm.get_numpy_dtype('bool'), np.bool_)
+
+  def test_unknown_dtype_defaults_to_float32(self):
+    self.assertEqual(bm.get_numpy_dtype('bfloat16'), np.float32)
+    self.assertEqual(bm.get_numpy_dtype(''), np.float32)
+
+
+class FakeHardwareAccelerator(enum.IntFlag):
+  CPU = 1
+  GPU = 2
+  NPU = 4
+
+
+class BuildHardwareAcceleratorsTest(unittest.TestCase):
+
+  def _make_args(self, **kwargs):
+    defaults = {
+        'use_cpu': True,
+        'use_gpu': False,
+        'use_npu': False,
+        'no_cpu': False,
+        'require_full_delegation': False,
+    }
+    defaults.update(kwargs)
+    return types.SimpleNamespace(**defaults)
+
+  def test_default_cpu_only(self):
+    args = self._make_args()
+    result = bm.build_hardware_accelerators(args, FakeHardwareAccelerator)
+    self.assertEqual(result, FakeHardwareAccelerator.CPU)
+
+  def test_npu_with_cpu_fallback(self):
+    args = self._make_args(use_npu=True)
+    result = bm.build_hardware_accelerators(args, FakeHardwareAccelerator)
+    self.assertEqual(
+        result, FakeHardwareAccelerator.NPU | FakeHardwareAccelerator.CPU
+    )
+
+  def test_npu_only_no_cpu(self):
+    args = self._make_args(use_npu=True, no_cpu=True)
+    result = bm.build_hardware_accelerators(args, FakeHardwareAccelerator)
+    self.assertEqual(result, FakeHardwareAccelerator.NPU)
+
+  def test_require_full_delegation_disables_cpu(self):
+    args = self._make_args(use_npu=True, require_full_delegation=True)
+    result = bm.build_hardware_accelerators(args, FakeHardwareAccelerator)
+    self.assertEqual(result, FakeHardwareAccelerator.NPU)
+
+  def test_gpu_and_npu(self):
+    args = self._make_args(use_gpu=True, use_npu=True)
+    result = bm.build_hardware_accelerators(args, FakeHardwareAccelerator)
+    expected = (
+        FakeHardwareAccelerator.GPU
+        | FakeHardwareAccelerator.NPU
+        | FakeHardwareAccelerator.CPU
+    )
+    self.assertEqual(result, expected)
+
+  def test_no_accel_falls_back_to_cpu(self):
+    args = self._make_args(no_cpu=True, require_full_delegation=True)
+    result = bm.build_hardware_accelerators(args, FakeHardwareAccelerator)
+    self.assertEqual(result, FakeHardwareAccelerator.CPU)
+
+
+class DispatchPathConversionTest(unittest.TestCase):
+  """Test that file paths are converted to directory paths for dispatch."""
+
+  def _make_args(self, dispatch_path='', **kwargs):
+    defaults = {
+        'runtime_path': '',
+        'compiler_plugin_path': '',
+        'dispatch_library_path': dispatch_path,
+        'num_threads': 1,
+    }
+    defaults.update(kwargs)
+    return types.SimpleNamespace(**defaults)
+
+  def test_file_path_converted_to_directory(self):
+    """If dispatch_library_path points to a file, dirname should be used."""
+    with tempfile.NamedTemporaryFile(suffix='.so') as f:
+      args = self._make_args(dispatch_path=f.name)
+      # We can't call create_environment without LiteRT installed, but
+      # we can verify the path logic directly.
+      dispatch_path = args.dispatch_library_path
+      if os.path.isfile(dispatch_path):
+        dispatch_path = os.path.dirname(dispatch_path)
+      self.assertTrue(os.path.isdir(dispatch_path))
+
+  def test_directory_path_unchanged(self):
+    with tempfile.TemporaryDirectory() as d:
+      args = self._make_args(dispatch_path=d)
+      dispatch_path = args.dispatch_library_path
+      if os.path.isfile(dispatch_path):
+        dispatch_path = os.path.dirname(dispatch_path)
+      self.assertEqual(dispatch_path, d)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/litert/vendors/intel_openvino/README.md
+++ b/litert/vendors/intel_openvino/README.md
@@ -19,19 +19,21 @@ compiler plugin and dispatch API support for Intel NPU hardware.
 
 ## Table of Contents
 
--   [Supported Platforms](#supported-platforms)
--   [Prerequisites](#prerequisites)
--   [Quick Start](#quick-start)
--   [Verifying NPU Execution](#verifying-npu-execution)
--   [AOT Compilation](#aot-compilation)
--   [Setting Up an Intel NPU Device on Linux](#setting-up-an-intel-npu-device-on-linux)
--   [Setting Up an Intel NPU Device on Windows](#setting-up-an-intel-npu-device-on-windows)
--   [Validating on a PTL Device](#validating-on-a-ptl-device)
--   [Building the Python Wheel from Source](#building-the-python-wheel-from-source)
--   [Running Unit Tests](#running-unit-tests)
--   [Troubleshooting](#troubleshooting)
--   [Component Versions](#component-versions)
--   [Architecture](#architecture)
+- [Supported Platforms](#supported-platforms)
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Verifying NPU Execution](#verifying-npu-execution)
+- [OpenVINO Configuration Options](#openvino-configuration-options)
+  - [AOT Compilation](#aot-compilation)
+  - [Benchmark Tool](#benchmark-tool)
+- [Setting Up an Intel NPU Device on Linux (PTL / LNL)](#setting-up-an-intel-npu-device-on-linux-ptl--lnl)
+- [Setting Up an Intel NPU Device on Windows](#setting-up-an-intel-npu-device-on-windows)
+- [Validating on a PTL Device](#validating-on-a-ptl-device)
+- [Building the Python Wheel from Source](#building-the-python-wheel-from-source)
+- [Running Unit Tests](#running-unit-tests)
+- [Troubleshooting](#troubleshooting)
+- [Component Versions](#component-versions)
+- [Architecture](#architecture)
 
 **Validated on:** - Linux: Intel Panther Lake (PTL, NPU5010), Ubuntu 24.04,
 OpenVINO 2026.1.0, NPU driver v1.32.0. - Windows: Intel Core Ultra Series 2/3,
@@ -130,7 +132,39 @@ model.run_by_index(sig_idx, input_buffers, output_buffers)
 print("Fully accelerated:", model.is_fully_accelerated())
 ```
 
---------------------------------------------------------------------------------
+### 5. Benchmark
+
+```bash
+# Find dispatch library path
+DISPATCH_DIR=$(python3 -c "
+from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend
+print(intel_openvino_backend.get_dispatch_dir())
+")
+
+# NPU benchmark
+litert-benchmark --model=model.tflite --use_npu \
+    --dispatch_library_path=$DISPATCH_DIR --num_runs=50
+
+# CPU benchmark (for comparison)
+litert-benchmark --model=model.tflite --num_runs=50 --num_threads=4
+
+# NPU only — fail if model can't be fully accelerated
+litert-benchmark --model=model.tflite --use_npu \
+    --dispatch_library_path=$DISPATCH_DIR --require_full_delegation
+
+# Save results as JSON
+litert-benchmark --model=model.tflite --use_npu \
+    --dispatch_library_path=$DISPATCH_DIR --result_json=results.json
+```
+
+You can also run the benchmark tool as a Python module:
+
+```bash
+python3 -m ai_edge_litert.tools.benchmark_litert_model \
+    --model=model.tflite --use_npu --dispatch_library_path=$DISPATCH_DIR
+```
+
+---
 
 ## Verifying NPU Execution
 
@@ -264,6 +298,8 @@ model = CompiledModel.from_file(
 Follow these steps on your target Intel NPU machine (Panther Lake or Lunar Lake)
 running Ubuntu 24.04.
 
+ ℹ️ **_NOTE:_** If you want to do only AOT you can skip this section, as npu driver are not required for AOT compilation
+
 ### Step 1: Install NPU Drivers
 
 <!--* pragma: { seclinter_this_is_fine: true } *-->
@@ -296,14 +332,6 @@ If you encounter conflicts with existing Level Zero packages:
 ```bash
 sudo dpkg --purge --force-remove-reinstreq level-zero level-zero-devel
 sudo dpkg -i libze1_*.deb
-```
-
-### Step 3: Install OpenVINO Runtime
-
-**Option A: pip (recommended)**
-
-```bash
-pip install openvino==2026.1.0
 ```
 
 **Option B: APT repository**
@@ -341,6 +369,10 @@ correctly.
 ```bash
 pip install ai-edge-litert[npu-intel]
 
+#or install the intel sdk nightly seperately
+pip install ai-edge-litert
+pip install ai-edge-litert-sdk-intel-nightly
+
 # Verify backend
 python3 -c "
 from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend
@@ -356,9 +388,7 @@ print('Dispatch dir:', intel_openvino_backend.get_dispatch_dir())
 Follow these steps on a Windows machine with Intel NPU hardware (Panther Lake or
 Lunar Lake).
 
-**Validated on:** Windows 11, Intel Core Ultra Series 2/3, NPU driver
-32.0.100.4724, OpenVINO 2026.1.0, Python 3.11 (only supported version on Windows
-— hardcoded in `.bazelrc` `build:windows` config).
+ℹ️ **_NOTE:_** If you want to do only AOT you can skip this section, as npu driver are not required for AOT compilation
 
 ### Step 1: Install Intel NPU Driver
 
@@ -374,6 +404,10 @@ After installation, verify the NPU device appears in Device Manager under
 
 ```powershell
 python -m pip install ai-edge-litert[npu-intel]
+
+#or install intel nightly sdk seperately
+python -m pip install ai-edge-litert
+python -m pip install ai-edge-litert-sdk-intel-nightly
 
 # Verify backend
 python -c "from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend; print('Backend ID:', intel_openvino_backend.IntelOpenVinoBackend.id()); print('Dispatch dir:', intel_openvino_backend.get_dispatch_dir())"
@@ -403,33 +437,9 @@ print("Fully accelerated:", model.is_fully_accelerated())
 
 --------------------------------------------------------------------------------
 
-## Validating on a PTL Device
-
-Copy the wheel to your PTL device and run the verification steps:
-
-```bash
-# From build machine
-scp dist/ai_edge_litert-*.whl intel@<PTL_HOST>:/path/to/workdir/
-
-# On the PTL device
-ssh intel@<PTL_HOST>
-cd /path/to/workdir
-python3 -m venv venv && source venv/bin/activate
-pip install ai_edge_litert-*.whl[npu-intel]
-
-# Verify backend
-python3 -c "
-from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend
-print('Backend ID:', intel_openvino_backend.IntelOpenVinoBackend.id())
-print('Dispatch dir:', intel_openvino_backend.get_dispatch_dir())
-"
-```
-
---------------------------------------------------------------------------------
-
 ## Building the Python Wheel from Source
 
-### Option A: Docker Hermetic Build (Recommended)
+### Option A: Docker Hermetic Build only for Linux (Recommended)
 
 No local Bazel or build tools required. The Docker image includes all
 dependencies (Bazel 7.4.1, Android SDK/NDK, Clang 18, Python).
@@ -454,23 +464,11 @@ export no_proxy="localhost,127.0.0.1,.example.com"
 cd LiteRT/docker_build
 ./build_wheel_with_docker.sh
 ```
-
-Three layers of proxy forwarding are handled automatically:
-
-| Layer        | How                                     | Used by            |
-| ------------ | --------------------------------------- | ------------------ |
-| Docker image | `--build-arg http_proxy=...`            | `apt-get`, `wget`, |
-: build        :                                         : `pip` during image :
-:              :                                         : creation           :
-| Container    | `-e http_proxy=...`                     | `curl`, `pip`,     |
-: runtime      :                                         : general network    :
-:              :                                         : access             :
-| Bazel JVM    | `--host_jvm_args=-Dhttps.proxyHost=...` | Bazel repository   |
-: downloader   :                                         : fetches            :
-
-Outputs in `dist/`: - `ai_edge_litert-*.whl` (wheel with compiler plugin +
-dispatch library) - `ai_edge_litert_sdk_qualcomm-*.tar.gz` -
-`ai_edge_litert_sdk_mediatek-*.tar.gz` - `ai_edge_litert_sdk_intel-*.tar.gz`
+Outputs in `dist/`:
+- `ai_edge_litert-*.whl` (wheel with compiler plugin + dispatch library + benchmark tool)
+- `ai_edge_litert_sdk_qualcomm-*.tar.gz`
+- `ai_edge_litert_sdk_mediatek-*.tar.gz`
+- `ai_edge_litert_sdk_intel-*.tar.gz`
 
 Options: - `--use_existing_image` — skip `docker build`, reuse existing image -
 `--dbg` — build in debug mode - `--python=3.12` — set `HERMETIC_PYTHON_VERSION`
@@ -524,11 +522,15 @@ openvino`
 ```bash
 cd LiteRT
 ./configure
+# for Linux
 bash ci/build_pip_package_with_bazel.sh
+# for Windows
+bash ci/build_pip_package_with_bazel_windows.ps1
 ```
 
-### Building Individual Shared Libraries
 
+### Building Individual Shared Libraries
+For Linux:
 ```bash
 bazel build //litert/vendors/intel_openvino/compiler:libLiteRtCompilerPlugin_IntelOpenvino.so
 bazel build //litert/vendors/intel_openvino/dispatch:dispatch_api_so


### PR DESCRIPTION
Add a Python benchmark tool that mirrors the C++ benchmark_model, providing inference benchmarking via the LiteRT Python API.

New tool (litert/python/tools/):
- benchmark_litert_model.py: CPU/GPU/NPU benchmark with warmup, configurable iterations, percentile latency stats, JSON output
- benchmark_litert_model_test.py: unit tests
- README.md: CLI reference, flag documentation, JSON schema

Wheel packaging (ci/tools/python/wheel/):
- Registered as 'litert-benchmark' console script entry point
- Tool sources added to ALL_PY_SRC_MODULES

Intel OpenVINO vendor README (litert/vendors/intel_openvino/):
- New Quick Start Step 5 with NPU/CPU benchmark examples, dispatch library auto-discovery, --require_full_delegation, and JSON output workflows
- Added Benchmark Tool entry to table of contents
- Clarified ai-edge-litert-sdk-intel-nightly as the separate install path
- Added note that NPU driver setup can be skipped for AOT-only workflows