### PR TITLE
[Intel OV] Drop direct-URL openvino pin (PyPI rejects)

### DIFF
--- a/ci/tools/python/vendor_sdk/intel/setup.py
+++ b/ci/tools/python/vendor_sdk/intel/setup.py
@@ -49,16 +49,19 @@ IS_X86_ARCHITECTURE = platform.machine() in ('x86_64', 'AMD64', 'i386', 'i686')
 # --- Configuration for OpenVINO NPU Compiler Download ---
 #
 # Must match the OpenVINO build pinned in third_party/intel_openvino/
-# openvino.bzl. That workspace file pins the OpenVINO SDK used to compile the
-# Intel OV compiler plugin and dispatch library at build time; this file pins
-# the OpenVINO nightly archive that provides the NPU compiler shared library
-# fetched at pip install time, and the `openvino` PyPI wheel referenced by
-# install_requires below. All three must point at the same commit. OpenVINO's
-# build number (the numeric segment in `2026.2.0-21820-<commit>/`) uniquely
-# identifies a build: it appears both in the toolkit archive directory and as
-# the wheel filename's build tag (the `-21820-` between version and py-tag).
-# ci/check_openvino_version_sync.py enforces this across openvino.bzl and
-# this file.
+# openvino.bzl. That workspace file pins the OpenVINO SDK used to compile
+# the Intel OV compiler plugin and dispatch library at build time; the
+# archive URL below pins the matching toolkit build from which we extract
+# the NPU compiler shared library at pip install time. OpenVINO's build
+# number (the numeric segment in `2026.2.0-21820-<commit>/`) uniquely
+# identifies a build — ci/check_openvino_version_sync.py enforces that
+# this file and openvino.bzl pin the same one.
+#
+# install_requires pins the matching PyPI `openvino` wheel by PEP 440
+# version string (date-stamped, e.g. `2026.2.0.dev20260506`). PyPI does
+# not allow direct-URL dependencies in hosted packages, so users need
+# `--extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly`
+# at install time to locate the nightly wheel.
 # LINT.IfChange(wheel_openvino_sdk_version)
 _OV_BUILD_NUMBER = '21820'
 _OV_COMMIT = '9a25caa5a15'
@@ -67,12 +70,6 @@ _OV_ARCHIVE_DIR = f'2026.2.0-{_OV_BUILD_NUMBER}-{_OV_COMMIT}'
 _OV_BASE_URL = (
     'https://storage.openvinotoolkit.org/repositories/openvino/packages/nightly'
     f'/{_OV_ARCHIVE_DIR}'
-)
-# PyPI nightly wheel index used for install_requires direct URLs; lets a plain
-# `pip install ai-edge-litert-sdk-intel-nightly` pull the matching openvino
-# wheel without --extra-index-url.
-_OV_WHEEL_BASE_URL = (
-    'https://storage.openvinotoolkit.org/wheels/nightly/openvino'
 )
 # LINT.ThenChange(
 #   ../../../../../third_party/intel_openvino/openvino.bzl:openvino_packages,
@@ -132,70 +129,6 @@ _ARCHIVES = {
         'members': _WINDOWS_MEMBERS,
     },
 }
