### PR TITLE
fix(apple): load GPU accelerators from framework bundles

### DIFF
--- a/litert/runtime/accelerators/gpu_registry.cc
+++ b/litert/runtime/accelerators/gpu_registry.cc
@@ -42,6 +42,27 @@ namespace litert::internal {
 #define SO_EXT ".so"
 #endif
 
+#if defined(__APPLE__)
+std::filesystem::path AppleFrameworkBinaryPath(
+    const std::filesystem::path& runtime_lib_path,
+    absl::string_view plugin_path) {
+  if (runtime_lib_path.empty()) {
+    return {};
+  }
+  std::string framework_name(plugin_path);
+  if (framework_name.rfind("lib", 0) == 0) {
+    framework_name.erase(0, 3);
+  }
+  const std::string suffix = SO_EXT;
+  if (framework_name.size() >= suffix.size() &&
+      framework_name.compare(framework_name.size() - suffix.size(),
+                             suffix.size(), suffix) == 0) {
+    framework_name.erase(framework_name.size() - suffix.size());
+  }
+  return runtime_lib_path / (framework_name + ".framework") / framework_name;
+}
+#endif  // defined(__APPLE__)
+
 LiteRtStatus RegisterGpuAccelerator(LiteRtEnvironment environment) {
 #if !defined(LITERT_DISABLE_GPU)
   static constexpr absl::string_view kGpuAcceleratorLibs[] = {
@@ -110,6 +131,26 @@ LiteRtStatus RegisterGpuAccelerator(LiteRtEnvironment environment) {
         gpu_accelerator_registered = true;
         break;
       }
+#if defined(__APPLE__)
+      const auto framework_plugin_path =
+          AppleFrameworkBinaryPath(runtime_lib_path, plugin_path);
+      if (!framework_plugin_path.empty()) {
+        LITERT_LOG(LITERT_INFO,
+                   "Loading GPU accelerator Apple framework binary(%s).",
+                   framework_plugin_path.c_str());
+        registration = RegisterSharedObjectAcceleratorViaAcceleratorDef(
+            *environment, framework_plugin_path.string(), "LiteRtAcceleratorImpl",
+            /*try_default_on_failure=*/false);
+        if (registration.HasValue()) {
+          LITERT_LOG(LITERT_INFO,
+                     "Dynamically loaded GPU accelerator Apple framework(%s) "
+                     "registered.",
+                     framework_plugin_path.c_str());
+          gpu_accelerator_registered = true;
+          break;
+        }
+      }
+#endif  // defined(__APPLE__)
       // Try to load a GPU accelerator using `LiteRtRegisterGpuAccelerator`
       // symbol.
       registration = RegisterSharedObjectAcceleratorViaFunctionPointer(

--- a/litert/runtime/accelerators/registration_helper.cc
+++ b/litert/runtime/accelerators/registration_helper.cc
@@ -15,8 +15,10 @@
 #include "litert/runtime/accelerators/registration_helper.h"
 
 #include <cstddef>
+#include <string>
 #include <utility>
 
+#include "litert/c/internal/litert_logging.h"
 #include "absl/strings/string_view.h"  // from @com_google_absl
 #include "litert/c/internal/litert_accelerator_def.h"
 #include "litert/c/internal/litert_accelerator_registration.h"
@@ -32,8 +34,34 @@ namespace litert::internal {
 
 LiteRtStatus RegisterAcceleratorFromDef(
     LiteRtEnvironment env, const LiteRtAcceleratorDef* accelerator_def) {
-  if (accelerator_def->version != LITERT_ACCELERATOR_DEF_CURRENT_VERSION)
+  if (accelerator_def == nullptr) {
+    LITERT_LOG(LITERT_WARNING, "asc.12 accelerator def is null.");
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  LITERT_LOG(
+      LITERT_INFO,
+      "asc.12 accelerator def ptr=%p version=%d current=%d callbacks "
+      "name=%d version_fn=%d hardware=%d jit=%d create=%d "
+      "buffer_types=%zu",
+      accelerator_def, accelerator_def->version,
+      LITERT_ACCELERATOR_DEF_CURRENT_VERSION,
+      static_cast<int>(accelerator_def->get_name != nullptr),
+      static_cast<int>(accelerator_def->get_version != nullptr),
+      static_cast<int>(accelerator_def->get_hardware_support != nullptr),
+      static_cast<int>(
+          accelerator_def
+              ->is_tflite_delegate_responsible_for_jit_compilation != nullptr),
+      static_cast<int>(accelerator_def->create_delegate != nullptr),
+      accelerator_def->buffer_handlers.num_supported_buffer_types);
+
+  if (accelerator_def->version != LITERT_ACCELERATOR_DEF_CURRENT_VERSION) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 accelerator def version mismatch: got=%d expected=%d",
+               accelerator_def->version,
+               LITERT_ACCELERATOR_DEF_CURRENT_VERSION);
     return kLiteRtStatusErrorWrongVersion;
+  }
 
   if (accelerator_def->get_name == nullptr ||
       accelerator_def->get_version == nullptr ||
@@ -43,30 +71,75 @@ LiteRtStatus RegisterAcceleratorFromDef(
       accelerator_def->create_delegate == nullptr ||
       accelerator_def->buffer_handlers.num_supported_buffer_types >=
           LITERT_CUSTOM_BUFFER_HANDLERS_DEF_MAX_SUPPORTED_BUFFER_TYPES) {
+    LITERT_LOG(
+        LITERT_WARNING,
+        "asc.12 accelerator def invalid callbacks or buffer handler count.");
     return kLiteRtStatusErrorInvalidArgument;
   }
 
   LiteRtAccelerator accelerator;
-  LITERT_RETURN_IF_ERROR(LiteRtCreateAccelerator(&accelerator));
-  LITERT_RETURN_IF_ERROR(
-      LiteRtSetAcceleratorGetName(accelerator, accelerator_def->get_name));
-  LITERT_RETURN_IF_ERROR(LiteRtSetAcceleratorGetVersion(
-      accelerator, accelerator_def->get_version));
-  LITERT_RETURN_IF_ERROR(LiteRtSetAcceleratorGetHardwareSupport(
-      accelerator, accelerator_def->get_hardware_support));
-  LITERT_RETURN_IF_ERROR(
-      LiteRtSetDelegateFunction(accelerator, accelerator_def->create_delegate));
-  LITERT_RETURN_IF_ERROR(
-      LiteRtSetIsAcceleratorDelegateResponsibleForJitCompilation(
-          accelerator,
-          accelerator_def->is_tflite_delegate_responsible_for_jit_compilation));
+  LiteRtStatus status = LiteRtCreateAccelerator(&accelerator);
+  if (status != kLiteRtStatusOk) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 LiteRtCreateAccelerator failed: %s",
+               LiteRtGetStatusString(status));
+    return status;
+  }
+  status =
+      LiteRtSetAcceleratorGetName(accelerator, accelerator_def->get_name);
+  if (status != kLiteRtStatusOk) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 LiteRtSetAcceleratorGetName failed: %s",
+               LiteRtGetStatusString(status));
+    return status;
+  }
+  status = LiteRtSetAcceleratorGetVersion(accelerator,
+                                          accelerator_def->get_version);
+  if (status != kLiteRtStatusOk) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 LiteRtSetAcceleratorGetVersion failed: %s",
+               LiteRtGetStatusString(status));
+    return status;
+  }
+  status = LiteRtSetAcceleratorGetHardwareSupport(
+      accelerator, accelerator_def->get_hardware_support);
+  if (status != kLiteRtStatusOk) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 LiteRtSetAcceleratorGetHardwareSupport failed: %s",
+               LiteRtGetStatusString(status));
+    return status;
+  }
+  status = LiteRtSetDelegateFunction(accelerator,
+                                     accelerator_def->create_delegate);
+  if (status != kLiteRtStatusOk) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 LiteRtSetDelegateFunction failed: %s",
+               LiteRtGetStatusString(status));
+    return status;
+  }
+  status = LiteRtSetIsAcceleratorDelegateResponsibleForJitCompilation(
+      accelerator,
+      accelerator_def->is_tflite_delegate_responsible_for_jit_compilation);
+  if (status != kLiteRtStatusOk) {
+    LITERT_LOG(
+        LITERT_WARNING,
+        "asc.12 LiteRtSetIsAcceleratorDelegateResponsibleForJitCompilation "
+        "failed: %s",
+        LiteRtGetStatusString(status));
+    return status;
+  }
 
