### PR TITLE
Support Emscripten ES modules in LiteRT.js loader

### DIFF
--- a/litert/js/package-lock.json
+++ b/litert/js/package-lock.json
@@ -23,12 +23,13 @@
     },
     "apps/model_tester": {
       "name": "@litertjs/model-tester",
-      "version": "0.2.1",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@lit/task": "^1.0.2",
-        "@litertjs/core": "^0.2.1",
-        "@litertjs/tfjs-interop": "^0.2.1",
+        "@litertjs/core": "^2.0.0",
+        "@litertjs/tfjs-interop": "^2.0.0",
+        "@material/web": "^2.3.0",
         "argparse": "^2.0.1",
         "d3": "^5.16.0",
         "esbuild": "^0.23.0",
@@ -42,7 +43,7 @@
         "model-tester": "serve.js"
       },
       "devDependencies": {
-        "@litertjs/tsconfig": "^0.2.1",
+        "@litertjs/tsconfig": "^2.0.0",
         "@tensorflow/tfjs": "^4.22.0",
         "@tensorflow/tfjs-backend-cpu": "^4.22.0",
         "@tensorflow/tfjs-backend-webgpu": "^4.22.0",
@@ -60,14 +61,14 @@
     },
     "demos/depth_anything": {
       "name": "@litertjs/depth_anything_demo",
-      "version": "0.2.1",
+      "version": "2.0.0",
       "dependencies": {
-        "@litertjs/core": "^0.2.1",
+        "@litertjs/core": "^2.0.0",
         "esbuild": "^0.25.9",
         "lit": "^3.1.0"
       },
       "devDependencies": {
-        "@litertjs/tsconfig": "^0.2.1",
+        "@litertjs/tsconfig": "^2.0.0",
         "mkdirp": "^3.0.1",
         "rimraf": "^6.0.1",
         "typescript": "^5.0.0"
@@ -116,11 +117,11 @@
     },
     "demos/efficientvit_segmentation": {
       "name": "@litertjs/efficientvit_segmentation_demo",
-      "version": "0.2.1",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@litertjs/core": "^0.2.1",
-        "@litertjs/tfjs-interop": "^0.2.1",
+        "@litertjs/core": "^2.0.0",
+        "@litertjs/tfjs-interop": "^2.0.0",
         "@tensorflow/tfjs": "^4.22.0",
         "@tensorflow/tfjs-backend-webgpu": "^4.22.0",
         "@tensorflow/tfjs-core": "^4.22.0",
@@ -131,11 +132,11 @@
     },
     "demos/mobilenetv2": {
       "name": "@litertjs/mobilenetv2_demo",
-      "version": "0.2.1",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@litertjs/core": "^0.2.1",
-        "@litertjs/tfjs-interop": "^0.2.1",
+        "@litertjs/core": "^2.0.0",
+        "@litertjs/tfjs-interop": "^2.0.0",
         "@tensorflow/tfjs": "^4.22.0",
         "@tensorflow/tfjs-backend-webgpu": "^4.22.0",
         "@tensorflow/tfjs-core": "^4.22.0",
@@ -146,13 +147,13 @@
     },
     "demos/real_esrgan": {
       "name": "@litertjs/real_esrgan_demo",
-      "version": "0.2.1",
+      "version": "2.0.0",
       "dependencies": {
-        "@litertjs/core": "^0.2.1",
+        "@litertjs/core": "^2.0.0",
         "lit": "^3.1.0"
       },
       "devDependencies": {
-        "@litertjs/tsconfig": "^0.2.1",
+        "@litertjs/tsconfig": "^2.0.0",
         "esbuild": "^0.25.9",
         "mkdirp": "^3.0.1",
         "rimraf": "^6.0.1",
@@ -1317,6 +1318,10 @@
       "resolved": "demos/real_esrgan",
       "link": true
     },
+    "node_modules/@litertjs/tensor": {
+      "resolved": "packages/tensor",
+      "link": true
+    },
     "node_modules/@litertjs/tfjs-interop": {
       "resolved": "packages/tfjs_interop",
       "link": true
@@ -1341,6 +1346,13 @@
         "find-up": "^4.1.0",
         "fs-extra": "^8.1.0"
       }
+    },
+    "node_modules/@manypkg/find-root/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@manypkg/find-root/node_modules/fs-extra": {
       "version": "8.1.0",
@@ -1392,6 +1404,19 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@material/web": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@material/web/-/web-2.4.1.tgz",
+      "integrity": "sha512-0sk9t25acJ72Qv3r0n9r0lgDbPaAKnpm0p+QmEAAwYyZomHxuVbgrrAdtNXaRm7jFyGh+WsTr8bhtvCnpPRFjw==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "catalog"
+      ],
+      "dependencies": {
+        "lit": "^2.8.0 || ^3.0.0",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2329,10 +2354,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "license": "MIT"
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.13",
@@ -7213,6 +7241,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tsup": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.0.tgz",
@@ -7539,6 +7573,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -7846,14 +7886,14 @@
     },
     "packages/core": {
       "name": "@litertjs/core",
-      "version": "0.2.1",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@litertjs/wasm-utils": "^0.2.1"
+        "@litertjs/wasm-utils": "^2.0.0"
       },
       "devDependencies": {
-        "@litertjs/eslint-config": "^0.2.1",
-        "@litertjs/tsconfig": "^0.2.1",
+        "@litertjs/eslint-config": "^2.0.0",
+        "@litertjs/tsconfig": "^2.0.0",
         "@tensorflow/tfjs-backend-webgpu": "^4.22.0",
         "@tensorflow/tfjs-core": "^4.22.0",
         "@types/jasmine": "^5.1.8",
@@ -7878,31 +7918,40 @@
     },
     "packages/eslint_config": {
       "name": "@litertjs/eslint-config",
-      "version": "0.2.1",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.8.0",
         "typescript-eslint": "^8.0.0"
       }
     },
