### PR TITLE
Qualcomm AI Engine Direct - Support Custom Op Package.

### DIFF
--- a/litert/c/internal/litert_compiler_context.cc
+++ b/litert/c/internal/litert_compiler_context.cc
@@ -225,6 +225,8 @@ LiteRtCompilerContext* LrtGetCompilerContext() {
       .get_mirror_pad_mode_option = LiteRtGetMirrorPadModeOption,
 
       .get_squeeze_dims_option = LiteRtGetSqueezeDimsOption,
+
+      .get_custom_options = LiteRtGetCustomOptions,
   };
   return &ctx;
 }

--- a/litert/c/internal/litert_compiler_context.h
+++ b/litert/c/internal/litert_compiler_context.h
@@ -355,6 +355,10 @@ typedef struct LiteRtCompilerContext {
                                           const int32_t** squeeze_dims,
                                           int32_t* num_squeeze_dims);
 
+  // Op inspection
+  LiteRtStatus (*get_custom_options)(LiteRtOp op,
+                                     const uint8_t** custom_options,
+                                     size_t* custom_options_size);
 } LiteRtCompilerContext;
 
 // ABI compatibility check for LiteRtCompilerContext.
@@ -363,7 +367,7 @@ typedef struct LiteRtCompilerContext {
 // changes to this struct.
 #if defined(__cplusplus) && defined(__SIZEOF_POINTER__) && \
     __SIZEOF_POINTER__ == 8
-static_assert(sizeof(LiteRtCompilerContext) == 1024,
+static_assert(sizeof(LiteRtCompilerContext) == 1032,
               "LiteRtCompilerContext size mismatch");
 static_assert(offsetof(LiteRtCompilerContext, get_num_model_subgraphs) == 0,
               "LiteRtCompilerContext get_num_model_subgraphs offset mismatch");
@@ -865,6 +869,8 @@ static_assert(
     "LiteRtCompilerContext get_mirror_pad_mode_option offset mismatch");
 static_assert(offsetof(LiteRtCompilerContext, get_squeeze_dims_option) == 1016,
               "LiteRtCompilerContext get_squeeze_dims_option offset mismatch");
+static_assert(offsetof(LiteRtCompilerContext, get_custom_options) == 1024,
+              "LiteRtCompilerContext get_custom_options offset mismatch");
 #endif  // __cplusplus
 
 LiteRtCompilerContext* LrtGetCompilerContext();

--- a/litert/c/litert_model.cc
+++ b/litert/c/litert_model.cc
@@ -504,6 +504,17 @@ LiteRtStatus LiteRtGetCustomCode(LiteRtOp op, const char** code) {
   return kLiteRtStatusOk;
 }
 
+LiteRtStatus LiteRtGetCustomOptions(LiteRtOp op, const uint8_t** custom_options,
+                                    size_t* custom_options_size) {
+  if (!op || !custom_options || !custom_options_size) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+  auto custom_option = op->CustomOptions();
+  *custom_options = custom_option.Data();
+  *custom_options_size = custom_option.Size();
+  return kLiteRtStatusOk;
+}
+
 //
 // Weights
 //

--- a/litert/c/litert_model.h
+++ b/litert/c/litert_model.h
@@ -120,6 +120,10 @@ LiteRtStatus LiteRtGetOpCode(LiteRtOp op, LiteRtOpCode* code);
 // Get custom code for given op, returns error if op is not a custom op.
 LiteRtStatus LiteRtGetCustomCode(LiteRtOp op, const char** code);
 
+// Get custom options for given op. Returns size 0 when no custom options exist.
+LiteRtStatus LiteRtGetCustomOptions(LiteRtOp op, const uint8_t** custom_options,
+                                    size_t* custom_options_size);
+
 // Get input tensors of given op.
 LiteRtStatus LiteRtGetNumOpInputs(LiteRtOp op, LiteRtParamIndex* num_inputs);
 LiteRtStatus LiteRtGetOpInput(LiteRtOp op, LiteRtParamIndex input_index,

--- a/litert/c/litert_model_test.cc
+++ b/litert/c/litert_model_test.cc
@@ -354,6 +354,21 @@ TEST(LiteRtOpTest, GetCustomCodeNotCustom) {
   EXPECT_NE(LiteRtGetCustomCode(&op, &code), kLiteRtStatusOk);
 }
 
+TEST(LiteRtOpTest, GetCustomOptions) {
+  static constexpr std::array<uint8_t, 4> kOptions = {0x01, 0x02, 0x03, 0x04};
+
+  LiteRtOpT op;
+  op.SetCustomOptions(kOptions.data(), kOptions.size());
+
+  const uint8_t* options = nullptr;
+  size_t options_size = 0;
+  LITERT_ASSERT_OK(LiteRtGetCustomOptions(&op, &options, &options_size));
+
+  ASSERT_EQ(options_size, kOptions.size());
+  ASSERT_THAT(absl::MakeConstSpan(options, options_size),
+              ElementsAreArray(kOptions));
+}
+
 TEST(LiteRtSubgraphTest, GetInputs) {
   LiteRtTensorT input1;
   LiteRtTensorT input2;

--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -33,6 +33,59 @@
 
 using litert::internal::ParseToml;
 
+namespace {
+
+struct CustomOpPackage {
+  std::string name = "";
+  std::string interface_provider = "";
+  std::string compile_package_path = "";
+  std::string compile_target = "";
+  std::string dispatch_package_path = "";
+  std::string dispatch_target = "";
+};
+
+LiteRtStatus ParseCustomOpPackageValue(absl::string_view value,
+                                       CustomOpPackage& package) {
+  size_t start = 0;
+  while (start <= value.size()) {
+    const size_t end = value.find(';', start);
+    const size_t token_end =
+        (end == absl::string_view::npos) ? value.size() : end;
+    absl::string_view token = value.substr(start, token_end - start);
+    start = token_end + 1;
+
+    if (token.empty()) {
+      continue;
+    }
+
+    const size_t colon_pos = token.find(':');
+    if (colon_pos == absl::string_view::npos) {
+      return kLiteRtStatusErrorInvalidArgument;
+    }
+
+    const absl::string_view key = token.substr(0, colon_pos);
+    const absl::string_view val = token.substr(colon_pos + 1);
+
+    if (key == "name") {
+      package.name = std::string(val);
+    } else if (key == "interface_provider") {
+      package.interface_provider = std::string(val);
+    } else if (key == "compile_package_path") {
+      package.compile_package_path = std::string(val);
+    } else if (key == "compile_target") {
+      package.compile_target = std::string(val);
+    } else if (key == "dispatch_package_path") {
+      package.dispatch_package_path = std::string(val);
+    } else if (key == "dispatch_target") {
+      package.dispatch_target = std::string(val);
+    }
+  }
+
+  return kLiteRtStatusOk;
+}
+
+}  // namespace
+
 struct LrtQualcommOptionsT {
   std::optional<LrtQualcommOptionsLogLevel> log_level;
   std::optional<LrtQualcommOptionsProfiling> profiling;
@@ -56,6 +109,7 @@ struct LrtQualcommOptionsT {
   std::optional<std::string> saver_output_dir;
   std::optional<LrtQualcommOptionsGraphIOTensorMemType>
       graph_io_tensor_mem_type;
+  std::optional<CustomOpPackage> custom_op_package;
 };
 
 LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
@@ -175,6 +229,12 @@ LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
           status = LrtQualcommOptionsSetGraphIOTensorMemType(
               parsed_options,
               static_cast<LrtQualcommOptionsGraphIOTensorMemType>(*v));
+        } else if (key == "custom_op_package") {
+          CustomOpPackage package;
+          status = ParseCustomOpPackageValue(value, package);
+          if (status == kLiteRtStatusOk) {
+            parsed_options->custom_op_package = package;
+          }
         }
 
         return status;
@@ -288,6 +348,26 @@ LiteRtStatus LrtGetOpaqueQualcommOptionsData(LrtQualcommOptions options,
     toml << "graph_io_tensor_mem_type = "
          << static_cast<int>(*options->graph_io_tensor_mem_type) << "\n";
   }
+  if (options->custom_op_package.has_value()) {
+    const auto& package = *options->custom_op_package;
+    std::string value;
+    value.append("name:").append(package.name).append(";");
+    value.append("interface_provider:")
+        .append(package.interface_provider)
+        .append(";");
+    value.append("compile_package_path:")
+        .append(package.compile_package_path)
+        .append(";");
+    value.append("compile_target:").append(package.compile_target).append(";");
+    value.append("dispatch_package_path:")
+        .append(package.dispatch_package_path)
+        .append(";");
+    value.append("dispatch_target:")
+        .append(package.dispatch_target)
+        .append(";");
+    toml << "custom_op_package = \"" << value << "\"\n";
+  }
+
   *identifier = LrtQualcommOptionsGetIdentifier();
   std::string toml_str = toml.str();
   litert::internal::MakeCStringPayload(toml_str, payload, payload_deleter);
@@ -369,6 +449,58 @@ LiteRtStatus LrtQualcommOptionsGetSaverOutputDir(
                           ? options->saver_output_dir->c_str()
                           : "";
 
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsSetCustomOpPackage(
+    LrtQualcommOptions options, const char* name,
+    const char* interface_provider, const char* compile_package_path,
+    const char* compile_target, const char* dispatch_package_path,
+    const char* dispatch_target) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  CustomOpPackage package;
+  package.name = name;
+  package.interface_provider = interface_provider;
+  package.compile_package_path = compile_package_path;
+  package.compile_target = compile_target;
+  package.dispatch_package_path = dispatch_package_path;
+  package.dispatch_target = dispatch_target;
+  options->custom_op_package = package;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsGetCustomOpPackage(
+    LrtQualcommOptions options, const char** name,
+    const char** interface_provider, const char** compile_package_path,
+    const char** compile_target, const char** dispatch_package_path,
+    const char** dispatch_target) {
+  if (options == nullptr || name == nullptr || interface_provider == nullptr ||
+      compile_package_path == nullptr || compile_target == nullptr ||
+      dispatch_package_path == nullptr || dispatch_target == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  if (!options->custom_op_package.has_value()) {
+    *name = "";
+    *interface_provider = "";
+    *compile_package_path = "";
+    *compile_target = "";
+    *dispatch_package_path = "";
+    *dispatch_target = "";
+    return kLiteRtStatusOk;
+  }
+
+  const auto& package = *options->custom_op_package;
+  *name = package.name.c_str();
+  *interface_provider = package.interface_provider.c_str();
+  *compile_package_path = package.compile_package_path.c_str();
+  *compile_target = package.compile_target.c_str();
+  *dispatch_package_path = package.dispatch_package_path.c_str();
+  *dispatch_target = package.dispatch_target.c_str();
   return kLiteRtStatusOk;
 }
 

--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -67,17 +67,19 @@ LiteRtStatus ParseCustomOpPackageValue(absl::string_view value,
     const absl::string_view val = token.substr(colon_pos + 1);
 
     if (key == "name") {
-      package.name = std::string(val);
+      package.name = val;
     } else if (key == "interface_provider") {
-      package.interface_provider = std::string(val);
+      package.interface_provider = val;
     } else if (key == "compile_package_path") {
-      package.compile_package_path = std::string(val);
+      package.compile_package_path = val;
     } else if (key == "compile_target") {
-      package.compile_target = std::string(val);
+      package.compile_target = val;
     } else if (key == "dispatch_package_path") {
-      package.dispatch_package_path = std::string(val);
+      package.dispatch_package_path = val;
     } else if (key == "dispatch_target") {
-      package.dispatch_target = std::string(val);
+      package.dispatch_target = val;
+    } else {
+      return kLiteRtStatusErrorInvalidArgument;
     }
   }
 
@@ -350,22 +352,14 @@ LiteRtStatus LrtGetOpaqueQualcommOptionsData(LrtQualcommOptions options,
   }
   if (options->custom_op_package.has_value()) {
     const auto& package = *options->custom_op_package;
-    std::string value;
-    value.append("name:").append(package.name).append(";");
-    value.append("interface_provider:")
-        .append(package.interface_provider)
-        .append(";");
-    value.append("compile_package_path:")
-        .append(package.compile_package_path)
-        .append(";");
-    value.append("compile_target:").append(package.compile_target).append(";");
-    value.append("dispatch_package_path:")
-        .append(package.dispatch_package_path)
-        .append(";");
-    value.append("dispatch_target:")
-        .append(package.dispatch_target)
-        .append(";");
-    toml << "custom_op_package = \"" << value << "\"\n";
+    toml << "custom_op_package = \""
+         << "name:" << package.name << ";"
+         << "interface_provider:" << package.interface_provider << ";"
+         << "compile_package_path:" << package.compile_package_path << ";"
+         << "compile_target:" << package.compile_target << ";"
+         << "dispatch_package_path:" << package.dispatch_package_path << ";"
+         << "dispatch_target:" << package.dispatch_target << ";"
+         << "\"\n";
   }
 
   *identifier = LrtQualcommOptionsGetIdentifier();
@@ -468,7 +462,7 @@ LiteRtStatus LrtQualcommOptionsSetCustomOpPackage(
   package.compile_target = compile_target;
   package.dispatch_package_path = dispatch_package_path;
   package.dispatch_target = dispatch_target;
-  options->custom_op_package = package;
+  options->custom_op_package = std::move(package);
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -322,6 +322,19 @@ LiteRtStatus LrtQualcommOptionsSetSaverOutputDir(LrtQualcommOptions options,
 
 LiteRtStatus LrtQualcommOptionsGetSaverOutputDir(LrtQualcommOptions options,
                                                  const char** saver_output_dir);
+
+LiteRtStatus LrtQualcommOptionsSetCustomOpPackage(
+    LrtQualcommOptions options, const char* name,
+    const char* interface_provider, const char* compile_package_path,
+    const char* compile_target, const char* dispatch_package_path,
+    const char* dispatch_target);
+
+LiteRtStatus LrtQualcommOptionsGetCustomOpPackage(
+    LrtQualcommOptions options, const char** name,
+    const char** interface_provider, const char** compile_package_path,
+    const char** compile_target, const char** dispatch_package_path,
+    const char** dispatch_target);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -316,6 +316,54 @@ TEST(LiteRtQualcommOptionsTest, DumpTensorIds) {
   LrtDestroyQualcommOptions(qualcomm_options);
 }
 
+TEST(LiteRtQualcommOptionsTest, CustomOpPackageSetGet) {
+  LrtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
+
+  LITERT_ASSERT_OK(LrtQualcommOptionsSetCustomOpPackage(
+      qualcomm_options, "pkg", "provider", "compile.so", "CPU", "dispatch.so",
+      "HTP"));
+
+  const char* name = nullptr;
+  const char* interface_provider = nullptr;
+  const char* compile_package_path = nullptr;
+  const char* compile_target = nullptr;
+  const char* dispatch_package_path = nullptr;
+  const char* dispatch_target = nullptr;
+  LITERT_ASSERT_OK(LrtQualcommOptionsGetCustomOpPackage(
+      qualcomm_options, &name, &interface_provider, &compile_package_path,
+      &compile_target, &dispatch_package_path, &dispatch_target));
+
+  EXPECT_STREQ(name, "pkg");
+  EXPECT_STREQ(interface_provider, "provider");
+  EXPECT_STREQ(compile_package_path, "compile.so");
+  EXPECT_STREQ(compile_target, "CPU");
+  EXPECT_STREQ(dispatch_package_path, "dispatch.so");
+  EXPECT_STREQ(dispatch_target, "HTP");
+
+  LrtDestroyQualcommOptions(qualcomm_options);
+}
+
+TEST(LiteRtQualcommOptionsTest, CustomOpPackageRoundTrip) {
+  LrtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
+
+  LITERT_ASSERT_OK(LrtQualcommOptionsSetCustomOpPackage(
+      qualcomm_options, "pkg", "provider", "compile.so", "CPU", "dispatch.so",
+      "HTP"));
+
+  auto parsed = SerializeAndParse(qualcomm_options);
+  const auto custom_op_package = parsed.GetCustomOpPackage();
+  EXPECT_EQ(custom_op_package.name, "pkg");
+  EXPECT_EQ(custom_op_package.interface_provider, "provider");
+  EXPECT_EQ(custom_op_package.compile_package_path, "compile.so");
+  EXPECT_EQ(custom_op_package.compile_target, "CPU");
+  EXPECT_EQ(custom_op_package.dispatch_package_path, "dispatch.so");
+  EXPECT_EQ(custom_op_package.dispatch_target, "HTP");
+
+  LrtDestroyQualcommOptions(qualcomm_options);
+}
+
 TEST(QualcommOptionsTest, CppWrapper) {
   auto options = QualcommOptions::Create();
   ASSERT_TRUE(options);
@@ -412,6 +460,22 @@ TEST(QualcommOptionsTest, CppWrapper) {
       QualcommOptions::GraphIOTensorMemType::kMemHandle);
   EXPECT_EQ(options->GetGraphIOTensorMemType(),
             QualcommOptions::GraphIOTensorMemType::kMemHandle);
+
+  QualcommOptions::CustomOpPackage pkg;
+  pkg.name = "pkg";
+  pkg.interface_provider = "provider";
+  pkg.compile_package_path = "compile.so";
+  pkg.compile_target = "CPU";
+  pkg.dispatch_package_path = "dispatch.so";
+  pkg.dispatch_target = "HTP";
+  options->SetCustomOpPackage(pkg);
+  const auto custom_op_package = options->GetCustomOpPackage();
+  EXPECT_EQ(custom_op_package.name, "pkg");
+  EXPECT_EQ(custom_op_package.interface_provider, "provider");
+  EXPECT_EQ(custom_op_package.compile_package_path, "compile.so");
+  EXPECT_EQ(custom_op_package.compile_target, "CPU");
+  EXPECT_EQ(custom_op_package.dispatch_package_path, "dispatch.so");
+  EXPECT_EQ(custom_op_package.dispatch_target, "HTP");
 }
 
 }  // namespace

--- a/litert/cc/internal/litert_extended_model.h
+++ b/litert/cc/internal/litert_extended_model.h
@@ -399,6 +399,18 @@ class Op : public internal::NonOwnedHandle<LiteRtOp> {
     return absl::string_view(custom_code);
   }
 
+  /// @brief Gets the custom options.
+  /// @return The custom options if present, otherwise an error.
+  Expected<absl::Span<const uint8_t>> CustomOptions() const {
+    const uint8_t* options = nullptr;
+    size_t options_bytes = 0;
+    auto stat = LiteRtGetCustomOptions(Get(), &options, &options_bytes);
+    if (stat != kLiteRtStatusOk) {
+      return Error(stat, "Failed to get custom options");
+    }
+    return absl::MakeConstSpan(options, options_bytes);
+  }
+
   OpInputs Inputs() const {
     LiteRtParamIndex num_inputs;
     internal::AssertOk(LiteRtGetNumOpInputs, Get(), &num_inputs);

--- a/litert/cc/internal/litert_shared_library.h
+++ b/litert/cc/internal/litert_shared_library.h
@@ -85,7 +85,7 @@ struct RtldFlags {
 #endif
     };
   }
-  static constexpr RtldFlags Default() { return Lazy().Local().DeepBind(); }
+  static constexpr RtldFlags Default() { return Lazy().Global(); }
   constexpr RtldFlags& Global() {
 #if defined(RTLD_GLOBAL)
     flags |= RTLD_GLOBAL;

--- a/litert/cc/internal/litert_shared_library.h
+++ b/litert/cc/internal/litert_shared_library.h
@@ -85,7 +85,7 @@ struct RtldFlags {
 #endif
     };
   }
-  static constexpr RtldFlags Default() { return Lazy().Global(); }
+  static constexpr RtldFlags Default() { return Lazy().Local().DeepBind(); }
   constexpr RtldFlags& Global() {
 #if defined(RTLD_GLOBAL)
     flags |= RTLD_GLOBAL;

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -444,6 +444,48 @@ class QualcommOptions {
     return static_cast<GraphIOTensorMemType>(val);
   }
 
+  struct CustomOpPackage {
+    std::string name;
+    std::string interface_provider;
+    std::string compile_package_path;
+    std::string compile_target;
+    std::string dispatch_package_path;
+    std::string dispatch_target;
+  };
+
+  void SetCustomOpPackage(const CustomOpPackage& custom_op_package) {
+    LrtQualcommOptionsSetCustomOpPackage(
+        options_, custom_op_package.name.c_str(),
+        custom_op_package.interface_provider.c_str(),
+        custom_op_package.compile_package_path.c_str(),
+        custom_op_package.compile_target.c_str(),
+        custom_op_package.dispatch_package_path.c_str(),
+        custom_op_package.dispatch_target.c_str());
+  }
+
+  CustomOpPackage GetCustomOpPackage() {
+    const char* name = "";
+    const char* interface_provider = "";
+    const char* compile_package_path = "";
+    const char* compile_target = "";
+    const char* dispatch_package_path = "";
+    const char* dispatch_target = "";
+    auto status = LrtQualcommOptionsGetCustomOpPackage(
+        options_, &name, &interface_provider, &compile_package_path,
+        &compile_target, &dispatch_package_path, &dispatch_target);
+    if (status != kLiteRtStatusOk) {
+      return {};
+    }
+    CustomOpPackage custom_op_package;
+    custom_op_package.name = name;
+    custom_op_package.interface_provider = interface_provider;
+    custom_op_package.compile_package_path = compile_package_path;
+    custom_op_package.compile_target = compile_target;
+    custom_op_package.dispatch_package_path = dispatch_package_path;
+    custom_op_package.dispatch_target = dispatch_target;
+    return custom_op_package;
+  }
+
  private:
   LrtQualcommOptions options_;
 };

--- a/litert/compiler/cc/litert_model.h
+++ b/litert/compiler/cc/litert_model.h
@@ -262,6 +262,16 @@ class Op {
     return absl::string_view(custom_code);
   }
 
+  Expected<absl::Span<const uint8_t>> CustomOptions() const {
+    const uint8_t* options = nullptr;
+    size_t options_bytes = 0;
+    auto status = ctx_->get_custom_options(Get(), &options, &options_bytes);
+    if (status != kLiteRtStatusOk) {
+      return Error(status, "Failed to get custom options");
+    }
+    return absl::MakeConstSpan(options, options_bytes);
+  }
+
   bool Is(LiteRtOpCode code) const { return Code() == code; }
 
  private:

--- a/litert/core/model/model.cc
+++ b/litert/core/model/model.cc
@@ -456,6 +456,12 @@ void CloneTo(const LiteRtOpT& src, LiteRtOpT& dest) {
   litert::internal::SetTflOpCodeInd(dest,
                                     litert::internal::GetTflOpCodeInd(src));
   dest.SetOpCode(src.OpCode());
+  if (dest.OpCode() == kLiteRtOpCodeTflCustom) {
+    auto custom_code = src.CustomCode();
+    if (custom_code.HasValue()) {
+      dest.SetCustomCode(std::string(*custom_code));
+    }
+  }
 }
 
 LiteRtTensorT& MakeClone(LiteRtSubgraphT& parent, const LiteRtTensorT& src) {

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -524,6 +524,87 @@ std::string AbslUnparseFlag(QualcommOptions::Backend options) {
 }
 
 }  // namespace litert::qualcomm
+
+ABSL_FLAG(
+    litert::qualcomm::QualcommOptions::CustomOpPackage,
+    qualcomm_custom_op_package, {},
+    "Custom op package settings as key:value pairs separated by ';'. "
+    "Required keys: name, interface_provider, compile_package_path, "
+    "compile_target, dispatch_package_path, dispatch_target. "
+    "For compiler plugin, name/interface_provider/compile_package_path/"
+    "compile_target are used. For dispatch plugin, name/interface_provider/"
+    "dispatch_package_path/dispatch_target are used. Example: "
+    "\"name:TestPackage;interface_provider:Provider;compile_package_path:"
+    "libQnnTestPackage.so;compile_target:CPU;dispatch_package_path:"
+    "libQnnTestPackage.so;dispatch_target:HTP;\"");
+
+namespace litert::qualcomm {
+
+bool AbslParseFlag(absl::string_view text,
+                   QualcommOptions::CustomOpPackage* options,
+                   std::string* error) {
+  if (!text.empty()) {
+    size_t start = 0;
+    while (start <= text.size()) {
+      const size_t end = text.find(';', start);
+      const size_t token_end =
+          end == absl::string_view::npos ? text.size() : end;
+      const absl::string_view token = text.substr(start, token_end - start);
+      start = token_end + 1;
+
+      if (token.empty()) {
+        continue;
+      }
+
+      const size_t colon_pos = token.find(':');
+      if (colon_pos == absl::string_view::npos) {
+        *error = "Invalid custom op package flag.";
+        return false;
+      }
+
+      const absl::string_view key = token.substr(0, colon_pos);
+      const absl::string_view value = token.substr(colon_pos + 1);
+      if (key == "name") {
+        options->name = value;
+      } else if (key == "interface_provider") {
+        options->interface_provider = value;
+      } else if (key == "compile_package_path") {
+        options->compile_package_path = value;
+      } else if (key == "compile_target") {
+        options->compile_target = value;
+      } else if (key == "dispatch_package_path") {
+        options->dispatch_package_path = value;
+      } else if (key == "dispatch_target") {
+        options->dispatch_target = value;
+      } else {
+        *error = "Unsupported key in custom op package flag.";
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+std::string AbslUnparseFlag(QualcommOptions::CustomOpPackage options) {
+  std::string value;
+  auto append_pair = [&value](absl::string_view key, absl::string_view val) {
+    value.append(std::string(key))
+        .append(":")
+        .append(std::string(val))
+        .append(";");
+  };
+
+  append_pair("name", options.name);
+  append_pair("interface_provider", options.interface_provider);
+  append_pair("compile_package_path", options.compile_package_path);
+  append_pair("compile_target", options.compile_target);
+  append_pair("dispatch_package_path", options.dispatch_package_path);
+  append_pair("dispatch_target", options.dispatch_target);
+  return value;
+}
+
+}  // namespace litert::qualcomm
+
 // NOLINTEND(*alien-types*)
 
 namespace litert::qualcomm {
@@ -592,6 +673,10 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
   const auto graph_io_tensor_mem_type =
       absl::GetFlag(FLAGS_qualcomm_graph_io_tensor_mem_type);
   opts.SetGraphIOTensorMemType(graph_io_tensor_mem_type);
+
+  const auto custom_op_package =
+      absl::GetFlag(FLAGS_qualcomm_custom_op_package);
+  opts.SetCustomOpPackage(custom_op_package);
 
   return {};
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -587,11 +587,9 @@ bool AbslParseFlag(absl::string_view text,
 
 std::string AbslUnparseFlag(QualcommOptions::CustomOpPackage options) {
   std::string value;
+  value.reserve(256);
   auto append_pair = [&value](absl::string_view key, absl::string_view val) {
-    value.append(std::string(key))
-        .append(":")
-        .append(std::string(val))
-        .append(";");
+    value.append(key).append(":").append(val).append(";");
   };
 
   append_pair("name", options.name);

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -49,6 +49,19 @@ std::string AbslUnparseFlag(QualcommOptions::Backend options);
 
 }  // namespace litert::qualcomm
 
+ABSL_DECLARE_FLAG(litert::qualcomm::QualcommOptions::CustomOpPackage,
+                  qualcomm_custom_op_package);
+
+namespace litert::qualcomm {
+
+bool AbslParseFlag(absl::string_view text,
+                   QualcommOptions::CustomOpPackage* options,
+                   std::string* error);
+
+std::string AbslUnparseFlag(QualcommOptions::CustomOpPackage options);
+
+}  // namespace litert::qualcomm
+
 // COMPILATION OPTIONS /////////////////////////////////////////////////////////
 
 ABSL_DECLARE_FLAG(bool, qualcomm_enable_weight_sharing);

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -17,6 +17,7 @@
 #include <string>
 
 #include <gtest/gtest.h>
+#include "absl/flags/flag.h"  // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
 #include "litert/c/options/litert_qualcomm_options.h"
 #include "litert/cc/litert_expected.h"
@@ -487,6 +488,23 @@ TEST(GraphIOTensorMemTypeTest, Parse) {
     EXPECT_EQ(value, kMemHandleEnum);
     EXPECT_EQ(kMemHandle, AbslUnparseFlag(value));
   }
+}
+
+TEST(CustomOpPackageFlagTest, ParseUnparse) {
+  std::string error;
+  QualcommOptions::CustomOpPackage value;
+  static constexpr absl::string_view kFlagValue =
+      "name:pkg;interface_provider:provider;compile_package_path:compile.so;"
+      "compile_target:CPU;dispatch_package_path:dispatch.so;"
+      "dispatch_target:HTP;";
+  EXPECT_TRUE(AbslParseFlag(kFlagValue, &value, &error));
+  EXPECT_EQ(value.name, "pkg");
+  EXPECT_EQ(value.interface_provider, "provider");
+  EXPECT_EQ(value.compile_package_path, "compile.so");
+  EXPECT_EQ(value.compile_target, "CPU");
+  EXPECT_EQ(value.dispatch_package_path, "dispatch.so");
+  EXPECT_EQ(value.dispatch_target, "HTP");
+  EXPECT_EQ(AbslUnparseFlag(value), kFlagValue);
 }
 
 TEST(QualcommOptionsFromFlagsTest, DefaultValue) {

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -139,7 +139,12 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetSaverOutputDir(qualcomm_options.GetSaverOutputDir());
   qnn_options.SetGraphIOTensorMemType(static_cast<::qnn::GraphIOTensorMemType>(
       qualcomm_options.GetGraphIOTensorMemType()));
-
+  const auto custom_op_package = qualcomm_options.GetCustomOpPackage();
+  qnn_options.SetCustomOpPackage(
+      custom_op_package.name, custom_op_package.interface_provider,
+      custom_op_package.compile_package_path, custom_op_package.compile_target,
+      custom_op_package.dispatch_package_path,
+      custom_op_package.dispatch_target);
   LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
   return kLiteRtStatusOk;
 }

--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -246,6 +246,7 @@ litert_lib(
         "//litert/vendors/qualcomm/core/builders:conv2d_op_builder",
         "//litert/vendors/qualcomm/core/builders:conv3d_op_builder",
         "//litert/vendors/qualcomm/core/builders:cumsum_op_builder",
+        "//litert/vendors/qualcomm/core/builders:custom_op_builder",
         "//litert/vendors/qualcomm/core/builders:depthwise_conv2d_op_builder",
         "//litert/vendors/qualcomm/core/builders:dynamic_update_slice_op_builder",
         "//litert/vendors/qualcomm/core/builders:elementwise_op_builder",
@@ -304,6 +305,7 @@ litert_lib(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@qairt//:qnn_lib_headers",
+        "@flatbuffers//:runtime_cc",
     ],
 )
 

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -245,6 +245,13 @@ class LiteRtCompilerPluginT {
   const ::qnn::Options& Options() const { return qnn_options_; }
 
   void initQnnManager(std::unique_ptr<QnnManager> qnn_manager) {
+    if (const auto& custom_op_package = qnn_options_.GetCustomOpPackage();
+        !custom_op_package.name.empty()) {
+      qnn_manager->RegisterOpPackage(
+          custom_op_package.compile_package_path.c_str(),
+          custom_op_package.interface_provider.c_str(),
+          custom_op_package.compile_target.c_str());
+    }
     qnn_manager_ = std::move(qnn_manager);
   }
 
@@ -370,7 +377,8 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
 
     std::vector<::qnn::OpWrapper> op_wrappers;
     LITERT_RETURN_IF_ERROR(litert::qnn::ConvertOp(
-        compiler_plugin->Options().GetUseInt64BiasAsInt32(), op, tensor_pool,
+        compiler_plugin->Options().GetUseInt64BiasAsInt32(),
+        compiler_plugin->Options().GetCustomOpPackage(), op, tensor_pool,
         input_tensors, output_tensors, op_wrappers));
 
     // Empty op_wrappers means the op is not supported by QNN.

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -179,28 +179,14 @@ FlexbufferScalarType GetUniformScalarType(const flexbuffers::Reference& ref) {
     if (vec.IsTheEmptyVector()) {
       return FlexbufferScalarType::kUnsupported;
     } else {
-      // Typed vectors are accepted but still validated recursively.
-      const auto first_type = GetUniformScalarType(vec[0]);
-      for (size_t i = 1; i < vec.size(); ++i) {
-        if (GetUniformScalarType(vec[i]) != first_type) {
-          return FlexbufferScalarType::kUnsupported;
-        }
-      }
-      return first_type;
+      return GetUniformScalarType(vec[0]);
     }
   } else if (ref.IsFixedTypedVector()) {
     const auto& vec = ref.AsFixedTypedVector();
     if (vec.IsTheEmptyFixedTypedVector()) {
       return FlexbufferScalarType::kUnsupported;
     } else {
-      // Fixed typed vectors follow the same uniformity check.
-      const auto first_type = GetUniformScalarType(vec[0]);
-      for (size_t i = 1; i < vec.size(); ++i) {
-        if (GetUniformScalarType(vec[i]) != first_type) {
-          return FlexbufferScalarType::kUnsupported;
-        }
-      }
-      return first_type;
+      return GetUniformScalarType(vec[0]);
     }
   } else {
     return FlexbufferScalarType::kUnsupported;

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -23,12 +23,15 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <iterator>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"  // from @com_google_absl
@@ -39,6 +42,7 @@
 #include "absl/strings/string_view.h"  // from @com_google_absl
 #include "absl/types/span.h"  // from @com_google_absl
 #include "litert/c/internal/litert_compiler_context.h"
+#include "flatbuffers/flexbuffers.h"  // from @flatbuffers
 #include "litert/c/internal/litert_logging.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_model_types.h"
@@ -58,6 +62,7 @@
 #include "litert/vendors/qualcomm/core/builders/conv2d_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/conv3d_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/cumsum_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/custom_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/depthwise_conv2d_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/dynamic_update_slice_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/elementwise_op_builder.h"
@@ -135,6 +140,180 @@ std::string SanitizeName(std::string_view name) {
   }
   return out;
 }
+
+enum class FlexbufferScalarType {
+  kUnsupported = 0,
+  kBool,
+  kInt,
+  kUint,
+  kFloat,
+};
+
+// Returns the common scalar type for a scalar or vector tree.
+// Any mixed scalar types or empty vectors are treated as unsupported.
+FlexbufferScalarType GetUniformScalarType(const flexbuffers::Reference& ref) {
+  if (ref.IsBool()) {
+    return FlexbufferScalarType::kBool;
+  } else if (ref.IsInt()) {
+    return FlexbufferScalarType::kInt;
+  } else if (ref.IsUInt()) {
+    return FlexbufferScalarType::kUint;
+  } else if (ref.IsFloat()) {
+    return FlexbufferScalarType::kFloat;
+  } else if (ref.IsUntypedVector()) {
+    const auto& vec = ref.AsVector();
+    if (vec.IsTheEmptyVector()) {
+      return FlexbufferScalarType::kUnsupported;
+    } else {
+      // Recurse into the first element and ensure all others match.
+      const auto first_type = GetUniformScalarType(vec[0]);
+      for (size_t i = 1; i < vec.size(); ++i) {
+        if (GetUniformScalarType(vec[i]) != first_type) {
+          return FlexbufferScalarType::kUnsupported;
+        }
+      }
+      return first_type;
+    }
+  } else if (ref.IsTypedVector()) {
+    const auto& vec = ref.AsTypedVector();
+    if (vec.IsTheEmptyVector()) {
+      return FlexbufferScalarType::kUnsupported;
+    } else {
+      // Typed vectors are accepted but still validated recursively.
+      const auto first_type = GetUniformScalarType(vec[0]);
+      for (size_t i = 1; i < vec.size(); ++i) {
+        if (GetUniformScalarType(vec[i]) != first_type) {
+          return FlexbufferScalarType::kUnsupported;
+        }
+      }
+      return first_type;
+    }
+  } else if (ref.IsFixedTypedVector()) {
+    const auto& vec = ref.AsFixedTypedVector();
+    if (vec.IsTheEmptyFixedTypedVector()) {
+      return FlexbufferScalarType::kUnsupported;
+    } else {
+      // Fixed typed vectors follow the same uniformity check.
+      const auto first_type = GetUniformScalarType(vec[0]);
+      for (size_t i = 1; i < vec.size(); ++i) {
+        if (GetUniformScalarType(vec[i]) != first_type) {
+          return FlexbufferScalarType::kUnsupported;
+        }
+      }
+      return first_type;
+    }
+  } else {
+    return FlexbufferScalarType::kUnsupported;
+  }
+}
+
+// Returns the shape for a scalar/vector tree; nullopt for ragged vectors.
+std::optional<std::vector<uint32_t>> InferShape(
+    const flexbuffers::Reference& ref) {
+  if (ref.IsBool() || ref.IsInt() || ref.IsUInt() || ref.IsFloat()) {
+    return std::vector<uint32_t>{};
+  } else if (ref.IsUntypedVector()) {
+    const auto& vec = ref.AsVector();
+    if (vec.IsTheEmptyVector()) {
+      return std::vector<uint32_t>{0};
+    } else {
+      auto dimensions = InferShape(vec[0]);
+      if (!dimensions.has_value()) {
+        return std::nullopt;
+      }
+      for (size_t i = 1; i < vec.size(); ++i) {
+        const auto other_dimensions = InferShape(vec[i]);
+        if (!other_dimensions.has_value() ||
+            other_dimensions.value() != dimensions.value()) {
+          return std::nullopt;
+        }
+      }
+      dimensions->insert(dimensions->begin(),
+                         static_cast<uint32_t>(vec.size()));
+      return dimensions;
+    }
+  } else if (ref.IsTypedVector()) {
+    const auto& vec = ref.AsTypedVector();
+    if (vec.IsTheEmptyVector()) {
+      return std::vector<uint32_t>{0};
+    } else {
+      auto dimensions = InferShape(vec[0]);
+      if (!dimensions.has_value()) {
+        return std::nullopt;
+      }
+      for (size_t i = 1; i < vec.size(); ++i) {
+        const auto other_dimensions = InferShape(vec[i]);
+        if (!other_dimensions.has_value() ||
+            other_dimensions.value() != dimensions.value()) {
+          return std::nullopt;
+        }
+      }
+      dimensions->insert(dimensions->begin(),
+                         static_cast<uint32_t>(vec.size()));
+      return dimensions;
+    }
+  } else if (ref.IsFixedTypedVector()) {
+    const auto& vec = ref.AsFixedTypedVector();
+    if (vec.IsTheEmptyFixedTypedVector()) {
+      return std::vector<uint32_t>{0};
+    } else {
+      auto dimensions = InferShape(vec[0]);
+      if (!dimensions.has_value()) {
+        return std::nullopt;
+      }
+      for (size_t i = 1; i < vec.size(); ++i) {
+        const auto other_dimensions = InferShape(vec[i]);
+        if (!other_dimensions.has_value() ||
+            other_dimensions.value() != dimensions.value()) {
+          return std::nullopt;
+        }
+      }
+      dimensions->insert(dimensions->begin(),
+                         static_cast<uint32_t>(vec.size()));
+      return dimensions;
+    }
+  } else {
+    return std::nullopt;
+  }
+}
+
+template <typename T>
+void FillBuffer(const flexbuffers::Reference& ref, std::vector<T>& data) {
+  if (ref.IsUntypedVector()) {
+    const auto vec = ref.AsVector();
+    for (size_t i = 0; i < vec.size(); ++i) {
+      FillBuffer<T>(vec[i], data);
+    }
+    return;
+  }
+
+  if (ref.IsTypedVector()) {
+    const auto vec = ref.AsTypedVector();
+    for (size_t i = 0; i < vec.size(); ++i) {
+      FillBuffer<T>(vec[i], data);
+    }
+    return;
+  }
+
+  if (ref.IsFixedTypedVector()) {
+    const auto vec = ref.AsFixedTypedVector();
+    for (size_t i = 0; i < vec.size(); ++i) {
+      FillBuffer<T>(vec[i], data);
+    }
+    return;
+  }
+
+  if constexpr (std::is_same_v<T, uint8_t>) {
+    data.emplace_back(ref.AsBool());
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    data.emplace_back(ref.AsInt32());
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    data.emplace_back(ref.AsUInt32());
+  } else if constexpr (std::is_same_v<T, float>) {
+    data.emplace_back(ref.AsFloat());
+  }
+}
+
 }  // namespace
 
 LiteRtStatus ConvertPaddingType(const uint32_t litert_padding,
@@ -1407,9 +1586,147 @@ constexpr std::array<OpBuilder, kLiteRtOpCodeShloComposite + 1> kOpBuilders =
     GetOpBuilders();
 static_assert(kOpBuilders.size() == kLiteRtOpCodeShloComposite + 1);
 
+LiteRtStatus BuildCustomOp(const litert::compiler::Op& litert_op,
+                           ::qnn::TensorPool& tensor_pool,
+                           std::vector<::qnn::TensorWrapperRef>& input_tensors,
+                           std::vector<::qnn::TensorWrapperRef>& output_tensors,
+                           std::vector<::qnn::OpWrapper>& op_wrappers,
+                           const ::qnn::CustomOpPackage& custom_op_package) {
+  // use tflite custom code as op type in QNN custom op pacakge.
+  auto custom_code = litert_op.CustomCode();
+  if (!custom_code.HasValue() || custom_code->empty()) {
+    LITERT_LOG(LITERT_ERROR, "Custom op missing custom code.");
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  auto custom_options = litert_op.CustomOptions();
+  if (!custom_options.HasValue()) {
+    LITERT_LOG(LITERT_ERROR, "Custom op missing custom options.");
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  const char* package_name = custom_op_package.name.empty()
+                                 ? QNN_OP_PACKAGE_NAME_QTI_AISW
+                                 : custom_op_package.name.c_str();
+  auto& custom_op = op_wrappers.emplace_back(::qnn::CreateCustomOp(
+      package_name, custom_code->data(), input_tensors, output_tensors));
+
+  if (custom_options->size() < 2) {
+    LITERT_LOG(
+        LITERT_WARNING,
+        "Custom op custom options are too small to be a flexbuffer map, maybe "
+        "there is no custom options in custom op.");
+    return kLiteRtStatusOk;
+  }
+
+  const auto root =
+      flexbuffers::GetRoot(custom_options->data(), custom_options->size());
+  if (!root.IsMap()) {
+    LITERT_LOG(LITERT_ERROR,
+               "Custom op custom options are not a flexbuffer "
+               "map.");
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  const auto map = root.AsMap();
+  const auto keys = map.Keys();
+  const auto values = map.Values();
+  for (size_t i = 0; i < map.size(); ++i) {
+    const char* key = keys[i].AsKey();
+    const auto value = values[i];
+
+    const auto type = GetUniformScalarType(value);
+    if (type == FlexbufferScalarType::kUnsupported) {
+      LITERT_LOG(LITERT_WARNING,
+                 "Cannot get uniform scalar type from custom options key: %s. "
+                 "Skip this key.",
+                 key);
+      continue;
+    }
+
+    if (value.IsUntypedVector() || value.IsTypedVector() ||
+        value.IsFixedTypedVector()) {
+      const auto dimensons = InferShape(value);
+      if (!dimensons.has_value()) {
+        LITERT_LOG(LITERT_ERROR,
+                   "Custom options key '%s' has ragged vector dimensions. Skip "
+                   "this key.",
+                   key);
+        continue;
+      }
+
+      uint32_t num_elements =
+          std::accumulate(dimensons->begin(), dimensons->end(), uint32_t{1},
+                          std::multiplies<uint32_t>());
+      switch (type) {
+        case FlexbufferScalarType::kBool: {
+          std::vector<uint8_t> data;
+          data.reserve(num_elements);
+          FillBuffer<uint8_t>(value, data);
+          auto& tensor = tensor_pool.CreateStaticTensor(
+              QNN_DATATYPE_BOOL_8, {}, dimensons.value(),
+              static_cast<uint32_t>(num_elements * sizeof(uint8_t)),
+              data.data());
+          custom_op.AddTensorParam(key, tensor);
+          break;
+        }
+        case FlexbufferScalarType::kInt: {
+          std::vector<int32_t> data;
+          data.reserve(num_elements);
+          FillBuffer<int32_t>(value, data);
+          auto& tensor = tensor_pool.CreateStaticTensor(
+              QNN_DATATYPE_INT_32, {}, dimensons.value(),
+              static_cast<uint32_t>(num_elements * sizeof(int32_t)),
+              data.data());
+          custom_op.AddTensorParam(key, tensor);
+          break;
+        }
+        case FlexbufferScalarType::kUint: {
+          std::vector<uint32_t> data;
+          data.reserve(num_elements);
+          FillBuffer<uint32_t>(value, data);
+          auto& tensor = tensor_pool.CreateStaticTensor(
+              QNN_DATATYPE_UINT_32, {}, dimensons.value(),
+              static_cast<uint32_t>(num_elements * sizeof(uint32_t)),
+              data.data());
+          custom_op.AddTensorParam(key, tensor);
+          break;
+        }
+        case FlexbufferScalarType::kFloat: {
+          std::vector<float> data;
+          data.reserve(num_elements);
+          FillBuffer<float>(value, data);
+          auto& tensor = tensor_pool.CreateStaticTensor(
+              QNN_DATATYPE_FLOAT_32, {}, dimensons.value(),
+              static_cast<uint32_t>(num_elements * sizeof(float)), data.data());
+          custom_op.AddTensorParam(key, tensor);
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    } else if (type == FlexbufferScalarType::kBool) {
+      custom_op.AddScalarParam<bool>(key, value.AsBool());
+    } else if (type == FlexbufferScalarType::kInt) {
+      custom_op.AddScalarParam<std::int32_t>(key, value.AsInt32());
+    } else if (type == FlexbufferScalarType::kUint) {
+      custom_op.AddScalarParam<std::uint32_t>(key, value.AsUInt32());
+    } else if (type == FlexbufferScalarType::kFloat) {
+      custom_op.AddScalarParam<float>(key, value.AsFloat());
+    } else {
+      LITERT_LOG(LITERT_WARNING,
+                 "Unsupported types from custom options key: %s.", key);
+      continue;
+    }
+  }
+  return kLiteRtStatusOk;
+}
+
 }  // namespace
 
 LiteRtStatus ConvertOp(const bool use_int64_bias_as_int32,
+                       const ::qnn::CustomOpPackage& custom_op_package,
                        const litert::compiler::Op& litert_op,
                        ::qnn::TensorPool& tensor_pool,
                        std::vector<::qnn::TensorWrapperRef>& input_tensors,
@@ -1421,6 +1738,10 @@ LiteRtStatus ConvertOp(const bool use_int64_bias_as_int32,
     return builders[op_code](litert_op, tensor_pool, input_tensors,
                              output_tensors, op_wrappers,
                              use_int64_bias_as_int32);
+  }
+  if (op_code == kLiteRtOpCodeTflCustom) {
+    return BuildCustomOp(litert_op, tensor_pool, input_tensors, output_tensors,
+                         op_wrappers, custom_op_package);
   }
   LITERT_LOG(LITERT_ERROR,
              "LiteRT Op Code: %d is not supported in Qualcomm Compiler.",
@@ -1534,9 +1855,9 @@ LiteRtStatus MapGraph(const LiteRtCompilerContext* ctx, QnnManager& qnn,
     }
 
     std::vector<::qnn::OpWrapper> op_wrappers;
-    LITERT_RETURN_IF_ERROR(ConvertOp(options.GetUseInt64BiasAsInt32(), op,
-                                     tensor_pool, input_tensors, output_tensors,
-                                     op_wrappers));
+    LITERT_RETURN_IF_ERROR(ConvertOp(
+        options.GetUseInt64BiasAsInt32(), options.GetCustomOpPackage(), op,
+        tensor_pool, input_tensors, output_tensors, op_wrappers));
     for (auto& op_wrapper : op_wrappers) {
       // Add litert op id to qnn op name to preserve op mapping
       op_wrapper.AddSuffixToName(

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
@@ -43,6 +43,7 @@ LiteRtStatus ConvertTensor(
     bool is_tensor_output = false);
 
 LiteRtStatus ConvertOp(bool use_int64_bias_as_int32,
+                       const ::qnn::CustomOpPackage& custom_op_package,
                        const litert::compiler::Op& litert_op,
                        ::qnn::TensorPool& tensor_pool,
                        std::vector<::qnn::TensorWrapperRef>& input_tensors,

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -720,3 +720,15 @@ cc_library(
         "@qairt//:qnn_lib_headers",
     ],
 )
+
+cc_library(
+    name = "custom_op_builder",
+    srcs = ["custom_op_builder.cc"],
+    hdrs = ["custom_op_builder.h"],
+    deps = [
+        ":op_builder",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@qairt//:qnn_lib_headers",
+    ],
+)

--- a/litert/vendors/qualcomm/core/builders/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/builders/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(qnn_builders
         scatter_nd_op_builder.cc
         topk_op_builder.cc
         group_norm_op_builder.cc
+        custom_op_builder.cc
 )
 
 target_include_directories(qnn_builders

--- a/litert/vendors/qualcomm/core/builders/custom_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/custom_op_builder.cc
@@ -1,0 +1,25 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "QnnOpDef.h"  // from @qairt
+
+namespace qnn {
+
+OpWrapper CreateCustomOp(const char* package_name, const char* op_type,
+                         const std::vector<TensorWrapperRef>& inputs,
+                         const std::vector<TensorWrapperRef>& outputs) {
+  OpWrapper op(GetUniqueOpName(op_type), package_name, op_type,
+               QnnOpCode::kUnknown);
+  for (auto& input : inputs) {
+    op.AddInputTensor(input);
+  }
+  for (auto& output : outputs) {
+    op.AddOutputTensor(output);
+  }
+  return op;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/custom_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/custom_op_builder.h
@@ -1,0 +1,20 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CUSTOM_OP_BUILDER_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CUSTOM_OP_BUILDER_H_
+
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+OpWrapper CreateCustomOp(const char* package_name, const char* op_type,
+                         const std::vector<TensorWrapperRef>& inputs,
+                         const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CUSTOM_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -202,6 +202,24 @@ GraphIOTensorMemType Options::GetGraphIOTensorMemType() const {
   return graph_io_tensor_mem_type_;
 }
 
+void Options::SetCustomOpPackage(absl::string_view name,
+                                 absl::string_view interface_provider,
+                                 absl::string_view compile_package_path,
+                                 absl::string_view compile_target,
+                                 absl::string_view dispatch_package_path,
+                                 absl::string_view dispatch_target) {
+  custom_op_package_.name = name;
+  custom_op_package_.interface_provider = interface_provider;
+  custom_op_package_.compile_package_path = compile_package_path;
+  custom_op_package_.compile_target = compile_target;
+  custom_op_package_.dispatch_package_path = dispatch_package_path;
+  custom_op_package_.dispatch_target = dispatch_target;
+}
+
+const CustomOpPackage& Options::GetCustomOpPackage() const {
+  return custom_op_package_;
+}
+
 std::string Options::Dump() const {
   static constexpr absl::string_view kQnnOptionsDumpFormat =
       "\
@@ -224,7 +242,15 @@ HvxThread: %d\n\
 OptimizationLevel: %d\n\
 GraphPriority: %d\n\
 SaverOutputDir: %s\n\
-GraphIOTensorMemType: %d\n";  // NOLINT
+GraphIOTensorMemType: %d\n\
+CustomOpPackage: {\n\
+  name: %s\n\
+  interface_provider: %s\n\
+  compile_package_path: %s\n\
+  compile_target: %s\n\
+  dispatch_package_path: %s\n\
+  dispatch_target: %s\n\
+}";  // NOLINT
 
   std::string dump_tensor_ids = absl::StrJoin(dump_tensor_ids_, ",");
 
@@ -234,7 +260,12 @@ GraphIOTensorMemType: %d\n";  // NOLINT
       use_fold_relu_, htp_p_point_, htp_performance_mode_,
       dsp_performance_mode_, dump_tensor_ids, ir_json_dir_, dlc_dir_,
       vtcm_size_, num_hvx_threads_, optimization_level_, graph_priority_,
-      saver_output_dir_, graph_io_tensor_mem_type_);
+      saver_output_dir_, graph_io_tensor_mem_type_, custom_op_package_.name,
+      custom_op_package_.interface_provider,
+      custom_op_package_.compile_package_path,
+      custom_op_package_.compile_target,
+      custom_op_package_.dispatch_package_path,
+      custom_op_package_.dispatch_target);
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -83,6 +83,15 @@ enum class GraphPriority {
   kHigh = 4,
 };
 
+struct CustomOpPackage {
+  std::string name = "";
+  std::string interface_provider = "";
+  std::string compile_package_path = "";
+  std::string compile_target = "";
+  std::string dispatch_package_path = "";
+  std::string dispatch_target = "";
+};
+
 class Options {
  public:
   Options() = default;
@@ -147,6 +156,14 @@ class Options {
   void SetGraphIOTensorMemType(GraphIOTensorMemType mem_type);
   GraphIOTensorMemType GetGraphIOTensorMemType() const;
 
+  void SetCustomOpPackage(absl::string_view name,
+                          absl::string_view interface_provider,
+                          absl::string_view compile_package_path,
+                          absl::string_view compile_target,
+                          absl::string_view dispatch_package_path,
+                          absl::string_view dispatch_target);
+  const CustomOpPackage& GetCustomOpPackage() const;
+
  private:
   LogLevel log_level_ = LogLevel::kInfo;
   BackendType backend_type_ = BackendType::kHtpBackend;
@@ -169,6 +186,8 @@ class Options {
   std::string saver_output_dir_;
   GraphIOTensorMemType graph_io_tensor_mem_type_ =
       GraphIOTensorMemType::kMemHandle;
+  // Currently we only support one custom op package.
+  CustomOpPackage custom_op_package_;
 };
 
 // Gets a default logger implementation to stdout.

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -253,6 +253,28 @@ TEST(QnnOptionTest, SetGraphPriority) {
   EXPECT_EQ(options.GetGraphPriority(), GraphPriority::kDefault);
 }
 
+TEST(QnnOptionTest, SetCustomOpPackage) {
+  Options options;
+  const std::string name = "TestPackage";
+  const std::string interface_provider = "TestInterfaceProvider";
+  const std::string compile_package_path = "/tmp/compile_pkg.so";
+  const std::string compile_target = "CPU";
+  const std::string dispatch_package_path = "/tmp/dispatch_pkg.so";
+  const std::string dispatch_target = "HTP";
+
+  options.SetCustomOpPackage(name, interface_provider, compile_package_path,
+                             compile_target, dispatch_package_path,
+                             dispatch_target);
+
+  const CustomOpPackage& package = options.GetCustomOpPackage();
+  EXPECT_EQ(package.name, name);
+  EXPECT_EQ(package.interface_provider, interface_provider);
+  EXPECT_EQ(package.compile_package_path, compile_package_path);
+  EXPECT_EQ(package.compile_target, compile_target);
+  EXPECT_EQ(package.dispatch_package_path, dispatch_package_path);
+  EXPECT_EQ(package.dispatch_target, dispatch_target);
+}
+
 TEST(QnnOptionTest, Default) {
   Options options;
   EXPECT_EQ(options.GetLogLevel(), LogLevel::kInfo);
@@ -274,6 +296,13 @@ TEST(QnnOptionTest, Default) {
   EXPECT_EQ(options.GetGraphPriority(), GraphPriority::kDefault);
   EXPECT_EQ(options.GetGraphIOTensorMemType(),
             GraphIOTensorMemType::kMemHandle);
+  const CustomOpPackage& custom_op_package = options.GetCustomOpPackage();
+  EXPECT_TRUE(custom_op_package.name.empty());
+  EXPECT_TRUE(custom_op_package.interface_provider.empty());
+  EXPECT_TRUE(custom_op_package.compile_package_path.empty());
+  EXPECT_TRUE(custom_op_package.compile_target.empty());
+  EXPECT_TRUE(custom_op_package.dispatch_package_path.empty());
+  EXPECT_TRUE(custom_op_package.dispatch_target.empty());
 }
 
 TEST(QnnOptionTest, SetGraphIOTensorMemType) {

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -69,7 +69,7 @@ void OpWrapper::AddTensorParam(const char* name, const TensorWrapper& tensor) {
 
 Qnn_OpConfig_t OpWrapper::GetOpConfig() {
   Qnn_OpConfig_t qnn_op = QNN_OPCONFIG_INIT;
-  qnn_op.v1.packageName = QNN_OP_PACKAGE_NAME_QTI_AISW;
+  qnn_op.v1.packageName = package_name_;
   qnn_op.v1.typeName = type_name_;
   qnn_op.v1.name = name_.data();
   // input tensors

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -23,7 +23,15 @@ class OpWrapper final {
   explicit OpWrapper() = default;
 
   explicit OpWrapper(std::string name, const char* op_type, QnnOpCode op_code)
-      : type_name_{op_type}, name_{std::move(name)}, op_code_{op_code} {}
+      : OpWrapper(std::move(name), QNN_OP_PACKAGE_NAME_QTI_AISW, op_type,
+                  op_code) {}
+
+  explicit OpWrapper(std::string name, const char* package_name,
+                     const char* op_type, QnnOpCode op_code)
+      : package_name_{package_name},
+        type_name_{op_type},
+        name_{std::move(name)},
+        op_code_{op_code} {}
 
   bool operator==(const OpWrapper& other) const;
 
@@ -70,6 +78,7 @@ class OpWrapper final {
   void AddSuffixToName(absl::string_view suffix);
 
  private:
+  const char* package_name_{QNN_OP_PACKAGE_NAME_QTI_AISW};
   const char* type_name_{nullptr};
   std::string name_{};  // human readable name
   std::vector<std::reference_wrapper<const TensorWrapper>> input_tensors_{};

--- a/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
@@ -78,6 +78,21 @@ TEST(OpWrapperTest, SanityTest) {
   EXPECT_EQ(op_config_v1.outputTensors, nullptr);
 }
 
+TEST(OpWrapperTest, PackageNameConstructor) {
+  OpWrapper op_wrapper{"name", "custom_pkg", "OP_TYPE", QnnOpCode::kUnknown};
+  const Qnn_OpConfig_t op_config = op_wrapper.GetOpConfig();
+  EXPECT_EQ(op_config.version, QNN_OPCONFIG_VERSION_1);
+  EXPECT_STREQ(op_config.v1.packageName, "custom_pkg");
+  EXPECT_STREQ(op_config.v1.typeName, "OP_TYPE");
+  EXPECT_STREQ(op_config.v1.name, "name");
+  EXPECT_EQ(op_config.v1.numOfParams, 0);
+  EXPECT_EQ(op_config.v1.params, nullptr);
+  EXPECT_EQ(op_config.v1.numOfInputs, 0);
+  EXPECT_EQ(op_config.v1.inputTensors, nullptr);
+  EXPECT_EQ(op_config.v1.numOfOutputs, 0);
+  EXPECT_EQ(op_config.v1.outputTensors, nullptr);
+}
+
 TEST(OpWrapperTest, MoveCtorSanityTest) {
   OpWrapper op_wrapper{"name", "OP_TYPE", QnnOpCode::kUnknown};
   OpWrapper moved{std::move(op_wrapper)};

--- a/litert/vendors/qualcomm/dispatch/dispatch_api.cc
+++ b/litert/vendors/qualcomm/dispatch/dispatch_api.cc
@@ -135,6 +135,14 @@ LiteRtStatus Initialize(const LiteRtRuntimeContext* runtime_context,
     LITERT_LOG(LITERT_ERROR, "%s", qnn_manager.Error().Message().c_str());
     return qnn_manager.Error().Status();
   } else {
+    if (const auto& custom_op_package = qnn_options.GetCustomOpPackage();
+        !custom_op_package.name.empty()) {
+      (*qnn_manager)
+          ->RegisterOpPackage(custom_op_package.dispatch_package_path.c_str(),
+                              custom_op_package.interface_provider.c_str(),
+                              custom_op_package.dispatch_target.c_str());
+    }
+
     std::swap(QnnManagerStorage(), *qnn_manager);
   }
 

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -84,7 +84,7 @@ RtldFlags GetRtldFlags() {
   // Race condition segfault without NoDelete on android.
   return RtldFlags::Lazy().Local().NoDelete();
 #else
-  return RtldFlags::Default();
+  return RtldFlags::Lazy().Global();
 #endif
 }
 

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -429,6 +429,28 @@ LiteRtStatus QnnManager::ValidateOp(::qnn::OpWrapper& op) {
   return kLiteRtStatusOk;
 }
 
+LiteRtStatus QnnManager::RegisterOpPackage(
+    const std::string& package_path, const std::string& interface_provider,
+    const std::string& target) {
+  if (options_.GetBackendType() == ::qnn::BackendType::kIrBackend) {
+    LITERT_LOG(LITERT_INFO,
+               "Custom op package is not supportted in IrBackend. Ignore.");
+    return kLiteRtStatusOk;
+  }
+
+  if (auto status = Api()->backendRegisterOpPackage(
+          backend_->GetBackendHandle(), package_path.c_str(),
+          interface_provider.c_str(), target.c_str());
+      status != QNN_SUCCESS) {
+    LITERT_LOG(LITERT_ERROR, "Failed to register op package. Error code: %d",
+               status);
+    return kLiteRtStatusErrorRuntimeFailure;
+  }
+
+  LITERT_LOG(LITERT_INFO, "Op package loaded successfully.");
+  return kLiteRtStatusOk;
+}
+
 LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
                               std::optional<::qnn::SocInfo> soc_info,
                               const ::qnn::Options& options) {
@@ -533,6 +555,7 @@ LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
   const char* build_id;
   Api()->backendGetBuildId(&build_id);
   LITERT_ASSIGN_OR_RETURN(sdk_version_, ParseSdkVersion(build_id));
+
   return kLiteRtStatusOk;
 }
 

--- a/litert/vendors/qualcomm/qnn_manager.h
+++ b/litert/vendors/qualcomm/qnn_manager.h
@@ -161,6 +161,10 @@ class QnnManager {
 
   LiteRtStatus ValidateOp(::qnn::OpWrapper& op);
 
+  LiteRtStatus RegisterOpPackage(const std::string& package_path,
+                                 const std::string& interface_provider,
+                                 const std::string& target);
+
   bool IsFp16Supported() {
     // TODO(jiunkaiy): Remove this function after upgrading to stricter SDK
     // restrictions.


### PR DESCRIPTION
Qualcomm AI Engine Direct - Support Custom Op Package.
Summary:
- Support custom option getter, add unit tests.
- Support struct for custom op package options.
- Support QNN op package registration, custom op builder.
- Support conversion from tflite custom options to QNN op params.
- Support custom op package for both AOT and JIT flow.


# TEST
x86
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all


//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.7s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.7s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 1.5s
```

device:
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 15 tests from 3 test suites ran. (7 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 21 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 33 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (11 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (687 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (809 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1805 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1433 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (536 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1840 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (22 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test


SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (530 ms total)
[  PASSED  ] 2 tests.
```