-  LITERT_RETURN_IF_ERROR(
-      LiteRtRegisterAccelerator(env, accelerator, nullptr, nullptr));
+  status = LiteRtRegisterAccelerator(env, accelerator, nullptr, nullptr);
+  if (status != kLiteRtStatusOk) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 LiteRtRegisterAccelerator failed: %s",
+               LiteRtGetStatusString(status));
+    return status;
+  }
 
   for (size_t i = 0;
        i < accelerator_def->buffer_handlers.num_supported_buffer_types; ++i) {
-    LITERT_RETURN_IF_ERROR(LiteRtRegisterTensorBufferHandlers(
+    status = LiteRtRegisterTensorBufferHandlers(
         env, accelerator_def->buffer_handlers.supported_buffer_types[i],
         accelerator_def->buffer_handlers.create_func,
         accelerator_def->buffer_handlers.destroy_func,
@@ -75,50 +148,152 @@ LiteRtStatus RegisterAcceleratorFromDef(
         accelerator_def->buffer_handlers.clear_func,
         accelerator_def->buffer_handlers.import_func,
         accelerator_def->buffer_handlers.device_tag,
-        accelerator_def->buffer_handlers.queue_tag));
+        accelerator_def->buffer_handlers.queue_tag);
+    if (status != kLiteRtStatusOk) {
+      LITERT_LOG(LITERT_WARNING,
+                 "asc.12 LiteRtRegisterTensorBufferHandlers[%zu] failed: %s",
+                 i, LiteRtGetStatusString(status));
+      return status;
+    }
   }
 
+  LITERT_LOG(LITERT_INFO, "asc.12 accelerator def registered successfully.");
   return kLiteRtStatusOk;
 }
 
 Expected<SharedLibrary> LoadSharedLibrary(absl::string_view shlib_path,
                                           bool try_default_on_failure) {
+  const std::string path(shlib_path);
+  LITERT_LOG(LITERT_INFO,
+             "asc.12 LoadSharedLibrary path=%s try_default_on_failure=%d",
+             path.c_str(), static_cast<int>(try_default_on_failure));
   auto result = SharedLibrary::Load(shlib_path, RtldFlags::Lazy().Local());
   if (result || !try_default_on_failure) {
+    if (result) {
+      LITERT_LOG(LITERT_INFO,
+                 "asc.12 LoadSharedLibrary direct load succeeded path=%s",
+                 path.c_str());
+    } else {
+      LITERT_LOG(LITERT_WARNING,
+                 "asc.12 LoadSharedLibrary direct load failed path=%s "
+                 "status=%s message=%s",
+                 path.c_str(), LiteRtGetStatusString(result.Error().Status()),
+                 result.Error().Message().c_str());
+    }
     return result;
   }
-  return SharedLibrary::Load(RtldFlags::kDefault);
+  LITERT_LOG(LITERT_WARNING,
+             "asc.12 LoadSharedLibrary direct load failed path=%s status=%s "
+             "message=%s; trying RTLD_DEFAULT",
+             path.c_str(), LiteRtGetStatusString(result.Error().Status()),
+             result.Error().Message().c_str());
+  auto default_result = SharedLibrary::Load(RtldFlags::kDefault);
+  if (default_result) {
+    LITERT_LOG(LITERT_INFO,
+               "asc.12 LoadSharedLibrary RTLD_DEFAULT succeeded path=%s",
+               path.c_str());
+  } else {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 LoadSharedLibrary RTLD_DEFAULT failed path=%s "
+               "status=%s message=%s",
+               path.c_str(),
+               LiteRtGetStatusString(default_result.Error().Status()),
+               default_result.Error().Message().c_str());
+  }
+  return default_result;
 }
 
 Expected<void> RegisterSharedObjectAcceleratorViaFunctionPointer(
     LiteRtEnvironmentT& environment, absl::string_view shlib_path,
     absl::string_view registration_function_name, bool try_default_on_failure) {
-  LITERT_ASSIGN_OR_RETURN(
-      auto shlib, LoadSharedLibrary(shlib_path, try_default_on_failure));
-  LITERT_ASSIGN_OR_RETURN(
-      auto registration_function,
+  const std::string path(shlib_path);
+  const std::string symbol(registration_function_name);
+  auto shlib_result = LoadSharedLibrary(shlib_path, try_default_on_failure);
+  if (!shlib_result) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 function-pointer registration load failed path=%s "
+               "symbol=%s status=%s message=%s",
+               path.c_str(), symbol.c_str(),
+               LiteRtGetStatusString(shlib_result.Error().Status()),
+               shlib_result.Error().Message().c_str());
+    return shlib_result.Error();
+  }
+  auto shlib = std::move(*shlib_result);
+  auto registration_function_result =
       shlib.LookupSymbol<LiteRtStatus (*)(LiteRtEnvironment)>(
-          registration_function_name.data()));
-  LITERT_RETURN_IF_ERROR(registration_function(&environment));
+          registration_function_name.data());
+  if (!registration_function_result) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 function-pointer symbol lookup failed path=%s "
+               "symbol=%s status=%s message=%s",
+               path.c_str(), symbol.c_str(),
+               LiteRtGetStatusString(
+                   registration_function_result.Error().Status()),
+               registration_function_result.Error().Message().c_str());
+    return registration_function_result.Error();
+  }
+  auto registration_function = *registration_function_result;
+  LiteRtStatus status = registration_function(&environment);
+  if (status != kLiteRtStatusOk) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 function-pointer registration callback failed path=%s "
+               "symbol=%s status=%s",
+               path.c_str(), symbol.c_str(), LiteRtGetStatusString(status));
+    return Error(status);
+  }
   environment.GetAcceleratorRegistry().TakeOwnershipOfSharedLibrary(
       std::move(shlib));
