### PR TITLE
gpu_registry: load Metal accelerator from .framework path on Apple

### DIFF
--- a/litert/runtime/accelerators/gpu_registry.cc
+++ b/litert/runtime/accelerators/gpu_registry.cc
@@ -37,9 +37,27 @@ namespace litert::internal {
 #if defined(LITERT_WINDOWS_OS)
 #define SO_EXT ".dll"
 #elif defined(__APPLE__)
+#include <TargetConditionals.h>
 #define SO_EXT ".dylib"
 #else
 #define SO_EXT ".so"
+#endif
+
+// On Apple targets the LiteRT accelerator dylibs are bundled as
+// ``<X>.framework/<X>`` (iOS) or ``<X>.framework/Versions/A/<X>`` (macOS),
+// not as flat ``lib<X>.dylib`` files. Apple App Store Connect rejects
+// builds that drop loose ``lib<X>.dylib`` symlinks alongside frameworks
+// (ITMS-90432: "Frameworks must be embedded as a .framework bundle"), so
+// hardcoding the basename here breaks App Store distribution. Use the
+// framework-relative path on Apple and keep the flat basename elsewhere.
+#if defined(__APPLE__) && TARGET_OS_OSX
+#define LITERT_METAL_ACCEL_LIB \
+  "LiteRtMetalAccelerator.framework/Versions/A/LiteRtMetalAccelerator"
+#elif defined(__APPLE__) && TARGET_OS_IPHONE
+#define LITERT_METAL_ACCEL_LIB \
+  "LiteRtMetalAccelerator.framework/LiteRtMetalAccelerator"
+#else
+#define LITERT_METAL_ACCEL_LIB "libLiteRtMetalAccelerator" SO_EXT
 #endif
 
 LiteRtStatus RegisterGpuAccelerator(LiteRtEnvironment environment) {
@@ -56,7 +74,7 @@ LiteRtStatus RegisterGpuAccelerator(LiteRtEnvironment environment) {
 
 #elif TARGET_OS_IPHONE
 #if LITERT_HAS_METAL_SUPPORT
-      "libLiteRtMetalAccelerator" SO_EXT,
+      LITERT_METAL_ACCEL_LIB,
 #endif  // LITERT_HAS_METAL_SUPPORT
 #if LITERT_HAS_WEBGPU_SUPPORT
       "libLiteRtWebGpuAccelerator" SO_EXT,
@@ -70,7 +88,7 @@ LiteRtStatus RegisterGpuAccelerator(LiteRtEnvironment environment) {
       "libLiteRtOpenClAccelerator" SO_EXT,
 #endif  // LITERT_HAS_OPENCL_SUPPORT
 #if LITERT_HAS_METAL_SUPPORT
-      "libLiteRtMetalAccelerator" SO_EXT,
+      LITERT_METAL_ACCEL_LIB,
 #endif  // LITERT_HAS_METAL_SUPPORT
 #endif  // !__ANDROID__ && !TARGET_OS_IPHONE
 


### PR DESCRIPTION
## Summary

On Apple targets the upstream LiteRT Metal accelerator dylib ships as a `.framework` bundle, not as a flat `lib<X>.dylib` file. Today `gpu_registry.cc` hardcodes the basename `"libLiteRtMetalAccelerator.dylib"` in its dlopen list, which doesn't exist under that name in any standard Apple-bundled app. Switch to the framework-relative path under `#if __APPLE__` so `dyld` resolves the bundle layout natively.

This unblocks consumers that embed the dylib through a normal Apple pipeline (Dart Native Assets, Xcode "Embed Frameworks", CocoaPods `vendored_frameworks`) — including App Store distribution.

## Context

The historical workaround for this gap was to drop a `lib<X>.dylib` symlink alongside the framework. App Store Connect rejects builds with those symlinks:

```
ITMS-90432: Unexpected file found in Frameworks:
Payload/<App>.app/Frameworks/libLiteRtMetalAccelerator.dylib.
Frameworks must be embedded as a .framework bundle.
```

So Apple consumers cannot ship to the App Store while the basename lookup stands.

The full picture (including the related Apple companion-dylib `-headerpad_max_install_names` gap that we *can't* fix in this repo because the dylibs are pre-compiled prebuilts, not Bazel `cc_binary` targets) is documented in the umbrella issue **google-ai-edge/LiteRT-LM#2151**.

## What this PR changes

`litert/runtime/accelerators/gpu_registry.cc`:

- Include `<TargetConditionals.h>` in the `__APPLE__` branch so `TARGET_OS_OSX` / `TARGET_OS_IPHONE` are defined.
- Add a new `LITERT_METAL_ACCEL_LIB` macro that expands to:
  - `"LiteRtMetalAccelerator.framework/Versions/A/LiteRtMetalAccelerator"` on macOS
  - `"LiteRtMetalAccelerator.framework/LiteRtMetalAccelerator"` on iOS
  - `"libLiteRtMetalAccelerator" SO_EXT` everywhere else (unchanged behavior)
- Replace the two array entries (Metal accelerator on iOS branch and on the default-Apple-desktop branch) with the macro.

Linux / Windows / Android paths are unchanged — the macro expands to exactly the previous string on those platforms.

The relative framework path is appended onto `runtime_lib_path` (set via `kLiteRtEnvOptionTagRuntimeLibraryDir`) by `std::filesystem::path` concatenation, exactly like the existing flat-basename case. So callers that pass a directory like `@executable_path/../Frameworks` (macOS) or `@executable_path/Frameworks` (iOS) already get a fully resolvable dlopen path: `<Frameworks>/LiteRtMetalAccelerator.framework/.../LiteRtMetalAccelerator`. Verified on a built `Runner.app` from a Flutter consumer — `dyld` 4 resolves the path from both an exe in `Contents/MacOS/` and from a binary inside another framework's `Versions/A/`.

## What this PR does NOT change

`runtime/components/sampler_factory.cc` (in `google-ai-edge/LiteRT-LM`) has the same flat-basename hardcode for `libLiteRtTopKMetalSampler.dylib`. Fixing it without first resolving **google-ai-edge/LiteRT-LM#2073** (sampler dylib exports only 3 of 7 expected ABI symbols on macOS / iOS) makes things worse: `dlopen` succeeds, but `dlsym(UpdateConfig)` returns NULL, and a later virtual call through the half-initialized sampler vtable crashes with `EXC_BAD_ACCESS`. That fix should follow #2073.

## Test plan

- [x] Linux / Windows / Android dlopen list unchanged (macro expands to existing string in non-Apple branches — checked via preprocessor expansion locally)
- [x] macOS app bundle (`Contents/Frameworks/LiteRtMetalAccelerator.framework/Versions/A/LiteRtMetalAccelerator`): verified `dyld` resolves from a binary inside another framework's `Versions/A/` (`flutter_gemma`'s `LiteRtLm.framework`), which is the practical call site
- [x] iOS app bundle (`Frameworks/LiteRtMetalAccelerator.framework/LiteRtMetalAccelerator`): same verification path on iPhone 16 Pro
- [ ] Full upstream CI on this branch (would be helpful — flagging that I have no Bazel build environment that mirrors upstream)

## Cross-references

- google-ai-edge/LiteRT-LM#2151 — umbrella issue covering this and Apple companion dylib headerpad gap (the headerpad fix needs the dylibs to be rebuilt by the LiteRT team — pre-compiled prebuilts in `LiteRT-LM/prebuilt/`)
- google-ai-edge/LiteRT-LM#2073 — sampler dylib export gap (must land before sampler_factory.cc fix can follow)

## CLA

I haven't signed the Google CLA yet but will sign the Individual CLA before merge. Flagging here so reviewers know not to block on it now.