### PR TITLE
Python ov nightly

### DIFF
--- a/ci/check_openvino_version_sync.py
+++ b/ci/check_openvino_version_sync.py
@@ -16,8 +16,12 @@
 
 The Intel OV compiler plugin and dispatch library are built against the
 OpenVINO SDK pinned in third_party/intel_openvino/openvino.bzl. The NPU
-compiler shared library is fetched by ci/tools/python/vendor_sdk/intel/setup.py
-at pip install time. Both must pin the same OpenVINO build.
+compiler shared library and the `openvino` PyPI wheel pinned by
+install_requires are both wired up in ci/tools/python/vendor_sdk/intel/
+setup.py. All three must pin the same OpenVINO build; the build number
+(the numeric segment in `2026.2.0-21820-<commit>/`) is the unique
+identifier — it appears both in the toolkit archive directory and as the
+PyPI wheel filename's build tag.
 """
 
 import pathlib
@@ -28,23 +32,32 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 BZL = REPO_ROOT / "third_party/intel_openvino/openvino.bzl"
 SETUP = REPO_ROOT / "ci/tools/python/vendor_sdk/intel/setup.py"
 
-# OpenVINO build identifier: "<year>.<minor>.<patch>.<build>.<hash>", e.g.
-# "2026.1.0.21367.63e31528c62". The trailing commit hash is 7-40 hex chars.
-# The surrounding context in openvino.bzl URLs ("..._x86_64.tgz") is not a
-# word boundary for Python's \b, so we match a 5-component dotted identifier
-# ending with the hash and rely on the preceding "/" or "_" being non-alnum.
-_BUILD_RE = re.compile(r"\d{4}\.\d+\.\d+\.\d+\.[0-9a-f]{7,40}")
-_SETUP_BUILD_RE = re.compile(r"_OV_BUILD\s*=\s*'([^']+)'")
+# Nightly archive paths look like:
+#   .../packages/nightly/2026.2.0-21820-9a25caa5a15/openvino_toolkit_*.tgz
+# We extract the build number (21820) as the canonical sync key.
+_BZL_BUILD_RE = re.compile(
+    r"/nightly/\d{4}\.\d+\.\d+-(\d+)-[0-9a-f]{7,40}/"
+)
+_SETUP_BUILD_RE = re.compile(r"_OV_BUILD_NUMBER\s*=\s*'(\d+)'")
 
 
 def main() -> int:
-  bzl_builds = set(_BUILD_RE.findall(BZL.read_text()))
+  bzl_builds = set(_BZL_BUILD_RE.findall(BZL.read_text()))
   m = _SETUP_BUILD_RE.search(SETUP.read_text())
   if not m:
-    print(f"ERROR: could not find _OV_BUILD in {SETUP}", file=sys.stderr)
+    print(
+        f"ERROR: could not find _OV_BUILD_NUMBER in {SETUP}", file=sys.stderr
+    )
     return 1
   setup_build = m.group(1)
 
+  if not bzl_builds:
+    print(
+        f"ERROR: {BZL} contains no nightly OpenVINO URLs matching the"
+        " expected `/nightly/<version>-<build>-<commit>/` schema.",
+        file=sys.stderr,
+    )
+    return 1
   if len(bzl_builds) != 1:
     print(
         f"ERROR: {BZL} references multiple OpenVINO builds:"
@@ -56,10 +69,10 @@ def main() -> int:
 
   if setup_build != bzl_build:
     print(
-        "ERROR: OpenVINO build pin drift:\n"
+        "ERROR: OpenVINO build-number pin drift:\n"
         f"  {BZL}: {bzl_build}\n"
-        f"  {SETUP}: {setup_build}\n"
-        "Both must pin the same OpenVINO release.",
+        f"  {SETUP} _OV_BUILD_NUMBER: {setup_build}\n"
+        "Both must pin the same OpenVINO build.",
         file=sys.stderr,
     )
     return 1

--- a/ci/tools/python/vendor_sdk/intel/ai_edge_litert_sdk_intel/__init__.py
+++ b/ci/tools/python/vendor_sdk/intel/ai_edge_litert_sdk_intel/__init__.py
@@ -15,9 +15,12 @@
 
 """Intel OpenVINO SDK for AI Edge LiteRT.
 