+    "packages/tensor": {
+      "name": "@litertjs/tensor",
+      "version": "0.0.1",
+      "license": "Apache-2.0"
+    },
     "packages/tfjs_interop": {
       "name": "@litertjs/tfjs-interop",
-      "version": "0.2.1",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@litertjs/core": "^0.2.1",
-        "@litertjs/eslint-config": "^0.2.1",
-        "@litertjs/tsconfig": "^0.2.1",
+        "@litertjs/core": "^2.0.0",
+        "@litertjs/eslint-config": "^2.0.0",
+        "@litertjs/tsconfig": "^2.0.0",
         "@tensorflow/tfjs-backend-webgpu": "^4.22.0",
         "@tensorflow/tfjs-core": "^4.22.0",
+        "@types/jasmine": "^5.1.8",
         "@webgpu/types": "^0.1.54",
         "esbuild": "^0.23.0",
         "eslint": "^9.8.0",
+        "jasmine": "^5.8.0",
+        "jasmine-browser-runner": "^3.0.0",
+        "jasmine-core": "^5.8.0",
         "tsup": "^8.2.3",
         "typescript": "^5.5.4"
       },
       "peerDependencies": {
-        "@litertjs/core": "^0.2.1",
+        "@litertjs/core": "^2.0.0",
         "@tensorflow/tfjs-core": "^4.22.0"
       }
     },
