### PR TITLE
Avoid Abseil types in no-Absl C++ API

### DIFF
--- a/litert/c/internal/BUILD
+++ b/litert/c/internal/BUILD
@@ -577,3 +577,18 @@ filegroup(
         "//litert/cc:__pkg__",
     ],
 )
+
+filegroup(
+    name = "litert_logging_header",
+    srcs = ["litert_logging.h"],
+    visibility = ["//litert/cc:__pkg__"],
+)
+
+filegroup(
+    name = "litert_runtime_c_api_headers",
+    srcs = [
+        "litert_runtime_c_api.h",
+        "litert_scheduling_info.h",
+    ],
+    visibility = ["//litert/cc:__pkg__"],
+)

--- a/litert/cc/BUILD
+++ b/litert/cc/BUILD
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//litert/build_common:litert_build_defs.bzl", "cc_library_with_testonly_vis")
 load("//litert/build_common:special_rule.bzl", "get_compatible_with_portable", "gles_headers", "gles_linkopts", "litert_android_linkopts")
 load("//litert/integration_test:litert_device.bzl", "litert_device_exec", "litert_device_test")
@@ -37,6 +39,68 @@ package(
     features = ["allow_starlark_transitions"],
 )
 
+LITERT_CC_NO_ABSL_PUBLIC_HEADERS = [
+    "litert_any.h",
+    "litert_api_types.h",
+    "litert_buffer_ref.h",
+    "litert_common.h",
+    "litert_compiled_model.h",
+    "litert_custom_op_kernel.h",
+    "litert_element_type.h",
+    "litert_environment.h",
+    "litert_environment_options.h",
+    "litert_event.h",
+    "litert_expected.h",
+    "litert_layout.h",
+    "litert_macros.h",
+    "litert_model.h",
+    "litert_model_types.h",
+    "litert_opaque_options.h",
+    "litert_options.h",
+    "litert_profiler.h",
+    "litert_ranked_tensor_type.h",
+    "litert_tensor_buffer.h",
+    "litert_tensor_buffer_requirements.h",
+    "litert_tensor_buffer_types.h",
+    "//litert/cc/options:litert_compiler_options.h",
+    "//litert/cc/options:litert_cpu_options.h",
+    "//litert/cc/options:litert_google_tensor_options.h",
+    "//litert/cc/options:litert_gpu_options.h",
+    "//litert/cc/options:litert_intel_openvino_options.h",
+    "//litert/cc/options:litert_magic_number_options.h",
+    "//litert/cc/options:litert_mediatek_options.h",
+    "//litert/cc/options:litert_qualcomm_options.h",
+    "//litert/cc/options:litert_runtime_options.h",
+    "//litert/cc/options:litert_samsung_options.h",
+    "//litert/cc/options:litert_webnn_options.h",
+]
+
+LITERT_CC_NO_ABSL_SUPPORT_HEADERS = [
+    "//litert/c:litert_common.h",
+    "//litert/c:c_api_headers",
+    "//litert/c/internal:internal_headers",
+    "//litert/c/internal:litert_logging_header",
+    "//litert/c/internal:litert_runtime_c_api_headers",
+    "//litert/c/options:options_headers",
+    "//litert/cc/internal:litert_consts.h",
+    "//litert/cc/internal:litert_detail.h",
+    "//litert/cc/internal:litert_handle.h",
+    "//litert/cc/internal:litert_numerics.h",
+    "//litert/cc/internal:litert_runtime_builtin.h",
+    "//litert/cc/internal:litert_runtime_proxy.h",
+    "//litert/cc/internal:litert_shared_library.h",
+    "//litert/cc/internal:litert_source_location.h",
+    "//litert/cc/internal:litert_tensor_buffer_utils.h",
+    "//litert/cc/internal:scoped_file.h",
+    "//litert/cc/internal:scoped_file_posix.h",
+    "//litert/cc/internal:scoped_file_win.h",
+    "//litert/cc/internal:scoped_weight_source.h",
+    "//litert/core:options_header",
+    "//tflite:builtin_ops.h",
+    "//tflite/c:tensorflowlite_c_api_hdrs_filegroup",
+    "//tflite/core/c:headers_filegroup",
+]
+
 # -----------------------------------------------------------------------------
 # LiteRT C++ APIs which don't use C API calls to framework.
 #
