### PR TITLE
[Intel OV] Python npu compiler fix

### DIFF
--- a/ci/check_openvino_version_sync.py
+++ b/ci/check_openvino_version_sync.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Fail CI when OpenVINO versions drift between setup.py and openvino.bzl.
+
+The Intel OV compiler plugin and dispatch library are built against the
+OpenVINO SDK pinned in third_party/intel_openvino/openvino.bzl. The NPU
+compiler shared library is fetched by ci/tools/python/vendor_sdk/intel/setup.py
+at pip install time. Both must pin the same OpenVINO build.
+"""
+
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+BZL = REPO_ROOT / "third_party/intel_openvino/openvino.bzl"
+SETUP = REPO_ROOT / "ci/tools/python/vendor_sdk/intel/setup.py"
+
+# OpenVINO build identifier: "<year>.<minor>.<patch>.<build>.<hash>", e.g.
+# "2026.1.0.21367.63e31528c62". The trailing commit hash is 7-40 hex chars.
+# The surrounding context in openvino.bzl URLs ("..._x86_64.tgz") is not a
+# word boundary for Python's \b, so we match a 5-component dotted identifier
+# ending with the hash and rely on the preceding "/" or "_" being non-alnum.
+_BUILD_RE = re.compile(r"\d{4}\.\d+\.\d+\.\d+\.[0-9a-f]{7,40}")
+_SETUP_BUILD_RE = re.compile(r"_OV_BUILD\s*=\s*'([^']+)'")
+
+
+def main() -> int:
+  bzl_builds = set(_BUILD_RE.findall(BZL.read_text()))
+  m = _SETUP_BUILD_RE.search(SETUP.read_text())
+  if not m:
+    print(f"ERROR: could not find _OV_BUILD in {SETUP}", file=sys.stderr)
+    return 1
+  setup_build = m.group(1)
+
+  if len(bzl_builds) != 1:
+    print(
+        f"ERROR: {BZL} references multiple OpenVINO builds: {sorted(bzl_builds)}",
+        file=sys.stderr,
+    )
+    return 1
+  bzl_build = next(iter(bzl_builds))
+
+  if setup_build != bzl_build:
+    print(
+        "ERROR: OpenVINO build pin drift:\n"
+        f"  {BZL}: {bzl_build}\n"
+        f"  {SETUP}: {setup_build}\n"
+        "Both must pin the same OpenVINO release.",
+        file=sys.stderr,
+    )
+    return 1
+
+  print(f"OK: OpenVINO build {bzl_build} matches in both files.")
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/ci/tools/python/vendor_sdk/intel/MANIFEST.in
+++ b/ci/tools/python/vendor_sdk/intel/MANIFEST.in
@@ -1,1 +1,2 @@
+graft ai_edge_litert_sdk_intel/data
 include ai_edge_litert_sdk_intel/__init__.py

--- a/ci/tools/python/vendor_sdk/intel/ai_edge_litert_sdk_intel/__init__.py
+++ b/ci/tools/python/vendor_sdk/intel/ai_edge_litert_sdk_intel/__init__.py
@@ -13,6 +13,49 @@
 # limitations under the License.
 # ==============================================================================
 
-"""Intel OpenVINO SDK for AI Edge LiteRT."""
+"""Intel OpenVINO SDK for AI Edge LiteRT.
+
+Ships `libopenvino_intel_npu_compiler.{so,dll}` fetched from the OpenVINO
+toolkit archive at install time (see setup.py). Level Zero loader, NPU
+firmware, and the NPU UMD (intel-level-zero-npu / intel-fw-npu /
+intel-driver-compiler-npu) remain a user-installed prerequisite.
+"""
+
+import os
+import pathlib
+import sys
+from typing import Optional
 
 __version__ = "{{ PACKAGE_VERSION }}"
+
+_SDK_FILES_SUBDIR = "data"
+
+
+def get_sdk_path() -> Optional[pathlib.Path]:
+  """Returns the absolute path to the downloaded SDK data directory, or None.
+
+  Returns None when the directory does not exist (e.g. when the archive
+  download was skipped at install time).
+  """
+  sdk_path = pathlib.Path(__file__).parent.resolve() / _SDK_FILES_SUBDIR
+  if sdk_path.is_dir():
+    return sdk_path
+  return None
+
+
+def path_to_sdk_libs() -> Optional[pathlib.Path]:
+  """Returns the directory callers should prepend to LD_LIBRARY_PATH / PATH."""
+  return get_sdk_path()
+
+
+# On Windows, register the data dir with the process DLL search path so that
+# in-process consumers (e.g. the LiteRT dispatch DLL loading the NPU compiler)
+# can resolve openvino_intel_npu_compiler.dll without the caller manually
+# tweaking PATH. No-op on other platforms.
+if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
+  _sdk_path = get_sdk_path()
+  if _sdk_path is not None:
+    try:
+      os.add_dll_directory(str(_sdk_path))
+    except OSError:
+      pass

--- a/ci/tools/python/vendor_sdk/intel/ai_edge_litert_sdk_intel/__init__.py
+++ b/ci/tools/python/vendor_sdk/intel/ai_edge_litert_sdk_intel/__init__.py
@@ -23,12 +23,19 @@ intel-driver-compiler-npu) remain a user-installed prerequisite.
 
 import os
 import pathlib
+import shutil
 import sys
 from typing import Optional
 
 __version__ = "{{ PACKAGE_VERSION }}"
 
 _SDK_FILES_SUBDIR = "data"
+
+_COMPILER_LIB_NAME = (
+    "openvino_intel_npu_compiler.dll"
+    if sys.platform == "win32"
+    else "libopenvino_intel_npu_compiler.so"
+)
 
 
 def get_sdk_path() -> Optional[pathlib.Path]:
@@ -48,6 +55,50 @@ def path_to_sdk_libs() -> Optional[pathlib.Path]:
   return get_sdk_path()
 
 
+def _openvino_libs_dir() -> Optional[pathlib.Path]:
+  """Returns `<site-packages>/openvino/libs/` when the openvino pip package is
+  installed, or None."""
+  try:
+    import openvino  # pylint: disable=g-import-not-at-top
+  except ImportError:
+    return None
+  libs_dir = pathlib.Path(openvino.__file__).parent / "libs"
+  return libs_dir if libs_dir.is_dir() else None
+
+
+def _ensure_compiler_in_openvino_libs() -> None:
+  """Copies libopenvino_intel_npu_compiler.{so,dll} into openvino/libs/.
+
+  OpenVINO's NPU plugin looks for the VCL compiler next to libopenvino.so
+  (i.e. `<site-packages>/openvino/libs/`) when a non-default SOC target
+  triggers the external compiler load path (e.g. SOC_MODEL=LNL sets
+  NPU_PLATFORM=NPU4000, which invokes the VCL adapter).
+
+  The SDK sdist downloads the compiler to its own `data/` dir during pip
+  install; this copies it to openvino/libs/ on first import so it's picked
+  up without env vars or manual symlinks. Best-effort: if the copy fails
+  (permissions, readonly FS, already present), leave it alone.
+  """
+  sdk_data = get_sdk_path()
+  if sdk_data is None:
+    return
+  src = sdk_data / _COMPILER_LIB_NAME
+  if not src.is_file():
+    return
+  libs_dir = _openvino_libs_dir()
+  if libs_dir is None:
+    return
+  dst = libs_dir / _COMPILER_LIB_NAME
+  if dst.is_file() and dst.stat().st_size == src.stat().st_size:
+    return  # already in place
+  try:
+    shutil.copyfile(src, dst)
+  except OSError:
+    # Non-fatal: NPU AOT for non-default SOC targets will fail, but default
+    # SOC and JIT paths still work without this copy.
+    pass
+
+
 # On Windows, register the data dir with the process DLL search path so that
 # in-process consumers (e.g. the LiteRT dispatch DLL loading the NPU compiler)
 # can resolve openvino_intel_npu_compiler.dll without the caller manually
@@ -59,3 +110,5 @@ if sys.platform == "win32" and hasattr(os, "add_dll_directory"):
       os.add_dll_directory(str(_sdk_path))
     except OSError:
       pass
+
+_ensure_compiler_in_openvino_libs()

--- a/ci/tools/python/vendor_sdk/intel/setup.py
+++ b/ci/tools/python/vendor_sdk/intel/setup.py
@@ -12,17 +12,284 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""LiteRT is for mobile and embedded devices.
+"""Intel OpenVINO SDK for AI Edge LiteRT.
 