@@ -7915,16 +7964,16 @@
     },
     "packages/tsconfig": {
       "name": "@litertjs/tsconfig",
-      "version": "0.2.1",
+      "version": "2.0.0",
       "license": "Apache-2.0"
     },
     "packages/wasm_utils": {
       "name": "@litertjs/wasm-utils",
-      "version": "0.2.1",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@litertjs/eslint-config": "^0.2.1",
-        "@litertjs/tsconfig": "^0.2.1",
+        "@litertjs/eslint-config": "^2.0.0",
+        "@litertjs/tsconfig": "^2.0.0",
         "esbuild": "^0.23.0",
         "eslint": "^9.8.0",
         "tsup": "^8.2.3",

--- a/litert/js/packages/core/README.md
+++ b/litert/js/packages/core/README.md
@@ -68,3 +68,19 @@ console.log(result.toTypedArray());
 // Clean up the result tensor.
 result.delete();
 ```
+
+LiteRT.js can also load Emscripten ES module glue when the package includes the
+matching `.mjs` files:
+
+```typescript
+await loadLiteRt('/path/to/wasm/directory/', {wasmLoaderType: 'module'});
+```
+
+If your bundler or runtime needs a static ESM import, pass the Emscripten module
+factory directly:
+
+```typescript
+import createLiteRtWasm from '@litertjs/core/wasm/litert_wasm_internal.mjs';
+
+await loadLiteRt(createLiteRtWasm);
+```

--- a/litert/js/packages/core/src/load.ts
+++ b/litert/js/packages/core/src/load.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {createWasmLib} from '@litertjs/wasm-utils';
+import {
+  createWasmLib,
+  type FileLocator,
+  type WasmModuleFactory,
+} from '@litertjs/wasm-utils';
 
 import {LiteRt} from './litert_web';
 import {appendPathSegment, pathToString, UrlPath} from './url_path_utils';
@@ -24,6 +28,13 @@ const WASM_JS_FILE_NAME = 'litert_wasm_internal.js';
 const WASM_JS_COMPAT_FILE_NAME = 'litert_wasm_compat_internal.js';
 const WASM_JS_THREADED_FILE_NAME = 'litert_wasm_threaded_internal.js';
 const WASM_JS_JSPI_FILE_NAME = 'litert_wasm_jspi_internal.js';
+const WASM_MJS_FILE_NAME = 'litert_wasm_internal.mjs';
+const WASM_MJS_COMPAT_FILE_NAME = 'litert_wasm_compat_internal.mjs';
+const WASM_MJS_THREADED_FILE_NAME = 'litert_wasm_threaded_internal.mjs';
+const WASM_MJS_JSPI_FILE_NAME = 'litert_wasm_jspi_internal.mjs';
+
+export type WasmModuleSource = UrlPath|WasmModuleFactory;
+export type WasmLoaderType = 'script'|'module';
 
 /**
  * Options for loading LiteRT's Wasm module.
@@ -34,10 +45,18 @@ const WASM_JS_JSPI_FILE_NAME = 'litert_wasm_jspi_internal.js';
  * @property jspi Whether to load the JSPI version of the Wasm module. Defaults
  *     to false. Unused when specifying a .js file directly instead of a
  *     directory containing the Wasm files.
+ * @property wasmLoaderType Whether to load Emscripten's generated glue as a
+ *     classic script or as an ES module. Defaults to 'script'. When set to
+ *     'module' and a directory path is provided, LiteRT.js selects the
+ *     corresponding `.mjs` file.
+ * @property fileLocator File locator overrides passed to Emscripten's module
+ *     factory.
  **/
 export interface LoadOptions {
   threads?: boolean;
   jspi?: boolean;
+  wasmLoaderType?: WasmLoaderType;
+  fileLocator?: FileLocator;
 }
 
 /**
@@ -45,11 +64,60 @@ export interface LoadOptions {
  * global LiteRT instance.
  */
 export async function load(
-    path: UrlPath, options?: LoadOptions): Promise<LiteRt> {
-  const pathString = pathToString(path);
-  const isFullFilePath =
-      pathString.endsWith('.wasm') || pathString.endsWith('.js');
+    source: WasmModuleSource, options?: LoadOptions): Promise<LiteRt> {
+  if (typeof source === 'function') {
+    await validateLoadOptions(
+        options, /* isFullFilePath= */ true,
+        'the provided Wasm module factory');
+    return createWasmLib(LiteRt, {
+      fileLocator: options?.fileLocator,
+      moduleFactory: source,
+    });
+  }
 
+  const pathString = pathToString(source);
+  const isModule = options?.wasmLoaderType === 'module' ||
+      pathString.endsWith('.mjs');
+  const isFullFilePath = pathString.endsWith('.wasm') ||
+      pathString.endsWith('.js') || pathString.endsWith('.mjs');
+
+  const relaxedSimd =
+      await validateLoadOptions(options, isFullFilePath, pathString);
+  let fileName = isModule ? WASM_MJS_COMPAT_FILE_NAME : WASM_JS_COMPAT_FILE_NAME;
+  if (relaxedSimd) {
+    if (options?.threads) {
+      fileName =
+          isModule ? WASM_MJS_THREADED_FILE_NAME : WASM_JS_THREADED_FILE_NAME;
+    } else if (options?.jspi) {
+      fileName = isModule ? WASM_MJS_JSPI_FILE_NAME : WASM_JS_JSPI_FILE_NAME;
+    } else {
+      fileName = isModule ? WASM_MJS_FILE_NAME : WASM_JS_FILE_NAME;
+    }
+  }
+
+  let jsFilePath = source;
+  if (pathString.endsWith('.wasm')) {
+    throw new Error(
+        'Please load the `.js` file corresponding to the `.wasm` file, or ' +
+        'load the directory containing it.');
+  } else if (!pathString.endsWith('.js') && !pathString.endsWith('.mjs')) {
+    jsFilePath = appendPathSegment(source, fileName);
+  }
+
+  if (isModule) {
+    const wasmModuleFactory = await importWasmModuleFactory(jsFilePath);
+    return createWasmLib(LiteRt, {
+      fileLocator: options?.fileLocator,
+      moduleFactory: wasmModuleFactory,
+    });
+  }
+
+  return createWasmLib(LiteRt, jsFilePath, null, null, options?.fileLocator);
+}
+
+async function validateLoadOptions(
+    options: LoadOptions|undefined, isFullFilePath: boolean,
+    pathString: string): Promise<boolean> {
   const relaxedSimd = await supportsFeature('relaxedSimd');
   if (options?.threads) {
     if (options?.jspi) {
@@ -83,26 +151,39 @@ export async function load(
     }
     await throwIfFeatureNotSupported('jspi');
   }
+  return relaxedSimd;
+}
 
-  let fileName = WASM_JS_COMPAT_FILE_NAME;
-  if (relaxedSimd) {
-    if (options?.threads) {
-      fileName = WASM_JS_THREADED_FILE_NAME;
-    } else if (options?.jspi) {
-      fileName = WASM_JS_JSPI_FILE_NAME;
-    } else {
-      fileName = WASM_JS_FILE_NAME;
-    }
-  }
-
-  let jsFilePath = path;
-  if (pathString.endsWith('.wasm')) {
+async function importWasmModuleFactory(
+    jsFilePath: UrlPath): Promise<WasmModuleFactory> {
+  const moduleUrl = resolveModuleImportUrl(jsFilePath);
+  const wasmModule = await import(/* @vite-ignore */ moduleUrl);
+  if (typeof wasmModule.default !== 'function') {
     throw new Error(
-        'Please load the `.js` file corresponding to the `.wasm` file, or ' +
-        'load the directory containing it.');
-  } else if (!pathString.endsWith('.js')) {
-    jsFilePath = appendPathSegment(path, fileName);
+        `LiteRT Wasm ES module ${moduleUrl} must have a ` +
+        'default export module factory.');
   }
+  return wasmModule.default as WasmModuleFactory;
+}
 
-  return createWasmLib(LiteRt, jsFilePath);
+function resolveModuleImportUrl(jsFilePath: UrlPath): string {
+  const pathString = pathToString(jsFilePath);
+  const baseUrl = getResourceBaseUrl();
+  if (!baseUrl) return pathString;
+
+  try {
+    return new URL(pathString, baseUrl).href;
+  } catch {
+    return pathString;
+  }
+}
+
+function getResourceBaseUrl(): string|undefined {
+  if (typeof document !== 'undefined') {
+    return document.baseURI;
+  }
+  if (typeof location !== 'undefined') {
+    return location.href;
+  }
+  return undefined;
 }

--- a/litert/js/packages/core/src/load_litert.ts
+++ b/litert/js/packages/core/src/load_litert.ts
@@ -19,9 +19,7 @@
 import {Environment} from './environment';
 import {getGlobalLiteRt, getGlobalLiteRtPromise, hasGlobalLiteRt, hasGlobalLiteRtPromise, setGlobalLiteRt, setGlobalLiteRtPromise} from './global_litert';
 import {LiteRt} from './litert_web';
-import {load, LoadOptions} from './load';
-
-type UrlString = string;
+import {load, LoadOptions, WasmModuleSource} from './load';
 
 /**
  * Options for loading LiteRT.
@@ -33,7 +31,7 @@ type UrlString = string;
  *     to false. Unused when specifying a .js file directly instead of a
  *     directory containing the Wasm files.
  **/
-export interface LoadLiteRtOptions extends LoadOptions {}
+export type LoadLiteRtOptions = LoadOptions;
 
 /**
  * Load LiteRT.js Wasm files from the given URL. This needs to be called before
@@ -42,17 +40,19 @@ export interface LoadLiteRtOptions extends LoadOptions {}
  * The URL can be:
  *
  * - A directory containing the LiteRT Wasm files (e.g. `.../wasm/`), or
- * - The LiteRT Wasm's js file (e.g. `.../litert_wasm_internal.js`)
+ * - The LiteRT Wasm's js/mjs file (e.g. `.../litert_wasm_internal.js`), or
+ * - An Emscripten ES module factory imported from a generated `.mjs` file.
  *
  * If the URL is to a directory, LiteRT.js will detect what WASM features are
  * available in the browser and load the compatible WASM file. If the URL is
  * to a file, it will be loaded as is.
  *
  * @param path The path to the directory containing the LiteRT Wasm files, or
- *     the full URL of the LiteRT Wasm .js file.
+ *     the full URL of the LiteRT Wasm .js/.mjs file. Emscripten ES module
+ *     factories can also be passed directly.
  */
 export function loadLiteRt(
-    path: UrlString, options?: LoadLiteRtOptions): Promise<LiteRt> {
+    path: WasmModuleSource, options?: LoadLiteRtOptions): Promise<LiteRt> {
   if (hasGlobalLiteRtPromise()) {
     throw new Error('LiteRT is already loading / loaded.');
   }

--- a/litert/js/packages/core/wasm/litert_wasm_compat_internal.d.mts
+++ b/litert/js/packages/core/wasm/litert_wasm_compat_internal.d.mts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {WasmModuleFactory} from '@litertjs/wasm-utils';
+
+declare const moduleFactory: WasmModuleFactory;
+export default moduleFactory;

--- a/litert/js/packages/core/wasm/litert_wasm_internal.d.mts
+++ b/litert/js/packages/core/wasm/litert_wasm_internal.d.mts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {WasmModuleFactory} from '@litertjs/wasm-utils';
+
+declare const moduleFactory: WasmModuleFactory;
+export default moduleFactory;

--- a/litert/js/packages/core/wasm/litert_wasm_jspi_internal.d.mts
+++ b/litert/js/packages/core/wasm/litert_wasm_jspi_internal.d.mts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {WasmModuleFactory} from '@litertjs/wasm-utils';
+
+declare const moduleFactory: WasmModuleFactory;
+export default moduleFactory;

--- a/litert/js/packages/core/wasm/litert_wasm_threaded_internal.d.mts
+++ b/litert/js/packages/core/wasm/litert_wasm_threaded_internal.d.mts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {WasmModuleFactory} from '@litertjs/wasm-utils';
+
+declare const moduleFactory: WasmModuleFactory;
+export default moduleFactory;

--- a/litert/js/packages/wasm_utils/src/wasm_loader.ts
+++ b/litert/js/packages/wasm_utils/src/wasm_loader.ts
@@ -40,6 +40,23 @@ export declare interface FileLocator {
 }
 
 /**
+ * Factory exported by Emscripten's ES module output.
+ */
+export type WasmModuleFactory =
+    (fileLocator?: FileLocator) => Promise<WasmModule>;
+
+/**
+ * Options for initializing a Wasm library.
+ */
+export declare interface CreateWasmLibOptions {
+  wasmLoaderScript?: UrlString|null;
+  assetLoaderScript?: UrlString|null;
+  glCanvas?: HTMLCanvasElement|OffscreenCanvas|null;
+  fileLocator?: FileLocator;
+  moduleFactory?: WasmModuleFactory;
+}
+
+/**
  * Global function interface to initialize Wasm blob and load runtime assets for
  *     a specialized Wasm library. Standard implementation is
  *     `createWasmLib<LibType>`.
@@ -54,6 +71,9 @@ export declare interface FileLocator {
  *     completed successfully.
  */
 export interface CreateWasmLibApi {
+  <LibType>(
+      constructorFcn: WasmConstructor<LibType>,
+      options?: CreateWasmLibOptions): Promise<LibType>;
   <LibType>(
       constructorFcn: WasmConstructor<LibType>,
       wasmLoaderScript?: UrlString|null, assetLoaderScript?: UrlString|null,
@@ -73,10 +93,27 @@ declare global {
 
 /** {@override CreateWasmLibApi} */
 export const createWasmLib: CreateWasmLibApi = async<LibType>(
-    constructorFcn: WasmConstructor<LibType>, wasmLoaderScript?: UrlString|null,
+    constructorFcn: WasmConstructor<LibType>,
+    wasmLoaderScriptOrOptions?: UrlString|null|CreateWasmLibOptions,
     assetLoaderScript?: UrlString|null,
     glCanvas?: HTMLCanvasElement|OffscreenCanvas|null,
     fileLocator?: FileLocator): Promise<LibType> => {
+  let wasmLoaderScript = wasmLoaderScriptOrOptions as UrlString|null|undefined;
+  let moduleFactory: WasmModuleFactory|undefined;
+  if (typeof wasmLoaderScriptOrOptions === 'object' &&
+      wasmLoaderScriptOrOptions !== null) {
+    wasmLoaderScript = wasmLoaderScriptOrOptions.wasmLoaderScript;
+    assetLoaderScript = wasmLoaderScriptOrOptions.assetLoaderScript;
+    glCanvas = wasmLoaderScriptOrOptions.glCanvas;
+    fileLocator = wasmLoaderScriptOrOptions.fileLocator;
+    moduleFactory = wasmLoaderScriptOrOptions.moduleFactory;
+  }
+
+  if (moduleFactory) {
+    const module = await moduleFactory(fileLocator);
+    return new constructorFcn(module, glCanvas);
+  }
+
   // Run wasm-loader script here
   if (wasmLoaderScript) {
     await runScript(wasmLoaderScript);


### PR DESCRIPTION
This PR makes it possible to instantiate LiteRT.js using Emscripten ES modules, in addition to the existing classic script glue.

## Why?

Some JavaScript runtime environments are very restricted. One important example is `AudioWorkletGlobalScope`:
https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletGlobalScope

Audio worklets are designed for low-latency, real-time audio processing. In practice, this means worklet code should not rely on fetching or asynchronously discovering runtime resources while processing audio.

In an Audio worklet:

- You cannot "import" a module
- You cannot "fetch" a file
- You don't have access to the URL object
- ...

Running audio through an on-device model is a valid use case for LiteRT.js, but the current loading path assumes that the generated Emscripten glue can be loaded as a script and that the `.wasm` file can be discovered/
fetched by that glue. This is not possible to use in an AudioWorklet.

## Can this be solved with a Worker?

A common alternative is to run inference in a Worker and transfer audio data between the AudioWorklet and the Worker. Chrome documents this architecture here:
https://developer.chrome.com/blog/audio-worklet-design-pattern#webaudio_powerhouse_audio_worklet_and_sharedarraybuffer

For low-latency audio, this generally requires `SharedArrayBuffer` to avoid routing data through the main thread. When `SharedArrayBuffer` is available, this is probably the better architecture: the worker can do more work,
can be easier to initialize, and can use more platform features.

However, `SharedArrayBuffer` requires a cross-origin isolated page, which means serving the right COOP/COEP headers. That is not possible in every deployment. For example, my use case depends on embedding third-party iframes
in a WorkAdventure virtual world, and enabling COOP/COEP would be too restrictive.

For environments where `SharedArrayBuffer` is not available, it is valuable to be able to bootstrap LiteRT.js directly inside an AudioWorklet.

## What this PR changes

This PR adds support for loading LiteRT.js from Emscripten ES module glue.

> [!WARNING]
> This assumes that the package build process will also publish Emscripten ES module glue files. The intended Emscripten output shape is the normal `MODULARIZE` + `EXPORT_ES6` factory export, not experimental `MODULARIZE=instance` or wasm ESM integration.

The directory-loading API can now request `.mjs` glue files:

```typescript
await loadLiteRt('/path/to/wasm/directory/', {wasmLoaderType: 'module'});
```

Note: the interest of doing this is limited. The really important new API is that callers can pass an Emscripten module factory directly:

```typescript
import createLiteRtWasm from '@litertjs/core/wasm/litert_wasm_internal.mjs';

await loadLiteRt(createLiteRtWasm);
```

This lets bundlers such as Vite include the Emscripten glue in the worklet bundle instead of loading it dynamically at runtime.

> [!NOTE]
> Passing a factory directly means LiteRT.js no longer chooses the wasm glue variant from a directory. The caller is responsible for importing the correct variant, for example the non-threaded CPU wasm variant. That is
> acceptable for AudioWorklet use cases, where the practical target is single-threaded CPU execution (because no other variant is available)

For a fully self-contained AudioWorklet, the .wasm binary and model bytes must also be bundled instead of fetched. With Vite, one possible approach is to inline the wasm asset and pass the decoded bytes through Emscripten's
wasmBinary option:

```typescript
  import {loadLiteRt} from '@litertjs/core';
  import createLiteRtWasm from './litert_wasm_internal.mjs';
  import wasmDataUrl from './litert_wasm_internal.wasm?inline';
  // wasmUrl === 'data:application/wasm;base64,...'

  function dataUrlToUint8Array(dataUrl: string): Uint8Array {
    const base64 = dataUrl.slice(dataUrl.indexOf(',') + 1);
    const binary = atob(base64);
    const bytes = new Uint8Array(binary.length);

    for (let i = 0; i < binary.length; i++) {
      bytes[i] = binary.charCodeAt(i);
    }

    return bytes;
  }

  const wasmBinary = dataUrlToUint8Array(wasmDataUrl);

  await loadLiteRt((moduleArg) =>
    createLiteRtWasm({
      ...moduleArg,
      wasmBinary,
    }),
  );
```

The code above works with Vite. The "?inline" modifier returns the data as a base64 string and a small helper is converting it in `Uint8Array` before passing that to LiteRT.
The model can be handled similarly by passing model bytes directly to loadAndCompile, instead of passing a URL.

Fixes #6470.