+  LITERT_LOG(LITERT_INFO,
+             "asc.12 function-pointer registration succeeded path=%s "
+             "symbol=%s",
+             path.c_str(), symbol.c_str());
   return {};
 }
 
 Expected<void> RegisterSharedObjectAcceleratorViaAcceleratorDef(
     LiteRtEnvironmentT& environment, absl::string_view shlib_path,
     absl::string_view accelerator_def_name, bool try_default_on_failure) {
-  LITERT_ASSIGN_OR_RETURN(
-      auto shlib, LoadSharedLibrary(shlib_path, try_default_on_failure));
-  LITERT_ASSIGN_OR_RETURN(
-      auto accelerator_def,
-      shlib.LookupSymbol<LiteRtAcceleratorDef*>(accelerator_def_name.data()));
+  const std::string path(shlib_path);
+  const std::string symbol(accelerator_def_name);
+  auto shlib_result = LoadSharedLibrary(shlib_path, try_default_on_failure);
+  if (!shlib_result) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 accelerator-def registration load failed path=%s "
+               "symbol=%s status=%s message=%s",
+               path.c_str(), symbol.c_str(),
+               LiteRtGetStatusString(shlib_result.Error().Status()),
+               shlib_result.Error().Message().c_str());
+    return shlib_result.Error();
+  }
+  auto shlib = std::move(*shlib_result);
+  auto accelerator_def_result =
+      shlib.LookupSymbol<LiteRtAcceleratorDef*>(accelerator_def_name.data());
+  if (!accelerator_def_result) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 accelerator-def symbol lookup failed path=%s "
+               "symbol=%s status=%s message=%s",
+               path.c_str(), symbol.c_str(),
+               LiteRtGetStatusString(accelerator_def_result.Error().Status()),
+               accelerator_def_result.Error().Message().c_str());
+    return accelerator_def_result.Error();
+  }
+  auto accelerator_def = *accelerator_def_result;
 
