### PR TITLE
[Intel OV] Add CPU backend support

### DIFF
--- a/litert/c/options/litert_intel_openvino_options.h
+++ b/litert/c/options/litert_intel_openvino_options.h
@@ -52,7 +52,6 @@ typedef enum LiteRtIntelOpenVinoDeviceType {
   kLiteRtIntelOpenVinoDeviceTypeCPU = 0,
   kLiteRtIntelOpenVinoDeviceTypeGPU = 1,
   kLiteRtIntelOpenVinoDeviceTypeNPU = 2,
-  kLiteRtIntelOpenVinoDeviceTypeAUTO = 3,
 } LiteRtIntelOpenVinoDeviceType;
 
 LiteRtStatus LrtIntelOpenVinoOptionsSetDeviceType(

--- a/litert/cc/options/litert_intel_openvino_options_test.cc
+++ b/litert/cc/options/litert_intel_openvino_options_test.cc
@@ -194,7 +194,7 @@ TEST(IntelOpenVinoOptionsCApiTest, RoundTripSerialization) {
   EXPECT_EQ(LrtIntelOpenVinoOptionsCreate(&options), kLiteRtStatusOk);
 
   EXPECT_EQ(LrtIntelOpenVinoOptionsSetDeviceType(
-                options, kLiteRtIntelOpenVinoDeviceTypeAUTO),
+                options, kLiteRtIntelOpenVinoDeviceTypeNPU),
             kLiteRtStatusOk);
   EXPECT_EQ(
       LrtIntelOpenVinoOptionsSetConfigsMapOption(options, "key1", "value1"),
@@ -206,7 +206,7 @@ TEST(IntelOpenVinoOptionsCApiTest, RoundTripSerialization) {
   LiteRtIntelOpenVinoDeviceType dev_type;
   ASSERT_EQ(LrtIntelOpenVinoOptionsGetDeviceType(parsed, &dev_type),
             kLiteRtStatusOk);
-  EXPECT_EQ(dev_type, kLiteRtIntelOpenVinoDeviceTypeAUTO);
+  EXPECT_EQ(dev_type, kLiteRtIntelOpenVinoDeviceTypeNPU);
 
   int num_configs;
   ASSERT_EQ(

--- a/litert/tools/flags/vendors/intel_openvino_flags.cc
+++ b/litert/tools/flags/vendors/intel_openvino_flags.cc
@@ -37,7 +37,7 @@
 
 ABSL_FLAG(LiteRtIntelOpenVinoDeviceType, intel_openvino_device_type,
           kLiteRtIntelOpenVinoDeviceTypeNPU,
-          "Device type for Intel OpenVINO inference (cpu, gpu, npu, auto).");
+          "Device type for Intel OpenVINO inference (cpu, gpu, npu).");
 
 ABSL_FLAG(LiteRtIntelOpenVinoPerformanceMode, intel_openvino_performance_mode,
           kLiteRtIntelOpenVinoPerformanceModeLatency,
@@ -66,11 +66,6 @@ bool AbslParseFlag(absl::string_view text,
     return true;
   }
 
-  if (text == "auto") {
-    *options = kLiteRtIntelOpenVinoDeviceTypeAUTO;
-    return true;
-  }
-
   *error = "Unknown Intel OpenVINO device type";
   return false;
 }
@@ -83,8 +78,6 @@ std::string AbslUnparseFlag(LiteRtIntelOpenVinoDeviceType options) {
       return "gpu";
     case kLiteRtIntelOpenVinoDeviceTypeNPU:
       return "npu";
-    case kLiteRtIntelOpenVinoDeviceTypeAUTO:
-      return "auto";
   }
 }
 

--- a/litert/tools/flags/vendors/intel_openvino_flags_example.cc
+++ b/litert/tools/flags/vendors/intel_openvino_flags_example.cc
@@ -60,9 +60,6 @@ void ExampleIntelOpenVinoFlagsUsage(int argc, char** argv) {
     case kLiteRtIntelOpenVinoDeviceTypeNPU:
       std::cout << "NPU";
       break;
-    case kLiteRtIntelOpenVinoDeviceTypeAUTO:
-      std::cout << "AUTO";
-      break;
   }
   std::cout << "\n";
 

--- a/litert/tools/flags/vendors/intel_openvino_flags_test.cc
+++ b/litert/tools/flags/vendors/intel_openvino_flags_test.cc
@@ -70,15 +70,6 @@ TEST(DeviceTypeFlagTest, Parse) {
     EXPECT_EQ(value, kDeviceEnum);
     EXPECT_EQ(kDevice, absl::UnparseFlag(value));
   }
-
-  {
-    static constexpr absl::string_view kDevice = "auto";
-    static constexpr LiteRtIntelOpenVinoDeviceType kDeviceEnum =
-        kLiteRtIntelOpenVinoDeviceTypeAUTO;
-    EXPECT_TRUE(absl::ParseFlag(kDevice, &value, &error));
-    EXPECT_EQ(value, kDeviceEnum);
-    EXPECT_EQ(kDevice, absl::UnparseFlag(value));
-  }
 }
 
 TEST(PerformanceModeFlagTest, Parse) {

--- a/litert/vendors/intel_openvino/README_options.md
+++ b/litert/vendors/intel_openvino/README_options.md
@@ -30,7 +30,6 @@ litert/
 -   **CPU**: Run inference on Intel CPU
 -   **GPU**: Run inference on Intel GPU
 -   **NPU**: Run inference on Intel NPU
--   **AUTO**: Let OpenVINO automatically select the best device
 
 ### Performance Mode
 

--- a/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
+++ b/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
@@ -58,8 +58,8 @@ OpenVinoCompileContext::OpenVinoCompileContext() {
       context.device_ = "NPU";
       break;
     case kLiteRtIntelOpenVinoDeviceTypeAUTO:
-      context.device_ = "AUTO";
-      break;
+      return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                           "AUTO device type is not supported");
   }
 
   LITERT_LOG(LITERT_INFO, "Using Intel OpenVINO device: %s",

--- a/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
+++ b/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
@@ -57,9 +57,6 @@ OpenVinoCompileContext::OpenVinoCompileContext() {
     case kLiteRtIntelOpenVinoDeviceTypeNPU:
       context.device_ = "NPU";
       break;
-    case kLiteRtIntelOpenVinoDeviceTypeAUTO:
-      return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                           "AUTO device type is not supported");
   }
 
   LITERT_LOG(LITERT_INFO, "Using Intel OpenVINO device: %s",

--- a/litert/vendors/intel_openvino/compiler/openvino_compiler_plugin.cc
+++ b/litert/vendors/intel_openvino/compiler/openvino_compiler_plugin.cc
@@ -1,4 +1,4 @@
-// Copyright 22026 Google LLC.
+// Copyright 2026 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <ios>
+#include <limits>
 #include <memory>
 #include <ostream>
 #include <streambuf>
@@ -135,30 +136,95 @@ constexpr LiteRtOpCode kSupportedOps[] = {
 };
 // clang format on
 
-// When exporting a model via the OpenVINO NPU plugin, standard string streams
-// might encounter a 32-bit std::streamsize limitation on specific platforms,
-// which restricts model export capacity. This custom output stream buffer
-// bypasses that limitation, enabling support for larger models.
+// When exporting a model via the OpenVINO, standard string streams might
+// encounter a 32-bit std::streamsize limitation on specific platforms, which
+// restricts model export capacity. This custom output stream buffer bypasses
+// that limitation, enabling support for larger models.
 class CustomOStreamBuf : public std::streambuf {
  public:
-  CustomOStreamBuf() = default;
+  CustomOStreamBuf() : pos_(0) {}
   std::string drain_str() { return std::move(target_); }
 
  protected:
   std::streamsize xsputn(const char* s, std::streamsize n) override {
-    target_.append(s, n);
+    if (n <= 0) {
+      return 0;
+    }
+    const size_t write_size = static_cast<size_t>(n);
+    if (write_size > target_.size() - pos_) {
+      target_.resize(pos_ + write_size);
+    }
+    std::memcpy(&target_[pos_], s, write_size);
+    pos_ += write_size;
     return n;
   }
   int_type overflow(int_type ch) override {
     if (ch != traits_type::eof()) {
-      target_.push_back(static_cast<char>(ch));
+      char c = static_cast<char>(ch);
+      if (pos_ >= target_.size()) {
+        target_.push_back(c);
+      } else {
+        target_[pos_] = c;
+      }
+      ++pos_;
       return ch;
     }
     return traits_type::eof();
   }
 
+  pos_type seekoff(off_type off, std::ios_base::seekdir dir,
+                   std::ios_base::openmode which) override {
+    // This buffer is output-only; reject seeks for other directions.
+    if (!(which & std::ios_base::out)) {
+      return pos_type(off_type(-1));
+    }
+
+    if (target_.size() >
+        static_cast<size_t>(std::numeric_limits<off_type>::max())) {
+      return pos_type(off_type(-1));
+    }
+
+    off_type base_pos = 0;
+    switch (dir) {
+      case std::ios_base::beg:
+        base_pos = 0;
+        break;
+      case std::ios_base::cur:
+        if (pos_ > static_cast<size_t>(std::numeric_limits<off_type>::max())) {
+          return pos_type(off_type(-1));
+        }
+        base_pos = static_cast<off_type>(pos_);
+        break;
+      case std::ios_base::end:
+        base_pos = static_cast<off_type>(target_.size());
+        break;
+      default:
+        return pos_type(off_type(-1));
+    }
+
+    // Guard against signed overflow when computing base_pos + off.
+    if ((off > 0 && base_pos > std::numeric_limits<off_type>::max() - off) ||
+        (off < 0 && base_pos < std::numeric_limits<off_type>::min() - off)) {
+      return pos_type(off_type(-1));
+    }
+
+    const off_type new_pos = base_pos + off;
+    // Keep position within [0, target_.size()] for valid write seeks.
+    if (new_pos < 0 || static_cast<size_t>(new_pos) > target_.size()) {
+      return pos_type(off_type(-1));
+    }
+
+    pos_ = static_cast<size_t>(new_pos);
+    return pos_type(pos_);
+  }
+
+  pos_type seekpos(pos_type pos, std::ios_base::openmode which) override {
+    return seekoff(off_type(pos), std::ios_base::beg, which);
+  }
+
  private:
   std::string target_;
+  size_t pos_;
 };
 }  // namespace
 

--- a/litert/vendors/intel_openvino/dispatch/invocation_context.cc
+++ b/litert/vendors/intel_openvino/dispatch/invocation_context.cc
@@ -152,10 +152,12 @@ LiteRtDispatchInvocationContextT::Create(
         device = "NPU";
         break;
       case kLiteRtIntelOpenVinoDeviceTypeAUTO:
-        device = "AUTO";
-        break;
+        return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                             "AUTO device type is not supported");
     }
   }
