### PR TITLE
Restore SB function-name override [reversion] (b/397771624)

### DIFF
--- a/litert/vendors/google_tensor/dispatch/dispatch_api.cc
+++ b/litert/vendors/google_tensor/dispatch/dispatch_api.cc
@@ -180,6 +180,14 @@ LiteRtStatus InvocationContextCreate(
   GT_LOG_RETURN_IF_NULL(exec_bytecode_buffer);
   GT_LOG_RETURN_IF_NULL(invocation_context);
 
+  // TODO(b/397771624): SouthBound implementations shipped to date do not
+  // support per-function dispatch and reject any non-empty function name
+  // ("Only Darwinn Tflite model is supported for TpuTachyonLoadedLibrary").
+  // Maintain the original empty-string override for older-SB compatibility.
+  // Once an SB version that supports per-function dispatch ships, gate this
+  // override behind a corresponding GoogleTensorSouthBoundFeature in
+  // sb_api_features.h.
+  function_name = "";
   return LiteRtDispatchInvocationContextT::CreateFromBytecode(
       device_context, exec_type, *exec_bytecode_buffer, function_name,
       num_inputs, num_outputs, *invocation_context);
@@ -394,6 +402,8 @@ LiteRtStatus AssignNodeFunction(LiteRtDispatchGraph graph,
                                 const char* function_name) {
   GT_LOG_RETURN_IF_NULL(graph);
 
+  // Older-SB compatibility (b/397771624); see InvocationContextCreate above.
+  function_name = "";
   return graph->AssignNodeFunction(node_id, exec_handle, function_name);
 }
 


### PR DESCRIPTION
The function-name override workaround in dispatch_api.cc was removed in e222c3c96 ("Update Google Tensor LiteRT for multi-signature support"), which exposed a backward-compatibility regression: SouthBound implementations shipped to date do not yet honor non-empty function names and reject any such call at thrInvocationContextGet time with

  E native: Failed to initialize the invocation context.
            INVALID_ARGUMENT: Only Darwinn Tflite model is supported for
            TpuTachyonLoadedLibrary.; node id: node_0,
            function_name: Partition_0

Reproducible on a stock Pixel 8 (Tensor G3) running an AOT-compiled  asset through LiteRtDispatchInvocationContextCreate.