@@ -44,10 +108,59 @@ package(
 # -----------------------------------------------------------------------------
 
 cc_library(
+    name = "litert_api_types",
+    hdrs = ["litert_api_types.h"],
+    compatible_with = get_compatible_with_portable(),
+    deps = [
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:inlined_vector",
+        "@com_google_absl//absl/functional:any_invocable",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_library(
+    name = "litert_api_no_absl_headers",
+    hdrs = LITERT_CC_NO_ABSL_PUBLIC_HEADERS + LITERT_CC_NO_ABSL_SUPPORT_HEADERS,
+    compatible_with = get_compatible_with_portable(),
+    defines = ["LITERT_NO_ABSL"],
+    deps = [
+        "//litert/build_common:build_config",
+        "@opencl_headers",
+    ],
+)
+
+cc_test(
+    name = "litert_no_absl_api_compile_test",
+    srcs = ["litert_no_absl_api_compile_test.cc"],
+    copts = ["-std=c++20"],
+    defines = ["LITERT_NO_ABSL"],
+    deps = [":litert_api_no_absl_headers"],
+)
+
+cc_binary(
+    name = "litert_no_absl_api_symbol_test_bin",
+    testonly = True,
+    srcs = ["litert_no_absl_api_compile_test.cc"],
+    copts = ["-std=c++20"],
+    defines = ["LITERT_NO_ABSL"],
+    deps = [":litert_api_no_absl_headers"],
+)
+
+sh_test(
+    name = "litert_no_absl_api_symbol_test",
+    srcs = ["litert_no_absl_api_symbol_test.sh"],
+    args = ["$(location :litert_no_absl_api_symbol_test_bin)"],
+    data = [":litert_no_absl_api_symbol_test_bin"],
+)
+
+cc_library(
     name = "litert_any",
     hdrs = ["litert_any.h"],
     compatible_with = get_compatible_with_portable(),
     deps = [
+        ":litert_api_types",
         ":litert_common",
         ":litert_expected",
         ":litert_macros",
@@ -77,6 +190,7 @@ cc_library(
     name = "litert_buffer_ref",
     hdrs = ["litert_buffer_ref.h"],
     deps = [
+        ":litert_api_types",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
@@ -109,6 +223,7 @@ cc_library(
     hdrs = ["litert_macros.h"],
     compatible_with = get_compatible_with_portable(),
     deps = [
+        ":litert_api_types",
         ":litert_common",
         ":litert_expected",
         "//litert/c:litert_common",
@@ -141,6 +256,7 @@ cc_library(
     hdrs = ["litert_expected.h"],
     compatible_with = get_compatible_with_portable(),
     deps = [
+        ":litert_api_types",
         ":litert_common",
         "//litert/c:litert_common",
         "@com_google_absl//absl/log:absl_check",
@@ -186,6 +302,7 @@ cc_library(
     name = "litert_layout",
     hdrs = ["litert_layout.h"],
     deps = [
+        ":litert_api_types",
         ":litert_expected",
         ":litert_macros",
         "//litert/c:litert_layout",
@@ -208,6 +325,7 @@ cc_library(
     name = "litert_opaque_options",
     hdrs = ["litert_opaque_options.h"],
     deps = [
+        ":litert_api_types",
         ":litert_common",
         ":litert_expected",
         ":litert_macros",
@@ -238,6 +356,7 @@ cc_library(
     name = "litert_environment_options",
     hdrs = ["litert_environment_options.h"],
     deps = [
+        ":litert_api_types",
         ":litert_any",
         ":litert_common",
         ":litert_expected",
@@ -278,6 +397,7 @@ cc_library(
         # copybara:comment_end
     ],
     deps = [
+        ":litert_api_types",
         ":litert_buffer_ref",
         ":litert_common",
         ":litert_environment",
@@ -821,6 +941,7 @@ cc_library(
         # copybara:comment_end
     ],
     deps = [
+        ":litert_api_types",
         ":litert_common",
         ":litert_element_type",
         ":litert_expected",
@@ -847,6 +968,7 @@ cc_library(
         # copybara:comment_end
     ],
     deps = [
+        ":litert_api_types",
         ":litert_buffer_ref",
         ":litert_common",
         ":litert_element_type",
@@ -878,6 +1000,7 @@ cc_library(
         # copybara:comment_end
     ],
     deps = [
+        ":litert_api_types",
         ":litert_common",
         ":litert_element_type",
         ":litert_expected",
@@ -944,6 +1067,7 @@ cc_library(
         # copybara:comment_end
     ],
     deps = [
+        ":litert_api_types",
         ":litert_common",
         ":litert_expected",
         ":litert_tensor_buffer_types",
@@ -979,6 +1103,7 @@ cc_library(
         # copybara:comment_end
     ],
     deps = [
+        ":litert_api_types",
         ":litert_common",
         ":litert_environment",
         ":litert_event",
@@ -1091,6 +1216,7 @@ cc_library_with_testonly_vis(
         # copybara:comment_end
     ],
     deps = [
+        ":litert_api_types",
         ":litert_common",
         ":litert_custom_op_kernel",
         ":litert_environment",
@@ -1230,6 +1356,7 @@ cc_library(
     name = "litert_api_with_dynamic_runtime",
     hdrs = [
         # C++ API headers.
+        "litert_api_types.h",
         "litert_any.h",
         "litert_common.h",
         "//litert/c/internal:litert_scheduling_info",
@@ -1312,6 +1439,7 @@ cc_library(
         "//litert/cc/options:litert_intel_openvino_options",
         "//litert/cc/options:litert_qualcomm_options",
         # Other (static) C++ API targets.
+        ":litert_api_types",
         ":litert_any",
         ":litert_buffer_ref",
         ":litert_common",

--- a/litert/cc/CMakeLists.txt
+++ b/litert/cc/CMakeLists.txt
@@ -17,6 +17,7 @@ cmake_minimum_required(VERSION 3.20)
 
 set(LITERT_CC_PUBLIC_HEADERS
     litert_any.h
+    litert_api_types.h
     litert_buffer_ref.h
     litert_common.h
     litert_compiled_model.h
@@ -147,14 +148,18 @@ set_target_properties(litert_cc_api PROPERTIES
 # shared library.
 add_library(litert_cc_api_headers INTERFACE)
 
+set(_LITERT_CC_API_HEADER_INCLUDE_DIRS
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+    $<BUILD_INTERFACE:${LITERT_GENERATED_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${TENSORFLOW_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${TFLITE_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/opencl_headers>
+)
+
 target_include_directories(litert_cc_api_headers
     INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-        $<BUILD_INTERFACE:${LITERT_GENERATED_INCLUDE_DIR}>
-        $<BUILD_INTERFACE:${TENSORFLOW_SOURCE_DIR}>
-        $<BUILD_INTERFACE:${TFLITE_SOURCE_DIR}>
-        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/opencl_headers>
+        ${_LITERT_CC_API_HEADER_INCLUDE_DIRS}
 )
 
 target_compile_features(litert_cc_api_headers INTERFACE cxx_std_20)
@@ -174,11 +179,33 @@ target_link_libraries(litert_cc_api_headers
         absl::die_if_null
 )
 
+add_library(litert_cc_api_no_absl_headers INTERFACE)
+
+target_include_directories(litert_cc_api_no_absl_headers
+    INTERFACE
+        ${_LITERT_CC_API_HEADER_INCLUDE_DIRS}
+)
+
+target_compile_definitions(litert_cc_api_no_absl_headers
+    INTERFACE
+        LITERT_NO_ABSL
+)
+
+target_compile_features(litert_cc_api_no_absl_headers INTERFACE cxx_std_20)
+
 add_library(litert_cc_api_with_dynamic_runtime INTERFACE)
 
 target_link_libraries(litert_cc_api_with_dynamic_runtime
     INTERFACE
         litert_cc_api_headers
+        litert_runtime_c_api_shared_lib
+)
+
+add_library(litert_cc_api_no_absl_with_dynamic_runtime INTERFACE)
+
+target_link_libraries(litert_cc_api_no_absl_with_dynamic_runtime
+    INTERFACE
+        litert_cc_api_no_absl_headers
         litert_runtime_c_api_shared_lib
 )
 

--- a/litert/cc/internal/BUILD
+++ b/litert/cc/internal/BUILD
@@ -145,6 +145,7 @@ cc_library(
     name = "litert_detail",
     hdrs = ["litert_detail.h"],
     deps = [
+        "//litert/cc:litert_api_types",
         "//litert/c:litert_common",
         "//litert/c/internal:litert_logging",
         "@com_google_absl//absl/log:absl_check",
@@ -358,6 +359,7 @@ cc_library(
         "litert_shared_library_windows.h",
     ],
     deps = [
+        "//litert/cc:litert_api_types",
         "//litert/c:litert_common",
         "//litert/c/internal:litert_logging",
         "//litert/cc:litert_common",
@@ -404,6 +406,7 @@ cc_library(
     hdrs = ["litert_model_predicates.h"],
     visibility = internal_static_library_visibility,
     deps = [
+        "//litert/cc:litert_api_types",
         ":litert_detail",
         ":litert_extended_model",
         "//litert/c:litert_common",
@@ -481,6 +484,7 @@ cc_library(
     hdrs = ["litert_builder.h"],
     visibility = internal_static_library_visibility,
     deps = [
+        "//litert/cc:litert_api_types",
         ":litert_detail",
         ":litert_extended_model",
         ":litert_handle",
@@ -691,6 +695,7 @@ cc_library(
         "scoped_file_win.h",
     ],
     deps = [
+        "//litert/cc:litert_api_types",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
@@ -702,6 +707,7 @@ cc_library(
     name = "scoped_weight_source",
     hdrs = ["scoped_weight_source.h"],
     deps = [
+        "//litert/cc:litert_api_types",
         ":scoped_file",
         "@com_google_absl//absl/container:flat_hash_map",
     ],
@@ -810,6 +816,7 @@ cc_library(
     name = "litert_runtime_proxy",
     hdrs = ["litert_runtime_proxy.h"],
     deps = [
+        "//litert/cc:litert_api_types",
         "//litert/c:litert_any",
         "//litert/c:litert_common",
         "//litert/c:litert_custom_op_kernel",

--- a/litert/cc/internal/litert_builder.h
+++ b/litert/cc/internal/litert_builder.h
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_builder.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_layout.h"
@@ -184,7 +184,7 @@ class Builder : public internal::NonOwnedHandle<LiteRtBuilder> {
 
   /// @brief Builds weights for a tensor.
   template <typename T>
-  Expected<Weights> BuildWeights(absl::Span<const T> data,
+  Expected<Weights> BuildWeights(Span<const T> data,
                                  Tensor& tensor) const {
     const uint8_t* data_uint8 = reinterpret_cast<const uint8_t*>(data.data());
     size_t size_uint8 = data.size() * sizeof(T);

--- a/litert/cc/internal/litert_detail.h
+++ b/litert/cc/internal/litert_detail.h
@@ -27,8 +27,7 @@
 #include <variant>
 #include <vector>
 
-#include "absl/log/absl_check.h"  // from @com_google_absl
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/internal/litert_logging.h"
 #include "litert/c/litert_common.h"
 
@@ -228,14 +227,14 @@ auto Avg(It begin, It end) -> RemoveCvRefT<decltype(*std::declval<It>())> {
 /// @brief Checks if a string starts with a given prefix.
 /// @note `std::string::ends_with` is not available until C++20, and
 /// `absl::StartsWith` is not portable.
-inline bool StartsWith(absl::string_view str, absl::string_view prefix) {
+inline bool StartsWith(StringView str, StringView prefix) {
   return str.size() >= prefix.size() &&
          std::equal(prefix.begin(), prefix.end(), str.begin());
 }
 /// @brief Checks if a string ends with a given suffix.
 /// @note `std::string::ends_with` is not available until C++20, and
 /// `absl::EndsWith` is not portable.
-inline bool EndsWith(absl::string_view str, absl::string_view suffix) {
+inline bool EndsWith(StringView str, StringView suffix) {
   return str.size() >= suffix.size() &&
          std::equal(suffix.rbegin(), suffix.rend(), str.rbegin());
 }
@@ -258,8 +257,8 @@ class CtStr {
   template <size_t N, class I = std::make_index_sequence<N - 1>>
   constexpr explicit CtStr(StrLiteral<N> lit) : CtStr(lit, I{}) {}
 
-  constexpr absl::string_view Str() const {
-    return absl::string_view(data_.data(), data_.size());
+  constexpr StringView Str() const {
+    return StringView(data_.data(), data_.size());
   }
 
   //  private:
@@ -303,7 +302,7 @@ namespace internal {
 template <class F, class Expected, typename... Args>
 inline void AssertEq(F get, Expected expected, Args&&... args) {
   auto status = get(std::forward<Args>(args)...);
-  ABSL_CHECK_EQ(status, expected);
+  LITERT_INTERNAL_CHECK_EQ(status, expected);
 }
 
 /// @brief Calls a function `get` and asserts that it returns `true`.

--- a/litert/cc/internal/litert_model_predicates.h
+++ b/litert/cc/internal/litert_model_predicates.h
@@ -21,8 +21,7 @@
 #include <utility>
 #include <vector>
 
-#include "absl/container/inlined_vector.h"  // from @com_google_absl
-#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_model_types.h"
 #include "litert/c/litert_op_code.h"
@@ -45,12 +44,12 @@ namespace litert {
 /// @brief Holds information about a tensor's type and dimensions for matching.
 struct TensorTypeInfo {
   std::optional<ElementType> element_type = std::nullopt;
-  std::optional<absl::InlinedVector<int32_t, 4>> dims = std::nullopt;
+  std::optional<SmallVector<int32_t, 4>> dims = std::nullopt;
 
   explicit TensorTypeInfo(ElementType element_type)
       : element_type(element_type) {}
-  explicit TensorTypeInfo(absl::InlinedVector<int32_t, 4> dims) : dims(dims) {}
-  TensorTypeInfo(ElementType element_type, absl::InlinedVector<int32_t, 4> dims)
+  explicit TensorTypeInfo(SmallVector<int32_t, 4> dims) : dims(dims) {}
+  TensorTypeInfo(ElementType element_type, SmallVector<int32_t, 4> dims)
       : element_type(element_type), dims(dims) {}
 };
 
@@ -84,7 +83,7 @@ bool MatchOpType(
 /// @param expected_data The expected weight data.
 /// @return `true` if the tensor's weights match the expected data.
 template <typename T>
-bool MatchWeights(const Tensor& tensor, absl::Span<const T> expected_data) {
+bool MatchWeights(const Tensor& tensor, Span<const T> expected_data) {
   auto weights = tensor.WeightsData<T>();
   return weights.HasValue() && *weights == expected_data;
 }
@@ -108,7 +107,7 @@ bool MatchUses(const Tensor& tensor, const std::vector<UseInfo>& expected_uses,
 namespace internal::model_predicates_detail {
 
 template <typename T>
-bool Any(absl::Span<const T> vals,
+bool Any(Span<const T> vals,
          const std::function<bool(const T&)>& unary_pred) {
   for (const auto& val : vals) {
     if (unary_pred(val)) {
@@ -142,7 +141,7 @@ inline bool MatchRankedTensorType(const RankedTensorType& tensor_type,
 
   if (expected.dims.has_value()) {
     auto actual_dims = tensor_type.Layout().Dimensions();
-    auto expected_dims = absl::MakeConstSpan(expected.dims.value());
+    auto expected_dims = internal::MakeConstSpan(expected.dims.value());
     return AllZip(actual_dims, expected_dims,
                   [](auto l, auto r) -> bool { return l == r; });
   }
@@ -165,11 +164,11 @@ inline bool MatchOpType(
     return MatchRankedTensorType(*actual_ranked_tensor_type, expected.value());
   };
 
-  const bool inputs_match = AllZip(absl::MakeConstSpan(op.Inputs()),
-                                   absl::MakeConstSpan(expected_inputs), match);
+  const bool inputs_match = AllZip(internal::MakeConstSpan(op.Inputs()),
+                                   internal::MakeConstSpan(expected_inputs), match);
   const bool outputs_match =
-      AllZip(absl::MakeConstSpan(op.Outputs()),
-             absl::MakeConstSpan(expected_outputs), match);
+      AllZip(internal::MakeConstSpan(op.Outputs()),
+             internal::MakeConstSpan(expected_outputs), match);
   return inputs_match && outputs_match;
 }
 

--- a/litert/cc/internal/litert_runtime_proxy.h
+++ b/litert/cc/internal/litert_runtime_proxy.h
@@ -17,9 +17,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 
-#include "absl/log/absl_check.h"  // from @com_google_absl
-#include "absl/log/die_if_null.h"  // from @com_google_absl
 #include "litert/c/internal/litert_runtime_c_api.h"
 #include "litert/c/internal/litert_scheduling_info.h"
 #include "litert/c/litert_any.h"
@@ -37,17 +36,18 @@
 #include "litert/c/litert_tensor_buffer_types.h"
 #include "litert/c/litert_webgpu_types.h"
 #include "litert/cc/internal/litert_runtime_builtin.h"
+#include "litert/cc/litert_api_types.h"
 
 namespace litert {
 class Options;
 namespace internal {
 
 #define LITERT_PROXY_METHOD_STATUS(method, ...) \
-  ABSL_CHECK(runtime_c_api_->method);           \
+  LITERT_INTERNAL_CHECK(runtime_c_api_->method); \
   return runtime_c_api_->method(__VA_ARGS__);
 
 #define LITERT_PROXY_METHOD_VOID(method, ...) \
-  ABSL_CHECK(runtime_c_api_->method);         \
+  LITERT_INTERNAL_CHECK(runtime_c_api_->method); \
   runtime_c_api_->method(__VA_ARGS__);
 
 // A proxy class that provides a C++ interface to the LiteRT Runtime C Api.
@@ -63,9 +63,9 @@ class RuntimeProxy {
   /// If the system runtime handle is not provided, the builtin runtime will be
   /// used.
   explicit RuntimeProxy(const LiteRtRuntimeCApiStruct* runtime_c_api)
-      : runtime_c_api_(ABSL_DIE_IF_NULL(runtime_c_api == nullptr
-                                            ? kLiteRtRuntimeBuiltin
-                                            : runtime_c_api)) {};
+      : runtime_c_api_(LITERT_INTERNAL_DIE_IF_NULL(
+            runtime_c_api == nullptr ? kLiteRtRuntimeBuiltin
+                                     : runtime_c_api)) {};
 
   ~RuntimeProxy() = default;
 
@@ -616,7 +616,7 @@ class RuntimeProxy {
                                         const char* format, Args&&... args) {
     // We cannot forward variadic arguments, so this function cannot use the
     // macro.
-    ABSL_CHECK(runtime_c_api_->litert_compiled_model_report_error);
+    LITERT_INTERNAL_CHECK(runtime_c_api_->litert_compiled_model_report_error);
     return runtime_c_api_->litert_compiled_model_report_error(
         compiled_model, format, std::forward<Args>(args)...);
   }

--- a/litert/cc/internal/litert_shared_library.h
+++ b/litert/cc/internal/litert_shared_library.h
@@ -20,9 +20,10 @@
 #include <string_view>
 #include <utility>
 
+#ifndef LITERT_NO_ABSL
 #include "absl/debugging/leak_check.h"  // from @com_google_absl
-#include "absl/strings/str_format.h"  // from @com_google_absl
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#endif  // LITERT_NO_ABSL
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/internal/litert_logging.h"  // IWYU pragma: keep
 #include "litert/cc/litert_common.h"
 #include "litert/cc/litert_expected.h"
@@ -199,7 +200,7 @@ class SharedLibrary {
   ~SharedLibrary() noexcept { Close(); }
 
   /// @brief Loads the library at the given path.
-  static Expected<SharedLibrary> Load(absl::string_view path,
+  static Expected<SharedLibrary> Load(StringView path,
                                       RtldFlags flags) noexcept {
     return LoadImpl(HandleKind::kPath, path, flags);
   }
@@ -217,7 +218,7 @@ class SharedLibrary {
   /// @brief Gets the last shared library operation error, if any.
   ///
   /// If there was no error, returns an empty view.
-  static absl::string_view DlError() noexcept { return DlErrorImpl(); }
+  static StringView DlError() noexcept { return DlErrorImpl(); }
 
   friend std::ostream& operator<<(std::ostream& os, const SharedLibrary& lib);
 
@@ -258,7 +259,7 @@ class SharedLibrary {
 
  private:
   enum class HandleKind { kInvalid, kPath, kRtldNext, kRtldDefault };
-  static absl::string_view DlErrorImpl() noexcept {
+  static StringView DlErrorImpl() noexcept {
     const char* error = internal::shared_library_detail::DlError();
     if (!error) {
       return {};
@@ -267,7 +268,7 @@ class SharedLibrary {
   }
 
   static Expected<SharedLibrary> LoadImpl(HandleKind handle_kind,
-                                          absl::string_view path,
+                                          StringView path,
                                           RtldFlags flags) {
     SharedLibrary lib;
     switch (handle_kind) {
@@ -283,7 +284,9 @@ class SharedLibrary {
         }
         lib.path_ = path;
         {
+#ifndef LITERT_NO_ABSL
           absl::LeakCheckDisabler disabler;
+#endif  // LITERT_NO_ABSL
           lib.handle_ = internal::shared_library_detail::DlOpen(
               lib.Path().c_str(),
               internal::shared_library_detail::SanitizeFlagsInCaseOfAsan(
@@ -291,8 +294,8 @@ class SharedLibrary {
         }
         if (!lib.handle_) {
           return Error(Status::kErrorDynamicLoading,
-                       absl::StrFormat("Could not load shared library %s: %s.",
-                                       lib.path_, DlError()));
+                       "Could not load shared library " + lib.path_ + ": " +
+                           std::string(DlError()) + ".");
         }
         break;
       case HandleKind::kRtldNext:
@@ -311,8 +314,8 @@ class SharedLibrary {
 
     if (!symbol) {
       return Error(Status::kErrorDynamicLoading,
-                   absl::StrFormat("Could not load symbol %s: %s.", symbol_name,
-                                   DlError()));
+                   "Could not load symbol " + std::string(symbol_name) +
+                       ": " + std::string(DlError()) + ".");
     }
     return symbol;
   }
@@ -323,8 +326,8 @@ class SharedLibrary {
 };
 
 inline std::ostream& operator<<(std::ostream& os, const SharedLibrary& lib) {
-  static constexpr absl::string_view kHeader = "/// DLL Info ///\n";
-  static constexpr absl::string_view kFooter = "////////////////\n";
+  static constexpr StringView kHeader = "/// DLL Info ///\n";
+  static constexpr StringView kFooter = "////////////////\n";
 
   if (lib.handle_ == nullptr) {
     os << kHeader << "Handle is nullptr.\n" << kFooter;

--- a/litert/cc/internal/scoped_file.h
+++ b/litert/cc/internal/scoped_file.h
@@ -16,16 +16,28 @@
 #define THIRD_PARTY_ODML_LITERT_LITERT_CC_INTERNAL_SCOPED_FILE_H_
 
 #include <cstddef>
+#include <string>
 #include <string_view>
 
+#ifndef LITERT_NO_ABSL
 #include "absl/status/status.h"  // from @com_google_absl
 #include "absl/status/statusor.h"  // from @com_google_absl
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#endif  // LITERT_NO_ABSL
+#include "litert/cc/litert_api_types.h"
+#include "litert/cc/litert_expected.h"
 
 /// @file
 /// @brief Defines a file wrapper that automatically closes on destruction.
 
 namespace litert {
+
+#ifndef LITERT_NO_ABSL
+template <typename T>
+using ScopedFileStatusOr = absl::StatusOr<T>;
+#else
+template <typename T>
+using ScopedFileStatusOr = Expected<T>;
+#endif  // LITERT_NO_ABSL
 
 /// @brief A file wrapper that ensures the underlying file handle is
 /// automatically closed when the object goes out of scope.
@@ -39,8 +51,8 @@ class ScopedFile {
   static constexpr PlatformFile kInvalidPlatformFile = -1;
 #endif
 
-  static absl::StatusOr<ScopedFile> Open(absl::string_view path);
-  static absl::StatusOr<ScopedFile> OpenWritable(absl::string_view path);
+  static ScopedFileStatusOr<ScopedFile> Open(StringView path);
+  static ScopedFileStatusOr<ScopedFile> OpenWritable(StringView path);
 
   ScopedFile() : file_(kInvalidPlatformFile) {}
   explicit ScopedFile(PlatformFile file) : file_(file) {}
@@ -66,11 +78,11 @@ class ScopedFile {
   bool IsValid() const { return file_ != kInvalidPlatformFile; }
 
   /// @brief Returns the size of the file in bytes.
-  static absl::StatusOr<size_t> GetSize(PlatformFile file);
-  absl::StatusOr<size_t> GetSize() const { return GetSize(file_); }
+  static ScopedFileStatusOr<size_t> GetSize(PlatformFile file);
+  ScopedFileStatusOr<size_t> GetSize() const { return GetSize(file_); }
 
   /// @brief Returns a `ScopedFile` pointing to the same underlying file.
-  absl::StatusOr<ScopedFile> Duplicate();
+  ScopedFileStatusOr<ScopedFile> Duplicate();
 
   /// @brief Releases ownership of the current file as a C file descriptor.
   ///
@@ -91,7 +103,7 @@ class ScopedFile {
   ///
   /// @warning While it is possible to get a `HANDLE` back from the file
   /// descriptor, **ownership will remain with the file descriptor**.
-  absl::StatusOr<int> Release();
+  ScopedFileStatusOr<int> Release();
 
  private:
   PlatformFile ReleasePlatformFile() {
@@ -105,7 +117,7 @@ class ScopedFile {
   /// The implementation can assume that the passed `PlatformFile` is valid.
   /// This must be ensured by the caller.
   static void CloseFile(PlatformFile file);
-  static absl::StatusOr<size_t> GetSizeImpl(PlatformFile file);
+  static ScopedFileStatusOr<size_t> GetSizeImpl(PlatformFile file);
 
   PlatformFile file_;
 };
@@ -118,9 +130,14 @@ inline bool IsFileValid(ScopedFile::PlatformFile file) {
 
 }  // namespace internal::scoped_file_detail
 
-inline absl::StatusOr<size_t> ScopedFile::GetSize(PlatformFile file) {
+inline ScopedFileStatusOr<size_t> ScopedFile::GetSize(PlatformFile file) {
   if (!internal::scoped_file_detail::IsFileValid(file)) {
+#ifndef LITERT_NO_ABSL
     return absl::FailedPreconditionError("Scoped file is not valid");
+#else
+    return Unexpected(Status::kErrorInvalidArgument,
+                      "Scoped file is not valid");
+#endif  // LITERT_NO_ABSL
   }
   return GetSizeImpl(file);
 }

--- a/litert/cc/internal/scoped_file_posix.h
+++ b/litert/cc/internal/scoped_file_posix.h
@@ -23,53 +23,81 @@
 
 #include <cerrno>
 #include <cstddef>
+#include <cstring>
 
+#ifndef LITERT_NO_ABSL
 #include "absl/status/status.h"  // from @com_google_absl
 #include "absl/status/statusor.h"  // from @com_google_absl
 #include "absl/strings/str_cat.h"  // from @com_google_absl
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#endif  // LITERT_NO_ABSL
 #include "litert/cc/internal/scoped_file.h"
 
 namespace litert {
 
-inline absl::StatusOr<ScopedFile> ScopedFile::Open(absl::string_view path) {
+inline ScopedFileStatusOr<ScopedFile> ScopedFile::Open(StringView path) {
   int fd = open(path.data(), O_RDONLY);
   if (fd < 0) {
+#ifndef LITERT_NO_ABSL
     return absl::ErrnoToStatus(errno, absl::StrCat("open() failed: ", path));
+#else
+    return Unexpected(Status::kErrorFileIO,
+                      "open() failed for " + std::string(path) + ": " +
+                          std::strerror(errno));
+#endif  // LITERT_NO_ABSL
   }
   return ScopedFile(fd);
 }
 
-inline absl::StatusOr<ScopedFile> ScopedFile::OpenWritable(
-    absl::string_view path) {
+inline ScopedFileStatusOr<ScopedFile> ScopedFile::OpenWritable(
+    StringView path) {
   int fd = open(path.data(), O_RDWR);
   if (fd < 0) {
+#ifndef LITERT_NO_ABSL
     return absl::ErrnoToStatus(errno, absl::StrCat("open() failed: ", path));
+#else
+    return Unexpected(Status::kErrorFileIO,
+                      "open() failed for " + std::string(path) + ": " +
+                          std::strerror(errno));
+#endif  // LITERT_NO_ABSL
   }
   return ScopedFile(fd);
 }
 
 inline void ScopedFile::CloseFile(int file) { close(file); }
 
-inline absl::StatusOr<size_t> ScopedFile::GetSizeImpl(int file) {
+inline ScopedFileStatusOr<size_t> ScopedFile::GetSizeImpl(int file) {
   struct stat info;
   int result = fstat(file, &info);
   if (result < 0) {
+#ifndef LITERT_NO_ABSL
     return absl::ErrnoToStatus(errno, "Failed to get file size");
+#else
+    return Unexpected(Status::kErrorFileIO,
+                      std::string("Failed to get file size: ") +
+                          std::strerror(errno));
+#endif  // LITERT_NO_ABSL
   }
   return info.st_size;
 }
 
-inline absl::StatusOr<ScopedFile> ScopedFile::Duplicate() {
+inline ScopedFileStatusOr<ScopedFile> ScopedFile::Duplicate() {
   if (!IsValid()) {
+#ifndef LITERT_NO_ABSL
     return absl::InvalidArgumentError("File is not opened.");
+#else
+    return Unexpected(Status::kErrorInvalidArgument, "File is not opened.");
+#endif  // LITERT_NO_ABSL
   }
   return ScopedFile(dup(file_));
 }
 
-inline absl::StatusOr<int> ScopedFile::Release() {
+inline ScopedFileStatusOr<int> ScopedFile::Release() {
   if (!IsValid()) {
+#ifndef LITERT_NO_ABSL
     return absl::InvalidArgumentError("File is not opened.");
+#else
+    return Unexpected(Status::kErrorInvalidArgument, "File is not opened.");
+#endif  // LITERT_NO_ABSL
   }
   return ReleasePlatformFile();
 }

--- a/litert/cc/internal/scoped_file_win.h
+++ b/litert/cc/internal/scoped_file_win.h
@@ -26,16 +26,17 @@
 #include <cstddef>
 #include <string>
 
+#ifndef LITERT_NO_ABSL
 #include "absl/status/status.h"  // from @com_google_absl
 #include "absl/status/statusor.h"  // from @com_google_absl
 #include "absl/strings/str_cat.h"  // from @com_google_absl
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#endif  // LITERT_NO_ABSL
 #include "litert/cc/internal/scoped_file.h"
 
 namespace litert {
 namespace internal::scoped_file_detail {
 
-inline std::wstring Utf8ToWideChar(absl::string_view utf8str) {
+inline std::wstring Utf8ToWideChar(StringView utf8str) {
   int size_required = MultiByteToWideChar(CP_UTF8, 0, utf8str.data(),
                                           (int)utf8str.size(), nullptr, 0);
   std::wstring ws_translated_str(size_required, 0);
@@ -44,8 +45,8 @@ inline std::wstring Utf8ToWideChar(absl::string_view utf8str) {
   return ws_translated_str;
 }
 
-inline absl::StatusOr<ScopedFile> OpenImpl(absl::string_view path,
-                                           DWORD file_attribute_flag) {
+inline ScopedFileStatusOr<ScopedFile> OpenImpl(StringView path,
+                                               DWORD file_attribute_flag) {
   std::wstring ws_path = Utf8ToWideChar(path);
 
   DWORD share_mode = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
@@ -56,7 +57,12 @@ inline absl::StatusOr<ScopedFile> OpenImpl(absl::string_view path,
   HANDLE hfile = ::CreateFileW(ws_path.c_str(), access, share_mode, nullptr,
                                OPEN_EXISTING, file_attribute_flag, nullptr);
   if (hfile == INVALID_HANDLE_VALUE) {
+#ifndef LITERT_NO_ABSL
     return absl::UnknownError(absl::StrCat("Failed to open: ", path));
+#else
+    return Unexpected(Status::kErrorFileIO,
+                      "Failed to open: " + std::string(path));
+#endif  // LITERT_NO_ABSL
   }
   return ScopedFile(hfile);
 }
@@ -84,57 +90,87 @@ inline std::string GetLastErrorString() {
 
 inline const HANDLE ScopedFile::kInvalidPlatformFile = INVALID_HANDLE_VALUE;
 
-inline absl::StatusOr<ScopedFile> ScopedFile::Open(absl::string_view path) {
+inline ScopedFileStatusOr<ScopedFile> ScopedFile::Open(StringView path) {
   return internal::scoped_file_detail::OpenImpl(path, FILE_ATTRIBUTE_READONLY);
 }
 
-inline absl::StatusOr<ScopedFile> ScopedFile::OpenWritable(
-    absl::string_view path) {
+inline ScopedFileStatusOr<ScopedFile> ScopedFile::OpenWritable(
+    StringView path) {
   return internal::scoped_file_detail::OpenImpl(path, FILE_ATTRIBUTE_NORMAL);
 }
 
 inline void ScopedFile::CloseFile(HANDLE file) { ::CloseHandle(file); }
 
-inline absl::StatusOr<size_t> ScopedFile::GetSizeImpl(HANDLE file) {
+inline ScopedFileStatusOr<size_t> ScopedFile::GetSizeImpl(HANDLE file) {
   LARGE_INTEGER size;
   if (!::GetFileSizeEx(file, &size)) {
+#ifndef LITERT_NO_ABSL
     return absl::UnknownError("Failed to get file size");
+#else
+    return Unexpected(Status::kErrorFileIO, "Failed to get file size");
+#endif  // LITERT_NO_ABSL
   }
   return static_cast<size_t>(size.QuadPart);
 }
 
-inline absl::StatusOr<ScopedFile> ScopedFile::Duplicate() {
+inline ScopedFileStatusOr<ScopedFile> ScopedFile::Duplicate() {
   if (!IsValid()) {
+#ifndef LITERT_NO_ABSL
     return absl::InvalidArgumentError("File is not opened.");
+#else
+    return Unexpected(Status::kErrorInvalidArgument, "File is not opened.");
+#endif  // LITERT_NO_ABSL
   }
   HANDLE duplicated;
   if (!DuplicateHandle(GetCurrentProcess(), file_, GetCurrentProcess(),
                        &duplicated, 0, FALSE, DUPLICATE_SAME_ACCESS)) {
+#ifndef LITERT_NO_ABSL
     return absl::FailedPreconditionError(
         "Could not duplicate handle: " +
         internal::scoped_file_detail::GetLastErrorString());
+#else
+    return Unexpected(Status::kErrorFileIO,
+                      "Could not duplicate handle: " +
+                          internal::scoped_file_detail::GetLastErrorString());
+#endif  // LITERT_NO_ABSL
   }
   return ScopedFile(duplicated);
 }
 
-inline absl::StatusOr<int> ScopedFile::Release() {
+inline ScopedFileStatusOr<int> ScopedFile::Release() {
   if (!IsValid()) {
+#ifndef LITERT_NO_ABSL
     return absl::InvalidArgumentError("File is not opened.");
+#else
+    return Unexpected(Status::kErrorInvalidArgument, "File is not opened.");
+#endif  // LITERT_NO_ABSL
   }
 
   char buffer[1];
   if (!ReadFile(file_, &buffer, /*nNumberOfBytesToRead=*/0,
                 /*lpNumberOfBytesRead=*/nullptr, /*lpOverlapped=*/nullptr)) {
+#ifndef LITERT_NO_ABSL
     return absl::FailedPreconditionError(
         "Could not convert asynchronous handle to C file descriptor: " +
         internal::scoped_file_detail::GetLastErrorString());
+#else
+    return Unexpected(Status::kErrorFileIO,
+                      "Could not convert asynchronous handle to C file "
+                      "descriptor: " +
+                          internal::scoped_file_detail::GetLastErrorString());
+#endif  // LITERT_NO_ABSL
   }
 
   const int fd = _open_osfhandle(reinterpret_cast<intptr_t>(file_),
                                  /*flags=*/_O_RDWR | _O_BINARY);
   if (fd < 0) {
+#ifndef LITERT_NO_ABSL
     return absl::ErrnoToStatus(
         errno, "Could not convert HANDLE to a C file descriptor");
+#else
+    return Unexpected(Status::kErrorFileIO,
+                      "Could not convert HANDLE to a C file descriptor");
+#endif  // LITERT_NO_ABSL
   }
   ReleasePlatformFile();
   return fd;

--- a/litert/cc/internal/scoped_weight_source.h
+++ b/litert/cc/internal/scoped_weight_source.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <utility>
 
-#include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/cc/internal/scoped_file.h"
 
 /// @file
@@ -41,7 +41,7 @@ struct ScopedWeightSource {
   ScopedWeightSource() = default;
   ScopedWeightSource(
       ScopedFile scoped_file,
-      absl::flat_hash_map<std::string, ScopedWeightSection> sections)
+      FlatHashMap<std::string, ScopedWeightSection> sections)
       : file(std::move(scoped_file)), sections(std::move(sections)) {}
 
   ScopedWeightSource(ScopedWeightSource&&) = default;
@@ -52,7 +52,7 @@ struct ScopedWeightSource {
   bool empty() const { return sections.empty(); }
 
   ScopedFile file;
-  absl::flat_hash_map<std::string, ScopedWeightSection> sections;
+  FlatHashMap<std::string, ScopedWeightSection> sections;
 };
 
 }  // namespace litert

--- a/litert/cc/litert_any.h
+++ b/litert/cc/litert_any.h
@@ -18,12 +18,12 @@
 #include <any>
 #include <cstdint>
 #include <limits>
+#include <sstream>
 #include <string>
 #include <type_traits>
 #include <variant>
 
-#include "absl/strings/str_format.h"  // from @com_google_absl
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_any.h"
 #include "litert/c/litert_common.h"
 #include "litert/cc/litert_common.h"
@@ -47,7 +47,7 @@ using LiteRtVariant =
                  float,              // kLiteRtAnyTypeReal (single)
                  double,             // kLiteRtAnyTypeReal (double)
                  const char*,        // kLiteRtAnyTypeString
-                 absl::string_view,  // kLiteRtAnyTypeString (alternative)
+                 StringView,  // kLiteRtAnyTypeString (alternative)
                  const void*,        // kLiteRtAnyTypeVoidPtr
                  void*               // kLiteRtAnyTypeVoidPtr (non-const)
                  >;
@@ -102,7 +102,7 @@ inline Expected<LiteRtAny> ToLiteRtAny(const LiteRtVariant& var) {
           result.type = kLiteRtAnyTypeString;
           result.str_value = arg;
           return result;
-        } else if constexpr (std::is_same_v<T, absl::string_view>) {
+        } else if constexpr (std::is_same_v<T, StringView>) {
           result.type = kLiteRtAnyTypeString;
           result.str_value = arg.data();
           return result;
@@ -128,11 +128,20 @@ inline Expected<void> CheckType(const LiteRtAny& any,
                                 const LiteRtAnyType type) {
   if (any.type != type) {
     return Error(Status::kErrorInvalidArgument,
-                 absl::StrFormat("Wrong LiteRtAny type. Expected %s, got %s.",
-                                 LiteRtAnyTypeToString(type),
-                                 LiteRtAnyTypeToString(any.type)));
+                 std::string("Wrong LiteRtAny type. Expected ") +
+                     LiteRtAnyTypeToString(type) + ", got " +
+                     LiteRtAnyTypeToString(any.type) + ".");
   }
   return {};
+}
+
+template <class T, class V>
+std::string OutOfRangeMessage(const char* type_name, V value) {
+  std::stringstream message;
+  message << "LiteRtAny " << type_name << " is out of range. "
+          << std::numeric_limits<T>::lowest() << " <= " << value << " <= "
+          << std::numeric_limits<T>::max();
+  return message.str();
 }
 
 template <class T>
@@ -140,11 +149,8 @@ Expected<T> GetInt(const LiteRtAny& any) {
   LITERT_RETURN_IF_ERROR(CheckType(any, kLiteRtAnyTypeInt));
   if (any.int_value > std::numeric_limits<T>::max() ||
       any.int_value < std::numeric_limits<T>::lowest()) {
-    return Error(
-        Status::kErrorInvalidArgument,
-        absl::StrFormat("LiteRtAny integer is out of range. %v <= %v <= %v",
-                        std::numeric_limits<T>::lowest(), any.int_value,
-                        std::numeric_limits<T>::max()));
+    return Error(Status::kErrorInvalidArgument,
+                 OutOfRangeMessage<T>("integer", any.int_value));
   }
   return static_cast<T>(any.int_value);
 }
@@ -154,11 +160,8 @@ Expected<T> GetReal(const LiteRtAny& any) {
   LITERT_RETURN_IF_ERROR(CheckType(any, kLiteRtAnyTypeReal));
   if (any.real_value > std::numeric_limits<T>::max() ||
       any.real_value < std::numeric_limits<T>::lowest()) {
-    return Error(
-        Status::kErrorInvalidArgument,
-        absl::StrFormat("LiteRtAny real is out of range. %v <= %v <= %v",
-                        std::numeric_limits<T>::lowest(), any.real_value,
-                        std::numeric_limits<T>::max()));
+    return Error(Status::kErrorInvalidArgument,
+                 OutOfRangeMessage<T>("real", any.real_value));
   }
   return static_cast<T>(any.real_value);
 }
@@ -211,9 +214,9 @@ inline Expected<std::string> Get(const LiteRtAny& any) {
 }
 
 template <>
-inline Expected<absl::string_view> Get(const LiteRtAny& any) {
+inline Expected<StringView> Get(const LiteRtAny& any) {
   LITERT_RETURN_IF_ERROR(internal::CheckType(any, kLiteRtAnyTypeString));
-  return absl::string_view(any.str_value);
+  return StringView(any.str_value);
 }
 
 template <>

--- a/litert/cc/litert_api_types.h
+++ b/litert/cc/litert_api_types.h
@@ -1,0 +1,181 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ODML_LITERT_LITERT_CC_LITERT_API_TYPES_H_
+#define ODML_LITERT_LITERT_CC_LITERT_API_TYPES_H_
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#ifdef LITERT_NO_ABSL
+#include <span>
+#else
+#include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "absl/container/inlined_vector.h"  // from @com_google_absl
+#include "absl/functional/any_invocable.h"  // from @com_google_absl
+#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "absl/types/span.h"  // from @com_google_absl
+#endif  // LITERT_NO_ABSL
+
+namespace litert {
+
+#ifdef LITERT_NO_ABSL
+using StringView = std::string_view;
+
+template <typename T>
+using Span = std::span<T>;
+
+template <typename K, typename V, typename Hash = std::hash<K>,
+          typename Eq = std::equal_to<K>,
+          typename Alloc = std::allocator<std::pair<const K, V>>>
+using FlatHashMap = std::unordered_map<K, V, Hash, Eq, Alloc>;
+
+template <typename Signature>
+using AnyInvocable = std::function<Signature>;
+
+template <typename T, std::size_t N>
+using SmallVector = std::vector<T>;
+#else
+using StringView = absl::string_view;
+
+template <typename T>
+using Span = absl::Span<T>;
+
+template <typename K, typename V, typename... Args>
+using FlatHashMap = absl::flat_hash_map<K, V, Args...>;
+
+template <typename Signature>
+using AnyInvocable = absl::AnyInvocable<Signature>;
+
+template <typename T, std::size_t N>
+using SmallVector = absl::InlinedVector<T, N>;
+#endif  // LITERT_NO_ABSL
+
+namespace internal {
+
+[[noreturn]] inline void CheckFailed(const char* expression, const char* file,
+                                     int line) {
+  std::cerr << "LiteRT check failed: " << expression << " at " << file << ":"
+            << line << '\n';
+  std::abort();
+}
+
+inline void Check(bool condition, const char* expression, const char* file,
+                  int line) {
+  if (!condition) {
+    CheckFailed(expression, file, line);
+  }
+}
+
+template <typename T>
+T* DieIfNull(T* ptr, const char* expression, const char* file, int line) {
+  if (ptr == nullptr) {
+    CheckFailed(expression, file, line);
+  }
+  return ptr;
+}
+
+template <typename T>
+constexpr Span<T> MakeSpan(T* data, std::size_t size) {
+  return Span<T>(data, size);
+}
+
+template <typename T>
+constexpr Span<const T> MakeConstSpan(const T* data, std::size_t size) {
+  return Span<const T>(data, size);
+}
+
+template <typename T, std::size_t N>
+constexpr Span<const T> MakeConstSpan(const T (&data)[N]) {
+  return Span<const T>(data, N);
+}
+
+template <typename Container>
+constexpr auto MakeSpan(Container& container)
+    -> Span<typename Container::value_type> {
+  return Span<typename Container::value_type>(container.data(),
+                                              container.size());
+}
+
+template <typename Container>
+constexpr auto MakeConstSpan(const Container& container)
+    -> Span<const typename Container::value_type> {
+  return Span<const typename Container::value_type>(container.data(),
+                                                    container.size());
+}
+
+inline constexpr StringView NullSafeStringView(const char* str) {
+  return str == nullptr ? StringView() : StringView(str);
+}
+
+template <typename CleanupFn>
+class Cleanup {
+ public:
+  explicit Cleanup(CleanupFn cleanup_fn)
+      : cleanup_fn_(std::move(cleanup_fn)), active_(true) {}
+  Cleanup(Cleanup&& other)
+      : cleanup_fn_(std::move(other.cleanup_fn_)), active_(other.active_) {
+    other.active_ = false;
+  }
+  Cleanup(const Cleanup&) = delete;
+  Cleanup& operator=(const Cleanup&) = delete;
+  Cleanup& operator=(Cleanup&&) = delete;
+  ~Cleanup() {
+    if (active_) {
+      cleanup_fn_();
+    }
+  }
+
+ private:
+  CleanupFn cleanup_fn_;
+  bool active_;
+};
+
+template <typename CleanupFn>
+Cleanup<std::decay_t<CleanupFn>> MakeCleanup(CleanupFn&& cleanup_fn) {
+  return Cleanup<std::decay_t<CleanupFn>>(
+      std::forward<CleanupFn>(cleanup_fn));
+}
+
+}  // namespace internal
+
+}  // namespace litert
+
+#define LITERT_INTERNAL_CHECK(expr) \
+  ::litert::internal::Check(static_cast<bool>(expr), #expr, __FILE__, __LINE__)
+
+#define LITERT_INTERNAL_CHECK_EQ(lhs, rhs) \
+  LITERT_INTERNAL_CHECK((lhs) == (rhs))
+
+#ifndef NDEBUG
+#define LITERT_INTERNAL_DCHECK(expr) LITERT_INTERNAL_CHECK(expr)
+#else
+#define LITERT_INTERNAL_DCHECK(expr) \
+  do {                               \
+  } while (false)
+#endif
+
+#define LITERT_INTERNAL_DIE_IF_NULL(expr) \
+  ::litert::internal::DieIfNull((expr), #expr, __FILE__, __LINE__)
+
+#endif  // ODML_LITERT_LITERT_CC_LITERT_API_TYPES_H_

--- a/litert/cc/litert_buffer_ref.h
+++ b/litert/cc/litert_buffer_ref.h
@@ -28,9 +28,7 @@
 #include <type_traits>
 #include <vector>
 
-#include "absl/strings/str_format.h"  // from @com_google_absl
-#include "absl/strings/string_view.h"  // from @com_google_absl
-#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 
 namespace litert {
 
@@ -124,7 +122,7 @@ class BufferRef {
       : end_offset_(end_offset),
         start_offset_(start_offset),
         data_(const_cast<ByteT*>(reinterpret_cast<const ByteT*>(data))) {}
-  explicit BufferRef(absl::Span<const ByteT> data)
+  explicit BufferRef(Span<const ByteT> data)
       : end_offset_(data.size()),
         start_offset_(0),
         data_(const_cast<ByteT*>(data.data())) {}
@@ -144,13 +142,13 @@ class BufferRef {
 
   /// @brief Returns a string view of the actual data.
   /// @note Ensures the view is null-terminated.
-  absl::string_view StrView() const {
-    return absl::string_view(StrData(), Size());
+  StringView StrView() const {
+    return StringView(StrData(), Size());
   }
 
   /// @brief Returns a const span of the actual data.
-  absl::Span<const ByteT> Span() const {
-    return absl::MakeConstSpan(Data(), Size());
+  Span<const ByteT> Span() const {
+    return internal::MakeConstSpan(Data(), Size());
   }
 
   /// @brief Copies the buffer data to a vector.
@@ -166,8 +164,7 @@ class BufferRef {
 
   /// @brief Prints information about this buffer.
   void Dump(std::ostream& out) const {
-    out << absl::StreamFormat("%s[%lu:%lu]\n", TypeName(), start_offset_,
-                              end_offset_);
+    out << TypeName() << "[" << start_offset_ << ":" << end_offset_ << "]\n";
   }
 
   BufferRef(const BufferRef& other) = default;
@@ -184,7 +181,7 @@ class BufferRef {
   ByteT* data_ = nullptr;
 
   /// @brief Returns the debug name of the class.
-  virtual absl::string_view TypeName() const { return "BufferRef"; }
+  virtual StringView TypeName() const { return "BufferRef"; }
 };
 template <typename ByteT = uint8_t>
 BufferRef(const ByteT*, size_t, size_t) -> BufferRef<ByteT>;
@@ -209,8 +206,8 @@ class MutableBufferRef : public BufferRef<ByteT> {
       : BufferRef<ByteT>(data, size, offset) {}
   MutableBufferRef(void* data, size_t size, size_t offset = 0)
       : BufferRef<ByteT>(data, size, offset) {}
-  explicit MutableBufferRef(absl::Span<ByteT> data) : BufferRef<ByteT>(data) {}
-  explicit MutableBufferRef(absl::Span<const ByteT> data) = delete;
+  explicit MutableBufferRef(Span<ByteT> data) : BufferRef<ByteT>(data) {}
+  explicit MutableBufferRef(Span<const ByteT> data) = delete;
   MutableBufferRef(const ByteT*, size_t, size_t) = delete;
   MutableBufferRef(const void*, size_t, size_t) = delete;
 
@@ -226,14 +223,14 @@ class MutableBufferRef : public BufferRef<ByteT> {
   }
 
   /// @brief Returns a mutable span of the actual data.
-  absl::Span<ByteT> Span() { return absl::MakeSpan(Data(), this->Size()); }
+  Span<ByteT> Span() { return internal::MakeSpan(Data(), this->Size()); }
 
   /// @brief Writes a string into the buffer at a specified offset.
   /// @param str The string to write.
   /// @param offset The offset at which to start writing.
   /// @return `true` if the entire string fits and is written, `false`
   /// otherwise.
-  bool WriteInto(absl::string_view str, size_t offset = 0) {
+  bool WriteInto(StringView str, size_t offset = 0) {
     if (str.size() > this->Size() - offset) {
       return false;
     }
@@ -246,7 +243,7 @@ class MutableBufferRef : public BufferRef<ByteT> {
 
  protected:
   /// @brief Returns the debug name of the class.
-  absl::string_view TypeName() const override { return "MutableBufferRef"; }
+  StringView TypeName() const override { return "MutableBufferRef"; }
 };
 template <typename ByteT>
 MutableBufferRef(ByteT*, size_t, size_t) -> MutableBufferRef<ByteT>;
@@ -284,7 +281,7 @@ class OwningBufferRef : public MutableBufferRef<ByteT> {
       : MutableBufferRef<ByteT>(data, size, offset) {}
   OwningBufferRef(void* data, size_t size, size_t offset = 0)
       : MutableBufferRef<ByteT>(data, size, offset) {}
-  explicit OwningBufferRef(absl::Span<ByteT> data)
+  explicit OwningBufferRef(Span<ByteT> data)
       : MutableBufferRef<ByteT>(data) {}
 
   /// @brief Copies the given buffer.
@@ -294,17 +291,17 @@ class OwningBufferRef : public MutableBufferRef<ByteT> {
     this->data_ = (ByteT*)Allocator()(size);
     std::memcpy(this->data_, data, size);
   }
-  explicit OwningBufferRef(absl::Span<const ByteT> data)
+  explicit OwningBufferRef(Span<const ByteT> data)
       : OwningBufferRef<ByteT, Allocator>(data.data(), data.size()) {}
 
   /// @brief Copies data from a given string.
-  explicit OwningBufferRef(absl::string_view data)
+  explicit OwningBufferRef(StringView data)
       : OwningBufferRef<ByteT, Allocator>(
             reinterpret_cast<const ByteT*>(data.data()), data.size()) {}
 
   /// @brief Copies data from a given C-style string.
   explicit OwningBufferRef(const char* data)
-      : OwningBufferRef<ByteT, Allocator>(absl::string_view(data)) {}
+      : OwningBufferRef<ByteT, Allocator>(StringView(data)) {}
 
   /// @brief Drops the reference to any owned memory.
   void Drop() {
@@ -375,7 +372,7 @@ class OwningBufferRef : public MutableBufferRef<ByteT> {
 
  protected:
   /// @brief Returns the debug name of the class.
-  absl::string_view TypeName() const override { return "OwningBufferRef"; }
+  StringView TypeName() const override { return "OwningBufferRef"; }
 };
 
 template <typename ByteT = uint8_t, class Allocator = Newlocator<ByteT>>

--- a/litert/cc/litert_compiled_model.h
+++ b/litert/cc/litert_compiled_model.h
@@ -27,11 +27,7 @@
 #include <variant>
 #include <vector>
 
-#include "absl/algorithm/container.h"  // from @com_google_absl
-#include "absl/container/flat_hash_map.h"  // from @com_google_absl
-#include "absl/functional/any_invocable.h"  // from @com_google_absl
-#include "absl/strings/string_view.h"  // from @com_google_absl
-#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/internal/litert_scheduling_info.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_layout.h"
@@ -125,14 +121,14 @@ inline Expected<TensorBufferRequirements> ToTensorBufferRequirements(
 
   if (num_strides == 0 || strides[0] == 0) {
     return TensorBufferRequirements::CreateWithAlignment(
-        absl::MakeConstSpan(supported_types), buffer_size, alignment);
+        internal::MakeConstSpan(supported_types), buffer_size, alignment);
   }
   return TensorBufferRequirements::CreateWithAlignment(
-      absl::MakeConstSpan(supported_types), buffer_size, alignment,
-      absl::MakeConstSpan(strides));
+      internal::MakeConstSpan(supported_types), buffer_size, alignment,
+      internal::MakeConstSpan(strides));
 }
 
-inline absl::string_view FetchTensorName(const internal::EnvironmentHolder& env,
+inline StringView FetchTensorName(const internal::EnvironmentHolder& env,
                                          LiteRtTensor tensor) {
   const char* name;
   LITERT_ABORT_IF_ERROR(env.runtime->GetTensorName(tensor, &name));
@@ -201,19 +197,19 @@ inline LiteRtQuantizationPerChannel FetchTensorQuantizationPerChannel(
   return per_channel_quantization;
 }
 
-inline absl::string_view FetchSignatureKey(
+inline StringView FetchSignatureKey(
     const internal::EnvironmentHolder& env, LiteRtSignature signature) {
   const char* key;
   LITERT_ABORT_IF_ERROR(env.runtime->GetSignatureKey(signature, &key));
   return key;
 }
 
-inline std::vector<absl::string_view> FetchSignatureInputNames(
+inline std::vector<StringView> FetchSignatureInputNames(
     const internal::EnvironmentHolder& env, LiteRtSignature signature) {
   LiteRtParamIndex num_inputs;
   LITERT_ABORT_IF_ERROR(
       env.runtime->GetNumSignatureInputs(signature, &num_inputs));
-  std::vector<absl::string_view> input_names;
+  std::vector<StringView> input_names;
   input_names.reserve(num_inputs);
   for (int i = 0; i < num_inputs; ++i) {
     const char* name;
@@ -224,12 +220,12 @@ inline std::vector<absl::string_view> FetchSignatureInputNames(
   return input_names;
 }
 
-inline std::vector<absl::string_view> FetchSignatureOutputNames(
+inline std::vector<StringView> FetchSignatureOutputNames(
     const internal::EnvironmentHolder& env, LiteRtSignature signature) {
   LiteRtParamIndex num_outputs;
   LITERT_ABORT_IF_ERROR(
       env.runtime->GetNumSignatureOutputs(signature, &num_outputs));
-  std::vector<absl::string_view> output_names;
+  std::vector<StringView> output_names;
   output_names.reserve(num_outputs);
   for (int i = 0; i < num_outputs; ++i) {
     const char* name;
@@ -413,7 +409,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Gets input buffer requirements for the given signature and input
   /// name.
   Expected<TensorBufferRequirements> GetInputBufferRequirements(
-      absl::string_view signature_name, absl::string_view input_name) {
+      StringView signature_name, StringView input_name) {
     LITERT_ASSIGN_OR_RETURN(size_t signature_index,
                             GetSignatureIndex(signature_name));
     return GetInputBufferRequirements(signature_index, input_name);
@@ -436,7 +432,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief An overload of `GetInputBufferRequirements` that takes an input
   /// tensor name.
   Expected<TensorBufferRequirements> GetInputBufferRequirements(
-      size_t signature_index, absl::string_view input_name) const {
+      size_t signature_index, StringView input_name) const {
     LITERT_ASSIGN_OR_RETURN(size_t input_index,
                             FindInputIndex(signature_index, input_name));
     return GetInputBufferRequirements(signature_index, input_index);
@@ -452,7 +448,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Gets input buffer requirements of the default signature for a given
   /// input name.
   Expected<TensorBufferRequirements> GetInputBufferRequirements(
-      absl::string_view input_name) const {
+      StringView input_name) const {
     return GetInputBufferRequirements(/*signature_index=*/0, input_name);
   }
 
@@ -460,7 +456,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Gets output buffer requirements for the given signature and output
   /// name.
   Expected<TensorBufferRequirements> GetOutputBufferRequirements(
-      absl::string_view signature_name, absl::string_view output_name) {
+      StringView signature_name, StringView output_name) {
     LITERT_ASSIGN_OR_RETURN(size_t signature_index,
                             GetSignatureIndex(signature_name));
     return GetOutputBufferRequirements(signature_index, output_name);
@@ -521,7 +517,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief An overload of `GetOutputBufferRequirements` that takes an output
   /// tensor name.
   Expected<TensorBufferRequirements> GetOutputBufferRequirements(
-      size_t signature_index, absl::string_view output_name) const {
+      size_t signature_index, StringView output_name) const {
     LITERT_ASSIGN_OR_RETURN(size_t output_index,
                             FindOutputIndex(signature_index, output_name));
     return GetOutputBufferRequirements(signature_index, output_index);
@@ -537,21 +533,21 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Gets input buffer requirements of the default signature for a given
   /// input name.
   Expected<TensorBufferRequirements> GetOutputBufferRequirements(
-      absl::string_view output_name) const {
+      StringView output_name) const {
     return GetOutputBufferRequirements(/*signature_index=*/0, output_name);
   }
 
   /// @brief Creates an input tensor buffer for the given signature and input
   /// name.
-  Expected<TensorBuffer> CreateInputBuffer(absl::string_view signature_name,
-                                           absl::string_view input_name) const {
+  Expected<TensorBuffer> CreateInputBuffer(StringView signature_name,
+                                           StringView input_name) const {
     return CreateInputOutputBuffer(signature_name, input_name,
                                    /*is_input=*/true);
   }
 
   /// @brief Creates an input tensor buffer for the default signature and a
   /// given input name.
-  Expected<TensorBuffer> CreateInputBuffer(absl::string_view input_name) const {
+  Expected<TensorBuffer> CreateInputBuffer(StringView input_name) const {
     return CreateInputOutputBuffer(/*signature_index=*/0, input_name,
                                    /*is_input=*/true);
   }
@@ -559,7 +555,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Creates an output tensor buffer for the given signature and output
   /// name.
   Expected<TensorBuffer> CreateOutputBuffer(
-      absl::string_view signature_name, absl::string_view output_name) const {
+      StringView signature_name, StringView output_name) const {
     return CreateInputOutputBuffer(signature_name, output_name,
                                    /*is_input=*/false);
   }
@@ -567,7 +563,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Creates an output tensor buffer for the default signature and a
   /// given output name.
   Expected<TensorBuffer> CreateOutputBuffer(
-      absl::string_view output_name) const {
+      StringView output_name) const {
     return CreateInputOutputBuffer(/*signature_index=*/0, output_name,
                                    /*is_input=*/false);
   }
@@ -578,7 +574,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// It uses `BufferRequirements` and `RankedTensorType` to create the input
   /// tensor buffers.
   Expected<std::vector<TensorBuffer>> CreateInputBuffers(
-      absl::string_view signature_name) const {
+      StringView signature_name) const {
     LITERT_ASSIGN_OR_RETURN(size_t signature_index,
                             GetSignatureIndex(signature_name));
     return CreateInputOutputBuffers(signature_index, /*is_input=*/true);
@@ -609,7 +605,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// It uses `BufferRequirements` and `RankedTensorType` to create the output
   /// tensor buffers.
   Expected<std::vector<TensorBuffer>> CreateOutputBuffers(
-      absl::string_view signature_name) const {
+      StringView signature_name) const {
     LITERT_ASSIGN_OR_RETURN(size_t signature_index,
                             GetSignatureIndex(signature_name));
     return CreateOutputBuffers(signature_index);
@@ -657,16 +653,16 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Runs the model for a given signature index synchronously with the
   /// provided input/output `TensorBuffer`s.
   Expected<void> Run(size_t signature_index,
-                     absl::Span<const TensorBuffer> input_buffers,
-                     absl::Span<const TensorBuffer> output_buffers) const {
+                     Span<const TensorBuffer> input_buffers,
+                     Span<const TensorBuffer> output_buffers) const {
     bool async = false;
     return RunHelper(signature_index, input_buffers, output_buffers, async);
   }
 
   /// @brief Runs the model for the default signature synchronously with the
   /// provided input/output `TensorBuffer`s.
-  Expected<void> Run(absl::Span<const TensorBuffer> input_buffers,
-                     absl::Span<const TensorBuffer> output_buffers) const {
+  Expected<void> Run(Span<const TensorBuffer> input_buffers,
+                     Span<const TensorBuffer> output_buffers) const {
     bool async = false;
     return RunHelper(/*signature_index=*/0, input_buffers, output_buffers,
                      async);
@@ -674,8 +670,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Runs with per-run options for a given signature index.
   Expected<void> Run(size_t signature_index,
-                     absl::Span<const TensorBuffer> input_buffers,
-                     absl::Span<const TensorBuffer> output_buffers,
+                     Span<const TensorBuffer> input_buffers,
+                     Span<const TensorBuffer> output_buffers,
                      Options* run_options) const {
     LiteRtOptions options_handle = nullptr;
     internal::LiteRtOptionsPtr owned_options;
@@ -691,8 +687,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Runs with per-request scheduling info for a given signature index.
   Expected<void> Run(size_t signature_index,
-                     absl::Span<const TensorBuffer> input_buffers,
-                     absl::Span<const TensorBuffer> output_buffers,
+                     Span<const TensorBuffer> input_buffers,
+                     Span<const TensorBuffer> output_buffers,
                      const LiteRtSchedulingInfo& scheduling_info) const {
     bool async = false;
     return RunHelper(signature_index, input_buffers, output_buffers, async,
@@ -700,8 +696,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   }
 
   /// @brief Runs default signature with per-run options.
-  Expected<void> Run(absl::Span<const TensorBuffer> input_buffers,
-                     absl::Span<const TensorBuffer> output_buffers,
+  Expected<void> Run(Span<const TensorBuffer> input_buffers,
+                     Span<const TensorBuffer> output_buffers,
                      Options* run_options) const {
     LiteRtOptions options_handle = nullptr;
     internal::LiteRtOptionsPtr owned_options;
@@ -717,8 +713,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   }
 
   /// @brief Runs default signature with per-request scheduling info.
-  Expected<void> Run(absl::Span<const TensorBuffer> input_buffers,
-                     absl::Span<const TensorBuffer> output_buffers,
+  Expected<void> Run(Span<const TensorBuffer> input_buffers,
+                     Span<const TensorBuffer> output_buffers,
                      const LiteRtSchedulingInfo& scheduling_info) const {
     bool async = false;
     return RunHelper(/*signature_index=*/0, input_buffers, output_buffers,
@@ -809,7 +805,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Runs the model for a given signature key synchronously with the
   /// provided input/output `TensorBuffer`s.
-  Expected<void> Run(absl::string_view signature_key,
+  Expected<void> Run(StringView signature_key,
                      const std::vector<TensorBuffer>& input_buffers,
                      const std::vector<TensorBuffer>& output_buffers) const {
     LITERT_ASSIGN_OR_RETURN(size_t signature_index,
@@ -818,7 +814,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   }
 
   /// @brief Runs by signature key with per-run options.
-  Expected<void> Run(absl::string_view signature_key,
+  Expected<void> Run(StringView signature_key,
                      const std::vector<TensorBuffer>& input_buffers,
                      const std::vector<TensorBuffer>& output_buffers,
                      Options* run_options) const {
@@ -828,7 +824,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   }
 
   /// @brief Runs by signature key with per-request scheduling info.
-  Expected<void> Run(absl::string_view signature_key,
+  Expected<void> Run(StringView signature_key,
                      const std::vector<TensorBuffer>& input_buffers,
                      const std::vector<TensorBuffer>& output_buffers,
                      const LiteRtSchedulingInfo& scheduling_info) const {
@@ -842,7 +838,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   ///
   /// If asynchronous execution is possible, `async` will be set to `true`;
   /// otherwise, the function runs the model synchronously.
-  Expected<void> RunAsync(absl::string_view signature_key,
+  Expected<void> RunAsync(StringView signature_key,
                           const std::vector<TensorBuffer>& input_buffers,
                           const std::vector<TensorBuffer>& output_buffers,
                           bool& async) const {
@@ -853,7 +849,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   }
 
   /// @brief Runs by signature key asynchronously with per-run options.
-  Expected<void> RunAsync(absl::string_view signature_key,
+  Expected<void> RunAsync(StringView signature_key,
                           const std::vector<TensorBuffer>& input_buffers,
                           const std::vector<TensorBuffer>& output_buffers,
                           bool& async, Options* run_options) const {
@@ -866,7 +862,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Runs by signature key asynchronously with per-request scheduling
   /// info.
-  Expected<void> RunAsync(absl::string_view signature_key,
+  Expected<void> RunAsync(StringView signature_key,
                           const std::vector<TensorBuffer>& input_buffers,
                           const std::vector<TensorBuffer>& output_buffers,
                           bool& async,
@@ -884,9 +880,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// If you have bound the input with external buffers through `Options`, you
   /// can skip providing those input buffers in the map.
   Expected<void> Run(
-      absl::string_view signature_key,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map)
+      StringView signature_key,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map)
       const {
     bool async = false;
     return RunMapHelper(signature_key, input_map, output_map, async);
@@ -894,9 +890,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Runs by signature key with per-run options using named maps.
   Expected<void> Run(
-      absl::string_view signature_key,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      StringView signature_key,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       Options* run_options) const {
     LiteRtOptions options_handle = nullptr;
     internal::LiteRtOptionsPtr owned_options;
@@ -913,9 +909,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Runs by signature key with per-request scheduling info using named
   /// maps.
   Expected<void> Run(
-      absl::string_view signature_key,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      StringView signature_key,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       const LiteRtSchedulingInfo& scheduling_info) const {
     bool async = false;
     return RunMapHelper(signature_key, input_map, output_map, async, nullptr,
@@ -928,8 +924,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// If you have bound the input with external buffers through `Options`, you
   /// can skip providing those input buffers in the map.
   Expected<void> Run(
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map)
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map)
       const {
     bool async = false;
     return RunMapWithIndexHelper(/*signature_index=*/0, input_map, output_map,
@@ -938,8 +934,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Runs default signature with per-run options using named maps.
   Expected<void> Run(
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       Options* run_options) const {
     LiteRtOptions options_handle = nullptr;
     internal::LiteRtOptionsPtr owned_options;
@@ -957,8 +953,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Runs default signature with per-request scheduling info using
   /// named maps.
   Expected<void> Run(
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       const LiteRtSchedulingInfo& scheduling_info) const {
     bool async = false;
     return RunMapWithIndexHelper(/*signature_index=*/0, input_map, output_map,
@@ -971,9 +967,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// If asynchronous execution is possible, `async` will be set to `true`;
   /// otherwise, the function runs the model synchronously.
   Expected<void> RunAsync(
-      absl::string_view signature_key,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      StringView signature_key,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       bool& async) const {
     async = true;
     return RunMapHelper(signature_key, input_map, output_map, async);
@@ -982,9 +978,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Runs by signature key asynchronously with per-run options using
   /// named maps.
   Expected<void> RunAsync(
-      absl::string_view signature_key,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      StringView signature_key,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       bool& async, Options* run_options) const {
     LiteRtOptions options_handle = nullptr;
     internal::LiteRtOptionsPtr owned_options;
@@ -1001,9 +997,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Runs by signature key asynchronously with per-request scheduling
   /// info using named maps.
   Expected<void> RunAsync(
-      absl::string_view signature_key,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      StringView signature_key,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       bool& async, const LiteRtSchedulingInfo& scheduling_info) const {
     async = true;
     return RunMapHelper(signature_key, input_map, output_map, async, nullptr,
@@ -1039,7 +1035,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// The callback will be called periodically during model execution. This is a
   /// C++-friendly version of `SetCancellationFunction`.
   void SetCancellationFunction(
-      absl::AnyInvocable<bool()> check_cancelled_func) {
+      AnyInvocable<bool()> check_cancelled_func) {
     check_cancelled_func_ = std::move(check_cancelled_func);
     env_.runtime->SetCompiledModelCancellationFunction(Get(), this,
                                                        &CheckCancelledWrapper);
@@ -1062,7 +1058,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @return Success if the resize operation completes successfully, or an
   /// error with an appropriate status code on failure.
   Expected<void> ResizeInputTensor(size_t signature_index, size_t input_index,
-                                   absl::Span<const int> dims) {
+                                   Span<const int> dims) {
     LITERT_RETURN_IF_ERROR(env_.runtime->CompiledModelResizeInputTensor(
         Get(), signature_index, input_index, dims.data(), dims.size()));
     return {};
@@ -1071,8 +1067,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Resizes the specified input tensor by name for the given
   /// signature.
   Expected<void> ResizeInputTensor(size_t signature_index,
-                                   absl::string_view input_name,
-                                   absl::Span<const int> dims) {
+                                   StringView input_name,
+                                   Span<const int> dims) {
     LITERT_ASSIGN_OR_RETURN(size_t input_index,
                             FindInputIndex(signature_index, input_name));
     return ResizeInputTensor(signature_index, input_index, dims);
@@ -1080,9 +1076,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Resizes the specified input tensor by name for the given signature
   /// name.
-  Expected<void> ResizeInputTensor(absl::string_view signature_name,
-                                   absl::string_view input_name,
-                                   absl::Span<const int> dims) {
+  Expected<void> ResizeInputTensor(StringView signature_name,
+                                   StringView input_name,
+                                   Span<const int> dims) {
     LITERT_ASSIGN_OR_RETURN(size_t signature_index,
                             GetSignatureIndex(signature_name));
     return ResizeInputTensor(signature_index, input_name, dims);
@@ -1091,14 +1087,14 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Resizes the specified input tensor of the default signature by
   /// index.
   Expected<void> ResizeInputTensor(size_t input_index,
-                                   absl::Span<const int> dims) {
+                                   Span<const int> dims) {
     return ResizeInputTensor(/*signature_index=*/0, input_index, dims);
   }
 
   /// @brief Resizes the specified input tensor of the default signature by
   /// name.
-  Expected<void> ResizeInputTensor(absl::string_view input_name,
-                                   absl::Span<const int> dims) {
+  Expected<void> ResizeInputTensor(StringView input_name,
+                                   Span<const int> dims) {
     return ResizeInputTensor(/*signature_index=*/0, input_name, dims);
   }
 
@@ -1106,7 +1102,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// allowing arbitrary shape updates when backends support them.
   Expected<void> ResizeInputTensorNonStrict(size_t signature_index,
                                             size_t input_index,
-                                            absl::Span<const int> dims) {
+                                            Span<const int> dims) {
     LITERT_RETURN_IF_ERROR(
         env_.runtime->CompiledModelResizeInputTensorNonStrict(
             Get(), signature_index, input_index, dims.data(), dims.size()));
@@ -1116,8 +1112,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Resizes the specified input tensor by name for the given
   /// signature.
   Expected<void> ResizeInputTensorNonStrict(size_t signature_index,
-                                            absl::string_view input_name,
-                                            absl::Span<const int> dims) {
+                                            StringView input_name,
+                                            Span<const int> dims) {
     LITERT_ASSIGN_OR_RETURN(size_t input_index,
                             FindInputIndex(signature_index, input_name));
     return ResizeInputTensorNonStrict(signature_index, input_index, dims);
@@ -1125,9 +1121,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Resizes the specified input tensor by name for the given signature
   /// name.
-  Expected<void> ResizeInputTensorNonStrict(absl::string_view signature_name,
-                                            absl::string_view input_name,
-                                            absl::Span<const int> dims) {
+  Expected<void> ResizeInputTensorNonStrict(StringView signature_name,
+                                            StringView input_name,
+                                            Span<const int> dims) {
     LITERT_ASSIGN_OR_RETURN(size_t signature_index,
                             GetSignatureIndex(signature_name));
     return ResizeInputTensorNonStrict(signature_index, input_name, dims);
@@ -1136,14 +1132,14 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Resizes the specified input tensor of the default signature by
   /// index.
   Expected<void> ResizeInputTensorNonStrict(size_t input_index,
-                                            absl::Span<const int> dims) {
+                                            Span<const int> dims) {
     return ResizeInputTensorNonStrict(/*signature_index=*/0, input_index, dims);
   }
 
   /// @brief Resizes the specified input tensor of the default signature by
   /// name.
-  Expected<void> ResizeInputTensorNonStrict(absl::string_view input_name,
-                                            absl::Span<const int> dims) {
+  Expected<void> ResizeInputTensorNonStrict(StringView input_name,
+                                            Span<const int> dims) {
     return ResizeInputTensorNonStrict(/*signature_index=*/0, input_name, dims);
   }
 
@@ -1153,8 +1149,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// execution and provide runtime hints and metadata for hardware accelerator
   /// optimization.
   Expected<void> SetDispatchAnnotation(size_t signature_index,
-                                       absl::string_view key,
-                                       absl::string_view value) {
+                                       StringView key,
+                                       StringView value) {
     const std::string key_string(key);
     const std::string value_string(value);
     LITERT_RETURN_IF_ERROR(env_.runtime->CompiledModelSetDispatchAnnotation(
@@ -1166,7 +1162,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   ///
   /// Returns `std::nullopt` if the key does not exist.
   Expected<std::optional<std::string>> GetDispatchAnnotation(
-      size_t signature_index, absl::string_view key) {
+      size_t signature_index, StringView key) {
     const std::string key_string(key);
     const char* value = nullptr;
     LITERT_RETURN_IF_ERROR(env_.runtime->CompiledModelGetDispatchAnnotation(
@@ -1181,7 +1177,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   ///
   /// This succeeds even if the key does not exist.
   Expected<void> RemoveDispatchAnnotation(size_t signature_index,
-                                          absl::string_view key) {
+                                          StringView key) {
     const std::string key_string(key);
     LITERT_RETURN_IF_ERROR(env_.runtime->CompiledModelRemoveDispatchAnnotation(
         Get(), signature_index, key_string.c_str()));
@@ -1189,27 +1185,27 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   }
 
   /// @brief Overloaded version for the default signature (index 0).
-  Expected<void> SetDispatchAnnotation(absl::string_view key,
-                                       absl::string_view value) {
+  Expected<void> SetDispatchAnnotation(StringView key,
+                                       StringView value) {
     return SetDispatchAnnotation(0, key, value);
   }
 
   /// @brief Overloaded version for the default signature (index 0).
   Expected<std::optional<std::string>> GetDispatchAnnotation(
-      absl::string_view key) {
+      StringView key) {
     return GetDispatchAnnotation(0, key);
   }
 
   /// @brief Overloaded version for the default signature (index 0).
-  Expected<void> RemoveDispatchAnnotation(absl::string_view key) {
+  Expected<void> RemoveDispatchAnnotation(StringView key) {
     return RemoveDispatchAnnotation(0, key);
   }
 
   /// @brief Overloaded version that takes a signature name instead of an
   /// index.
-  Expected<void> SetDispatchAnnotation(absl::string_view signature_name,
-                                       absl::string_view key,
-                                       absl::string_view value) {
+  Expected<void> SetDispatchAnnotation(StringView signature_name,
+                                       StringView key,
+                                       StringView value) {
     LITERT_ASSIGN_OR_RETURN(size_t signature_index,
                             GetSignatureIndex(signature_name));
     return SetDispatchAnnotation(signature_index, key, value);
@@ -1218,7 +1214,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Overloaded version that takes a signature name instead of an
   /// index.
   Expected<std::optional<std::string>> GetDispatchAnnotation(
-      absl::string_view signature_name, absl::string_view key) {
+      StringView signature_name, StringView key) {
     LITERT_ASSIGN_OR_RETURN(size_t signature_index,
                             GetSignatureIndex(signature_name));
     return GetDispatchAnnotation(signature_index, key);
@@ -1226,8 +1222,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Overloaded version that takes a signature name instead of an
   /// index.
-  Expected<void> RemoveDispatchAnnotation(absl::string_view signature_name,
-                                          absl::string_view key) {
+  Expected<void> RemoveDispatchAnnotation(StringView signature_name,
+                                          StringView key) {
     LITERT_ASSIGN_OR_RETURN(size_t signature_index,
                             GetSignatureIndex(signature_name));
     return RemoveDispatchAnnotation(signature_index, key);
@@ -1277,7 +1273,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   //----------------------------------------------------------------------------
 
   /// @brief Returns the default signature key of the model.
-  static absl::string_view DefaultSignatureKey() {
+  static StringView DefaultSignatureKey() {
     return kDefaultSignatureKey;
   }
 
@@ -1290,7 +1286,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   }
 
   /// @brief Returns the list of signature key names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureKeys() const {
+  Expected<std::vector<StringView>> GetSignatureKeys() const {
     return GetSignatureKeysImpl();
   }
 
@@ -1327,7 +1323,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Returns the signature index for a given signature key.
   ///
   /// Returns 0 if the signature key is empty.
-  Expected<size_t> GetSignatureIndex(absl::string_view signature_key) const {
+  Expected<size_t> GetSignatureIndex(StringView signature_key) const {
     if (signature_key.empty()) {
       return 0;
     }
@@ -1346,25 +1342,25 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   }
 
   Expected<SimpleSignature> FindSignature(
-      absl::string_view signature_key) const {
+      StringView signature_key) const {
     LITERT_ASSIGN_OR_RETURN(auto index, GetSignatureIndex(signature_key));
     return GetSignature(index);
   }
 
   /// @brief Returns the list of input names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureInputNames(
+  Expected<std::vector<StringView>> GetSignatureInputNames(
       size_t signature_index) const {
     return GetSignatureInputNamesImpl(signature_index);
   }
 
   /// @brief Returns the list of input names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureInputNames() const {
+  Expected<std::vector<StringView>> GetSignatureInputNames() const {
     return GetSignatureInputNames(/*signature_index=*/0);
   }
 
   /// @brief Returns the list of input names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureInputNames(
-      absl::string_view signature_key) const {
+  Expected<std::vector<StringView>> GetSignatureInputNames(
+      StringView signature_key) const {
     auto signature = FindSignature(signature_key);
     if (!signature) {
       return Unexpected(Status::kErrorNotFound, "Signature not found");
@@ -1373,19 +1369,19 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   }
 
   /// @brief Returns the list of output names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureOutputNames(
+  Expected<std::vector<StringView>> GetSignatureOutputNames(
       size_t signature_index) const {
     return GetSignatureOutputNamesImpl(signature_index);
   }
 
   /// @brief Returns the list of output names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureOutputNames() const {
+  Expected<std::vector<StringView>> GetSignatureOutputNames() const {
     return GetSignatureOutputNames(/*signature_index=*/0);
   }
 
   /// @brief Returns the list of output names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureOutputNames(
-      absl::string_view signature_key) const {
+  Expected<std::vector<StringView>> GetSignatureOutputNames(
+      StringView signature_key) const {
     auto signature = FindSignature(signature_key);
     if (!signature) {
       return Unexpected(Status::kErrorNotFound, "Signature not found");
@@ -1403,7 +1399,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Returns the tensor type for a given input tensor name.
   Expected<RankedTensorType> GetInputTensorType(
-      size_t signature_index, absl::string_view input_name) const {
+      size_t signature_index, StringView input_name) const {
     LITERT_ASSIGN_OR_RETURN(const SimpleSignature& signature,
                             GetSignature(signature_index));
     return signature.InputTensorType(input_name);
@@ -1411,7 +1407,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Returns the tensor type for a given input tensor name.
   Expected<RankedTensorType> GetInputTensorType(
-      absl::string_view signature_key, absl::string_view input_name) const {
+      StringView signature_key, StringView input_name) const {
     LITERT_ASSIGN_OR_RETURN(const SimpleSignature& signature,
                             FindSignature(signature_key));
     return signature.InputTensorType(input_name);
@@ -1420,7 +1416,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Gets the input tensor type of the default signature for a given
   /// input name.
   Expected<RankedTensorType> GetInputTensorType(
-      absl::string_view input_name) const {
+      StringView input_name) const {
     LITERT_ASSIGN_OR_RETURN(const SimpleSignature& signature,
                             GetSignature(/*signature_index=*/0));
     return signature.InputTensorType(input_name);
@@ -1436,7 +1432,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Returns the tensor type for a given output tensor name.
   Expected<RankedTensorType> GetOutputTensorType(
-      size_t signature_index, absl::string_view output_name) const {
+      size_t signature_index, StringView output_name) const {
     LITERT_ASSIGN_OR_RETURN(const SimpleSignature& signature,
                             GetSignature(signature_index));
     return signature.OutputTensorType(output_name);
@@ -1444,7 +1440,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Returns the tensor type for a given output tensor name.
   Expected<RankedTensorType> GetOutputTensorType(
-      absl::string_view signature_key, absl::string_view output_name) const {
+      StringView signature_key, StringView output_name) const {
     LITERT_ASSIGN_OR_RETURN(const SimpleSignature& signature,
                             FindSignature(signature_key));
     return signature.OutputTensorType(output_name);
@@ -1453,7 +1449,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Gets the output tensor type of the default signature for a given
   /// output name.
   Expected<RankedTensorType> GetOutputTensorType(
-      absl::string_view output_name) const {
+      StringView output_name) const {
     LITERT_ASSIGN_OR_RETURN(const SimpleSignature& signature,
                             GetSignature(/*signature_index=*/0));
     return signature.OutputTensorType(output_name);
@@ -1554,10 +1550,10 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Returns the signature input index for a given input tensor name.
   Expected<size_t> FindInputIndex(size_t signature_index,
-                                  absl::string_view input_name) const {
+                                  StringView input_name) const {
     LITERT_ASSIGN_OR_RETURN(const auto input_names,
                             GetSignatureInputNames(signature_index));
-    auto it = absl::c_find(input_names, input_name);
+    auto it = std::find(input_names.begin(), input_names.end(), input_name);
     if (it != input_names.end()) {
       return std::distance(input_names.begin(), it);
     }
@@ -1567,10 +1563,10 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Returns the signature output index for a given output tensor
   /// name.
   Expected<size_t> FindOutputIndex(size_t signature_index,
-                                   absl::string_view output_name) const {
+                                   StringView output_name) const {
     LITERT_ASSIGN_OR_RETURN(const auto output_names,
                             GetSignatureOutputNames(signature_index));
-    auto it = absl::c_find(output_names, output_name);
+    auto it = std::find(output_names.begin(), output_names.end(), output_name);
     if (it != output_names.end()) {
       return std::distance(output_names.begin(), it);
     }
@@ -1590,7 +1586,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   /// @brief Creates a `TensorBuffer` for a given signature index and tensor
   /// name.
   Expected<TensorBuffer> CreateInputOutputBuffer(size_t signature_index,
-                                                 absl::string_view tensor_name,
+                                                 StringView tensor_name,
                                                  bool is_input) const {
     Expected<RankedTensorType> tensor_type_expected =
         is_input ? GetInputTensorType(signature_index, tensor_name)
@@ -1629,7 +1625,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   /// @brief Creates a `TensorBuffer` for a given signature and tensor name.
   Expected<TensorBuffer> CreateInputOutputBuffer(
-      absl::string_view signature_name, absl::string_view tensor_name,
+      StringView signature_name, StringView tensor_name,
       bool is_input) const {
     LITERT_ASSIGN_OR_RETURN(size_t signature_index,
                             GetSignatureIndex(signature_name));
@@ -1641,7 +1637,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   Expected<std::vector<TensorBuffer>> CreateInputOutputBuffers(
       size_t signature_index, bool is_input) const {
     std::vector<TensorBuffer> tensor_buffers;
-    Expected<std::vector<absl::string_view>> tensor_names;
+    Expected<std::vector<StringView>> tensor_names;
     tensor_names = is_input ? GetSignatureInputNames(signature_index)
                             : GetSignatureOutputNames(signature_index);
     if (!tensor_names) {
@@ -1742,8 +1738,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   // Compatibility overload that routes to the richer helper with default args.
   Expected<void> RunHelper(size_t signature_index,
-                           absl::Span<const TensorBuffer> input_buffers,
-                           absl::Span<const TensorBuffer> output_buffers,
+                           Span<const TensorBuffer> input_buffers,
+                           Span<const TensorBuffer> output_buffers,
                            bool& async) const {
     return RunHelper(signature_index, input_buffers, output_buffers, async,
                      /*run_options=*/nullptr,
@@ -1752,8 +1748,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   // Compatibility overload that routes to the richer helper with default args.
   Expected<void> RunHelper(size_t signature_index,
-                           absl::Span<const TensorBuffer> input_buffers,
-                           absl::Span<const TensorBuffer> output_buffers,
+                           Span<const TensorBuffer> input_buffers,
+                           Span<const TensorBuffer> output_buffers,
                            bool& async, LiteRtOptions run_options) const {
     return RunHelper(signature_index, input_buffers, output_buffers, async,
                      run_options,
@@ -1761,8 +1757,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   }
 
   Expected<void> RunHelper(size_t signature_index,
-                           absl::Span<const TensorBuffer> input_buffers,
-                           absl::Span<const TensorBuffer> output_buffers,
+                           Span<const TensorBuffer> input_buffers,
+                           Span<const TensorBuffer> output_buffers,
                            bool& async, LiteRtOptions run_options,
                            const LiteRtSchedulingInfo* scheduling_info) const {
     auto input_buffers_ptr =
@@ -1783,9 +1779,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   // Compatibility overload that routes to the richer helper with default args.
   Expected<void> RunMapHelper(
-      absl::string_view signature_key,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      StringView signature_key,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       bool& async) const {
     return RunMapHelper(signature_key, input_map, output_map, async,
                         /*run_options=*/nullptr,
@@ -1794,9 +1790,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   // Compatibility overload that routes to the richer helper with default args.
   Expected<void> RunMapHelper(
-      absl::string_view signature_key,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      StringView signature_key,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       bool& async, LiteRtOptions run_options) const {
     auto signature_index = GetSignatureIndex(signature_key);
     return RunMapHelper(signature_key, input_map, output_map, async,
@@ -1805,9 +1801,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   }
 
   Expected<void> RunMapHelper(
-      absl::string_view signature_key,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      StringView signature_key,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       bool& async, LiteRtOptions run_options,
       const LiteRtSchedulingInfo* scheduling_info) const {
     auto signature_index = GetSignatureIndex(signature_key);
@@ -1822,8 +1818,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   // Compatibility overload that routes to the richer helper with default args.
   Expected<void> RunMapWithIndexHelper(
       size_t signature_index,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       bool& async) const {
     return RunMapWithIndexHelper(signature_index, input_map, output_map, async,
                                  /*run_options=*/nullptr,
@@ -1833,8 +1829,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
   // Compatibility overload that routes to the richer helper with default args.
   Expected<void> RunMapWithIndexHelper(
       size_t signature_index,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       bool& async, LiteRtOptions run_options) const {
     return RunMapWithIndexHelper(signature_index, input_map, output_map, async,
                                  run_options,
@@ -1843,8 +1839,8 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   Expected<void> RunMapWithIndexHelper(
       size_t signature_index,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& input_map,
-      const absl::flat_hash_map<absl::string_view, TensorBuffer>& output_map,
+      const FlatHashMap<StringView, TensorBuffer>& input_map,
+      const FlatHashMap<StringView, TensorBuffer>& output_map,
       bool& async, LiteRtOptions run_options,
       const LiteRtSchedulingInfo* scheduling_info) const {
     LITERT_ASSIGN_OR_RETURN(auto input_names,
@@ -1852,7 +1848,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
     size_t num_inputs = input_names.size();
     auto input_buffers_ptr = std::make_unique<LiteRtTensorBuffer[]>(num_inputs);
     for (int i = 0; i < num_inputs; ++i) {
-      absl::string_view input_name = input_names[i];
+      StringView input_name = input_names[i];
       auto it = input_map.find(input_name);
       if (it == input_map.end()) {
         input_buffers_ptr[i] = nullptr;
@@ -1866,7 +1862,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
     auto output_buffers_ptr =
         std::make_unique<LiteRtTensorBuffer[]>(num_outputs);
     for (int i = 0; i < num_outputs; ++i) {
-      absl::string_view output_name = output_names[i];
+      StringView output_name = output_names[i];
       auto it = output_map.find(output_name);
       if (it == output_map.end()) {
         return Unexpected(Status::kErrorNotFound,
@@ -1879,9 +1875,9 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
                          run_options, scheduling_info);
   }
 
-  Expected<std::vector<absl::string_view>> GetSignatureKeysImpl() const {
+  Expected<std::vector<StringView>> GetSignatureKeysImpl() const {
     size_t num_signatures = GetNumSignatures();
-    std::vector<absl::string_view> signature_keys;
+    std::vector<StringView> signature_keys;
     signature_keys.reserve(num_signatures);
     for (int i = 0; i < num_signatures; ++i) {
       LiteRtSignature lite_rt_signature;
@@ -1893,7 +1889,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
     }
     return signature_keys;
   }
-  Expected<std::vector<absl::string_view>> GetSignatureInputNamesImpl(
+  Expected<std::vector<StringView>> GetSignatureInputNamesImpl(
       size_t signature_index) const {
     LiteRtSignature lite_rt_signature;
     LITERT_RETURN_IF_ERROR(env_.runtime->GetModelSignature(
@@ -1901,7 +1897,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
     return internal::compiled_model_detail::FetchSignatureInputNames(
         env_, lite_rt_signature);
   }
-  Expected<std::vector<absl::string_view>> GetSignatureOutputNamesImpl(
+  Expected<std::vector<StringView>> GetSignatureOutputNamesImpl(
       size_t signature_index) const {
     LiteRtSignature lite_rt_signature;
     LITERT_RETURN_IF_ERROR(env_.runtime->GetModelSignature(
@@ -1912,7 +1908,7 @@ class CompiledModel : public internal::BaseHandle<LiteRtCompiledModel> {
 
   internal::EnvironmentHolder env_;
   internal::LiteRtOptionsPtr options_;
-  absl::AnyInvocable<bool()> check_cancelled_func_;
+  AnyInvocable<bool()> check_cancelled_func_;
   internal::BaseHandle<LiteRtModel> model_;
 };
 

--- a/litert/cc/litert_environment.h
+++ b/litert/cc/litert_environment.h
@@ -23,7 +23,7 @@
 #include <variant>
 #include <vector>
 
-#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/internal/litert_logging.h"
 #include "litert/c/litert_any.h"
 #include "litert/c/litert_common.h"
@@ -107,7 +107,7 @@ class Environment {
     return FromCOptions(options);
   }
 
-  static Expected<Environment> Create(absl::Span<const Option> options) {
+  static Expected<Environment> Create(Span<const Option> options) {
     std::vector<EnvironmentOptions::Option> env_options;
     env_options.reserve(options.size());
     for (const auto& option : options) {
@@ -275,7 +275,7 @@ class Environment {
       handle_;
 
   static Expected<std::vector<LiteRtEnvOption>> ToCOptions(
-      absl::Span<const EnvironmentOptions::Option> options) {
+      Span<const EnvironmentOptions::Option> options) {
     std::vector<LiteRtEnvOption> c_options;
     c_options.reserve(options.size());
 

--- a/litert/cc/litert_environment_options.h
+++ b/litert/cc/litert_environment_options.h
@@ -20,8 +20,7 @@
 #include <variant>
 #include <vector>
 
-#include "absl/strings/string_view.h"  // from @com_google_absl
-#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_environment_options.h"
 #include "litert/cc/litert_any.h"
 #include "litert/cc/litert_common.h"
@@ -100,8 +99,8 @@ class EnvironmentOptions {
     std::string str_value;
 
     Option(Tag param_tag, LiteRtVariant param_value) : tag(param_tag) {
-      if (std::holds_alternative<absl::string_view>(param_value)) {
-        str_value = std::get<absl::string_view>(param_value);
+      if (std::holds_alternative<StringView>(param_value)) {
+        str_value = std::get<StringView>(param_value);
         value = str_value.c_str();
       } else if (std::holds_alternative<const char*>(param_value)) {
         str_value = std::get<const char*>(param_value);
@@ -158,13 +157,13 @@ class EnvironmentOptions {
   /// Constructs an `EnvironmentOptions` object from a span of options.
   /// @param options A span of `Option` objects to initialize the environment
   /// options with.
-  explicit EnvironmentOptions(absl::Span<const Option> options)
+  explicit EnvironmentOptions(Span<const Option> options)
       : options_(options.begin(), options.end()) {}
 
   /// Retrieves all options.
   /// @return A span of all options.
-  absl::Span<const Option> GetOptions() const {
-    return absl::MakeConstSpan(options_);
+  Span<const Option> GetOptions() const {
+    return internal::MakeConstSpan(options_);
   }
 
   /// Retrieves the value of an option specified by a tag.

--- a/litert/cc/litert_expected.h
+++ b/litert/cc/litert_expected.h
@@ -24,10 +24,13 @@
 #include <type_traits>
 #include <utility>
 
+#ifndef LITERT_NO_ABSL
 #include "absl/log/absl_check.h"  // from @com_google_absl
 #include "absl/strings/str_cat.h"  // from @com_google_absl
 #include "absl/strings/str_format.h"  // from @com_google_absl
+#endif  // LITERT_NO_ABSL
 #include "litert/c/litert_common.h"
+#include "litert/cc/litert_api_types.h"
 #include "litert/cc/litert_common.h"
 
 /// @file
@@ -49,13 +52,13 @@ class Error {
   explicit Error(::litert::Status status, std::string message = "")
       : status_(static_cast<LiteRtStatus>(status)),
         message_(std::move(message)) {
-    ABSL_DCHECK(status != ::litert::Status::kOk);
+    LITERT_INTERNAL_DCHECK(status != ::litert::Status::kOk);
   }
 
   [[deprecated("Use the constructor that takes ::litert::Status instead.")]]
   explicit Error(LiteRtStatus status, std::string message = "")
       : status_(status), message_(std::move(message)) {
-    ABSL_DCHECK(status != kLiteRtStatusOk);
+    LITERT_INTERNAL_DCHECK(status != kLiteRtStatusOk);
   }
 
   /// @brief Gets the status.
@@ -81,6 +84,7 @@ class Error {
     return stream;
   }
 
+#ifndef LITERT_NO_ABSL
   template <class Sink>
   friend void AbslStringify(Sink& sink, const Error& error) {
     absl::Format(&sink, "%s", LiteRtGetStatusString(error.status_));
@@ -88,6 +92,7 @@ class Error {
       absl::Format(&sink, ": %v", error.Message());
     }
   }
+#endif  // LITERT_NO_ABSL
 
  private:
   LiteRtStatus status_;
@@ -127,10 +132,12 @@ class Unexpected {
   }
   constexpr class Error&& Error() && noexcept { return std::move(error_); }
 
+#ifndef LITERT_NO_ABSL
   template <class Sink>
   friend void AbslStringify(Sink& sink, const Unexpected& unexpected) {
     AbslStringify(sink, unexpected.Error());
   }
+#endif  // LITERT_NO_ABSL
 
  private:
   class Error error_;
@@ -377,8 +384,8 @@ class Expected {
     StorageType value_;
     Unexpected unexpected_;
   };
-  void CheckNoVal() const { ABSL_CHECK(!HasValue()); }
-  void CheckVal() const { ABSL_CHECK(HasValue()); }
+  void CheckNoVal() const { LITERT_INTERNAL_CHECK(!HasValue()); }
+  void CheckVal() const { LITERT_INTERNAL_CHECK(HasValue()); }
 };
 
 template <class T>
@@ -387,6 +394,7 @@ Expected(const T&) -> Expected<T>;
 template <class T>
 Expected(T&&) -> Expected<T>;
 
+#ifndef LITERT_NO_ABSL
 namespace internal {
 template <class T>
 struct CanBeAbslFormated {
@@ -419,6 +427,7 @@ void AbslStringify(Sink& sink, const Expected<T>& expected) {
     }
   }
 }
+#endif  // LITERT_NO_ABSL
 
 /// @brief A specialization of `Expected` for `void`.
 ///
@@ -474,8 +483,8 @@ class Expected<void> {
 
  private:
   std::optional<Unexpected> unexpected_;
-  void CheckNoVal() const { ABSL_CHECK(!HasValue()); }
-  void CheckVal() const { ABSL_CHECK(HasValue()); }
+  void CheckNoVal() const { LITERT_INTERNAL_CHECK(!HasValue()); }
+  void CheckVal() const { LITERT_INTERNAL_CHECK(HasValue()); }
 };
 
 }  // namespace litert

--- a/litert/cc/litert_layout.h
+++ b/litert/cc/litert_layout.h
@@ -22,8 +22,7 @@
 #include <optional>
 #include <utility>
 
-#include "absl/container/inlined_vector.h"  // from @com_google_absl
-#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_layout.h"
 #include "litert/cc/internal/litert_consts.h"
 #include "litert/cc/litert_expected.h"
@@ -34,8 +33,8 @@
 
 namespace litert {
 
-using Dimensions = absl::InlinedVector<int32_t, kExpectedMaxTensorRank>;
-using Strides = absl::InlinedVector<uint32_t, kExpectedMaxTensorRank>;
+using Dimensions = SmallVector<int32_t, kExpectedMaxTensorRank>;
+using Strides = SmallVector<uint32_t, kExpectedMaxTensorRank>;
 
 /// @brief Small standalone helper functions for working with the C layout API.
 
@@ -77,16 +76,16 @@ inline constexpr LiteRtLayout BuildLayout(std::initializer_list<int32_t> dims,
 }
 
 /// @brief Gets the dimensions as a span.
-inline constexpr absl::Span<const int32_t> DimsSpan(
+inline constexpr Span<const int32_t> DimsSpan(
     const LiteRtLayout& layout) {
-  return absl::MakeConstSpan(layout.dimensions, layout.rank);
+  return internal::MakeConstSpan(layout.dimensions, layout.rank);
 }
 
 /// @brief Gets the strides as a span if they exist.
-inline constexpr std::optional<absl::Span<const uint32_t>> StridesSpan(
+inline constexpr std::optional<Span<const uint32_t>> StridesSpan(
     const LiteRtLayout& layout) {
   if (layout.has_strides) {
-    return absl::MakeConstSpan(layout.strides, layout.rank);
+    return internal::MakeConstSpan(layout.strides, layout.rank);
   }
   return {};
 }
@@ -119,13 +118,13 @@ class Layout {
 
   uint32_t Rank() const { return lrt_layout_.rank; }
 
-  absl::Span<const Dim> Dimensions() const {
-    return absl::MakeSpan(lrt_layout_.dimensions, Rank());
+  Span<const Dim> Dimensions() const {
+    return internal::MakeSpan(lrt_layout_.dimensions, Rank());
   }
 
   bool HasStrides() const { return lrt_layout_.has_strides; }
 
-  absl::Span<const uint32_t> Strides() const {
+  Span<const uint32_t> Strides() const {
     if (HasStrides()) {
       return {lrt_layout_.strides, Rank()};
     } else {

--- a/litert/cc/litert_macros.h
+++ b/litert/cc/litert_macros.h
@@ -23,12 +23,15 @@
 #include <type_traits>
 #include <utility>
 
+#ifndef LITERT_NO_ABSL
 #include "absl/log/absl_check.h"  // from @com_google_absl
 #include "absl/status/status.h"  // from @com_google_absl
 #include "absl/status/statusor.h"  // from @com_google_absl
+#endif  // LITERT_NO_ABSL
 #include "litert/c/internal/litert_logging.h"
 #include "litert/c/litert_common.h"
 #include "litert/cc/internal/litert_source_location.h"
+#include "litert/cc/litert_api_types.h"
 #include "litert/cc/litert_common.h"
 #include "litert/cc/litert_expected.h"
 
@@ -152,12 +155,14 @@ class ErrorStatusBuilder {
     return litert::Unexpected(error_.StatusCC(), LogMessage());
   }
 
+#ifndef LITERT_NO_ABSL
   operator absl::Status() const noexcept { return ToAbslStatus(); }
 
   template <class T>
   operator absl::StatusOr<T>() const noexcept {
     return ToAbslStatus();
   }
+#endif  // LITERT_NO_ABSL
   // NOLINTEND(*-explicit-constructor)
 
   template <class T>
@@ -235,6 +240,7 @@ class ErrorStatusBuilder {
     return e.Value();
   }
 
+#ifndef LITERT_NO_ABSL
   template <class T>
   static T&& ForwardWrappedValue(absl::StatusOr<T>& e) {
     return std::move(e).value();
@@ -244,6 +250,7 @@ class ErrorStatusBuilder {
   static T& ForwardWrappedValue(absl::StatusOr<T&>& e) {
     return e.value();
   }
+#endif  // LITERT_NO_ABSL
 
  private:
   bool ShouldLog() const noexcept {
@@ -251,7 +258,9 @@ class ErrorStatusBuilder {
            (!error_.Message().empty() || extra_log_);
   }
 
+#ifndef LITERT_NO_ABSL
   absl::Status ToAbslStatus() const noexcept;
+#endif  // LITERT_NO_ABSL
   std::string LogMessage() const;
 
   litert::Error error_;
@@ -311,6 +320,7 @@ struct ErrorStatusBuilder::ErrorConversion<litert::Unexpected> {
   }
 };
 
+#ifndef LITERT_NO_ABSL
 template <>
 struct ErrorStatusBuilder::ErrorConversion<absl::Status> {
   static bool IsError(const absl::Status& value) { return !value.ok(); };
@@ -329,6 +339,7 @@ struct ErrorStatusBuilder::ErrorConversion<absl::StatusOr<T>> {
         std::move(value.status()));
   }
 };
+#endif  // LITERT_NO_ABSL
 
 // NOLINTEND(*-explicit-constructor)
 
@@ -447,7 +458,8 @@ class LogBeforeAbort {
 #define _LITERT_VAN_LITERT_ISH
 #endif
 
-#define LITERT_CHECK_STATUS_HAS_CODE(expr, code) ABSL_CHECK(expr == code);
+#define LITERT_CHECK_STATUS_HAS_CODE(expr, code) \
+  LITERT_INTERNAL_CHECK((expr) == (code));
 
 #define LITERT_CHECK_STATUS_OK(expr) \
   LITERT_CHECK_STATUS_HAS_CODE(expr, kLiteRtStatusOk);
@@ -472,6 +484,7 @@ class LogBeforeAbort {
     *e = init;                                  \
   }
 
+#ifndef LITERT_NO_ABSL
 namespace litert::internal::macros_detail {
 
 inline LiteRtStatus ToLiteRtStatus(const absl::StatusCode& code) {
@@ -593,6 +606,11 @@ inline absl::Status ErrorStatusBuilder::ToAbslStatus() const noexcept {
   }
   return absl::UnknownError(LogMessage());
 }
+
+}  // namespace litert
+#endif  // LITERT_NO_ABSL
+
+namespace litert {
 
 inline std::string ErrorStatusBuilder::LogMessage() const {
   LiteRtLogger logger = LiteRtGetDefaultLogger();

--- a/litert/cc/litert_model.h
+++ b/litert/cc/litert_model.h
@@ -24,8 +24,7 @@
 #include <variant>
 #include <vector>
 
-#include "absl/strings/string_view.h"  // from @com_google_absl
-#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_model.h"
 #include "litert/c/litert_model_types.h"
@@ -50,7 +49,7 @@ namespace litert {
 
 namespace internal::model_detail {
 
-inline absl::string_view FetchTensorName(LiteRtTensor tensor) {
+inline StringView FetchTensorName(LiteRtTensor tensor) {
   const char* name;
   internal::AssertOk(LiteRtGetTensorName, tensor, &name);
   return name;
@@ -112,17 +111,17 @@ inline LiteRtQuantizationPerChannel FetchTensorQuantizationPerChannel(
   return per_channel_quantization;
 }
 
-inline absl::string_view FetchSignatureKey(LiteRtSignature signature) {
+inline StringView FetchSignatureKey(LiteRtSignature signature) {
   const char* key;
   internal::AssertOk(LiteRtGetSignatureKey, signature, &key);
   return key;
 }
 
-inline std::vector<absl::string_view> FetchSignatureInputNames(
+inline std::vector<StringView> FetchSignatureInputNames(
     LiteRtSignature signature) {
   LiteRtParamIndex num_inputs;
   internal::AssertOk(LiteRtGetNumSignatureInputs, signature, &num_inputs);
-  std::vector<absl::string_view> input_names;
+  std::vector<StringView> input_names;
   input_names.reserve(num_inputs);
   for (int i = 0; i < num_inputs; ++i) {
     const char* name;
@@ -132,11 +131,11 @@ inline std::vector<absl::string_view> FetchSignatureInputNames(
   return input_names;
 }
 
-inline std::vector<absl::string_view> FetchSignatureOutputNames(
+inline std::vector<StringView> FetchSignatureOutputNames(
     LiteRtSignature signature) {
   LiteRtParamIndex num_outputs;
   internal::AssertOk(LiteRtGetNumSignatureOutputs, signature, &num_outputs);
-  std::vector<absl::string_view> output_names;
+  std::vector<StringView> output_names;
   output_names.reserve(num_outputs);
   for (int i = 0; i < num_outputs; ++i) {
     const char* name;
@@ -249,7 +248,7 @@ class Model : public internal::BaseHandle<LiteRtModel> {
   // copybara:uncomment_end
 #endif  // !defined(LITERT_DYNAMIC_RUNTIME)
 
-  Expected<absl::Span<const uint8_t>> Metadata(
+  Expected<Span<const uint8_t>> Metadata(
       const std::string& metadata_key) const {
     const void* buffer;
     size_t buffer_size;
@@ -257,7 +256,7 @@ class Model : public internal::BaseHandle<LiteRtModel> {
                                &buffer_size) != kLiteRtStatusOk) {
       return Unexpected(Status::kErrorNotFound, "Metadata key not found");
     }
-    return absl::MakeSpan(static_cast<const uint8_t*>(buffer), buffer_size);
+    return internal::MakeSpan(static_cast<const uint8_t*>(buffer), buffer_size);
   }
 
   size_t GetNumSignatures() const {
@@ -279,24 +278,24 @@ class Model : public internal::BaseHandle<LiteRtModel> {
   }
 
   /// @brief Returns the list of signature key names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureKeys() const {
+  Expected<std::vector<StringView>> GetSignatureKeys() const {
     return GetSignatureKeysImpl();
   }
 
   /// @brief Returns the list of input names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureInputNames(
+  Expected<std::vector<StringView>> GetSignatureInputNames(
       size_t signature_index) const {
     return GetSignatureInputNamesImpl(signature_index);
   }
 
   /// @brief Returns the list of input names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureInputNames() const {
+  Expected<std::vector<StringView>> GetSignatureInputNames() const {
     return GetSignatureInputNames(/*signature_index=*/0);
   }
 
   /// @brief Returns the list of input names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureInputNames(
-      absl::string_view signature_key) const {
+  Expected<std::vector<StringView>> GetSignatureInputNames(
+      StringView signature_key) const {
     auto signature = FindSignature(signature_key);
     if (!signature) {
       return Unexpected(Status::kErrorNotFound, "Signature not found");
@@ -305,19 +304,19 @@ class Model : public internal::BaseHandle<LiteRtModel> {
   }
 
   /// @brief Returns the list of output names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureOutputNames(
+  Expected<std::vector<StringView>> GetSignatureOutputNames(
       size_t signature_index) const {
     return GetSignatureOutputNamesImpl(signature_index);
   }
 
   /// @brief Returns the list of output names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureOutputNames() const {
+  Expected<std::vector<StringView>> GetSignatureOutputNames() const {
     return GetSignatureOutputNames(/*signature_index=*/0);
   }
 
   /// @brief Returns the list of output names defined in the signature.
-  Expected<std::vector<absl::string_view>> GetSignatureOutputNames(
-      absl::string_view signature_key) const {
+  Expected<std::vector<StringView>> GetSignatureOutputNames(
+      StringView signature_key) const {
     auto signature = FindSignature(signature_key);
     if (!signature) {
       return Unexpected(Status::kErrorNotFound, "Signature not found");
@@ -342,7 +341,7 @@ class Model : public internal::BaseHandle<LiteRtModel> {
   /// @brief Returns the signature index for the given signature key.
   ///
   /// Returns 0 if the signature key is empty.
-  Expected<size_t> GetSignatureIndex(absl::string_view signature_key) const {
+  Expected<size_t> GetSignatureIndex(StringView signature_key) const {
     if (signature_key.empty()) {
       return 0;
     }
@@ -362,13 +361,13 @@ class Model : public internal::BaseHandle<LiteRtModel> {
   ///
   /// Returns the default signature if the signature key is empty.
   Expected<SimpleSignature> FindSignature(
-      absl::string_view signature_key) const {
+      StringView signature_key) const {
     LITERT_ASSIGN_OR_RETURN(auto signature_index,
                             GetSignatureIndex(signature_key));
     return GetSignature(signature_index);
   }
 
-  static absl::string_view DefaultSignatureKey() {
+  static StringView DefaultSignatureKey() {
     return kDefaultSignatureKey;
   }
 
@@ -382,7 +381,7 @@ class Model : public internal::BaseHandle<LiteRtModel> {
 
   /// @brief Returns the tensor type for the given input tensor name.
   Expected<RankedTensorType> GetInputTensorType(
-      size_t signature_index, absl::string_view input_name) const {
+      size_t signature_index, StringView input_name) const {
     LITERT_ASSIGN_OR_RETURN(const SimpleSignature& signature,
                             GetSignature(signature_index));
     return signature.InputTensorType(input_name);
@@ -390,7 +389,7 @@ class Model : public internal::BaseHandle<LiteRtModel> {
 
   /// @brief Returns the tensor type for the given input tensor name.
   Expected<RankedTensorType> GetInputTensorType(
-      absl::string_view signature_key, absl::string_view input_name) const {
+      StringView signature_key, StringView input_name) const {
     LITERT_ASSIGN_OR_RETURN(const SimpleSignature& signature,
                             FindSignature(signature_key));
     return signature.InputTensorType(input_name);
@@ -399,7 +398,7 @@ class Model : public internal::BaseHandle<LiteRtModel> {
   /// @brief Gets the input tensor type of the default signature for a given
   /// input name.
   Expected<RankedTensorType> GetInputTensorType(
-      absl::string_view input_name) const {
+      StringView input_name) const {
     return GetInputTensorType(/*signature_index=*/0, input_name);
   }
 
@@ -413,7 +412,7 @@ class Model : public internal::BaseHandle<LiteRtModel> {
 
   /// @brief Returns the tensor type for the given output tensor name.
   Expected<RankedTensorType> GetOutputTensorType(
-      size_t signature_index, absl::string_view output_name) const {
+      size_t signature_index, StringView output_name) const {
     LITERT_ASSIGN_OR_RETURN(const SimpleSignature& signature,
                             GetSignature(signature_index));
     return signature.OutputTensorType(output_name);
@@ -421,7 +420,7 @@ class Model : public internal::BaseHandle<LiteRtModel> {
 
   /// @brief Returns the tensor type for the given output tensor name.
   Expected<RankedTensorType> GetOutputTensorType(
-      absl::string_view signature_key, absl::string_view output_name) const {
+      StringView signature_key, StringView output_name) const {
     LITERT_ASSIGN_OR_RETURN(const SimpleSignature& signature,
                             FindSignature(signature_key));
     return signature.OutputTensorType(output_name);
@@ -430,7 +429,7 @@ class Model : public internal::BaseHandle<LiteRtModel> {
   /// @brief Gets the output tensor type of the default signature for a given
   /// output name.
   Expected<RankedTensorType> GetOutputTensorType(
-      absl::string_view output_name) const {
+      StringView output_name) const {
     return GetOutputTensorType(/*signature_index=*/0, output_name);
   }
 
@@ -441,9 +440,9 @@ class Model : public internal::BaseHandle<LiteRtModel> {
       : internal::BaseHandle<LiteRtModel>(model, LiteRtDestroyModel, owned) {}
 
  private:
-  Expected<std::vector<absl::string_view>> GetSignatureKeysImpl() const {
+  Expected<std::vector<StringView>> GetSignatureKeysImpl() const {
     size_t num_signatures = GetNumSignatures();
-    std::vector<absl::string_view> signature_keys;
+    std::vector<StringView> signature_keys;
     signature_keys.reserve(num_signatures);
     for (int i = 0; i < num_signatures; ++i) {
       LiteRtSignature lite_rt_signature;
@@ -453,14 +452,14 @@ class Model : public internal::BaseHandle<LiteRtModel> {
     }
     return signature_keys;
   }
-  Expected<std::vector<absl::string_view>> GetSignatureInputNamesImpl(
+  Expected<std::vector<StringView>> GetSignatureInputNamesImpl(
       size_t signature_index) const {
     LiteRtSignature lite_rt_signature;
     internal::AssertOk(LiteRtGetModelSignature, Get(), signature_index,
                        &lite_rt_signature);
     return internal::model_detail::FetchSignatureInputNames(lite_rt_signature);
   }
-  Expected<std::vector<absl::string_view>> GetSignatureOutputNamesImpl(
+  Expected<std::vector<StringView>> GetSignatureOutputNamesImpl(
       size_t signature_index) const {
     LiteRtSignature lite_rt_signature;
     internal::AssertOk(LiteRtGetModelSignature, Get(), signature_index,

--- a/litert/cc/litert_model_types.h
+++ b/litert/cc/litert_model_types.h
@@ -24,7 +24,7 @@
 #include <variant>
 #include <vector>
 
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_model_types.h"
 #include "litert/cc/litert_common.h"
@@ -54,7 +54,7 @@ class SimpleTensor {
   /// @param per_channel_quantization The per-channel quantization of the
   /// tensor.
   explicit SimpleTensor(
-      LiteRtParamIndex index, absl::string_view name,
+      LiteRtParamIndex index, StringView name,
       LiteRtTensorTypeId type_id,
       std::variant<LiteRtUnrankedTensorType, litert::RankedTensorType>&& type,
       LiteRtQuantizationTypeId quantization_type_id,
@@ -123,7 +123,7 @@ class SimpleTensor {
   }
 
   /// @brief Returns the name of the tensor.
-  absl::string_view Name() const { return name_; }
+  StringView Name() const { return name_; }
 
   /// @brief Returns the index of the tensor.
   std::uint32_t TensorIndex() const { return index_; }
@@ -169,9 +169,9 @@ class SimpleSignature {
   /// @param output_names The names of the output tensors.
   /// @param output_tensors The output tensors.
   explicit SimpleSignature(
-      absl::string_view key, std::vector<absl::string_view> input_names,
+      StringView key, std::vector<StringView> input_names,
       std::vector<std::unique_ptr<SimpleTensor>> input_tensors,
-      std::vector<absl::string_view> output_names,
+      std::vector<StringView> output_names,
       std::vector<std::unique_ptr<SimpleTensor>> output_tensors)
       : key_(key),
         input_names_(std::move(input_names)),
@@ -183,11 +183,11 @@ class SimpleSignature {
   SimpleSignature& operator=(SimpleSignature&&) = default;
 
   /// @brief Returns the key of the signature.
-  absl::string_view Key() const { return key_; }
+  StringView Key() const { return key_; }
 
   /// @brief Returns the names of the input tensors.
-  std::vector<absl::string_view> InputNames() const {
-    std::vector<absl::string_view> input_names;
+  std::vector<StringView> InputNames() const {
+    std::vector<StringView> input_names;
     input_names.reserve(input_names_.size());
     for (const auto& input_name : input_names_) {
       input_names.push_back(input_name);
@@ -196,8 +196,8 @@ class SimpleSignature {
   }
 
   /// @brief Returns the names of the output tensors.
-  std::vector<absl::string_view> OutputNames() const {
-    std::vector<absl::string_view> output_names;
+  std::vector<StringView> OutputNames() const {
+    std::vector<StringView> output_names;
     output_names.reserve(output_names_.size());
     for (const auto& output_name : output_names_) {
       output_names.push_back(output_name);
@@ -209,7 +209,7 @@ class SimpleSignature {
   /// @param name The name of the input tensor.
   /// @return The ranked tensor type, or an error if the tensor is not found or
   /// not ranked.
-  Expected<RankedTensorType> InputTensorType(absl::string_view name) const {
+  Expected<RankedTensorType> InputTensorType(StringView name) const {
     LITERT_ASSIGN_OR_RETURN(auto tensor, InputTensor(name));
     return tensor.RankedTensorType();
   }
@@ -228,7 +228,7 @@ class SimpleSignature {
   /// @param name The name of the output tensor.
   /// @return The ranked tensor type, or an error if the tensor is not found or
   /// not ranked.
-  Expected<RankedTensorType> OutputTensorType(absl::string_view name) const {
+  Expected<RankedTensorType> OutputTensorType(StringView name) const {
     LITERT_ASSIGN_OR_RETURN(auto tensor, OutputTensor(name));
     return tensor.RankedTensorType();
   }
@@ -245,7 +245,7 @@ class SimpleSignature {
   /// @brief Returns the input tensor for the given input signature name.
   /// @param name The name of the input tensor.
   /// @return The input tensor, or an error if the tensor is not found.
-  Expected<const SimpleTensor&> InputTensor(absl::string_view name) const {
+  Expected<const SimpleTensor&> InputTensor(StringView name) const {
     for (int i = 0; i < input_names_.size(); ++i) {
       if (input_names_[i] == name) {
         return *input_tensors_[i];
@@ -267,7 +267,7 @@ class SimpleSignature {
   /// @brief Returns the output tensor for the given output signature name.
   /// @param name The name of the output tensor.
   /// @return The output tensor, or an error if the tensor is not found.
-  Expected<const SimpleTensor&> OutputTensor(absl::string_view name) const {
+  Expected<const SimpleTensor&> OutputTensor(StringView name) const {
     for (int i = 0; i < output_names_.size(); ++i) {
       if (output_names_[i] == name) {
         return *output_tensors_[i];
@@ -288,9 +288,9 @@ class SimpleSignature {
 
  private:
   std::string_view key_;
-  std::vector<absl::string_view> input_names_;
+  std::vector<StringView> input_names_;
   std::vector<std::unique_ptr<SimpleTensor>> input_tensors_;
-  std::vector<absl::string_view> output_names_;
+  std::vector<StringView> output_names_;
   std::vector<std::unique_ptr<SimpleTensor>> output_tensors_;
 };
 

--- a/litert/cc/litert_no_absl_api_compile_test.cc
+++ b/litert/cc/litert_no_absl_api_compile_test.cc
@@ -1,0 +1,92 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LITERT_NO_ABSL
+#error "This test must be compiled with LITERT_NO_ABSL."
+#endif
+
+#include <cstdint>
+#include <span>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+#include "litert/cc/litert_any.h"
+#include "litert/cc/litert_api_types.h"
+#include "litert/cc/litert_buffer_ref.h"
+#include "litert/cc/litert_common.h"
+#include "litert/cc/litert_compiled_model.h"
+#include "litert/cc/litert_custom_op_kernel.h"
+#include "litert/cc/litert_element_type.h"
+#include "litert/cc/litert_environment.h"
+#include "litert/cc/litert_environment_options.h"
+#include "litert/cc/litert_event.h"
+#include "litert/cc/litert_expected.h"
+#include "litert/cc/litert_layout.h"
+#include "litert/cc/litert_macros.h"
+#include "litert/cc/litert_model.h"
+#include "litert/cc/litert_model_types.h"
+#include "litert/cc/litert_opaque_options.h"
+#include "litert/cc/litert_options.h"
+#include "litert/cc/litert_profiler.h"
+#include "litert/cc/litert_ranked_tensor_type.h"
+#include "litert/cc/litert_tensor_buffer.h"
+#include "litert/cc/litert_tensor_buffer_requirements.h"
+#include "litert/cc/litert_tensor_buffer_types.h"
+#include "litert/cc/options/litert_compiler_options.h"
+#include "litert/cc/options/litert_cpu_options.h"
+#include "litert/cc/options/litert_google_tensor_options.h"
+#include "litert/cc/options/litert_gpu_options.h"
+#include "litert/cc/options/litert_intel_openvino_options.h"
+#include "litert/cc/options/litert_magic_number_options.h"
+#include "litert/cc/options/litert_mediatek_options.h"
+#include "litert/cc/options/litert_qualcomm_options.h"
+#include "litert/cc/options/litert_runtime_options.h"
+#include "litert/cc/options/litert_samsung_options.h"
+#include "litert/cc/options/litert_webnn_options.h"
+
+static_assert(std::is_same_v<litert::StringView, std::string_view>);
+static_assert(std::is_same_v<litert::Span<const int>, std::span<const int>>);
+static_assert(std::is_same_v<litert::Dimensions, std::vector<int32_t>>);
+static_assert(std::is_same_v<litert::Strides, std::vector<uint32_t>>);
+
+static_assert(std::is_same_v<decltype(litert::Model::DefaultSignatureKey()),
+                             std::string_view>);
+static_assert(std::is_same_v<
+              decltype(std::declval<litert::Model&>().GetSignatureKeys()),
+              litert::Expected<std::vector<std::string_view>>>);
+
+using TensorBufferMap =
+    std::unordered_map<std::string_view, litert::TensorBuffer>;
+static_assert(std::is_same_v<
+              litert::FlatHashMap<litert::StringView, litert::TensorBuffer>,
+              TensorBufferMap>);
+static_assert(std::is_same_v<
+              decltype(std::declval<litert::CompiledModel&>().Run(
+                  std::declval<std::string_view>(),
+                  std::declval<const TensorBufferMap&>(),
+                  std::declval<const TensorBufferMap&>())),
+              litert::Expected<void>>);
+
+static_assert(std::is_same_v<
+              decltype(std::declval<litert::EnvironmentOptions&>()
+                           .GetOptions()),
+              std::span<const litert::EnvironmentOptions::Option>>);
+static_assert(std::is_same_v<
+              decltype(std::declval<litert::TensorBufferRequirements&>()
+                           .Strides()),
+              litert::Expected<std::span<const uint32_t>>>);
+
+int main() { return 0; }

--- a/litert/cc/litert_no_absl_api_symbol_test.sh
+++ b/litert/cc/litert_no_absl_api_symbol_test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <binary>" >&2
+  exit 2
+fi
+
+binary="$1"
+if nm "$binary" | c++filt | grep -E '(^|[^[:alnum:]_])absl::|Absl|_ZN4absl' >&2; then
+  echo "Found Abseil symbols in $binary" >&2
+  exit 1
+fi

--- a/litert/cc/litert_opaque_options.h
+++ b/litert/cc/litert_opaque_options.h
@@ -22,7 +22,7 @@
 #include <string_view>
 #include <type_traits>
 
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_opaque_options.h"
 #include "litert/cc/internal/litert_handle.h"
@@ -56,11 +56,11 @@ class OpaqueOptions : public internal::BaseHandle<LiteRtOpaqueOptions> {
     return OpaqueOptions(options, OwnHandle::kYes);
   }
 
-  Expected<absl::string_view> GetIdentifier() const {
+  Expected<StringView> GetIdentifier() const {
     const char* payload_identifier;
     LITERT_RETURN_IF_ERROR(
         LiteRtGetOpaqueOptionsIdentifier(Get(), &payload_identifier));
-    return absl::string_view(payload_identifier);
+    return StringView(payload_identifier);
   }
 
   template <typename T>

--- a/litert/cc/litert_options.h
+++ b/litert/cc/litert_options.h
@@ -23,7 +23,7 @@
 #include <utility>
 #include <vector>
 
-#include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_custom_op_kernel.h"
 #include "litert/c/options/litert_compiler_options.h"
@@ -136,7 +136,7 @@ class Options {
   /// inside a `ScopedFile` that backs a single external buffer group. This map
   /// provides the mapping between the group name and its section.
   using ScopedWeightSectionMap =
-      absl::flat_hash_map<std::string, ScopedWeightSection>;
+      FlatHashMap<std::string, ScopedWeightSection>;
 
   Options() = default;
 

--- a/litert/cc/litert_ranked_tensor_type.h
+++ b/litert/cc/litert_ranked_tensor_type.h
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_layout.h"
 #include "litert/c/litert_model_types.h"
 #include "litert/cc/litert_common.h"

--- a/litert/cc/litert_tensor_buffer.h
+++ b/litert/cc/litert_tensor_buffer.h
@@ -17,13 +17,11 @@
 
 #include <cstddef>
 #include <cstring>
+#include <string>
 #include <utility>
 #include <vector>
 
-#include "absl/cleanup/cleanup.h"  // from @com_google_absl
-#include "absl/log/absl_check.h"  // from @com_google_absl
-#include "absl/strings/str_format.h"  // from @com_google_absl
-#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_custom_tensor_buffer.h"
 #include "litert/c/litert_gl_types.h"
@@ -120,7 +118,7 @@ class TensorBuffer : public internal::BaseHandle<LiteRtTensorBuffer> {
         internal::tensor_buffer_detail::ToLiteRtTensorBufferRequirements(
             env_holder, requirements));
 
-    auto cleanup = absl::MakeCleanup([&env_holder, litert_requirements] {
+    auto cleanup = internal::MakeCleanup([&env_holder, litert_requirements] {
       env_holder.runtime->DestroyTensorBufferRequirements(litert_requirements);
     });
 
@@ -519,7 +517,7 @@ class TensorBuffer : public internal::BaseHandle<LiteRtTensorBuffer> {
   bool HasEvent() const {
     bool has_event;
     auto status = env_.runtime->HasTensorBufferEvent(Get(), &has_event);
-    ABSL_CHECK_EQ(status, kLiteRtStatusOk);
+    LITERT_INTERNAL_CHECK_EQ(status, kLiteRtStatusOk);
     return has_event;
   }
 
@@ -595,47 +593,46 @@ class TensorBuffer : public internal::BaseHandle<LiteRtTensorBuffer> {
     return {};
   }
 
-  /// @brief Writes data from a user-provided `absl::Span<const T>` to the
+  /// @brief Writes data from a user-provided `Span<const T>` to the
   /// tensor buffer.
   ///
   /// Returns an error if the provided buffer is larger than the tensor
   /// buffer's size.
   template <typename T>
-  Expected<void> Write(absl::Span<const T> data) {
+  Expected<void> Write(Span<const T> data) {
     LITERT_ASSIGN_OR_RETURN(void* host_mem_addr, Lock(LockMode::kWrite));
-    absl::Cleanup unlock = [this] { Unlock(); };
+    auto unlock = internal::MakeCleanup([this] { Unlock(); });
     LITERT_ASSIGN_OR_RETURN(size_t size, PackedSize());
     if (size < data.size() * sizeof(T)) {
       return Unexpected(
           kLiteRtStatusErrorRuntimeFailure,
-          absl::StrFormat(
-              "TensorBuffer host memory buffer size is smaller than the "
-              "given data size, %zu vs %zu",
-              size, data.size() * sizeof(T)));
+          "TensorBuffer host memory buffer size is smaller than the given "
+          "data size, " +
+              std::to_string(size) + " vs " +
+              std::to_string(data.size() * sizeof(T)));
     }
     std::memcpy(host_mem_addr, data.data(), data.size() * sizeof(T));
     return {};
   }
 
   /// @brief Reads data from the tensor buffer into a user-provided
-  /// `absl::Span<T>`.
+  /// `Span<T>`.
   ///
   /// If the provided buffer is smaller than the tensor buffer, data will be
   /// read up to the size of the provided buffer. Returns an error if the
   /// provided buffer is larger than the tensor buffer.
   template <typename T>
-  Expected<void> Read(absl::Span<T> data) {
+  Expected<void> Read(Span<T> data) {
     LITERT_ASSIGN_OR_RETURN(void* host_mem_addr, Lock(LockMode::kRead));
-    absl::Cleanup unlock = [this] { Unlock(); };
+    auto unlock = internal::MakeCleanup([this] { Unlock(); });
     LITERT_ASSIGN_OR_RETURN(size_t size, PackedSize());
     size_t total_read_size = data.size() * sizeof(T);
     if (size < total_read_size) {
       return Unexpected(
           kLiteRtStatusErrorRuntimeFailure,
-          absl::StrFormat(
-              "TensorBuffer host memory buffer size is smaller than the "
-              "given data size, %zu vs %zu",
-              size, total_read_size));
+          "TensorBuffer host memory buffer size is smaller than the given "
+          "data size, " +
+              std::to_string(size) + " vs " + std::to_string(total_read_size));
     }
     std::memcpy(data.data(), host_mem_addr, total_read_size);
     return {};
@@ -652,7 +649,7 @@ class TensorBuffer : public internal::BaseHandle<LiteRtTensorBuffer> {
 
     // Fall back to synchronous write.
     LITERT_ASSIGN_OR_RETURN(void* host_mem_addr, Lock(LockMode::kWrite));
-    absl::Cleanup unlock = [this] { Unlock(); };
+    auto unlock = internal::MakeCleanup([this] { Unlock(); });
     LITERT_ASSIGN_OR_RETURN(size_t size, PackedSize());
     std::memset(host_mem_addr, 0, size);
     return {};

--- a/litert/cc/litert_tensor_buffer_requirements.h
+++ b/litert/cc/litert_tensor_buffer_requirements.h
@@ -22,7 +22,7 @@
 #include <utility>
 #include <vector>
 
-#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/internal/litert_logging.h"
 #include "litert/cc/litert_common.h"
 #include "litert/cc/litert_expected.h"
@@ -44,18 +44,18 @@ class TensorBufferRequirements {
   TensorBufferRequirements() = default;
 
   static Expected<TensorBufferRequirements> Create(
-      absl::Span<const TensorBufferType> buffer_types, size_t buffer_size,
-      absl::Span<const uint32_t> strides =
-          absl::MakeSpan(static_cast<const uint32_t*>(nullptr), 0)) {
+      Span<const TensorBufferType> buffer_types, size_t buffer_size,
+      Span<const uint32_t> strides =
+          internal::MakeSpan(static_cast<const uint32_t*>(nullptr), 0)) {
     return CreateWithAlignment(buffer_types, buffer_size,
                                kHostMemoryBufferAlignment, strides);
   }
 
   static Expected<TensorBufferRequirements> CreateWithAlignment(
-      absl::Span<const TensorBufferType> buffer_types, size_t buffer_size,
+      Span<const TensorBufferType> buffer_types, size_t buffer_size,
       size_t alignment,
-      absl::Span<const uint32_t> strides =
-          absl::MakeSpan(static_cast<const uint32_t*>(nullptr), 0)) {
+      Span<const uint32_t> strides =
+          internal::MakeSpan(static_cast<const uint32_t*>(nullptr), 0)) {
     if (buffer_types.empty() || alignment == 0 ||
         (alignment & (alignment - 1)) != 0) {
       LITERT_LOG(LITERT_ERROR,
@@ -86,8 +86,8 @@ class TensorBufferRequirements {
   /// @brief Returns the strides of the tensor buffer requirements.
   ///
   /// If the strides are not specified, an empty span is returned.
-  Expected<absl::Span<const uint32_t>> Strides() const {
-    return absl::MakeConstSpan(strides_);
+  Expected<Span<const uint32_t>> Strides() const {
+    return internal::MakeConstSpan(strides_);
   }
 
   Expected<size_t> Alignment() const { return alignment_; }

--- a/litert/cc/options/BUILD
+++ b/litert/cc/options/BUILD
@@ -30,6 +30,7 @@ cc_library(
     name = "litert_cpu_options",
     hdrs = ["litert_cpu_options.h"],
     deps = [
+        "//litert/cc:litert_api_types",
         "//litert/c:litert_common",
         "//litert/c/options:litert_cpu_options",
         "//litert/cc:litert_expected",
@@ -136,6 +137,7 @@ cc_library(
     name = "litert_google_tensor_options",
     hdrs = ["litert_google_tensor_options.h"],
     deps = [
+        "//litert/cc:litert_api_types",
         "//litert/c:litert_common",
         "//litert/c/options:litert_google_tensor_options",
         "//litert/c/options:litert_google_tensor_options_type",
@@ -151,6 +153,7 @@ cc_library(
     name = "litert_qualcomm_options",
     hdrs = ["litert_qualcomm_options.h"],
     deps = [
+        "//litert/cc:litert_api_types",
         "//litert/c:litert_common",
         "//litert/c/options:litert_qualcomm_options",
         "//litert/cc:litert_expected",
@@ -166,6 +169,7 @@ cc_library(
     name = "litert_mediatek_options",
     hdrs = ["litert_mediatek_options.h"],
     deps = [
+        "//litert/cc:litert_api_types",
         "//litert/c:litert_common",
         "//litert/c/options:litert_mediatek_options",
         "//litert/cc:litert_expected",

--- a/litert/cc/options/litert_cpu_options.h
+++ b/litert/cc/options/litert_cpu_options.h
@@ -18,7 +18,7 @@
 #include <cstdint>
 #include <memory>
 
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/options/litert_cpu_options.h"
 #include "litert/cc/litert_expected.h"
@@ -100,14 +100,14 @@ class CpuOptions {
   }
 
   /// @brief Gets the XNNPack weight cache file path.
-  Expected<absl::string_view> GetXNNPackWeightCachePath() const {
+  Expected<StringView> GetXNNPackWeightCachePath() const {
     const char* path;
     auto s = LrtGetCpuOptionsXnnPackWeightCachePath(options_.get(), &path);
     if (s == kLiteRtStatusErrorNotFound) {
-      return absl::string_view();
+      return StringView();
     }
     LITERT_RETURN_IF_ERROR(s);
-    return absl::NullSafeStringView(path);
+    return internal::NullSafeStringView(path);
   }
 
   /// @brief Sets the XNNPack weight cache file descriptor.

--- a/litert/cc/options/litert_google_tensor_options.h
+++ b/litert/cc/options/litert_google_tensor_options.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/options/litert_google_tensor_options.h"
 #include "litert/c/options/litert_google_tensor_options_type.h"
@@ -76,17 +76,17 @@ class GoogleTensorOptions {
     return int64_to_int32_truncation;
   }
 
-  void SetOutputDir(absl::string_view output_dir) {
+  void SetOutputDir(StringView output_dir) {
     internal::AssertOk(LrtGoogleTensorOptionsSetOutputDir, Get(),
                        output_dir.data());
   }
 
-  absl::string_view GetOutputDir() const {
+  StringView GetOutputDir() const {
     LrtGoogleTensorOptions options_data = Get();
     const char* output_dir;
     internal::AssertOk(LrtGoogleTensorOptionsGetOutputDir, options_data,
                        &output_dir);
-    return absl::string_view(output_dir);
+    return StringView(output_dir);
   }
 
   void SetDumpOpTimings(bool dump_op_timings) {
@@ -197,17 +197,17 @@ class GoogleTensorOptions {
     return static_cast<PerformanceMode>(performance_mode);
   }
 
-  void SetOpFiltersProto(absl::string_view op_filters_proto) {
+  void SetOpFiltersProto(StringView op_filters_proto) {
     internal::AssertOk(LrtGoogleTensorOptionsSetOpFiltersProto, Get(),
                        op_filters_proto.data());
   }
 
-  absl::string_view GetOpFiltersProto() const {
+  StringView GetOpFiltersProto() const {
     LrtGoogleTensorOptions options_data = Get();
     const char* op_filters_proto;
     internal::AssertOk(LrtGoogleTensorOptionsGetOpFiltersProto, options_data,
                        &op_filters_proto);
-    return absl::string_view(op_filters_proto);
+    return StringView(op_filters_proto);
   }
 
  private:

--- a/litert/cc/options/litert_mediatek_options.h
+++ b/litert/cc/options/litert_mediatek_options.h
@@ -17,7 +17,7 @@
 #include <memory>
 #include <string>
 
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/options/litert_mediatek_options.h"
 #include "litert/cc/internal/litert_detail.h"
 #include "litert/cc/internal/litert_handle.h"
@@ -126,11 +126,11 @@ class MediatekOptions {
                        mediatek_dla_dir.c_str());
   }
 
-  absl::string_view GetMediatekDlaDir() {
+  StringView GetMediatekDlaDir() {
     const char* mediatek_dla_dir;
     internal::AssertOk(LrtGetMediatekOptionsMediatekDlaDir, Get(),
                        &mediatek_dla_dir);
-    return absl::string_view(mediatek_dla_dir);
+    return StringView(mediatek_dla_dir);
   }
 
   void SetAotCompilationOptions(const std::string& aot_compilation_options) {
@@ -138,11 +138,11 @@ class MediatekOptions {
                        aot_compilation_options.c_str());
   }
 
-  absl::string_view GetAotCompilationOptions() {
+  StringView GetAotCompilationOptions() {
     const char* aot_compilation_options;
     internal::AssertOk(LrtGetMediatekOptionsAotCompilationOptions, Get(),
                        &aot_compilation_options);
-    return absl::string_view(aot_compilation_options);
+    return StringView(aot_compilation_options);
   }
 
  private:

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/cc/litert_api_types.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/options/litert_qualcomm_options.h"
 #include "litert/cc/litert_expected.h"
@@ -289,7 +289,7 @@ class QualcommOptions {
   void SetIrJsonDir(const std::string& ir_json_dir) {
     LrtQualcommOptionsSetIrJsonDir(options_, ir_json_dir.c_str());
   }
-  absl::string_view GetIrJsonDir() {
+  StringView GetIrJsonDir() {
     const char* val;
     auto status = LrtQualcommOptionsGetIrJsonDir(options_, &val);
     if (status == kLiteRtStatusErrorNotFound) {
@@ -301,7 +301,7 @@ class QualcommOptions {
   void SetDlcDir(const std::string& dlc_dir) {
     LrtQualcommOptionsSetDlcDir(options_, dlc_dir.c_str());
   }
-  absl::string_view GetDlcDir() {
+  StringView GetDlcDir() {
     const char* val;
     auto status = LrtQualcommOptionsGetDlcDir(options_, &val);
     if (status == kLiteRtStatusErrorNotFound) {
@@ -399,7 +399,7 @@ class QualcommOptions {
   void SetSaverOutputDir(const std::string& saver_output_dir) {
     LrtQualcommOptionsSetSaverOutputDir(options_, saver_output_dir.c_str());
   }
-  absl::string_view GetSaverOutputDir() {
+  StringView GetSaverOutputDir() {
     const char* val;
     auto status = LrtQualcommOptionsGetSaverOutputDir(options_, &val);
     if (status == kLiteRtStatusErrorNotFound) {

--- a/litert/core/BUILD
+++ b/litert/core/BUILD
@@ -27,6 +27,12 @@ package(
     ],
 )
 
+filegroup(
+    name = "options_header",
+    srcs = ["options.h"],
+    visibility = ["//litert/cc:__pkg__"],
+)
+
 cc_library(
     name = "options",
     hdrs = [


### PR DESCRIPTION
## Summary
- Adds dependency-selectable C++ API aliases in `litert_api_types.h` for `LITERT_NO_ABSL`.
- Updates public C++ headers to use those aliases instead of spelling Abseil types directly.
- Adds compile and symbol guard tests for the no-Absl API surface.

## Validation
- `git diff --check origin/main..HEAD`
- `bazel test //litert/cc:litert_no_absl_api_compile_test //litert/cc:litert_no_absl_api_symbol_test`