+  LITERT_LOG(LITERT_INFO, "Using Intel OpenVINO device: %s", device.c_str());
+
   OpenVINOSharedCore::GetInstance()->SetDevice(device);
 
   if (!exec_bytecode_ptr || exec_bytecode_size == 0) {

--- a/litert/vendors/intel_openvino/dispatch/invocation_context.cc
+++ b/litert/vendors/intel_openvino/dispatch/invocation_context.cc
@@ -151,9 +151,6 @@ LiteRtDispatchInvocationContextT::Create(
       case kLiteRtIntelOpenVinoDeviceTypeNPU:
         device = "NPU";
         break;
-      case kLiteRtIntelOpenVinoDeviceTypeAUTO:
-        return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                             "AUTO device type is not supported");
     }
   }
   LITERT_LOG(LITERT_INFO, "Using Intel OpenVINO device: %s", device.c_str());

--- a/litert/vendors/intel_openvino/dispatch/openvino_shared_core.h
+++ b/litert/vendors/intel_openvino/dispatch/openvino_shared_core.h
@@ -16,9 +16,11 @@
 #define ODML_LITERT_LITERT_VENDORS_OPENVINO_DISPATCH_OPENVINO_SHARED_CORE_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "openvino/runtime/core.hpp"
+#include "openvino/runtime/remote_context.hpp"
 
 class OpenVINOSharedCore {
  public:
@@ -32,8 +34,18 @@ class OpenVINOSharedCore {
   // Return the core shared_pointer.
   std::shared_ptr<ov::Core> getCore() const { return core_; }
 
-  void SetDevice(const std::string device) { device_ = device; }
+  void SetDevice(const std::string device) {
+    device_ = device;
+    remote_context_.reset();
+  }
   std::string GetDevice() { return device_; }
+
+  ov::RemoteContext GetRemoteContext() {
+    if (!remote_context_.has_value()) {
+      remote_context_ = core_->get_default_context(device_);
+    }
+    return *remote_context_;
+  }
 
  private:
   OpenVINOSharedCore();
@@ -41,6 +53,7 @@ class OpenVINOSharedCore {
 
   std::shared_ptr<ov::Core> core_;
   std::string device_ = "NPU";  // Default device
+  std::optional<ov::RemoteContext> remote_context_;
 };
 
 #endif  // ODML_LITERT_LITERT_VENDORS_OPENVINO_DISPATCH_OPENVINO_SHARED_CORE_H_

--- a/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.cc
+++ b/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.cc
@@ -39,14 +39,23 @@ litert::Expected<void> OpenVinoTensorBuffer::Alloc(
   // TODO:: Release the shared OpenVINO Core.
   std::shared_ptr<ov::Core> core = OpenVINOSharedCore::GetInstance()->getCore();
   std::string device = OpenVINOSharedCore::GetInstance()->GetDevice();
-  auto context = core->get_default_context(device);
   ov::element::Type ov_element_type =
       litert::openvino::MapLiteTypeToOV(tensor_type.element_type);
+
   std::vector<int32_t> ov_shape_vec(tensor_type.layout.rank);
   for (size_t i = 0; i < ov_shape_vec.size(); i++)
     ov_shape_vec[i] = tensor_type.layout.dimensions[i];
-  host_tensor_ = context.create_host_tensor(
-      ov_element_type, ov::Shape{ov_shape_vec.begin(), ov_shape_vec.end()});
+  ov::Shape ov_shape{ov_shape_vec.begin(), ov_shape_vec.end()};
+
+  if (device == "NPU" || device == "GPU") {
+    auto context = core->get_default_context(device);
+    ov_tensor_ = context.create_host_tensor(ov_element_type, ov_shape);
+  } else if (device == "CPU") {
+    ov_tensor_ = ov::Tensor(ov_element_type, ov_shape);
+  } else {
+    return litert::Unexpected(kLiteRtStatusErrorInvalidArgument,
+                              "Unsupported OpenVINO device: " + device);
+  }
   allocated_ = true;
 
   return {};
@@ -55,15 +64,15 @@ litert::Expected<void> OpenVinoTensorBuffer::Alloc(
 litert::Expected<void*> OpenVinoTensorBuffer::GetTensorData() {
   if (!allocated_) {
     return litert::Unexpected(kLiteRtStatusErrorInvalidArgument,
-                              "The remote tensor didn't allocate.");
+                              "The tensor didn't allocate.");
   }
-  return host_tensor_.data();
+  return ov_tensor_.data();
 }
 
 litert::Expected<ov::Tensor> OpenVinoTensorBuffer::GetOVTensor() {
   if (!allocated_) {
     return litert::Unexpected(kLiteRtStatusErrorInvalidArgument,
-                              "Failed to get zero buffer remote tensor.");
+                              "Failed to get tensor.");
   }
-  return host_tensor_;
+  return ov_tensor_;
 }

--- a/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.cc
+++ b/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.cc
@@ -16,12 +16,10 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <vector>
 
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
-#include "openvino/runtime/core.hpp"
 #include "openvino/runtime/intel_npu/level_zero/level_zero.hpp"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_model_types.h"
@@ -37,7 +35,6 @@ litert::Expected<void> OpenVinoTensorBuffer::Alloc(
   }
 
   // TODO:: Release the shared OpenVINO Core.
-  std::shared_ptr<ov::Core> core = OpenVINOSharedCore::GetInstance()->getCore();
   std::string device = OpenVINOSharedCore::GetInstance()->GetDevice();
   ov::element::Type ov_element_type =
       litert::openvino::MapLiteTypeToOV(tensor_type.element_type);
@@ -48,7 +45,7 @@ litert::Expected<void> OpenVinoTensorBuffer::Alloc(
   ov::Shape ov_shape{ov_shape_vec.begin(), ov_shape_vec.end()};
 
   if (device == "NPU" || device == "GPU") {
-    auto context = core->get_default_context(device);
+    auto context = OpenVINOSharedCore::GetInstance()->GetRemoteContext();
     ov_tensor_ = context.create_host_tensor(ov_element_type, ov_shape);
   } else if (device == "CPU") {
     ov_tensor_ = ov::Tensor(ov_element_type, ov_shape);

--- a/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.h
+++ b/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.h
@@ -28,7 +28,7 @@ class OpenVinoTensorBuffer {
   OpenVinoTensorBuffer(OpenVinoTensorBuffer&&) = default;
   OpenVinoTensorBuffer& operator=(OpenVinoTensorBuffer&&) = default;
 
-  OpenVinoTensorBuffer() : host_tensor_(), allocated_(false) {};
+  OpenVinoTensorBuffer() : ov_tensor_(), allocated_(false) {};
   ~OpenVinoTensorBuffer() = default;
 
   litert::Expected<void> Alloc(const LiteRtRankedTensorType& tensor_type,
@@ -39,7 +39,7 @@ class OpenVinoTensorBuffer {
   litert::Expected<ov::Tensor> GetOVTensor();
 
  private:
-  ov::Tensor host_tensor_;
+  ov::Tensor ov_tensor_;
   bool allocated_;
 };
 

--- a/litert/vendors/intel_openvino/intel_openvino_options_example.cc
+++ b/litert/vendors/intel_openvino/intel_openvino_options_example.cc
@@ -30,7 +30,7 @@ void example_intel_openvino_options_usage() {
   }
   auto options = std::move(options_result.Value());
 
-  // Configure device type (NPU, CPU, GPU, AUTO)
+  // Configure device type (NPU, CPU, GPU)
   options.SetDeviceType(kLiteRtIntelOpenVinoDeviceTypeNPU);
 
   // Configure performance mode


### PR DESCRIPTION
Extend Intel OpenVINO integration to support CPU execution.

- Implement seekoff and seekpos in CustomOStreamBuf, required by the CPU path.
- Use device-specific tensor allocation: 
  - NPU/GPU: create_host_tensor 
  - CPU: ov::Tensor
- Remove AUTO device and require explicit device targets (NPU, GPU, or CPU), because tensor allocation depends on the selected device type.
- Cache the remote context in OpenVINOSharedCore to prevent redundant creation.

Test:
bazel-bin\litert\tools\run_model.exe --print_tensors --compare_numerical --accelerator=npu --compiler_plugin_library_dir=%PLUGIN_DIR% --dispatch_library_dir=%PLUGIN_DIR% --graph=model.tflite --intel_openvino_device_type=cpu