-LiteRT is the official solution for running machine learning models on mobile
-and embedded devices. It enables on-device machine learning inference with low
-latency and a small binary size on Android, iOS, and other operating systems.
+This setup.py fetches `libopenvino_intel_npu_compiler.{so,dll}` from the
+OpenVINO toolkit archives at install time. The public `openvino` pip wheel
+ships the NPU plugin but not this compiler library, so AOT compile for
+Intel NPU fails without it. Level Zero loader, NPU firmware and UMD
+(intel-level-zero-npu, intel-fw-npu, intel-driver-compiler-npu) remain a
+user-installed prerequisite.
 """
 
+import os
+import platform
+import sys
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+
 import setuptools
+from setuptools.command.build_py import build_py as _build_py  # pylint: disable=g-importing-member
 
 PACKAGE_NAME = '{{ PACKAGE_NAME }}'
 PACKAGE_VERSION = '{{ PACKAGE_VERSION }}'
+
+SKIP_SDK_DOWNLOAD = os.environ.get('SKIP_SDK_DOWNLOAD', '').strip().lower() in (
+    '1',
+    'true',
+    'yes',
+)
+
+IS_LINUX = sys.platform == 'linux'
+IS_WINDOWS = sys.platform == 'win32'
+IS_X86_ARCHITECTURE = platform.machine() in ('x86_64', 'AMD64', 'i386', 'i686')
+
+# --- Configuration for OpenVINO NPU Compiler Download ---
+#
+# Must match the OpenVINO build pinned in third_party/intel_openvino/
+# openvino.bzl. That workspace file pins the OpenVINO SDK used to compile the
+# Intel OV compiler plugin and dispatch library at build time; this file pins
+# the OpenVINO release that provides the NPU compiler shared library fetched
+# at pip install time. Drift between the two causes runtime compiler/plugin
+# ABI mismatches. ci/check_openvino_version_sync.py enforces this.
+# LINT.IfChange(wheel_openvino_sdk_version)
+_OV_BUILD = '2026.1.0.21367.63e31528c62'
+_OV_BASE_URL = (
+    'https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.1'
+)
+# LINT.ThenChange(
+#   ../../../../../third_party/intel_openvino/openvino.bzl:openvino_packages,
+# )
+
+# Archive -> in-archive member is always <archive_prefix>/<member_suffix>, where
+# archive_prefix is the archive filename minus the extension.
+_ARCHIVES = {
+    'ubuntu22': {
+        'url': f'{_OV_BASE_URL}/linux/openvino_toolkit_ubuntu22_{_OV_BUILD}_x86_64.tgz',
+        'member_suffix': 'runtime/lib/intel64/libopenvino_intel_npu_compiler.so',
+        'output_name': 'libopenvino_intel_npu_compiler.so',
+    },
+    'ubuntu24': {
+        'url': f'{_OV_BASE_URL}/linux/openvino_toolkit_ubuntu24_{_OV_BUILD}_x86_64.tgz',
+        'member_suffix': 'runtime/lib/intel64/libopenvino_intel_npu_compiler.so',
+        'output_name': 'libopenvino_intel_npu_compiler.so',
+    },
+    'windows': {
+        'url': f'{_OV_BASE_URL}/windows/openvino_toolkit_windows_{_OV_BUILD}_x86_64.zip',
+        'member_suffix': 'runtime/bin/intel64/Release/openvino_intel_npu_compiler.dll',
+        'output_name': 'openvino_intel_npu_compiler.dll',
+    },
+}
+
+_TARGET_DIR = 'ai_edge_litert_sdk_intel/data'
+
+
+def _parse_os_release() -> tuple[str, str]:
+  """Returns (ID, VERSION_ID) from /etc/os-release, or ('', '')."""
+  path = '/etc/os-release'
+  if not os.path.isfile(path):
+    return '', ''
+  data = {}
+  try:
+    with open(path, 'rt', encoding='utf-8') as f:
+      for line in f:
+        if '=' not in line:
+          continue
+        key, _, value = line.strip().partition('=')
+        data[key] = value.strip().strip('"').strip("'")
+  except OSError:
+    return '', ''
+  return data.get('ID', ''), data.get('VERSION_ID', '')
+
+
+def _select_archive_key() -> str | None:
+  """Returns the _ARCHIVES key to use, or None to skip."""
+  override = os.environ.get('LITERT_OV_OS_ID', '').strip().lower()
+  if override:
+    if override in _ARCHIVES:
+      print(f'Using LITERT_OV_OS_ID override: {override}')
+      return override
+    print(
+        f'WARNING: LITERT_OV_OS_ID={override!r} is not a known archive key;'
+        f' ignoring. Known keys: {sorted(_ARCHIVES)}',
+        file=sys.stderr,
+    )
+
+  if IS_WINDOWS and IS_X86_ARCHITECTURE:
+    return 'windows'
+
+  if not (IS_LINUX and IS_X86_ARCHITECTURE):
+    print(
+        'IGNORED: Intel NPU AOT is only supported on Linux x86_64 (Ubuntu'
+        ' 22/24) and Windows x86_64.'
+    )
+    return None
+
+  os_id, version_id = _parse_os_release()
+  if os_id == 'ubuntu':
+    if version_id.startswith('22.'):
+      return 'ubuntu22'
+    if version_id.startswith(('24.', '25.')):
+      return 'ubuntu24'
+    if version_id.startswith('20.'):
+      print(
+          'WARNING: Ubuntu 20.04 detected. Falling back to the ubuntu22'
+          ' archive; the NPU compiler may fail to load if the host glibc is'
+          ' too old.',
+          file=sys.stderr,
+      )
+      return 'ubuntu22'
+  if os_id == 'debian' and version_id.startswith('12'):
+    print('Debian 12 detected; using ubuntu22 archive.')
+    return 'ubuntu22'
+
+  print(
+      f'IGNORED: Unsupported Linux distribution (ID={os_id!r},'
+      f' VERSION_ID={version_id!r}). Only Ubuntu 22/24 x86_64 is supported.'
+      ' Set LITERT_OV_OS_ID=ubuntu22 or ubuntu24 to force a selection.'
+  )
+  return None
+
+
+def _member_target_path(
+    normalized_path: str,
+    member_suffix: str,
+    output_name: str,
+    target_dir: str,
+) -> str | None:
+  """Returns the absolute output path for the one member we want, or None."""
+  if not normalized_path.replace(os.sep, '/').endswith(member_suffix):
+    return None
+  candidate = os.path.normpath(os.path.join(target_dir, output_name))
+  if os.path.isabs(output_name) or output_name.startswith('..'):
+    return None
+  return candidate
+
+
+def _extract_tar(
+    archive_path: str,
+    member_suffix: str,
+    output_name: str,
+    target_dir: str,
+) -> bool:
+  with tarfile.open(archive_path, 'r:gz') as tar:
+    for member in tar.getmembers():
+      if not member.isfile():
+        continue
+      normalized_path = os.path.normpath(member.name)
+      if normalized_path.startswith('..') or os.path.isabs(normalized_path):
+        continue
+      out_path = _member_target_path(
+          normalized_path, member_suffix, output_name, target_dir
+      )
+      if out_path is None:
+        continue
+      os.makedirs(os.path.dirname(out_path), exist_ok=True)
+      source = tar.extractfile(member)
+      if source is None:
+        continue
+      with source, open(out_path, 'wb') as target:
+        target.write(source.read())
+      print(f'Extracted {member.name} -> {out_path}')
+      return True
+  return False
+
+
+def _extract_zip(
+    archive_path: str,
+    member_suffix: str,
+    output_name: str,
+    target_dir: str,
+) -> bool:
+  with zipfile.ZipFile(archive_path, 'r') as zipf:
+    for info in zipf.infolist():
+      if info.is_dir():
+        continue
+      normalized_path = os.path.normpath(info.filename)
+      if normalized_path.startswith('..') or os.path.isabs(normalized_path):
+        continue
+      out_path = _member_target_path(
+          normalized_path, member_suffix, output_name, target_dir
+      )
+      if out_path is None:
+        continue
+      os.makedirs(os.path.dirname(out_path), exist_ok=True)
+      with zipf.open(info) as source, open(out_path, 'wb') as target:
+        target.write(source.read())
+      print(f'Extracted {info.filename} -> {out_path}')
+      return True
+  return False
+
+
+def _download_and_extract_compiler(target_dir: str) -> None:
+  """Downloads an OpenVINO archive and extracts just the NPU compiler lib."""
+  archive_key = _select_archive_key()
+  if archive_key is None:
+    return
+
+  spec = _ARCHIVES[archive_key]
+  url = spec['url']
+  member_suffix = spec['member_suffix']
+  output_name = spec['output_name']
+
+  os.makedirs(target_dir, exist_ok=True)
+
+  with tempfile.TemporaryDirectory() as tmpdir:
+    archive_path = os.path.join(tmpdir, os.path.basename(url))
+    print(f'Downloading OpenVINO archive from {url}...')
+    try:
+      urllib.request.urlretrieve(url, archive_path)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      print(f'ERROR: Failed to download archive: {e}', file=sys.stderr)
+      print(
+          'Install will continue without the NPU compiler; Intel NPU AOT'
+          ' compile will not work until it is provided.',
+          file=sys.stderr,
+      )
+      return
+
+    print(f'Extracting {output_name}...')
+    try:
+      if url.endswith('.zip'):
+        found = _extract_zip(
+            archive_path, member_suffix, output_name, target_dir
+        )
+      elif url.endswith('.tgz') or url.endswith('.tar.gz'):
+        found = _extract_tar(
+            archive_path, member_suffix, output_name, target_dir
+        )
+      else:
+        print(f'ERROR: Unsupported archive type for URL: {url}', file=sys.stderr)
+        return
+    except (tarfile.TarError, zipfile.BadZipFile) as e:
+      print(f'ERROR: Failed to extract archive: {e}', file=sys.stderr)
+      return
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      print(
+          f'ERROR: Unexpected error during archive extraction: {e}',
+          file=sys.stderr,
+      )
+      return
+
+    if not found:
+      print(
+          f'ERROR: Member ending in {member_suffix!r} not found in archive.',
+          file=sys.stderr,
+      )
+
+
+class CustomBuildPy(_build_py):
+  """Runs the NPU compiler download as part of build_py."""
+
+  def run(self):
+    print('Preparing Intel OpenVINO SDK...')
+    if SKIP_SDK_DOWNLOAD:
+      print('SKIP_SDK_DOWNLOAD set; skipping NPU compiler download.')
+    else:
+      _download_and_extract_compiler(_TARGET_DIR)
+    super().run()
 
 
 setuptools.setup(
@@ -36,6 +303,7 @@ setuptools.setup(
     author_email='packages@tensorflow.org',
     license='Apache 2.0',
     include_package_data=True,
+    has_ext_modules=lambda: True,
     keywords='litert tflite tensorflow tensor machine learning',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -62,5 +330,8 @@ setuptools.setup(
     install_requires=[
         'openvino==2026.1.0',
     ],
+    cmdclass={
+        'build_py': CustomBuildPy,
+    },
     zip_safe=False,
 )

--- a/ci/tools/python/wheel/utils/wheel_builder.py
+++ b/ci/tools/python/wheel/utils/wheel_builder.py
@@ -215,6 +215,15 @@ else:
     if _os.path.isfile(_litert_so):
         import ctypes as _ctypes
         _ctypes.CDLL(_litert_so, mode=_os.RTLD_LAZY | _ctypes.RTLD_GLOBAL)
+    # Import vendor SDKs so their __init__.py runs (which on Linux copies
+    # bundled libraries like libopenvino_intel_npu_compiler.so into their
+    # expected locations under openvino/libs/). Silent on ImportError since
+    # the SDK packages are optional extras.
+    for _sdk_mod in ("ai_edge_litert_sdk_intel",):
+        try:
+            __import__(_sdk_mod)
+        except ImportError:
+            pass
 """
 
 