-  LITERT_RETURN_IF_ERROR(
-      RegisterAcceleratorFromDef(&environment, accelerator_def));
+  LiteRtStatus status = RegisterAcceleratorFromDef(&environment, accelerator_def);
+  if (status != kLiteRtStatusOk) {
+    LITERT_LOG(LITERT_WARNING,
+               "asc.12 accelerator-def registration failed path=%s symbol=%s "
+               "status=%s",
+               path.c_str(), symbol.c_str(), LiteRtGetStatusString(status));
+    return Error(status);
+  }
 
   environment.GetAcceleratorRegistry().TakeOwnershipOfSharedLibrary(
       std::move(shlib));
+  LITERT_LOG(LITERT_INFO,
+             "asc.12 accelerator-def registration succeeded path=%s "
+             "symbol=%s",
+             path.c_str(), symbol.c_str());
   return {};
 }
 


### PR DESCRIPTION
## Summary
- add an Apple framework-binary fallback in GPU accelerator registration
- map basename loads such as `libLiteRtMetalAccelerator.dylib` to `<runtime_lib_path>/LiteRtMetalAccelerator.framework/LiteRtMetalAccelerator`
- add diagnostic logging around accelerator load/register failures

## Why
iOS/TestFlight apps cannot ship raw nested dylibs; accelerator sidecars need to be packaged as signed frameworks. The existing basename load path cannot find those framework binaries from the app sandbox, so GPU registration fails before compiled-model creation.

## Validation
- Used with LiteRT-LM runtime-library-dir forwarding in b4 iPhone 16 Pro validation.
- Device stderr showed `GPU Metal` registered and Gemma 4 E2B decode completed via Metal.
- The same branch produced clearer diagnostics when registration failed during earlier bundle-layout tests.