-
-# Pin the `openvino` PyPI wheel to the exact nightly build that matches
-# _OV_ARCHIVE_DIR. One direct URL per supported (python, os); pip picks the
-# right one via the PEP 508 environment marker.
-# Wheel filename schema at _OV_WHEEL_BASE_URL:
-#   openvino-<pep440>-<build>-<py>-<abi>-<plat>.whl
-# Linux wheels use manylinux2014_x86_64, Windows uses win_amd64.
-_OV_WHEEL_TARGETS = (
-    # (py_tag, abi_tag, platform_tag, env_marker)
-    (
-        'cp310',
-        'cp310',
-        'manylinux_2_28_x86_64',
-        (
-            'python_version == "3.10" and sys_platform == "linux" and'
-            ' platform_machine == "x86_64"'
-        ),
-    ),
-    (
-        'cp311',
-        'cp311',
-        'manylinux_2_28_x86_64',
-        (
-            'python_version == "3.11" and sys_platform == "linux" and'
-            ' platform_machine == "x86_64"'
-        ),
-    ),
-    (
-        'cp312',
-        'cp312',
-        'manylinux_2_28_x86_64',
-        (
-            'python_version == "3.12" and sys_platform == "linux" and'
-            ' platform_machine == "x86_64"'
-        ),
-    ),
-    (
-        'cp313',
-        'cp313',
-        'manylinux_2_28_x86_64',
-        (
-            'python_version == "3.13" and sys_platform == "linux" and'
-            ' platform_machine == "x86_64"'
-        ),
-    ),
-    (
-        'cp311',
-        'cp311',
-        'win_amd64',
-        'python_version == "3.11" and sys_platform == "win32"',
-    ),
-)
-
-
-def _openvino_install_requires():
-  reqs = []
-  for py_tag, abi_tag, plat_tag, marker in _OV_WHEEL_TARGETS:
-    wheel = (
-        f'openvino-{_OV_PEP440_VERSION}-{_OV_BUILD_NUMBER}'
-        f'-{py_tag}-{abi_tag}-{plat_tag}.whl'
-    )
-    reqs.append(f'openvino @ {_OV_WHEEL_BASE_URL}/{wheel} ; {marker}')
-  return reqs
-
 
 _TARGET_DIR = 'ai_edge_litert_sdk_intel/data'
 