--- a/ci/tools/python/wheel/utils/wheel_builder.py
+++ b/ci/tools/python/wheel/utils/wheel_builder.py
@@ -161,16 +161,54 @@ import os as _os
 import sys as _sys
 
 if _sys.platform == "win32" and hasattr(_os, "add_dll_directory"):
+    # Collect DLL dirs and register them two ways:
+    #   1) os.add_dll_directory  -> honored by LoadLibraryExA(LOAD_LIBRARY_*).
+    #   2) prepend to PATH       -> honored by plain LoadLibraryA.
+    # Both are needed because LiteRT's C++ shared-library loader falls back to
+    # LoadLibraryA when LoadLibraryExA rejects the flag combination used with
+    # absolute paths; that fallback only consults PATH, not add_dll_directory.
+    _dll_dirs = []
     _pkg_dir = _os.path.dirname(_os.path.abspath(__file__))
     if _os.path.isdir(_pkg_dir):
-        _os.add_dll_directory(_pkg_dir)
+        _dll_dirs.append(_pkg_dir)
     try:
         import openvino as _ov
         _ov_libs = _os.path.join(_os.path.dirname(_ov.__file__), "libs")
         if _os.path.isdir(_ov_libs):
-            _os.add_dll_directory(_ov_libs)
+            _dll_dirs.append(_ov_libs)
     except ImportError:
         pass
+    # Register vendor SDK data dirs so in-process dispatch DLLs can resolve
+    # vendor-shipped dependencies (e.g. openvino_intel_npu_compiler.dll).
+    # The SDK packages also self-register on import; this loop covers the
+    # case where the user imports ai_edge_litert before the SDK.
+    for _sdk_mod in ("ai_edge_litert_sdk_intel",):
+        try:
+            _sdk = __import__(_sdk_mod)
+        except ImportError:
+            continue
+        try:
+            _sdk_dir = _sdk.path_to_sdk_libs()
+        except AttributeError:
+            continue
+        if _sdk_dir and _os.path.isdir(str(_sdk_dir)):
+            _dll_dirs.append(str(_sdk_dir))
+    _seen = set()
+    for _d in _dll_dirs:
+        if _d in _seen:
+            continue
+        _seen.add(_d)
+        try:
+            _os.add_dll_directory(_d)
+        except OSError:
+            pass
+    if _dll_dirs:
+        _cur_path = _os.environ.get("PATH", "")
+        _path_parts = _cur_path.split(_os.pathsep) if _cur_path else []
+        _path_lower = {p.lower() for p in _path_parts}
+        _new_prefix = [d for d in _dll_dirs if d.lower() not in _path_lower]
+        if _new_prefix:
+            _os.environ["PATH"] = _os.pathsep.join(_new_prefix + _path_parts)
 else:
     _pkg_dir = _os.path.dirname(_os.path.abspath(__file__))
     _litert_so = _os.path.join(_pkg_dir, "libLiteRt.so")
@@ -240,6 +278,56 @@ def _postprocess_macos_binaries(package_dir: str) -> None:
     for name in files:
       if name.endswith((".dylib", ".so")):
         _dedupe_macos_rpaths(os.path.join(root, name))