-Ships `libopenvino_intel_npu_compiler.{so,dll}` fetched from the OpenVINO
-toolkit archive at install time (see setup.py). Level Zero loader, NPU
-firmware, and the NPU UMD (intel-level-zero-npu / intel-fw-npu /
+Ships the NPU compiler shared libraries fetched from the OpenVINO toolkit
+archive at install time (see setup.py). In OpenVINO 2026.2+ this is two
+files: the compiler (`libopenvino_intel_npu_compiler.{so,dll}`) and the VCL
+loader (`libopenvino_intel_npu_compiler_loader.{so,dll}`) that carries the
+entry points the NPU plugin dlopens. Level Zero loader, NPU firmware, and
+the NPU UMD (intel-level-zero-npu / intel-fw-npu /
 intel-driver-compiler-npu) remain a user-installed prerequisite.
 """
 
@@ -31,11 +34,16 @@ __version__ = "{{ PACKAGE_VERSION }}"
 
 _SDK_FILES_SUBDIR = "data"
 
-_COMPILER_LIB_NAME = (
-    "openvino_intel_npu_compiler.dll"
-    if sys.platform == "win32"
-    else "libopenvino_intel_npu_compiler.so"
-)
+if sys.platform == "win32":
+  _COMPILER_LIB_NAMES = (
+      "openvino_intel_npu_compiler.dll",
+      "openvino_intel_npu_compiler_loader.dll",
+  )
+else:
+  _COMPILER_LIB_NAMES = (
+      "libopenvino_intel_npu_compiler.so",
+      "libopenvino_intel_npu_compiler_loader.so",
+  )
 
 
 def get_sdk_path() -> Optional[pathlib.Path]:
@@ -70,36 +78,39 @@ def _openvino_libs_dir() -> Optional[pathlib.Path]:
 
 
 def _ensure_compiler_in_openvino_libs() -> None:
-  """Copies libopenvino_intel_npu_compiler.{so,dll} into openvino/libs/.
+  """Copies NPU compiler + VCL loader libs into openvino/libs/.
 
-  OpenVINO's NPU plugin looks for the VCL compiler next to libopenvino.so
-  (i.e. `<site-packages>/openvino/libs/`) when a non-default SOC target
-  triggers the external compiler load path (e.g. SOC_MODEL=LNL sets
-  NPU_PLATFORM=NPU4000, which invokes the VCL adapter).
+  OpenVINO's NPU plugin dlopens these next to libopenvino.so (i.e.
+  `<site-packages>/openvino/libs/`) when a non-default SOC target triggers
+  the external compiler load path (e.g. SOC_MODEL=LNL sets
+  NPU_PLATFORM=NPU4000, which invokes the VCL adapter). In 2026.2 the VCL
+  entry points (`vclGetVersion` etc.) live in the `_compiler_loader`
+  sibling, so both files need to be present.
 
-  The SDK sdist downloads the compiler to its own `data/` dir during pip
-  install; this copies it to openvino/libs/ on first import so it's picked
-  up without env vars or manual symlinks. Best-effort: if the copy fails
+  The SDK sdist downloads these to its own `data/` dir during pip install;
+  this copies them to openvino/libs/ on first import so they're picked up
+  without env vars or manual symlinks. Best-effort: if the copy fails
   (permissions, readonly FS, already present), leave it alone.
   """
   sdk_data = get_sdk_path()
   if sdk_data is None:
     return
-  src = sdk_data / _COMPILER_LIB_NAME
-  if not src.is_file():
-    return
   libs_dir = _openvino_libs_dir()
   if libs_dir is None:
     return
-  dst = libs_dir / _COMPILER_LIB_NAME
-  if dst.is_file() and dst.stat().st_size == src.stat().st_size:
-    return  # already in place
-  try:
-    shutil.copyfile(src, dst)
-  except OSError:
-    # Non-fatal: NPU AOT for non-default SOC targets will fail, but default
-    # SOC and JIT paths still work without this copy.
-    pass
+  for name in _COMPILER_LIB_NAMES:
+    src = sdk_data / name
+    if not src.is_file():
+      continue
+    dst = libs_dir / name
+    if dst.is_file() and dst.stat().st_size == src.stat().st_size:
+      continue  # already in place
+    try:
+      shutil.copyfile(src, dst)
+    except OSError:
+      # Non-fatal: NPU AOT for non-default SOC targets may fail, but default
+      # SOC and JIT paths still work without this copy.
+      pass
 
 
 # On Windows, register the data dir with the process DLL search path so that

--- a/ci/tools/python/vendor_sdk/intel/setup.py
+++ b/ci/tools/python/vendor_sdk/intel/setup.py
@@ -51,49 +51,118 @@ IS_X86_ARCHITECTURE = platform.machine() in ('x86_64', 'AMD64', 'i386', 'i686')
 # Must match the OpenVINO build pinned in third_party/intel_openvino/
 # openvino.bzl. That workspace file pins the OpenVINO SDK used to compile the
 # Intel OV compiler plugin and dispatch library at build time; this file pins
-# the OpenVINO release that provides the NPU compiler shared library fetched
-# at pip install time. Drift between the two causes runtime compiler/plugin
-# ABI mismatches. ci/check_openvino_version_sync.py enforces this.
+# the OpenVINO nightly archive that provides the NPU compiler shared library
+# fetched at pip install time, and the `openvino` PyPI wheel referenced by
+# install_requires below. All three must point at the same commit. OpenVINO's
+# build number (the numeric segment in `2026.2.0-21820-<commit>/`) uniquely
+# identifies a build: it appears both in the toolkit archive directory and as
+# the wheel filename's build tag (the `-21820-` between version and py-tag).
+# ci/check_openvino_version_sync.py enforces this across openvino.bzl and
+# this file.
 # LINT.IfChange(wheel_openvino_sdk_version)
-_OV_BUILD = '2026.1.0.21367.63e31528c62'
+_OV_BUILD_NUMBER = '21820'
+_OV_COMMIT = '9a25caa5a15'
+_OV_PEP440_VERSION = '2026.2.0.dev20260506'
+_OV_ARCHIVE_DIR = f'2026.2.0-{_OV_BUILD_NUMBER}-{_OV_COMMIT}'
 _OV_BASE_URL = (
-    'https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.1'
+    'https://storage.openvinotoolkit.org/repositories/openvino/packages/nightly'
+    f'/{_OV_ARCHIVE_DIR}'
+)
+# PyPI nightly wheel index used for install_requires direct URLs; lets a plain
+# `pip install ai-edge-litert-sdk-intel-nightly` pull the matching openvino
+# wheel without --extra-index-url.
+_OV_WHEEL_BASE_URL = (
+    'https://storage.openvinotoolkit.org/wheels/nightly/openvino'
 )
 # LINT.ThenChange(
 #   ../../../../../third_party/intel_openvino/openvino.bzl:openvino_packages,
 # )
 
-# Archive -> in-archive member is always <archive_prefix>/<member_suffix>, where
-# archive_prefix is the archive filename minus the extension.
-_ARCHIVES = {
-    'ubuntu22': {
-        'url': (
-            f'{_OV_BASE_URL}/linux/openvino_toolkit_ubuntu22_{_OV_BUILD}_x86_64.tgz'
-        ),
+# Archive -> list of members to extract. OpenVINO 2026.2 split the NPU VCL
+# adapter out of libopenvino_intel_npu_compiler.{so,dll}: the `_compiler_loader`
+# sibling carries the VCL entry points (vclGetVersion etc.) that the NPU plugin
+# dlopens, and `_compiler` now holds the actual compiler backend. Both files
+# must land in openvino/libs/ for AOT to succeed.
+_LINUX_MEMBERS = (
+    {
         'member_suffix': (
             'runtime/lib/intel64/libopenvino_intel_npu_compiler.so'
         ),
         'output_name': 'libopenvino_intel_npu_compiler.so',
     },
-    'ubuntu24': {
-        'url': (
-            f'{_OV_BASE_URL}/linux/openvino_toolkit_ubuntu24_{_OV_BUILD}_x86_64.tgz'
-        ),
+    {
         'member_suffix': (
-            'runtime/lib/intel64/libopenvino_intel_npu_compiler.so'
+            'runtime/lib/intel64/libopenvino_intel_npu_compiler_loader.so'
         ),
-        'output_name': 'libopenvino_intel_npu_compiler.so',
+        'output_name': 'libopenvino_intel_npu_compiler_loader.so',
     },
-    'windows': {
-        'url': (
-            f'{_OV_BASE_URL}/windows/openvino_toolkit_windows_{_OV_BUILD}_x86_64.zip'
-        ),
+)
+_WINDOWS_MEMBERS = (
+    {
         'member_suffix': (
             'runtime/bin/intel64/Release/openvino_intel_npu_compiler.dll'
         ),
         'output_name': 'openvino_intel_npu_compiler.dll',
     },
+    {
+        'member_suffix': (
+            'runtime/bin/intel64/Release/openvino_intel_npu_compiler_loader.dll'
+        ),
+        'output_name': 'openvino_intel_npu_compiler_loader.dll',
+    },
+)
+
+_ARCHIVES = {
+    'ubuntu22': {
+        'url': (
+            f'{_OV_BASE_URL}/openvino_toolkit_ubuntu22_{_OV_PEP440_VERSION}_x86_64.tgz'
+        ),
+        'members': _LINUX_MEMBERS,
+    },
+    'ubuntu24': {
+        'url': (
+            f'{_OV_BASE_URL}/openvino_toolkit_ubuntu24_{_OV_PEP440_VERSION}_x86_64.tgz'
+        ),
+        'members': _LINUX_MEMBERS,
+    },
+    'windows': {
+        'url': (
+            f'{_OV_BASE_URL}/openvino_toolkit_windows_{_OV_PEP440_VERSION}_x86_64.zip'
+        ),
+        'members': _WINDOWS_MEMBERS,
+    },
 }
+
+# Pin the `openvino` PyPI wheel to the exact nightly build that matches
+# _OV_ARCHIVE_DIR. One direct URL per supported (python, os); pip picks the
+# right one via the PEP 508 environment marker.
+# Wheel filename schema at _OV_WHEEL_BASE_URL:
+#   openvino-<pep440>-<build>-<py>-<abi>-<plat>.whl
+# Linux wheels use manylinux2014_x86_64, Windows uses win_amd64.
+_OV_WHEEL_TARGETS = (
+    # (py_tag, abi_tag, platform_tag, env_marker)
+    ('cp310', 'cp310', 'manylinux_2_28_x86_64',
+     'python_version == "3.10" and sys_platform == "linux" and platform_machine == "x86_64"'),
+    ('cp311', 'cp311', 'manylinux_2_28_x86_64',
+     'python_version == "3.11" and sys_platform == "linux" and platform_machine == "x86_64"'),
+    ('cp312', 'cp312', 'manylinux_2_28_x86_64',
+     'python_version == "3.12" and sys_platform == "linux" and platform_machine == "x86_64"'),
+    ('cp313', 'cp313', 'manylinux_2_28_x86_64',
+     'python_version == "3.13" and sys_platform == "linux" and platform_machine == "x86_64"'),
+    ('cp311', 'cp311', 'win_amd64',
+     'python_version == "3.11" and sys_platform == "win32"'),
+)
+
+
+def _openvino_install_requires():
+  reqs = []
+  for py_tag, abi_tag, plat_tag, marker in _OV_WHEEL_TARGETS:
+    wheel = (
+        f'openvino-{_OV_PEP440_VERSION}-{_OV_BUILD_NUMBER}'
+        f'-{py_tag}-{abi_tag}-{plat_tag}.whl'
+    )
+    reqs.append(f'openvino @ {_OV_WHEEL_BASE_URL}/{wheel} ; {marker}')
+  return reqs
 
 _TARGET_DIR = 'ai_edge_litert_sdk_intel/data'
 
@@ -182,93 +251,97 @@ def _member_target_path(
 
 def _extract_tar(
     archive_path: str,
-    member_suffix: str,
-    output_name: str,
+    members: tuple,
     target_dir: str,
-) -> bool:
-  """Extracts a specific file from a gzipped tar archive.
+) -> set:
+  """Extracts a set of files from a gzipped tar archive.
 
   Args:
     archive_path: The path to the .tgz archive.
-    member_suffix: The suffix of the path to the member file within the archive
-      that should be extracted.
-    output_name: The desired filename for the extracted file.
-    target_dir: The directory where the extracted file should be placed.
+    members: Tuple of {'member_suffix', 'output_name'} dicts to extract.
+    target_dir: The directory where extracted files should be placed.
 
   Returns:
-    True if the member was found and extracted, False otherwise.
+    Set of output_name values that were successfully extracted.
   """
+  found = set()
+  remaining = {spec['member_suffix']: spec for spec in members}
   with tarfile.open(archive_path, 'r:gz') as tar:
     for member in tar.getmembers():
-      if not member.isfile():
+      if not member.isfile() or not remaining:
         continue
       normalized_path = os.path.normpath(member.name)
       if normalized_path.startswith('..') or os.path.isabs(normalized_path):
         continue
-      out_path = _member_target_path(
-          normalized_path, member_suffix, output_name, target_dir
-      )
-      if out_path is None:
-        continue
-      os.makedirs(os.path.dirname(out_path), exist_ok=True)
-      source = tar.extractfile(member)
-      if source is None:
-        continue
-      with source, open(out_path, 'wb') as target:
-        target.write(source.read())
-      print(f'Extracted {member.name} -> {out_path}')
-      return True
-  return False
+      for suffix, spec in list(remaining.items()):
+        out_path = _member_target_path(
+            normalized_path, suffix, spec['output_name'], target_dir
+        )
+        if out_path is None:
+          continue
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        source = tar.extractfile(member)
+        if source is None:
+          break
+        with source, open(out_path, 'wb') as target:
+          target.write(source.read())
+        print(f'Extracted {member.name} -> {out_path}')
+        found.add(spec['output_name'])
+        remaining.pop(suffix)
+        break
+  return found
 
 
 def _extract_zip(
     archive_path: str,
-    member_suffix: str,
-    output_name: str,
+    members: tuple,
     target_dir: str,
-) -> bool:
-  """Extracts a specific file from a zip archive.
+) -> set:
+  """Extracts a set of files from a zip archive.
 
   Args:
     archive_path: The path to the .zip archive.
-    member_suffix: The suffix of the path to the member file within the archive
-      that should be extracted.
-    output_name: The desired filename for the extracted file.
-    target_dir: The directory where the extracted file should be placed.
+    members: Tuple of {'member_suffix', 'output_name'} dicts to extract.
+    target_dir: The directory where extracted files should be placed.
 
   Returns:
-    True if the member was found and extracted, False otherwise.
+    Set of output_name values that were successfully extracted.
   """
+  found = set()
+  remaining = {spec['member_suffix']: spec for spec in members}
   with zipfile.ZipFile(archive_path, 'r') as zipf:
     for info in zipf.infolist():
-      if info.is_dir():
+      if info.is_dir() or not remaining:
         continue
       normalized_path = os.path.normpath(info.filename)
       if normalized_path.startswith('..') or os.path.isabs(normalized_path):
         continue
-      out_path = _member_target_path(
-          normalized_path, member_suffix, output_name, target_dir
-      )
-      if out_path is None:
-        continue
-      os.makedirs(os.path.dirname(out_path), exist_ok=True)
-      with zipf.open(info) as source, open(out_path, 'wb') as target:
-        target.write(source.read())
-      print(f'Extracted {info.filename} -> {out_path}')
-      return True
-  return False
+      for suffix, spec in list(remaining.items()):
+        out_path = _member_target_path(
+            normalized_path, suffix, spec['output_name'], target_dir
+        )
+        if out_path is None:
+          continue
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        with zipf.open(info) as source, open(out_path, 'wb') as target:
+          target.write(source.read())
+        print(f'Extracted {info.filename} -> {out_path}')
+        found.add(spec['output_name'])
+        remaining.pop(suffix)
+        break
+  return found
 
 
 def _download_and_extract_compiler(target_dir: str) -> None:
-  """Downloads an OpenVINO archive and extracts just the NPU compiler lib."""
+  """Downloads an OpenVINO archive and extracts the NPU compiler libs."""
   archive_key = _select_archive_key()
   if archive_key is None:
     return
 
   spec = _ARCHIVES[archive_key]
   url = spec['url']
-  member_suffix = spec['member_suffix']
-  output_name = spec['output_name']
+  members = spec['members']
+  expected = {m['output_name'] for m in members}
 
   os.makedirs(target_dir, exist_ok=True)
 
@@ -286,16 +359,12 @@ def _download_and_extract_compiler(target_dir: str) -> None:
       )
       return
 
-    print(f'Extracting {output_name}...')
+    print(f'Extracting {sorted(expected)}...')
     try:
       if url.endswith('.zip'):
-        found = _extract_zip(
-            archive_path, member_suffix, output_name, target_dir
-        )
+        found = _extract_zip(archive_path, members, target_dir)
       elif url.endswith('.tgz') or url.endswith('.tar.gz'):
-        found = _extract_tar(
-            archive_path, member_suffix, output_name, target_dir
-        )
+        found = _extract_tar(archive_path, members, target_dir)
       else:
         print(
             f'ERROR: Unsupported archive type for URL: {url}', file=sys.stderr
@@ -311,9 +380,10 @@ def _download_and_extract_compiler(target_dir: str) -> None:
       )
       return
 
-    if not found:
+    missing = expected - found
+    if missing:
       print(
-          f'ERROR: Member ending in {member_suffix!r} not found in archive.',
+          f'ERROR: Expected archive members not found: {sorted(missing)}',
           file=sys.stderr,
       )
 
@@ -365,9 +435,7 @@ setuptools.setup(
     packages=['ai_edge_litert_sdk_intel'],
     package_dir={'ai_edge_litert_sdk_intel': 'ai_edge_litert_sdk_intel'},
     python_requires='>=3.10',
-    install_requires=[
-        'openvino==2026.1.0',
-    ],
+    install_requires=_openvino_install_requires(),
     cmdclass={
         'build_py': CustomBuildPy,
     },

--- a/litert/vendors/intel_openvino/README.md
+++ b/litert/vendors/intel_openvino/README.md
@@ -52,12 +52,21 @@ Intel Core Ultra Series 3 | NPU5010 | Panther Lake (PTL) | Linux, Windows
 > **In short:** the NPU driver is needed only on machines that **execute** the
 > model on NPU hardware. Pure AOT-build machines can skip it.
 
-> **Note:** `openvino==2026.1.0` is installed transitively by
-> `ai-edge-litert-sdk-intel-nightly`. The Intel SDK nightly also fetches the NPU
-> compiler shared library (`libopenvino_intel_npu_compiler.so` / `.dll`) into
-> its `data/` dir at `pip install` time — without it, AOT fails with `Device
-> with "NPU" name is not registered`. To override Linux distro detection, set
-> `LITERT_OV_OS_ID=ubuntu22` or `ubuntu24` before `pip install`.
+> **Note:** `ai-edge-litert-sdk-intel-nightly` pins the matching OpenVINO
+> nightly wheel via a direct URL in `install_requires` (one per supported
+> Python × OS combo, selected by pip at install time via PEP 508 env
+> markers). The plugin and dispatch libraries must be ABI-compatible with
+> this exact OpenVINO build, so the wheel URL is pinned to the same build
+> number as the archive fetched at compile time; a plain `pip install
+> ai-edge-litert-sdk-intel-nightly` is sufficient — no `--extra-index-url`
+> required.
+>
+> The SDK nightly also fetches the NPU compiler shared library
+> (`libopenvino_intel_npu_compiler.so` / `.dll`) from the matching toolkit
+> archive into its `data/` dir at `pip install` time — without it, AOT
+> fails with `Device with "NPU" name is not registered`. To override Linux
+> distro detection, set `LITERT_OV_OS_ID=ubuntu22` or `ubuntu24` before
+> `pip install`.
 
 For building from source: Bazel 7.4.1+ via
 [Bazelisk](https://github.com/bazelbuild/bazelisk) or Docker.

--- a/third_party/intel_openvino/openvino.bzl
+++ b/third_party/intel_openvino/openvino.bzl
@@ -35,27 +35,27 @@ def openvino_configure():
         local_path_env = "OPENVINO_NATIVE_DIR",
         packages = json.encode([
             {
-                "url": "https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.1/windows/openvino_toolkit_windows_2026.1.0.21367.63e31528c62_x86_64.zip",
+                "url": "https://storage.openvinotoolkit.org/repositories/openvino/packages/nightly/2026.2.0-21820-9a25caa5a15/openvino_toolkit_windows_2026.2.0.dev20260506_x86_64.zip",
                 "host_os": "windows",
                 "file_extension": "zip",
                 "symlink_mapping": {
-                    "openvino": "openvino_toolkit_windows_2026.1.0.21367.63e31528c62_x86_64",
+                    "openvino": "openvino_toolkit_windows_2026.2.0.dev20260506_x86_64",
                 },
             },
             {
-                "url": "https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.1/linux/openvino_toolkit_ubuntu24_2026.1.0.21367.63e31528c62_x86_64.tgz",
+                "url": "https://storage.openvinotoolkit.org/repositories/openvino/packages/nightly/2026.2.0-21820-9a25caa5a15/openvino_toolkit_ubuntu24_2026.2.0.dev20260506_x86_64.tgz",
                 "host_os": "linux",
                 "file_extension": "tgz",
                 "symlink_mapping": {
-                    "openvino": "openvino_toolkit_ubuntu24_2026.1.0.21367.63e31528c62_x86_64",
+                    "openvino": "openvino_toolkit_ubuntu24_2026.2.0.dev20260506_x86_64",
                 },
             },
             {
-                "url": "https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.1/linux/openvino_toolkit_android_2026.1.0.21367.63e31528c62_x86_64.tgz",
+                "url": "https://storage.openvinotoolkit.org/repositories/openvino/packages/nightly/2026.2.0-21820-9a25caa5a15/openvino_toolkit_android_2026.2.0.dev20260506_x86_64.tgz",
                 "host_os": "linux",
                 "file_extension": "tgz",
                 "symlink_mapping": {
-                    "openvino_android": "openvino_toolkit_android_2026.1.0.21367.63e31528c62_x86_64",
+                    "openvino_android": "openvino_toolkit_android_2026.2.0.dev20260506_x86_64",
                 },
             },
         ]),


### PR DESCRIPTION

## Summary

Ensures `pip install ai-edge-litert-sdk-intel-nightly` installs a **self-consistent OpenVINO stack**.  
The OpenVINO wheel, NPU compiler, and plugin binaries are all pinned to **nightly build 21820**.

- ✅ Single `pip install`
- ✅ No `--extra-index-url`

Depends on **#7281** (pinning `openvino.bzl` to `2026.2.0-21820`, cherry-picked first).

---

## Changes

- **Pinned OpenVINO via PEP 508 URLs**  
  `install_requires` uses per Python/OS direct URLs matching the `-21820-` nightly in `openvino.bzl`.

- **Ship VCL loader**  
  Added `libopenvino_intel_npu_compiler_loader.{so|dll}` (required since OV 2026.2) to fix LNL cross-compile failures.

- **Tighter drift check**  
  CI now verifies the nightly **build number** matches between `openvino.bzl` and `setup.py`.

- **README cleanup**  
  Removed `--extra-index-url`.