@@ -468,7 +401,7 @@ setuptools.setup(
     packages=['ai_edge_litert_sdk_intel'],
     package_dir={'ai_edge_litert_sdk_intel': 'ai_edge_litert_sdk_intel'},
     python_requires='>=3.10',
-    install_requires=_openvino_install_requires(),
+    install_requires=[f'openvino=={_OV_PEP440_VERSION}'],
     cmdclass={
         'build_py': CustomBuildPy,
     },

--- a/litert/vendors/intel_openvino/README.md
+++ b/litert/vendors/intel_openvino/README.md
@@ -17,9 +17,6 @@ limitations under the License. -->
 This directory contains the Intel OpenVINO integration for LiteRT, providing
 compiler plugin and dispatch API support for Intel NPU hardware.
 
-Validated on: Linux (PTL, Ubuntu 24.04, OpenVINO 2026.1.0, NPU driver v1.32.1)
-and Windows 11 (Core Ultra 2/3, NPU driver 32.0.100.4724).
-
 ## Supported Platforms
 
 Platform                  | NPU     | Codename           | OS
@@ -29,43 +26,41 @@ Intel Core Ultra Series 3 | NPU5010 | Panther Lake (PTL) | Linux, Windows
 
 ## Prerequisites
 
-| Requirement | Linux                    | Windows                    |
-| ----------- | ------------------------ | -------------------------- |
-| OS          | Ubuntu 22.04 or 24.04    | Windows 10/11 (x86_64)     |
-:             : LTS (x86_64)             :                            :
-| Python      | 3.10 – 3.13              | 3.11 only                  |
-| NPU driver  | v1.32.1 — see [Linux NPU | 32.0.100.4724+ — see       |
-:             : Setup](#linux-npu-setup) : [Windows NPU               :
-:             :                          : Setup](#windows-npu-setup) :
+**Linux (x86_64):**
+
+-   Ubuntu 22.04 or 24.04 LTS
+-   Python 3.10+ — install from [python.org](https://www.python.org/downloads/)
+    or your distro (`sudo apt install python3 python3-venv`)
+-   Intel NPU driver **v1.32.1** — see [Linux NPU Setup](#linux-npu-setup)
+
+**Windows (x86_64):**
+
+-   Windows 10 or 11
+-   Python 3.10+ — install from
+    [python.org](https://www.python.org/downloads/windows/)
+-   Intel NPU driver **32.0.100.4724+** — see [Windows NPU Setup](#windows-npu-setup)
+
+For building from source, Bazel 7.4.1+ via
+[Bazelisk](https://github.com/bazelbuild/bazelisk) or the hermetic Docker
+build is also required.
 
 ### When is the NPU driver required?
 
-| Task                              | Needs NPU driver installed?            |
-| --------------------------------- | -------------------------------------- |
-| AOT compile a `.tflite` for Intel | **No.** Cross-compilation works — e.g. |
-: NPU                               : compile on Linux, run the resulting    :
-:                                   : `.tflite` on Windows.                  :
-| Run inference on an Intel NPU     | **Yes.** The dispatch library talks to |
-: (Python or C++ API, JIT or        : the hardware via the Level Zero loader :
-: AOT-compiled model)               : shipped in the NPU driver package.     :
+The NPU driver is only needed on systems that **execute** the model on NPU
+hardware. Pure AOT-build systems can skip it.
 
-> **In short:** the NPU driver is needed only on machines that **execute** the
-> model on NPU hardware. Pure AOT-build machines can skip it.
+| Task          | NPU driver required? | Notes |
+| ------------- | -------------------- | ----- |
+| AOT Compile   | No                   | Cross-compilation works — e.g. compile on Linux, run the resulting `.tflite` on Windows. |
+| Inference     | Yes                  | The dispatch library talks to the hardware via the Level Zero loader shipped in the NPU driver package. |
 
 > **Note:** `ai-edge-litert-sdk-intel-nightly` pins the matching OpenVINO
 > nightly wheel by PEP 440 version (e.g. `openvino==2026.2.0.dev20260506`),
 > so pip needs `--extra-index-url
 > https://storage.openvinotoolkit.org/simple/wheels/nightly` to locate it —
-> see the install command below.
->
-> The SDK nightly also fetches the NPU compiler shared library
-> (`libopenvino_intel_npu_compiler.so` / `.dll`) from the matching toolkit
-> archive into its `data/` dir at `pip install` time — without it, AOT fails
-> with `Device with "NPU" name is not registered`. To override Linux distro
-> detection, set `LITERT_OV_OS_ID=ubuntu22` or `ubuntu24` before `pip install`.
-
-For building from source: Bazel 7.4.1+ via
-[Bazelisk](https://github.com/bazelbuild/bazelisk) or Docker.
+> see the install command below. On Linux, if distro auto-detection picks
+> the wrong archive, set `LITERT_OV_OS_ID=ubuntu22` or `ubuntu24` before
+> `pip install`.
 
 ## Quick Start
 
@@ -74,7 +69,22 @@ For building from source: Bazel 7.4.1+ via
 See [Linux NPU Setup](#linux-npu-setup) or
 [Windows NPU Setup](#windows-npu-setup). Skip if you only need AOT.
 
-### 2. Install the pip Package
+### 2. Create a Python Virtual Environment
+
+Recommended to keep the nightly `openvino` wheel isolated from any
+system-wide OpenVINO install.
+
+```bash
+python -m venv litert_env
+# Linux / macOS
+source litert_env/bin/activate
+# Windows (PowerShell)
+.\litert_env\Scripts\Activate.ps1
+
+python -m pip install --upgrade pip
+```
+
+### 3. Install the pip Package
 
 ```bash
 pip install --pre \
@@ -85,23 +95,30 @@ pip install --pre \
 The `--extra-index-url` lets pip resolve the pinned `openvino` nightly
 wheel from OpenVINO's index alongside packages on PyPI.
 
-### 3. Verify Installation
+### 4. Verify Installation
 
 ```bash
-python3 -c "
+python -c "
 from ai_edge_litert.aot.vendors.intel_openvino import intel_openvino_backend
 import ai_edge_litert_sdk_intel, openvino, os
 print('Backend:', intel_openvino_backend.IntelOpenVinoBackend.id())
 print('Dispatch:', intel_openvino_backend.get_dispatch_dir())
 print('OpenVINO:', openvino.__version__)
 print('SDK libs:', sorted(os.listdir(ai_edge_litert_sdk_intel.path_to_sdk_libs())))
+print('Available devices:', openvino.Core().available_devices)
 "
 ```
 
-> **Note:** `SDK libs` must list `libopenvino_intel_npu_compiler.so` (Linux) or
-> `openvino_intel_npu_compiler.dll` (Windows).
+What to check in the output:
 
-### 4. AOT Compile (Optional)
+-   `SDK libs` lists `libopenvino_intel_npu_compiler.so` (Linux) or
+    `openvino_intel_npu_compiler.dll` (Windows) — required for AOT.
+-   `Available devices` includes `NPU` — confirms the NPU driver is
+    installed and OpenVINO can talk to the device. `NPU` will be absent on
+    AOT-only systems (where the driver is not installed) and on systems
+    without Intel NPU hardware.
+
+### 5. AOT Compile (Optional)
 
 -   Pre-compiles a `.tflite` for a specific Intel NPU target (PTL or LNL) so the
     runtime skips the compiler plugin step.
@@ -127,23 +144,20 @@ aot_compile.aot_compile(
 aot_compile.aot_compile("model.tflite", output_dir="out", keep_going=True)
 ```
 
-Pass the AOT-compiled `.tflite` to the inference snippet below — no extra wiring
-needed. `Environment.create()` auto-discovers the dispatch library under the
-installed `ai_edge_litert` package.
+Pass the AOT-compiled `.tflite` to the inference snippet below — no extra
+wiring needed.
 
-### 5. Run NPU Inference
+### 6. Run NPU Inference
 
 LiteRT supports two inference paths on Intel NPU:
 
--   **JIT** — load a raw `.tflite`, the compiler plugin partitions and compiles
-    supported ops for the NPU at `CompiledModel.from_file()` time. No AOT step
-    needed; ~250 ms extra first-run latency for a typical model.
+-   **JIT** — load a raw `.tflite`; the compiler plugin partitions and
+    compiles supported ops for the NPU at `CompiledModel.from_file()` time.
+    Adds some first-run latency (varies by model).
 -   **AOT-compiled** — load a `<model>_IntelOpenVINO_<SoC>_apply_plugin.tflite`
     produced by step 4. Skips the partition/compile step at load time.
 
-The snippet below works for both; `Environment.create()` auto-discovers the
-Intel OV compiler plugin (JIT only) and dispatch library from the installed
-wheel.
+The snippet below works for both:
 
 ```python
 from ai_edge_litert.compiled_model import CompiledModel
@@ -162,18 +176,60 @@ model.run_by_index(sig_idx, input_buffers, output_buffers)
 print("Fully accelerated:", model.is_fully_accelerated())
 ```
 
-#### Mixed-vendor wheels: pinning JIT to Intel OV
+#### Confirming JIT actually ran
 
-The pip wheel ships compiler plugins for every registered vendor
-(`intel_openvino/`, `google_tensor/`, `mediatek/`, `qualcomm/`, `samsung/`).
-Auto-discovery picks the compiler plugin from the same vendor as the selected
-dispatch library, and today only Intel OV ships a dispatch library, so
-`CompiledModel.from_file(hardware_accel=NPU)` ends up on the Intel OV path by
-default.
+When JIT succeeds, the log contains (file extension is `.so` on Linux,
+`.dll` on Windows):
 
-If you want to be explicit — or if a future wheel bundles additional dispatch
-libraries and changes the auto-discovery pick — pass the Intel OV directories by
-hand:
+```
+INFO: [compiler_plugin.cc:236] Loaded plugin at: .../LiteRtCompilerPlugin_IntelOpenvino.{so,dll}
+INFO: [compiler_plugin.cc:690] Partitioned subgraph<0>, selected N ops, from a total of N ops
+INFO: [compiled_model.cc:1006] JIT compilation changed model, reserializing...
+```
+
+If those lines are absent but `Fully accelerated: True` is still reported,
+the model was run on XNNPACK CPU fallback, not on the NPU — see the JIT
+troubleshooting row below.
+
+### 7. Benchmark
+
+```bash
+# Dispatch library and the NPU compiler are auto-discovered from the wheel.
+litert-benchmark --model=model.tflite --use_npu --num_runs=50
+```
+
+Common flags:
+
+| Flag                        | Default | Description |
+| --------------------------- | ------- | ----------- |
+| `--model PATH`              | —       | Path to the `.tflite` model (required). |
+| `--signature KEY`           | first   | Signature key to run. |
+| `--use_cpu` / `--no_cpu`    | on      | Toggle the CPU accelerator / CPU fallback. |
+| `--use_gpu`                 | off     | Enable the GPU accelerator. |
+| `--use_npu`                 | off     | Enable the Intel NPU accelerator. |
+| `--require_full_delegation` | off     | Fail if the model is not fully offloaded to the selected accelerator. |
+| `--num_runs N`              | 50      | Number of timed inference iterations. |
+| `--warmup_runs N`           | 5       | Untimed warm-up iterations before measurement. |
+| `--num_threads N`           | 1       | CPU thread count. |
+| `--result_json PATH`        | —       | Write a JSON summary (latency stats, throughput, accelerator list). |
+| `--verbose`                 | off     | Extra runtime logging. |
+
+Advanced / override flags — only needed to point at custom builds:
+`--dispatch_library_path`, `--compiler_plugin_path`, `--runtime_path`.
+
+### Mixed-vendor wheels: pinning JIT to Intel OV
+
+> **Note:** When `Environment.create()` is called without explicit paths,
+> it auto-discovers vendors under `ai_edge_litert/vendors/` in alphabetical
+> order and registers the first one it finds. In a mixed-vendor install
+> this may not be Intel OV — pass the Intel OV directories explicitly to
+> force the right pick.
+
+-   The pip wheel ships compiler plugins for every registered vendor
+    (`intel_openvino/`, `google_tensor/`, `mediatek/`, `qualcomm/`,
+    `samsung/`).
+-   To force the Intel OV path (recommended when multiple vendor SDKs are
+    installed), pass the Intel OV directories by hand:
 
 ```python
 from ai_edge_litert.environment import Environment
@@ -208,52 +264,6 @@ litert-benchmark --model=model.tflite --use_npu \
     --dispatch_library_path=$DISPATCH_DIR
 ```
 
-#### Confirming JIT actually ran
-
-When JIT succeeds, the log contains:
-
-```
-INFO: [compiler_plugin.cc:236] Loaded plugin at: .../libLiteRtCompilerPlugin_IntelOpenvino.so
-INFO: [compiler_plugin.cc:690] Partitioned subgraph<0>, selected N ops, from a total of N ops
-INFO: [compiled_model.cc:1006] JIT compilation changed model, reserializing...
-```
-
-If those lines are absent but `Fully accelerated: True` is still reported, the
-model was run on XNNPACK CPU fallback, not on the NPU — see the JIT
-troubleshooting row below.
-
-### 6. Benchmark
-
-```bash
-# Dispatch library and the NPU compiler are auto-discovered from the wheel.
-litert-benchmark --model=model.tflite --use_npu --num_runs=50
-```
-
-Common flags:
-
-| Flag                        | Default | Description                          |
-| --------------------------- | ------- | ------------------------------------ |
-| `--model PATH`              | —       | Path to the `.tflite` model          |
-:                             :         : (required).                          :
-| `--signature KEY`           | first   | Signature key to run.                |
-| `--use_cpu` / `--no_cpu`    | on      | Toggle the CPU accelerator / CPU     |
-:                             :         : fallback.                            :
-| `--use_gpu`                 | off     | Enable the GPU accelerator.          |
-| `--use_npu`                 | off     | Enable the Intel NPU accelerator.    |
-| `--require_full_delegation` | off     | Fail if the model is not fully       |
-:                             :         : offloaded to the selected            :
-:                             :         : accelerator.                         :
-| `--num_runs N`              | 50      | Number of timed inference            |
-:                             :         : iterations.                          :
-| `--warmup_runs N`           | 5       | Untimed warm-up iterations before    |
-:                             :         : measurement.                         :
-| `--num_threads N`           | 1       | CPU thread count.                    |
-| `--result_json PATH`        | —       | Write a JSON summary (latency stats, |
-:                             :         : throughput, accelerator list).       :
-| `--verbose`                 | off     | Extra runtime logging.               |
-
-Advanced / override flags — only needed to point at custom builds:
-`--dispatch_library_path`, `--compiler_plugin_path`, `--runtime_path`.
 
 --------------------------------------------------------------------------------
 
@@ -262,8 +272,8 @@ Advanced / override flags — only needed to point at custom builds:
 To confirm the model actually ran on the NPU, check for **both** signals:
 
 1.  The log contains `Loading shared library:
-    .../libLiteRtDispatch_IntelOpenvino.so` — the Intel dispatch library was
-    loaded.
+    .../LiteRtDispatch_IntelOpenvino.{so,dll}` — the Intel dispatch library
+    was loaded (`.so` on Linux, `.dll` on Windows).
 2.  `model.is_fully_accelerated()` returns `True` — every op was offloaded to
     the selected accelerator.
 
@@ -313,7 +323,8 @@ Then run the install + verify snippet from [Quick Start](#quick-start).
 
 -   Install the Intel NPU driver (**32.0.100.4724+**) from the
     [Intel Download Center](https://www.intel.com/content/www/us/en/download/794734/intel-npu-driver-windows.html).
--   Verify Device Manager lists **Neural processors → Intel(R) AI Boost**.
+-   Verify Device Manager lists the NPU device under **Neural processors**
+    (shown as `Intel(R) AI Boost` or `Intel(R) NPU` depending on the driver).
 -   Run the install + verify snippet from [Quick Start](#quick-start), replacing
     `pip` with `python -m pip`.
 
@@ -325,6 +336,10 @@ Then run the install + verify snippet from [Quick Start](#quick-start).
 --------------------------------------------------------------------------------
 
 ## Building from Source
+
+> **Behind a proxy?** Export `http_proxy` / `https_proxy` / `no_proxy`
+> before running the build scripts — they forward these into Docker and
+> the container.
 
 Linux (Docker, hermetic):
 
@@ -345,8 +360,6 @@ Outputs land in `dist/`:
     sdists.
 -   The Intel sdist is ~5 KB; the NPU compiler `.so`/`.dll` is fetched at `pip
     install` time, so the same sdist works on Linux and Windows.
--   Behind a proxy? Export `http_proxy` / `https_proxy` / `no_proxy` — the
-    scripts forward them into Docker and the container.
 
 --------------------------------------------------------------------------------
 
@@ -368,7 +381,7 @@ Issue                                                                           
 ------------------------------------------------------------------------------------------------------------------------------- | ---
 AOT fails: `Device with "NPU" name is not registered`                                                                           | NPU compiler not fetched. Check `ai_edge_litert_sdk_intel.path_to_sdk_libs()` lists `libopenvino_intel_npu_compiler.so` / `.dll`. If empty, reinstall with network access, or set `LITERT_OV_OS_ID=ubuntu22`/`ubuntu24`.
 JIT runs on CPU instead of NPU (no `Partitioned subgraph` log, no `Loaded plugin` log, `Fully accelerated: True` still printed) | Compiler plugin was not discovered. Confirm `ov.get_compiler_plugin_dir()` returns a path under `ai_edge_litert/vendors/intel_openvino/compiler/`. If multiple vendor SDKs are installed, pass `compiler_plugin_path=ov.get_compiler_plugin_dir()` explicitly to `Environment.create()` (or `--compiler_plugin_path=...` to `litert-benchmark`).
-JIT fails: `Cannot load library .../openvino/libs/libopenvino_intel_npu_compiler.so`                                            | The SDK sdist copies the NPU compiler to `openvino/libs/` on first `import ai_edge_litert_sdk_intel`. If the copy was skipped (readonly FS, missing `openvino`), reinstall `ai-edge-litert-sdk-intel` after `openvino` is installed, then `import ai_edge_litert` in a fresh process.
+JIT fails: `Cannot load library .../openvino/libs/libopenvino_intel_npu_compiler.so` (Linux) / `openvino_intel_npu_compiler.dll` (Windows) | The SDK sdist copies the NPU compiler to `openvino/libs/` on first `import ai_edge_litert_sdk_intel`. If the copy was skipped (readonly FS, missing `openvino`), reinstall `ai-edge-litert-sdk-intel` after `openvino` is installed, then `import ai_edge_litert` in a fresh process.
 `Level0 pfnCreate2 result: ZE_RESULT_ERROR_UNSUPPORTED_FEATURE`                                                                 | Upgrade NPU driver to v1.32.1 (Linux).
 `/dev/accel/accel0` not found                                                                                                   | `sudo dmesg \| grep -i vpu` to debug the driver; reboot after install.
 Permission denied on NPU                                                                                                        | `sudo gpasswd -a ${USER} render && newgrp render`.

--- a/litert/vendors/intel_openvino/README.md
+++ b/litert/vendors/intel_openvino/README.md
@@ -53,13 +53,10 @@ Intel Core Ultra Series 3 | NPU5010 | Panther Lake (PTL) | Linux, Windows
 > model on NPU hardware. Pure AOT-build machines can skip it.
 
 > **Note:** `ai-edge-litert-sdk-intel-nightly` pins the matching OpenVINO
-> nightly wheel via a direct URL in `install_requires` (one per supported Python
-> × OS combo, selected by pip at install time via PEP 508 env markers). The
-> plugin and dispatch libraries must be ABI-compatible with this exact OpenVINO
-> build, so the wheel URL is pinned to the same build number as the archive
-> fetched at compile time; a plain `pip install
-> ai-edge-litert-sdk-intel-nightly` is sufficient — no `--extra-index-url`
-> required.
+> nightly wheel by PEP 440 version (e.g. `openvino==2026.2.0.dev20260506`),
+> so pip needs `--extra-index-url
+> https://storage.openvinotoolkit.org/simple/wheels/nightly` to locate it —
+> see the install command below.
 >
 > The SDK nightly also fetches the NPU compiler shared library
 > (`libopenvino_intel_npu_compiler.so` / `.dll`) from the matching toolkit
@@ -80,8 +77,13 @@ See [Linux NPU Setup](#linux-npu-setup) or
 ### 2. Install the pip Package
 
 ```bash
-pip install ai-edge-litert-nightly ai-edge-litert-sdk-intel-nightly
+pip install --pre \
+    --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly \
+    ai-edge-litert-nightly ai-edge-litert-sdk-intel-nightly
 ```
+
+The `--extra-index-url` lets pip resolve the pinned `openvino` nightly
+wheel from OpenVINO's index alongside packages on PyPI.
 
 ### 3. Verify Installation
 


### PR DESCRIPTION
PyPI policy blocks Requires-Dist entries of the form `<name> @ <url>`, so the nightly upload job was 400ing on the Intel sdist:

  400 Can't have direct dependency: openvino @
  https://storage.openvinotoolkit.org/wheels/nightly/openvino/...

Switch install_requires to a plain PEP 440 pin
(`openvino==2026.2.0.dev20260506`) and put the `--extra-index-url` step back in the README install command. Delete the now-unused _OV_WHEEL_BASE_URL, _OV_WHEEL_TARGETS, and _openvino_install_requires() from setup.py.

The trade-off is small: pip picks whichever wheel with that date stamp has the newest build tag at install time. Same-date respins are rare, and check_openvino_version_sync.py still catches archive vs setup.py date-stamp drift.

Long-term, OpenVINO will bundle the NPU compiler library in the Linux PyPI wheel (matching the Windows wheel); at that point the toolkit archive fetch and the compiler-lib copy logic can be dropped entirely.