+
+
+# Add an RPATH hint to the Intel OpenVINO compiler plugin and dispatch library
+# so they can locate their OpenVINO runtime deps (libopenvino.so.* and the
+# device plugins libopenvino_intel_npu_plugin.so etc.) via the pip-installed
+# `openvino` package at `<site-packages>/openvino/libs/`.
+#
+# Without this, the plugin's dlopen fails on machines that don't have a
+# system-wide OpenVINO installation: the bundled plugin .so has no RPATH and
+# ld.so falls back to LD_LIBRARY_PATH / /etc/ld.so.cache, which don't know
+# about the venv's openvino/libs/.
+#
+# Scoped to intel_openvino only — other vendors ship their own SDK bundles
+# (Qualcomm QNN, MediaTek Neuron, etc.) and should not inherit an Intel path.
+_INTEL_OV_WHEEL_RPATH = "$ORIGIN/../../../../openvino/libs"
+
+
+def _postprocess_linux_binaries(package_dir: str) -> None:
+  if sys.platform != "linux":
+    return
+  # package_dir is already <tree>/ai_edge_litert (see prepare_build_tree:
+  # src_dir = os.path.join(tree_path, project_name.replace("-", "_"))).
+  intel_ov_dir = os.path.join(package_dir, "vendors", "intel_openvino")
+  if not os.path.isdir(intel_ov_dir):
+    return
+  if not shutil.which("patchelf"):
+    print(
+        "warning: patchelf not found; skipping Intel OpenVINO RPATH injection."
+        " libLiteRtCompilerPlugin_IntelOpenvino.so will fail to locate"
+        " libopenvino.so at runtime unless LD_LIBRARY_PATH is set manually.",
+        file=sys.stderr,
+    )
+    return
+  for root, _, files in os.walk(intel_ov_dir):
+    for name in files:
+      if not name.endswith(".so"):
+        continue
+      path = os.path.join(root, name)
+      try:
+        subprocess.run(
+            ["patchelf", "--set-rpath", _INTEL_OV_WHEEL_RPATH, path],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+      except subprocess.CalledProcessError as e:
+        print(
+            f"warning: patchelf failed on {path}: {e.stderr}",
+            file=sys.stderr,
+        )
 
 
 def prepare_build_tree(tree_path, args, project_name: str):
@@ -323,6 +411,7 @@ def prepare_build_tree(tree_path, args, project_name: str):
       os.makedirs(os.path.dirname(dest), exist_ok=True)
       shutil.copyfile(src, dest)
   _postprocess_macos_binaries(src_dir)
+  _postprocess_linux_binaries(src_dir)
 
 
 def build_pyproject_wheel(

--- a/docker_build/hermetic_build.Dockerfile
+++ b/docker_build/hermetic_build.Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update && apt-get install -y \
     clang-18 \
     libc++-dev \
     libc++abi-dev \
+    patchelf \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/litert/python/aot/vendors/intel_openvino/intel_openvino_backend.py
+++ b/litert/python/aot/vendors/intel_openvino/intel_openvino_backend.py
@@ -177,6 +177,21 @@ def _apply_plugin(
     lib_dir = os.path.dirname(plugin_path)
 
     sdk_libs_path = _get_openvino_libs_path()
+    try:
+      # pytype: disable=import-error
+      import ai_edge_litert_sdk_intel  # pylint: disable=g-import-not-at-top
+      # pytype: enable=import-error
+
+      intel_sdk_libs = ai_edge_litert_sdk_intel.path_to_sdk_libs()
+      if intel_sdk_libs:
+        sdk_libs_path = (
+            f"{intel_sdk_libs}{os.pathsep}{sdk_libs_path}"
+            if sdk_libs_path
+            else str(intel_sdk_libs)
+        )
+    except ImportError:
+      pass
+
     extra_kwargs = {
         "libs": lib_dir,
         "sdk_libs_path": sdk_libs_path,

--- a/litert/python/litert_wrapper/environment_wrapper/environment.py
+++ b/litert/python/litert_wrapper/environment_wrapper/environment.py
@@ -15,7 +15,9 @@
 """Python wrapper for LiteRT environments."""
 
 import dataclasses
+import glob
 import os
+import sys
 from typing import Optional, Union
 
 # pylint: disable=g-import-not-at-top
@@ -28,6 +30,88 @@ if not os.path.splitext(__file__)[0].endswith(
 else:
   from ai_edge_litert import _pywrap_litert_environment_wrapper as _env
 # pylint: enable=g-import-not-at-top
+
+
+def _vendors_dir() -> str:
+  """Returns `<ai_edge_litert>/vendors`, or "" when the package is missing."""
+  try:
+    import ai_edge_litert  # pytype: disable=import-error  # pylint: disable=g-import-not-at-top
+  except ImportError:
+    return ""
+  path = os.path.join(
+      os.path.dirname(os.path.abspath(ai_edge_litert.__file__)), "vendors"
+  )
+  return path if os.path.isdir(path) else ""
+
+
+def _vendor_subdir_if_has_lib(
+    vendor: str, subdir: str, win_glob: str, nix_glob: str
+) -> str:
+  """Returns `<vendors>/<vendor>/<subdir>/` iff it has a matching library."""
+  base = _vendors_dir()
+  if not base:
+    return ""
+  lib_glob = win_glob if sys.platform == "win32" else nix_glob
+  path = os.path.join(base, vendor, subdir)
+  if os.path.isdir(path) and glob.glob(os.path.join(path, lib_glob)):
+    return path
+  return ""
+
+
+def _find_first_vendor_with_library(
+    subdir: str, win_glob: str, nix_glob: str
+) -> str:
+  """Returns the vendor name of the first `<vendors>/<vendor>/<subdir>/` dir
+  that contains a matching library, or "" when none is found."""
+  base = _vendors_dir()
+  if not base:
+    return ""
+  try:
+    entries = sorted(os.listdir(base))
+  except OSError:
+    return ""
+  for entry in entries:
+    if _vendor_subdir_if_has_lib(entry, subdir, win_glob, nix_glob):
+      return entry
+  return ""
+
+
+def _autodiscover_dispatch_library_path() -> str:
+  """Returns a vendor dispatch directory under the installed ai_edge_litert."""
+  vendor = _find_first_vendor_with_library(
+      "dispatch", "LiteRtDispatch*.dll", "libLiteRtDispatch_*.so"
+  )
+  if not vendor:
+    return ""
+  return _vendor_subdir_if_has_lib(
+      vendor, "dispatch", "LiteRtDispatch*.dll", "libLiteRtDispatch_*.so"
+  )
+
+
+def _autodiscover_compiler_plugin_path(preferred_vendor: str = "") -> str:
+  """Returns a vendor compiler-plugin directory under the installed
+  ai_edge_litert.
+
+  When `preferred_vendor` is set, prefer that vendor's compiler plugin so the
+  compiler and dispatch libraries come from the same vendor. Falls back to the
+  first vendor with a compiler plugin otherwise.
+  """
+  compiler_win = "LiteRtCompilerPlugin*.dll"
+  compiler_nix = "libLiteRtCompilerPlugin_*.so"
+  if preferred_vendor:
+    path = _vendor_subdir_if_has_lib(
+        preferred_vendor, "compiler", compiler_win, compiler_nix
+    )
+    if path:
+      return path
+  vendor = _find_first_vendor_with_library(
+      "compiler", compiler_win, compiler_nix
+  )
+  if not vendor:
+    return ""
+  return _vendor_subdir_if_has_lib(
+      vendor, "compiler", compiler_win, compiler_nix
+  )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -67,9 +151,16 @@ class Environment:
       runtime_path: Optional path to the LiteRT runtime library directory. This
         shortcut is mutually exclusive with options.
       compiler_plugin_path: Optional path to compiler plugin libraries. This
-        shortcut is mutually exclusive with options.
+        shortcut is mutually exclusive with options. When omitted or empty,
+        auto-discovers a vendor compiler-plugin directory under the installed
+        `ai_edge_litert` package (the first `vendors/<vendor>/compiler/` dir
+        that contains a compiler-plugin shared library). Needed for JIT
+        compilation of raw .tflite models.
       dispatch_library_path: Optional path to dispatch libraries. This shortcut
-        is mutually exclusive with options.
+        is mutually exclusive with options. When omitted or empty, auto-
+        discovers a vendor dispatch directory under the installed
+        `ai_edge_litert` package (the first `vendors/<vendor>/dispatch/` dir
+        that contains a dispatch shared library).
 
     Returns:
       A new Environment instance.
@@ -92,6 +183,32 @@ class Environment:
           compiler_plugin_path=compiler_plugin_path,
           dispatch_library_path=dispatch_library_path,
       )
+
+    # Auto-discover a vendor dispatch directory when the caller did not set
+    # one, so NPU accelerator registration succeeds out of the box.
+    if not options.dispatch_library_path:
+      discovered = _autodiscover_dispatch_library_path()
+      if discovered:
+        options = dataclasses.replace(options, dispatch_library_path=discovered)
+
+    # Auto-discover the compiler-plugin directory too, so JIT compilation
+    # for raw .tflite models works out of the box. Without this, dispatch
+    # loads and silently returns a non-partitioned model that the TFLite
+    # fallback interpreter runs on CPU while the benchmark still reports
+    # "Fully accelerated: True". Pair the compiler plugin with whichever
+    # vendor's dispatch library was selected, so mixed wheels (e.g.
+    # google_tensor + intel_openvino) do not cross-wire an Intel compile
+    # into a google_tensor dispatch path.
+    if not options.compiler_plugin_path:
+      preferred_vendor = ""
+      if options.dispatch_library_path:
+        # dispatch path looks like <vendors>/<vendor>/dispatch/ — extract
+        # <vendor>.
+        parent = os.path.dirname(options.dispatch_library_path.rstrip(os.sep))
+        preferred_vendor = os.path.basename(parent)
+      discovered = _autodiscover_compiler_plugin_path(preferred_vendor)
+      if discovered:
+        options = dataclasses.replace(options, compiler_plugin_path=discovered)
 
     # Determine the final runtime path to be used.
     final_runtime_path = (

--- a/litert/python/tools/benchmark_litert_model.py
+++ b/litert/python/tools/benchmark_litert_model.py
@@ -230,7 +230,7 @@ def create_environment(args, environment, environment_options):
       dispatch_path = os.path.dirname(dispatch_path)
     kwargs['dispatch_library_path'] = dispatch_path
 
-  return environment.create(environment_options(**kwargs))
+  return environment.create(options=environment_options(**kwargs))
 
 
 def create_model_options(args, options, cpu_options, hardware_accel):

--- a/litert/vendors/intel_openvino/README.md
+++ b/litert/vendors/intel_openvino/README.md
@@ -17,22 +17,8 @@ limitations under the License. -->
 This directory contains the Intel OpenVINO integration for LiteRT, providing
 compiler plugin and dispatch API support for Intel NPU hardware.
 
-## Table of Contents
-
--   [Supported Platforms](#supported-platforms)
--   [Prerequisites](#prerequisites)
--   [Quick Start](#quick-start)
--   [Verifying NPU Execution](#verifying-npu-execution)
--   [AOT Compilation](#aot-compilation)
--   [Building the Python Wheel from Source](#building-the-python-wheel-from-source)
--   [Running Unit Tests](#running-unit-tests)
--   [Troubleshooting](#troubleshooting)
--   [Component Versions](#component-versions)
--   [Architecture](#architecture)
-
-**Validated on:** - Linux: Intel Panther Lake (PTL, NPU5010), Ubuntu 24.04,
-OpenVINO 2026.1.0, NPU driver v1.32.0. - Windows: Intel Core Ultra Series 2/3,
-Windows 11, OpenVINO 2026.1.0, NPU driver 32.0.100.4724.
+Validated on: Linux (PTL, Ubuntu 24.04, OpenVINO 2026.1.0, NPU driver v1.32.1)
+and Windows 11 (Core Ultra 2/3, NPU driver 32.0.100.4724).
 
 ## Supported Platforms
 
@@ -43,72 +29,93 @@ Intel Core Ultra Series 3 | NPU5010 | Panther Lake (PTL) | Linux, Windows
 
 ## Prerequisites
 
-Requirement | Linux                               | Windows
------------ | ----------------------------------- | -------
-OS          | Ubuntu 24.04 LTS (x86_64)           | Windows 10/11 (x86_64)
-Python      | 3.10, 3.11, 3.12, or 3.13           | 3.11 only
-OpenVINO    | `pip install openvino==2026.1.0`    | `pip install openvino==2026.1.0`
-NPU driver  | v1.32.0 (system package via `dpkg`) | 32.0.100.4724+ ([download](https://www.intel.com/content/www/us/en/download/794734/intel-npu-driver-windows.html))
+Requirement | Linux                              | Windows
+----------- | ---------------------------------- | -------
+OS          | Ubuntu 22.04 or 24.04 LTS (x86_64) | Windows 10/11 (x86_64)
+Python      | 3.10 – 3.13                        | 3.11 only
+NPU driver  | v1.32.1 — see [Linux NPU Setup](#linux-npu-setup) | 32.0.100.4724+ — see [Windows NPU Setup](#windows-npu-setup)
 
-For building from source you also need one of: - Bazel 7.4.1+ (install via
-[Bazelisk](https://github.com/bazelbuild/bazelisk)) - Docker (for hermetic
-builds)
+### When is the NPU driver required?
+
+| Task                                                | Needs NPU driver installed? |
+| --------------------------------------------------- | --------------------------- |
+| AOT compile a `.tflite` for Intel NPU               | **No.** Cross-compilation works — e.g. compile on Linux, run the resulting `.tflite` on Windows. |
+| Run inference on an Intel NPU (Python or C++ API, JIT or AOT-compiled model) | **Yes.** The dispatch library talks to the hardware via the Level Zero loader shipped in the NPU driver package. |
+
+> **In short:** the NPU driver is needed only on machines that **execute** the
+> model on NPU hardware. Pure AOT-build machines can skip it.
+
+> **Note:** `openvino==2026.1.0` is installed transitively by
+> `ai-edge-litert-sdk-intel-nightly`. The Intel SDK nightly also fetches the
+> NPU compiler shared library (`libopenvino_intel_npu_compiler.so` / `.dll`)
+> into its `data/` dir at `pip install` time — without it, AOT fails with
+> `Device with "NPU" name is not registered`. To override Linux distro
+> detection, set `LITERT_OV_OS_ID=ubuntu22` or `ubuntu24` before
+> `pip install`.
+
+For building from source: Bazel 7.4.1+ via
+[Bazelisk](https://github.com/bazelbuild/bazelisk) or Docker.
 
 ## Quick Start
 
 ### 1. Install NPU Drivers
 
-Set up your Intel NPU device first: - **Linux:** See
-[Linux Device Setup](#setting-up-an-intel-npu-device-on-linux) -
-**Windows:** See
-[Windows Device Setup](#setting-up-an-intel-npu-device-on-windows)
+See [Linux NPU Setup](#linux-npu-setup) or [Windows NPU Setup](#windows-npu-setup).
+Skip if you only need AOT.
 
 ### 2. Install the pip Package
 
 ```bash
-# Single command: installs wheel + Intel OpenVINO SDK (which pulls in openvino)
-pip install ai-edge-litert[npu-intel]
-
-# Or install separately:
-pip install ai-edge-litert
-pip install ai-edge-litert-sdk-intel
+pip install ai-edge-litert-nightly ai-edge-litert-sdk-intel-nightly
 ```
-
-The `ai-edge-litert` wheel bundles both shared libraries:
-
-Library          | Linux                                      | Windows
----------------- | ------------------------------------------ | -------
-Compiler plugin  | `libLiteRtCompilerPlugin_IntelOpenvino.so` | `LiteRtCompilerPlugin.dll`
-Dispatch library | `libLiteRtDispatch_IntelOpenvino.so`       | `LiteRtDispatch.dll`
-
-The `[npu-intel]` extra installs `ai-edge-litert-sdk-intel`, which depends on
-`openvino==2026.1.0`. If OpenVINO is already installed, pip skips it
-automatically.
-
-> **Windows DLL discovery:** `import ai_edge_litert` automatically registers the
-> required DLL directories via `os.add_dll_directory()`. Python scripts work out
-> of the box without PATH setup. See [Windows Troubleshooting](#windows) if
-> you encounter DLL errors from non-Python contexts.
 
 ### 3. Verify Installation
 
 ```bash
-# Check Intel backend loads
 python3 -c "
 from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend
-print('Backend ID:', intel_openvino_backend.IntelOpenVinoBackend.id())
-print('Dispatch dir:', intel_openvino_backend.get_dispatch_dir())
+import ai_edge_litert_sdk_intel, openvino, os
+print('Backend:', intel_openvino_backend.IntelOpenVinoBackend.id())
+print('Dispatch:', intel_openvino_backend.get_dispatch_dir())
+print('OpenVINO:', openvino.__version__)
+print('SDK libs:', sorted(os.listdir(ai_edge_litert_sdk_intel.path_to_sdk_libs())))
 "
-
-# Check OpenVINO runtime
-python3 -c "import openvino; print('OpenVINO:', openvino.__version__)"
 ```
 
-Expected output: `Backend ID: intel_openvino Dispatch dir:
-/path/to/site-packages/ai_edge_litert/vendors/intel_openvino/dispatch OpenVINO:
-2026.1.0-...`
+> **Note:** `SDK libs` must list `libopenvino_intel_npu_compiler.so` (Linux)
+> or `openvino_intel_npu_compiler.dll` (Windows).
 
-### 4. Run NPU Inference
+### 4. AOT Compile (Optional)
+
+- Pre-compiles a `.tflite` for a specific Intel NPU target (PTL or LNL) so
+  the runtime skips the compiler plugin step.
+- Does **not** need a physical NPU or the NPU driver — only
+  `ai-edge-litert-nightly` and `ai-edge-litert-sdk-intel-nightly`.
+- Cross-compilation is supported: compile on any Linux or Windows host, ship
+  the resulting `.tflite` to a target of either OS and run it there.
+
+Output files are named `<model>_IntelOpenVINO_<SoC>_apply_plugin.tflite`.
+
+```python
+from ai_edge_litert.aot import aot_compile
+from ai_edge_litert.aot.vendors.intel_openvino import target as intel_target
+
+# Compile for a single Intel NPU target (PTL or LNL).
+aot_compile.aot_compile(
+    "model.tflite",
+    output_dir="out",
+    target=intel_target.Target(soc_model=intel_target.SocModel.PTL),
+)
+
+# Or omit target= to compile for every registered backend/target.
+aot_compile.aot_compile("model.tflite", output_dir="out", keep_going=True)
+```
+
+Pass the AOT-compiled `.tflite` to the inference snippet below — no extra
+wiring needed. `Environment.create()` auto-discovers the dispatch library
+under the installed `ai_edge_litert` package.
+
+### 5. Run NPU Inference
 
 ```python
 from ai_edge_litert.compiled_model import CompiledModel
@@ -127,418 +134,127 @@ model.run_by_index(sig_idx, input_buffers, output_buffers)
 print("Fully accelerated:", model.is_fully_accelerated())
 ```
 
-### 5. Benchmark
+### 6. Benchmark
 
 ```bash
-# Find dispatch library path
-DISPATCH_DIR=$(python3 -c "
-from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend
-print(intel_openvino_backend.get_dispatch_dir())
-")
-
-# NPU benchmark
-litert-benchmark --model=model.tflite --use_npu \
-    --dispatch_library_path=$DISPATCH_DIR --num_runs=50
-
-# CPU benchmark (for comparison)
-litert-benchmark --model=model.tflite --num_runs=50 --num_threads=4
-
-# NPU only, fail if model can't be fully accelerated
-litert-benchmark --model=model.tflite --use_npu \
-    --dispatch_library_path=$DISPATCH_DIR --require_full_delegation
-
-# Save results as JSON
-litert-benchmark --model=model.tflite --use_npu \
-    --dispatch_library_path=$DISPATCH_DIR --result_json=results.json
+# Dispatch library and the NPU compiler are auto-discovered from the wheel.
+litert-benchmark --model=model.tflite --use_npu --num_runs=50
 ```
 
-You can also run the benchmark tool as a Python module:
+Common flags:
 
-```bash
-python3 -m ai_edge_litert.tools.benchmark_litert_model \
-    --model=model.tflite --use_npu --dispatch_library_path=$DISPATCH_DIR
-```
+| Flag                          | Default | Description |
+| ----------------------------- | ------- | ----------- |
+| `--model PATH`                | —       | Path to the `.tflite` model (required). |
+| `--signature KEY`             | first   | Signature key to run. |
+| `--use_cpu` / `--no_cpu`      | on      | Toggle the CPU accelerator / CPU fallback. |
+| `--use_gpu`                   | off     | Enable the GPU accelerator. |
+| `--use_npu`                   | off     | Enable the Intel NPU accelerator. |
+| `--require_full_delegation`   | off     | Fail if the model is not fully offloaded to the selected accelerator. |
+| `--num_runs N`                | 50      | Number of timed inference iterations. |
+| `--warmup_runs N`             | 5       | Untimed warm-up iterations before measurement. |
+| `--num_threads N`             | 1       | CPU thread count. |
+| `--result_json PATH`          | —       | Write a JSON summary (latency stats, throughput, accelerator list). |
+| `--verbose`                   | off     | Extra runtime logging. |
+
+Advanced / override flags — only needed to point at custom builds:
+`--dispatch_library_path`, `--compiler_plugin_path`, `--runtime_path`.
 
 --------------------------------------------------------------------------------
 
 ## Verifying NPU Execution
 
-After running inference, check the runtime log to confirm the model is executing
-on the NPU via OpenVINO rather than falling back to CPU.
+To confirm the model actually ran on the NPU, check for **both** signals:
 
-### Key Log Indicators
+1. The log contains `Loading shared library:
+   .../libLiteRtDispatch_IntelOpenvino.so` — the Intel dispatch library was
+   loaded.
+2. `model.is_fully_accelerated()` returns `True` — every op was offloaded to
+   the selected accelerator.
 
-| Log line                                | Meaning                            |
-| --------------------------------------- | ---------------------------------- |
-| `NPU accelerator registered.`           | Dispatch library found; NPU        |
-:                                         : accelerator loaded.                :
-| `Loading shared library:                | OpenVINO dispatch loaded at model  |
-: .../libLiteRtDispatch_IntelOpenvino.so` : compilation time.                  :
-| `[Openvino]Found device plugin for:     | OpenVINO runtime initialized (CPU  |
-: CPU`                                    : plugin always reported; NPU plugin :
-:                                         : loads internally).                 :
-| `Fully accelerated: True`               | All model ops dispatched to the    |
-:                                         : accelerator.                       :
-
-### NPU Execution (Success)
-
-```
-INFO: [auto_registration.cc:171] NPU accelerator registered.
-INFO: [litert_dispatch.cc:145] Loading shared library: .../libLiteRtDispatch_IntelOpenvino.so
-INFO: [dispatch_api.cc:115] [Openvino]Found device plugin for: CPU
-INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
-Fully accelerated: True
-```
-
-### CPU-Only Execution (No NPU)
-
-When NPU is not available or the dispatch path is not set, only the XNNPACK
-delegate appears — no dispatch library loading:
-
-```
-INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
-Fully accelerated: True
-```
-
-`Fully accelerated: True` with CPU-only means all ops ran on XNNPACK. The key
-difference is the **absence** of `Loading shared library:
-.../libLiteRtDispatch_IntelOpenvino.so`.
-
-### Programmatic Check
-
-```python
-model = CompiledModel.from_file("model.tflite", ...)
-print("Fully accelerated:", model.is_fully_accelerated())
-```
-
-### Known Harmless Warning
-
-```
-WARNING: NPU accelerator could not be loaded and registered: kLiteRtStatusErrorInvalidArgument.
-```
-
-This warning appears in two scenarios and **does not affect inference**:
-
-1.  **During `Environment.create()` without a dispatch path** —
-    Auto-registration tries to register NPU but no dispatch directory was
-    provided. When using the dispatch path is provided explicitly, NPU registers
-    on the first attempt and this warning only appears on an internal
-    environment created by the runtime.
-2.  **During the first `model.run()` call** — The LiteRT runtime lazily creates
-    an internal environment that does not inherit the dispatch path. This is
-    upstream runtime behavior; the NPU dispatch was already initialized from the
-    user's environment.
-
-If you see `Loading shared library: .../libLiteRtDispatch_IntelOpenvino.so` and
-`Fully accelerated: True`, the model is running on NPU correctly.
+`is_fully_accelerated()` alone is **not** sufficient: if the dispatch library
+never loaded, ops were fully offloaded to XNNPACK/CPU, not the NPU.
 
 --------------------------------------------------------------------------------
 
-## AOT Compilation
+## Linux NPU Setup
 
-AOT (ahead-of-time) compilation pre-compiles a `.tflite` model for a specific
-Intel NPU target (PTL or LNL). The resulting model loads faster at runtime
-because the compiler plugin step is already done.
+> **Note:** Skip this section if you only need AOT — a physical NPU isn't
+> required.
 
-#### End-to-End Example
-
-```python
-from ai_edge_litert.aot import aot_compile
-
-# Compile for all supported Intel targets (LNL + PTL)
-results = aot_compile.aot_compile(
-    "model.tflite",
-    output_dir="compiled_output",
-    keep_going=True,  # don't stop on first failure (e.g. missing MediaTek SDK)
-)
-
-# Compile for a specific target only
-results = aot_compile.aot_compile(
-    "model.tflite",
-    output_dir="compiled_output",
-    target_models=["PTL"],
-    keep_going=True,
-)
-```
-
-Output files are named `<model>_IntelOpenVINO_<SoC>_apply_plugin.tflite`, e.g.
-`000_IntelOpenVINO_PTL_apply_plugin.tflite`.
-
-#### Running AOT-Compiled Models
-
-AOT-compiled models still require the dispatch library at runtime but skip the
-compiler plugin step:
-
-```python
-from ai_edge_litert.compiled_model import CompiledModel
-from ai_edge_litert.hardware_accelerator import HardwareAccelerator
-from ai_edge_litert.environment import Environment
-from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend as ov
-
-env = Environment.create(
-    dispatch_library_path=ov.get_dispatch_dir(),
-)
-model = CompiledModel.from_file(
-    "compiled_output/000_IntelOpenVINO_PTL_apply_plugin.tflite",
-    hardware_accel=HardwareAccelerator.NPU | HardwareAccelerator.CPU,
-    environment=env,
-)
-# model.run(input_buffers) ...
-```
-
---------------------------------------------------------------------------------
-
-## Setting Up an Intel NPU Device on Linux
-
-Follow these steps on your target Intel NPU machine (Panther Lake or Lunar Lake)
-running Ubuntu 24.04.
-
-ℹ️ ***NOTE:*** If you want to do only AOT you can skip this section, as npu
-driver are not required for AOT compilation
-
-### Step 1: Install NPU Drivers
-
-<!--* pragma: { seclinter_this_is_fine: true } *-->
+> **Info:** Use NPU driver **[v1.32.1](https://github.com/intel/linux-npu-driver/releases/tag/v1.32.1)**
+> (paired with OpenVINO 2026.1). Older drivers fail with
+> `Level0 pfnCreate2 result: ZE_RESULT_ERROR_UNSUPPORTED_FEATURE`.
 
 ```bash
-# Remove old packages (if any)
+# 1. NPU driver (Ubuntu 24.04 — use -ubuntu2204 tarball for 22.04).
 sudo dpkg --purge --force-remove-reinstreq \
-  intel-driver-compiler-npu intel-fw-npu intel-level-zero-npu intel-level-zero-npu-dbgsym
-
-# Download and extract NPU driver v1.32.0
-wget https://github.com/intel/linux-npu-driver/releases/download/v1.32.0/linux-npu-driver-v1.32.0.20260402-23905121947-ubuntu2404.tar.gz
-tar -xf linux-npu-driver-v1.32.0.20260402-23905121947-ubuntu2404.tar.gz
-
-# Install dependency
+  intel-driver-compiler-npu intel-fw-npu intel-level-zero-npu intel-level-zero-npu-dbgsym || true
+wget https://github.com/intel/linux-npu-driver/releases/download/v1.32.1/linux-npu-driver-v1.32.1.20260422-24767473183-ubuntu2404.tar.gz
+tar -xf linux-npu-driver-v1.32.1.*.tar.gz
 sudo apt update && sudo apt install -y libtbb12
+sudo dpkg -i intel-fw-npu_*.deb intel-level-zero-npu_*.deb intel-driver-compiler-npu_*.deb
 
-# Install all driver packages
-sudo dpkg -i *.deb
-```
-
-### Step 2: Install Level Zero Loader
-
-```bash
+# 2. Level Zero loader v1.27.0.
 wget https://snapshot.ppa.launchpadcontent.net/kobuk-team/intel-graphics/ubuntu/20260324T100000Z/pool/main/l/level-zero-loader/libze1_1.27.0-1~24.04~ppa2_amd64.deb
 sudo dpkg -i libze1_*.deb
+
+# 3. Permissions + verify.
+sudo gpasswd -a ${USER} render && newgrp render
+ls /dev/accel/accel0   # must exist after reboot
 ```
 
-If you encounter conflicts with existing Level Zero packages:
-
-```bash
-sudo dpkg --purge --force-remove-reinstreq level-zero level-zero-devel
-sudo dpkg -i libze1_*.deb
-```
-
-**Option B: APT repository**
-
-```bash
-wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
-  sudo gpg --dearmor -o /usr/share/keyrings/intel-openvino.gpg
-echo "deb [signed-by=/usr/share/keyrings/intel-openvino.gpg] https://apt.repos.intel.com/openvino/2026 ubuntu24 main" | \
-  sudo tee /etc/apt/sources.list.d/intel-openvino.list
-sudo apt update && sudo apt install openvino
-```
-
-### Step 4: Configure User Permissions
-
-```bash
-sudo gpasswd -a ${USER} render
-newgrp render
-```
-
-### Step 5: Verify NPU Device
-
-```bash
-# Check NPU device exists
-ls /dev/accel/accel0
-
-# Check driver loaded
-sudo dmesg | grep -i vpu
-```
-
-After a reboot, you should see `/dev/accel/accel0` if the NPU driver is loaded
-correctly.
-
-### Step 6: Install and Test
-
-```bash
-pip install ai-edge-litert[npu-intel]
-
-#or install the intel sdk nightly seperately
-pip install ai-edge-litert
-pip install ai-edge-litert-sdk-intel-nightly
-
-# Verify backend
-python3 -c "
-from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend
-print('Backend ID:', intel_openvino_backend.IntelOpenVinoBackend.id())
-print('Dispatch dir:', intel_openvino_backend.get_dispatch_dir())
-"
-```
+Then run the install + verify snippet from [Quick Start](#quick-start).
 
 --------------------------------------------------------------------------------
 
-## Setting Up an Intel NPU Device on Windows
+## Windows NPU Setup
 
-Follow these steps on a Windows machine with Intel NPU hardware (Panther Lake or
-Lunar Lake).
+> **Note:** Skip this section if you only need AOT — a physical NPU isn't
+> required.
 
-ℹ️ ***NOTE:*** If you want to do only AOT you can skip this section, as npu
-driver are not required for AOT compilation
+- Install the Intel NPU driver (**32.0.100.4724+**) from the
+  [Intel Download Center](https://www.intel.com/content/www/us/en/download/794734/intel-npu-driver-windows.html).
+- Verify Device Manager lists **Neural processors → Intel(R) AI Boost**.
+- Run the install + verify snippet from [Quick Start](#quick-start), replacing
+  `pip` with `python -m pip`.
 
-### Step 1: Install Intel NPU Driver
+> **Info:** `import ai_edge_litert` auto-registers DLL directories via
+> `os.add_dll_directory()`, so Python scripts need no `PATH` setup. For
+> non-Python consumers, run `setupvars.bat` or prepend `<openvino>/libs` to
+> `PATH`.
 
-Download and install the Intel NPU driver from:
-https://www.intel.com/content/www/us/en/download/794734/intel-npu-driver-windows.html
+--------------------------------------------------------------------------------
 
-Tested version: **32.0.100.4724**
+## Building from Source
 
-After installation, verify the NPU device appears in Device Manager under
-"Neural processors" -> "Intel(R) AI Boost".
+Linux (Docker, hermetic):
 
-### Step 2: Install and Verify
+```bash
+cd LiteRT/docker_build && ./build_wheel_with_docker.sh
+```
+
+Windows (PowerShell, Bazel in PATH):
 
 ```powershell
-python -m pip install ai-edge-litert[npu-intel]
-
-#or install intel nightly sdk seperately
-python -m pip install ai-edge-litert
-python -m pip install ai-edge-litert-sdk-intel-nightly
-
-# Verify backend
-python -c "from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend; print('Backend ID:', intel_openvino_backend.IntelOpenVinoBackend.id()); print('Dispatch dir:', intel_openvino_backend.get_dispatch_dir())"
-
-# Verify OpenVINO
-python -c "import openvino; print('OpenVINO:', openvino.__version__)"
+.\ci\build_pip_package_with_bazel_windows.ps1
 ```
 
-### Step 3: Run NPU Inference
+Outputs land in `dist/`:
 
-```python
-from ai_edge_litert.compiled_model import CompiledModel
-from ai_edge_litert.hardware_accelerator import HardwareAccelerator
-
-model = CompiledModel.from_file(
-    "model.tflite",
-    hardware_accel=HardwareAccelerator.NPU | HardwareAccelerator.CPU,
-)
-
-sig_key = list(model.get_signature_list().keys())[0]
-sig_idx = model.get_signature_index(sig_key)
-input_buffers = model.create_input_buffers(sig_idx)
-output_buffers = model.create_output_buffers(sig_idx)
-model.run_by_index(sig_idx, input_buffers, output_buffers)
-print("Fully accelerated:", model.is_fully_accelerated())
-```
+- `ai_edge_litert-*.whl` — the runtime wheel.
+- `ai_edge_litert_sdk_{intel,qualcomm,mediatek,samsung}-*.tar.gz` — vendor
+  sdists.
+- The Intel sdist is ~5 KB; the NPU compiler `.so`/`.dll` is fetched at
+  `pip install` time, so the same sdist works on Linux and Windows.
+- Behind a proxy? Export `http_proxy` / `https_proxy` / `no_proxy` — the
+  scripts forward them into Docker and the container.
 
 --------------------------------------------------------------------------------
 
-## Building the Python Wheel from Source
-
-### Option A: Docker Hermetic Build only for Linux (Recommended)
-
-No local Bazel or build tools required. The Docker image includes all
-dependencies (Bazel 7.4.1, Android SDK/NDK, Clang 18, Python).
+## Unit Tests
 
 ```bash
-cd LiteRT/docker_build
-./build_wheel_with_docker.sh
-```
-
-#### Proxy Configuration
-
-If you are behind a corporate proxy, export the standard proxy environment
-variables **before** running any Docker build script. The scripts automatically
-forward these into the Docker image build (`--build-arg`) and container runtime
-(`-e`). When unset or empty, the proxy code is a complete no-op.
-
-```bash
-export http_proxy="http://proxy.example.com:912"
-export https_proxy="http://proxy.example.com:912"
-export no_proxy="localhost,127.0.0.1,.example.com"
-
-cd LiteRT/docker_build
-./build_wheel_with_docker.sh
-```
-
-Outputs in `dist/`: - `ai_edge_litert-*.whl` (wheel with compiler plugin +
-dispatch library + benchmark tool) - `ai_edge_litert_sdk_qualcomm-*.tar.gz` -
-`ai_edge_litert_sdk_mediatek-*.tar.gz` - `ai_edge_litert_sdk_intel-*.tar.gz`
-
-Options: - `--use_existing_image` — skip `docker build`, reuse existing image -
-`--dbg` — build in debug mode - `--python=3.12` — set `HERMETIC_PYTHON_VERSION`
-
-#### Building Individual Intel OpenVINO Binaries with Docker
-
-```bash
-cd LiteRT/docker_build
-./build_with_docker.sh   # Build image first (only needed once)
-
-docker run --rm \
-  --security-opt seccomp=unconfined \
-  --user $(id -u):$(id -g) \
-  -e HOME=/litert_build \
-  -e USER=$(id -un) \
-  -e http_proxy="${http_proxy:-}" \
-  -e https_proxy="${https_proxy:-}" \
-  -e no_proxy="${no_proxy:-}" \
-  -v $(cd .. && pwd):/litert_build \
-  litert_build_env \
-  bash -c '
-source /setup_bazel_env.sh
-bazel ${EXTRA_STARTUP} build //litert/vendors/intel_openvino/compiler:libLiteRtCompilerPlugin_IntelOpenvino.so
-bazel ${EXTRA_STARTUP} build //litert/vendors/intel_openvino/dispatch:dispatch_api_so
-bazel ${EXTRA_STARTUP} build //litert/tools:benchmark_model
-'
-```
-
-### Option B: Manual Bazel Build (No Docker)
-
-Requires Bazel 7.4.1+ (via Bazelisk), Clang, and Python 3.10+.
-
-```bash
-cd LiteRT
-./configure
-
-bazel build -c opt \
-  --cxxopt=-std=gnu++17 \
-  --repo_env=USE_PYWRAP_RULES=True \
-  //ci/tools/python/wheel:litert_wheel
-
-mkdir -p dist/
-cp bazel-bin/ci/tools/python/wheel/dist/*.whl dist/
-```
-
-Verify Intel OpenVINO binaries are bundled: `bash unzip -l dist/*.whl | grep
-openvino`
-
-### Option C: CI Build Script
-
-```bash
-cd LiteRT
-./configure
-# for Linux
-bash ci/build_pip_package_with_bazel.sh
-# for Windows
-bash ci/build_pip_package_with_bazel_windows.ps1
-```
-
-### Building Individual Shared Libraries
-
-For Linux: `bash bazel build
-//litert/vendors/intel_openvino/compiler:libLiteRtCompilerPlugin_IntelOpenvino.so
-bazel build //litert/vendors/intel_openvino/dispatch:dispatch_api_so bazel build
-//litert/tools:benchmark_model`
-
---------------------------------------------------------------------------------
-
-## Running Unit Tests
-
-### Bazel Tests (Source Tree)
-
-```bash
-# All Intel OpenVINO tests
 bazel test \
   //litert/python/aot/vendors/intel_openvino:intel_openvino_backend_test \
   //litert/c/options:litert_intel_openvino_options_test \
@@ -546,106 +262,23 @@ bazel test \
   //litert/tools/flags/vendors:intel_openvino_flags_test
 ```
 
-Individual tests:
-
-Test                                                                     | Covers
------------------------------------------------------------------------- | ------
-`//litert/python/aot/vendors/intel_openvino:intel_openvino_backend_test` | AOT backend config, specialization, flags
-`//litert/c/options:litert_intel_openvino_options_test`                  | C API options
-`//litert/cc/options:litert_intel_openvino_options_test`                 | C++ API options
-`//litert/tools/flags/vendors:intel_openvino_flags_test`                 | CLI flags parsing
-
 --------------------------------------------------------------------------------
 
 ## Troubleshooting
 
-### Linux
-
-| Issue                               | Solution                               |
-| ----------------------------------- | -------------------------------------- |
-| `/dev/accel/accel0` not found       | Check NPU driver: `sudo dmesg \| grep  |
-:                                     : -i vpu`. Reboot after installing       :
-:                                     : drivers.                               :
-| Level Zero conflicts                | Purge old packages: `sudo dpkg --purge |
-:                                     : --force-remove-reinstreq level-zero    :
-:                                     : level-zero-devel`                      :
-| OpenVINO import errors              | Verify: `python3 -c "import openvino;  |
-:                                     : print(openvino.__version__)"`. Must be :
-:                                     : 2026.1+.                               :
-| Permission denied on NPU            | `sudo gpasswd -a ${USER} render &&     |
-:                                     : newgrp render`                         :
-| Compiler plugin not found in wheel  | `unzip -l dist/*.whl \| grep compiler` |
-| Dispatch library not found in wheel | `unzip -l dist/*.whl \| grep dispatch` |
-| `get_dispatch_dir()` returns `None` | Dispatch `.so` not bundled. Check      |
-:                                     : wheel contents or specify              :
-:                                     : `--dispatch_library_path` manually.    :
-| `directory iterator cannot open     | Pass a directory path (not file path)  |
-: directory`                          : to `dispatch_library_path`.            :
-
-### Windows
-
-Issue                                              | Solution
--------------------------------------------------- | --------
-NPU not found in Device Manager                    | Install NPU driver from [Intel Download Center](https://www.intel.com/content/www/us/en/download/794734/intel-npu-driver-windows.html). Reboot after installation.
-`ModuleNotFoundError: No module named 'openvino'`  | `pip install openvino==2026.1.0`
-NPU accelerator could not be loaded                | Verify driver version in Device Manager -> Neural processors -> Properties -> Driver. Must be 32.0.100.4724+.
-`Failed to initialize Dispatch API`                | OpenVINO or LiteRT DLLs not found. Ensure `import ai_edge_litert` runs before dispatch loads (auto-registers DLL dirs). If running outside Python, add OpenVINO libs to PATH: `$OvDir = python -c "import openvino, os; print(os.path.dirname(openvino.__file__))"` then `$env:PATH = "$OvDir\libs;$env:PATH"`.
-`.dll` not found errors                            | Same as above. For non-Python contexts, run `setupvars.bat` or set PATH manually.
-`get_dispatch_dir()` returns `None`                | Dispatch DLL not bundled. Check wheel contents or specify `--dispatch_library_path`. If running from the source tree, the fallback looks in the installed `ai_edge_litert` package.
-`LNK2001: fixed_address_empty_string` during build | Protobuf ABI mismatch. `ci/build_pip_package_with_bazel_windows.ps1` must patch `port.h` to force `GlobalEmptyStringDynamicInit` on MSVC. Do NOT add `PROTOBUF_USE_DLLS` to `.bazelrc.user`.
-`C2491: definition of dllimport` during build      | Remove `PROTOBUF_USE_DLLS` and `LIBPROTOBUF_EXPORTS` from `.bazelrc.user`.
-Python 3.12+ build fails on Windows                | Only Python 3.11 is supported (hardcoded in `.bazelrc` `build:windows`).
+Issue                                                    | Fix
+-------------------------------------------------------- | ---
+AOT fails: `Device with "NPU" name is not registered`    | NPU compiler not fetched. Check `ai_edge_litert_sdk_intel.path_to_sdk_libs()` lists `libopenvino_intel_npu_compiler.so` / `.dll`. If empty, reinstall with network access, or set `LITERT_OV_OS_ID=ubuntu22`/`ubuntu24`.
+`Level0 pfnCreate2 result: ZE_RESULT_ERROR_UNSUPPORTED_FEATURE` | Upgrade NPU driver to v1.32.1 (Linux).
+`/dev/accel/accel0` not found                            | `sudo dmesg \| grep -i vpu` to debug the driver; reboot after install.
+Permission denied on NPU                                 | `sudo gpasswd -a ${USER} render && newgrp render`.
+Windows: NPU not in Device Manager                       | Install NPU driver 32.0.100.4724+ from [Intel Download Center](https://www.intel.com/content/www/us/en/download/794734/intel-npu-driver-windows.html).
+Windows: `Failed to initialize Dispatch API` / missing DLLs | Ensure `import ai_edge_litert` runs first (auto-registers DLL dirs); for non-Python callers, run `setupvars.bat` or prepend `<openvino>/libs` to `PATH`.
+Windows build: `LNK2001 fixed_address_empty_string`, `C2491 dllimport`, `Python 3.12+ fails` | Protobuf ABI / Python version constraint — see `ci/build_pip_package_with_bazel_windows.ps1`; Windows builds require Python 3.11.
 
 --------------------------------------------------------------------------------
 
-## Known Limitations
+## Limitations
 
--   **Only NPU device is supported** through the OpenVINO dispatch path. CPU
-    inference is available through XNNPACK — use `HardwareAccelerator.CPU`
-    without `HardwareAccelerator.NPU` for CPU-only.
-
---------------------------------------------------------------------------------
-
-## Component Versions
-
-Component    | Linux                  | Windows
------------- | ---------------------- | ---------------------
-OpenVINO SDK | 2026.1.0               | 2026.1.0
-NPU Driver   | v1.32.0                | 32.0.100.4724
-Level Zero   | v1.27.0                | (bundled with driver)
-Python       | 3.10, 3.11, 3.12, 3.13 | 3.11 only
-OS           | Ubuntu 24.04 LTS       | Windows 10/11
-
-## Architecture
-
-The Intel OpenVINO integration consists of two components, both bundled in the
-`ai-edge-litert` pip wheel:
-
--   **Compiler Plugin** (`compiler/`): Partitions model ops and compiles
-    supported subgraphs into OpenVINO IR for NPU execution.
-
--   **Dispatch API** (`dispatch/`): Runtime counterpart that loads compiled
-    bytecode and executes it on the NPU via the Level Zero API.
-
-### Python Packaging Layout
-
-```
-ai-edge-litert (wheel)
-  ai_edge_litert/
-    __init__.py                                      # version + Windows DLL auto-discovery
-    vendors/intel_openvino/
-      compiler/
-        libLiteRtCompilerPlugin_IntelOpenvino.so     # compiler plugin
-      dispatch/
-        libLiteRtDispatch_IntelOpenvino.so            # dispatch library
-    aot/vendors/intel_openvino/
-      intel_openvino_backend.py                      # AOT backend + dispatch auto-discovery
-      target.py                                      # SoC target definitions (LNL, PTL)
-  extras_require:
-    npu-intel -> ai-edge-litert-sdk-intel~=0.2.0 -> openvino==2026.1.0
-```
-
-User-managed prerequisites (not in wheel): - `openvino==2026.1.0` (via `pip
-install`, `[npu-intel]` extra, or SDK package) - Intel NPU driver (system
-package, requires `sudo` / admin) - Level Zero loader v1.27.0 (Linux only,
-system package).
+Only the NPU device is supported through the OpenVINO dispatch path. For CPU
+inference, use `HardwareAccelerator.CPU` alone (XNNPACK).

--- a/litert/vendors/intel_openvino/README.md
+++ b/litert/vendors/intel_openvino/README.md
@@ -117,12 +117,24 @@ under the installed `ai_edge_litert` package.
 
 ### 5. Run NPU Inference
 
+LiteRT supports two inference paths on Intel NPU:
+
+- **JIT** — load a raw `.tflite`, the compiler plugin partitions and compiles
+  supported ops for the NPU at `CompiledModel.from_file()` time. No AOT step
+  needed; ~250 ms extra first-run latency for a typical model.
+- **AOT-compiled** — load a `<model>_IntelOpenVINO_<SoC>_apply_plugin.tflite`
+  produced by step 4. Skips the partition/compile step at load time.
+
+The snippet below works for both; `Environment.create()` auto-discovers the
+Intel OV compiler plugin (JIT only) and dispatch library from the installed
+wheel.
+
 ```python
 from ai_edge_litert.compiled_model import CompiledModel
 from ai_edge_litert.hardware_accelerator import HardwareAccelerator
 
 model = CompiledModel.from_file(
-    "model.tflite",
+    "model.tflite",  # raw tflite (JIT) or ..._apply_plugin.tflite (AOT)
     hardware_accel=HardwareAccelerator.NPU | HardwareAccelerator.CPU,
 )
 
@@ -133,6 +145,66 @@ output_buffers = model.create_output_buffers(sig_idx)
 model.run_by_index(sig_idx, input_buffers, output_buffers)
 print("Fully accelerated:", model.is_fully_accelerated())
 ```
+
+#### Mixed-vendor wheels: pinning JIT to Intel OV
+
+The pip wheel ships compiler plugins for every registered vendor
+(`intel_openvino/`, `google_tensor/`, `mediatek/`, `qualcomm/`, `samsung/`).
+Auto-discovery picks the compiler plugin from the same vendor as the
+selected dispatch library, and today only Intel OV ships a dispatch
+library, so `CompiledModel.from_file(hardware_accel=NPU)` ends up on the
+Intel OV path by default.
+
+If you want to be explicit — or if a future wheel bundles additional
+dispatch libraries and changes the auto-discovery pick — pass the Intel OV
+directories by hand:
+
+```python
+from ai_edge_litert.environment import Environment
+from ai_edge_litert.compiled_model import CompiledModel
+from ai_edge_litert.hardware_accelerator import HardwareAccelerator
+from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend as ov
+
+env = Environment.create(
+    compiler_plugin_path=ov.get_compiler_plugin_dir(),   # JIT compiler
+    dispatch_library_path=ov.get_dispatch_dir(),          # runtime
+)
+model = CompiledModel.from_file(
+    "model.tflite",
+    hardware_accel=HardwareAccelerator.NPU | HardwareAccelerator.CPU,
+    environment=env,
+)
+```
+
+The runtime loads every shared library it finds in the given directory, so
+pointing at `vendors/intel_openvino/compiler/` loads only the Intel plugin;
+the Google Tensor / MediaTek / Qualcomm / Samsung plugins in sibling
+directories are never touched.
+
+For the CLI, the equivalent flags are:
+
+```bash
+DISPATCH_DIR=$(python3 -c 'from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend as ov; print(ov.get_dispatch_dir())')
+COMPILER_DIR=$(python3 -c 'from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend as ov; print(ov.get_compiler_plugin_dir())')
+
+litert-benchmark --model=model.tflite --use_npu \
+    --compiler_plugin_path=$COMPILER_DIR \
+    --dispatch_library_path=$DISPATCH_DIR
+```
+
+#### Confirming JIT actually ran
+
+When JIT succeeds, the log contains:
+
+```
+INFO: [compiler_plugin.cc:236] Loaded plugin at: .../libLiteRtCompilerPlugin_IntelOpenvino.so
+INFO: [compiler_plugin.cc:690] Partitioned subgraph<0>, selected N ops, from a total of N ops
+INFO: [compiled_model.cc:1006] JIT compilation changed model, reserializing...
+```
+
+If those lines are absent but `Fully accelerated: True` is still reported,
+the model was run on XNNPACK CPU fallback, not on the NPU — see the JIT
+troubleshooting row below.
 
 ### 6. Benchmark
 
@@ -269,6 +341,8 @@ bazel test \
 Issue                                                    | Fix
 -------------------------------------------------------- | ---
 AOT fails: `Device with "NPU" name is not registered`    | NPU compiler not fetched. Check `ai_edge_litert_sdk_intel.path_to_sdk_libs()` lists `libopenvino_intel_npu_compiler.so` / `.dll`. If empty, reinstall with network access, or set `LITERT_OV_OS_ID=ubuntu22`/`ubuntu24`.
+JIT runs on CPU instead of NPU (no `Partitioned subgraph` log, no `Loaded plugin` log, `Fully accelerated: True` still printed) | Compiler plugin was not discovered. Confirm `ov.get_compiler_plugin_dir()` returns a path under `ai_edge_litert/vendors/intel_openvino/compiler/`. If multiple vendor SDKs are installed, pass `compiler_plugin_path=ov.get_compiler_plugin_dir()` explicitly to `Environment.create()` (or `--compiler_plugin_path=...` to `litert-benchmark`).
+JIT fails: `Cannot load library .../openvino/libs/libopenvino_intel_npu_compiler.so` | The SDK sdist copies the NPU compiler to `openvino/libs/` on first `import ai_edge_litert_sdk_intel`. If the copy was skipped (readonly FS, missing `openvino`), reinstall `ai-edge-litert-sdk-intel` after `openvino` is installed, then `import ai_edge_litert` in a fresh process.
 `Level0 pfnCreate2 result: ZE_RESULT_ERROR_UNSUPPORTED_FEATURE` | Upgrade NPU driver to v1.32.1 (Linux).
 `/dev/accel/accel0` not found                            | `sudo dmesg \| grep -i vpu` to debug the driver; reboot after install.
 Permission denied on NPU                                 | `sudo gpasswd -a ${USER} render && newgrp render`.

--- a/third_party/intel_openvino/openvino.bzl
+++ b/third_party/intel_openvino/openvino.bzl
@@ -22,6 +22,13 @@ def openvino_configure():
     # are downloaded. Bazel's select() picks the correct one at build time based on
     # target platform, enabling Android cross-compilation from Linux.
     # On Windows hosts, only the Windows SDK is downloaded.
+    #
+    # The OpenVINO build pinned here must match the build that
+    # ci/tools/python/vendor_sdk/intel/setup.py fetches at pip install time;
+    # otherwise the Intel OV compiler plugin (built against the version below)
+    # will be paired with a mismatched libopenvino_intel_npu_compiler at
+    # runtime.
+    # LINT.IfChange(openvino_packages)
     configurable_repo(
         name = "intel_openvino",
         build_file = "@//third_party/intel_openvino:openvino.bazel",
@@ -53,3 +60,6 @@ def openvino_configure():
             },
         ]),
     )
+    # LINT.ThenChange(
+    #   //ci/tools/python/vendor_sdk/intel/setup.py:wheel_openvino_sdk_version,
+    # )


### PR DESCRIPTION

*Bundle Intel NPU compiler in SDK sdist + auto‑discover dispatch path**

Fixes Intel NPU AOT compilation failures caused by the OpenVINO pip wheel missing
the NPU compiler library. The Intel SDK now downloads
`libopenvino_intel_npu_compiler.{so,dll}` at pip install time from the official
OpenVINO toolkit, keeping the sdist small and matching the Qualcomm SDK flow.

**Highlights**
- OS‑aware archive selection (ubuntu22 vs ubuntu24; Windows zip)
- Non‑fatal, skippable downloads for hermetic builds
- Automatic DLL resolution on Windows and correct library propagation to AOT
- Auto‑discovery of `dispatch_library_path` (explicit paths still win)
- CI guard enforcing OpenVINO version pin sync to prevent ABI drift

**Result**
Intel NPU AOT compile and `litert-benchmark --use_npu` work out of the box.