### PR TITLE
Samsung Exynos AI LiteCore : Add Samsung Schema

### DIFF
--- a/litert/vendors/samsung/CMakeLists.txt
+++ b/litert/vendors/samsung/CMakeLists.txt
@@ -60,3 +60,4 @@ target_link_libraries(samsung_ai_litecore_manager
 # Add subdirectories for modular build
 add_subdirectory(compiler)
 add_subdirectory(dispatch)
+add_subdirectory(schema)

--- a/litert/vendors/samsung/compiler/BUILD
+++ b/litert/vendors/samsung/compiler/BUILD
@@ -123,6 +123,7 @@ cc_library(
         "//litert/vendors/samsung/compiler/builders:transpose_conv_op_builder",
         "//litert/vendors/samsung/compiler/builders:transpose_op_builder",
         "//litert/vendors/samsung/compiler/builders:utils",
+        "//litert/vendors/samsung/schema:samsung_byte_code",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:inlined_vector",

--- a/litert/vendors/samsung/dispatch/BUILD
+++ b/litert/vendors/samsung/dispatch/BUILD
@@ -28,12 +28,14 @@ litert_dynamic_lib(
         "enn_manager.cc",
         "litert_dispatch_device_context.cc",
         "litert_dispatch_invocation_context.cc",
+        "litert_weight_binary_manager.cc",
     ],
     hdrs = [
         "enn_manager.h",
         "enn_type.h",
         "litert_dispatch_device_context.h",
         "litert_dispatch_invocation_context.h",
+        "litert_weight_binary_manager.h",
     ],
     copts = [
         "-Os",

--- a/litert/vendors/samsung/dispatch/BUILD
+++ b/litert/vendors/samsung/dispatch/BUILD
@@ -74,6 +74,7 @@ litert_dynamic_lib(
         "//litert/cc/internal:litert_shared_library",
         "//litert/core/util:tensor_type_util",
         "//litert/vendors/c:litert_dispatch_c_api",
+        "//litert/vendors/samsung/schema:samsung_byte_code",
         "@com_google_absl//absl/base:no_destructor",
         "@com_google_absl//absl/strings:string_view",
     ],

--- a/litert/vendors/samsung/dispatch/CMakeLists.txt
+++ b/litert/vendors/samsung/dispatch/CMakeLists.txt
@@ -21,16 +21,21 @@ target_sources(dispatch_api_samsung_so
         enn_manager.cc
         litert_dispatch_device_context.cc
         litert_dispatch_invocation_context.cc
+        litert_weight_binary_manager.cc
 )
+add_dependencies(dispatch_api_samsung_so samsung_schema_gen)
+
 target_include_directories(dispatch_api_samsung_so
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../schema/generated/include>
         $<$<BOOL:${LITECORE_HEADERS_DIR}>:${LITECORE_HEADERS_DIR}>
 )
 target_link_libraries(dispatch_api_samsung_so
     PRIVATE
         samsung_soc_model
         samsung_ai_litecore_manager
+        samsung_byte_code
         litert_runtime_c_api_static
 )
 if(CMAKE_SYSTEM_NAME STREQUAL "Android")

--- a/litert/vendors/samsung/dispatch/enn_manager.cc
+++ b/litert/vendors/samsung/dispatch/enn_manager.cc
@@ -71,6 +71,9 @@ LiteRtStatus EnnManager::LoadEnnRuntimeLibrary(absl::string_view path) {
   ENN_LOAD_API(enn_runtime_lib_, EnnInitialize);
   ENN_LOAD_API(enn_runtime_lib_, EnnOpenModelFromMemory);
   ENN_LOAD_API(enn_runtime_lib_, EnnCreateBufferFromFdWithOffset);
+  ENN_LOAD_API(enn_runtime_lib_, EnnOpenModelFromFdWithWeight);
+  ENN_LOAD_API(enn_runtime_lib_, EnnOpenModelWithFileOpenFdWeight);
+  ENN_LOAD_API(enn_runtime_lib_, EnnOpenModelWithFileOpenFd);
   ENN_LOAD_API(enn_runtime_lib_, EnnBufferCommit);
   ENN_LOAD_API(enn_runtime_lib_, EnnGetBuffersInfo);
   ENN_LOAD_API(enn_runtime_lib_, EnnSetBufferByIndex);

--- a/litert/vendors/samsung/dispatch/enn_manager.cc
+++ b/litert/vendors/samsung/dispatch/enn_manager.cc
@@ -70,6 +70,7 @@ LiteRtStatus EnnManager::LoadEnnRuntimeLibrary(absl::string_view path) {
 
   ENN_LOAD_API(enn_runtime_lib_, EnnInitialize);
   ENN_LOAD_API(enn_runtime_lib_, EnnOpenModelFromMemory);
+  ENN_LOAD_API(enn_runtime_lib_, EnnOpenModelFromMemoryWithWeight);
   ENN_LOAD_API(enn_runtime_lib_, EnnCreateBufferFromFdWithOffset);
   ENN_LOAD_API(enn_runtime_lib_, EnnCreateBufferCache);
   ENN_LOAD_API(enn_runtime_lib_, EnnOpenModelFromFdWithWeight);

--- a/litert/vendors/samsung/dispatch/enn_manager.cc
+++ b/litert/vendors/samsung/dispatch/enn_manager.cc
@@ -71,6 +71,7 @@ LiteRtStatus EnnManager::LoadEnnRuntimeLibrary(absl::string_view path) {
   ENN_LOAD_API(enn_runtime_lib_, EnnInitialize);
   ENN_LOAD_API(enn_runtime_lib_, EnnOpenModelFromMemory);
   ENN_LOAD_API(enn_runtime_lib_, EnnCreateBufferFromFdWithOffset);
+  ENN_LOAD_API(enn_runtime_lib_, EnnCreateBufferCache);
   ENN_LOAD_API(enn_runtime_lib_, EnnOpenModelFromFdWithWeight);
   ENN_LOAD_API(enn_runtime_lib_, EnnOpenModelWithFileOpenFdWeight);
   ENN_LOAD_API(enn_runtime_lib_, EnnOpenModelWithFileOpenFd);

--- a/litert/vendors/samsung/dispatch/enn_manager.h
+++ b/litert/vendors/samsung/dispatch/enn_manager.h
@@ -53,6 +53,11 @@ struct EnnManager::PublicApi {
   EnnReturn (*EnnInitialize)(void);
   EnnReturn (*EnnOpenModelFromMemory)(const char* va, const uint32_t size,
                                       EnnModelId* model_id);
+  EnnReturn (*EnnOpenModelFromMemoryWithWeight)(const char* va,
+                                                const uint32_t size,
+                                                EnnBufferPtr* weights,
+                                                uint32_t n_weights,
+                                                EnnModelId* model_id);
   EnnReturn (*EnnOpenModelFromFdWithWeight)(const uint32_t fd,
                                             const uint32_t size,
                                             const uint32_t offset,

--- a/litert/vendors/samsung/dispatch/enn_manager.h
+++ b/litert/vendors/samsung/dispatch/enn_manager.h
@@ -73,6 +73,7 @@ struct EnnManager::PublicApi {
                                                const uint32_t size,
                                                const uint32_t offset,
                                                EnnBufferPtr* out);
+  EnnReturn (*EnnCreateBufferCache)(const uint32_t req_size, EnnBufferPtr *out);
   EnnReturn (*EnnAllocateAllBuffers)(const EnnModelId model_id,
                                      EnnBufferPtr** out_buffers,
                                      NumberOfBuffersInfo* out_buffers_info);

--- a/litert/vendors/samsung/dispatch/enn_manager.h
+++ b/litert/vendors/samsung/dispatch/enn_manager.h
@@ -53,6 +53,22 @@ struct EnnManager::PublicApi {
   EnnReturn (*EnnInitialize)(void);
   EnnReturn (*EnnOpenModelFromMemory)(const char* va, const uint32_t size,
                                       EnnModelId* model_id);
+  EnnReturn (*EnnOpenModelFromFdWithWeight)(const uint32_t fd,
+                                            const uint32_t size,
+                                            const uint32_t offset,
+                                            EnnBufferPtr* weights,
+                                            uint32_t n_weights,
+                                            EnnModelId* model_id);
+  EnnReturn (*EnnOpenModelWithFileOpenFdWeight)(const int fd,
+                                                const uint32_t size,
+                                                const uint32_t offset,
+                                                EnnBufferPtr* weights,
+                                                uint32_t n_weights,
+                                                EnnModelId* model_id);
+  EnnReturn (*EnnOpenModelWithFileOpenFd)(const int fd,
+                                          const uint32_t size,
+                                          const uint32_t offset,
+                                          EnnModelId* model_id);
   EnnReturn (*EnnCreateBufferFromFdWithOffset)(const uint32_t fd,
                                                const uint32_t size,
                                                const uint32_t offset,

--- a/litert/vendors/samsung/dispatch/litert_dispatch_device_context.h
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_device_context.h
@@ -49,15 +49,6 @@ class LiteRtDispatchDeviceContextT {
     return tensor_buffer_registry_.Find(tensor_buffer_handle);
   }
 
-  litert::Expected<EnnBufferPtr*> GetEnnCommittedBuffer(void) {
-    return _commit_buf_set;
-  }
-
-  litert::Expected<void> SetEnnCommittedBuffer(EnnBufferPtr* update) {
-    _commit_buf_set = update;
-    return {};
-  }
-
   const LiteRtRuntimeContext* runtime_context() const {
     return runtime_context_;
   }
@@ -88,7 +79,6 @@ class LiteRtDispatchDeviceContextT {
   const LiteRtRuntimeContext* runtime_context_;
   const litert::samsung::EnnManager* enn_manager_;
   EnnBufferRegistry tensor_buffer_registry_;
-  EnnBufferPtr* _commit_buf_set;
 };
 
 #endif  // LITERT_VENDORS_SAMSUNG_DISPATCH_DEVICE_CONTEXT_H_

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
@@ -308,7 +308,6 @@ LiteRtDispatchInvocationContextT::Create(
   }
   LITERT_LOG(LITERT_INFO, "Buffers allocated successfully");
 
-  device_context->SetEnnCommittedBuffer(tmp_buf_ptr);
   LITERT_LOG(LITERT_INFO, "=== Model Loading Complete ===");
 
   model_guard.release();
@@ -316,6 +315,9 @@ LiteRtDispatchInvocationContextT::Create(
   auto context = LiteRtDispatchInvocationContextT::UniquePtr(
       new LiteRtDispatchInvocationContextT(enn_manager, device_context,
                                            model_id, num_inputs, num_outputs));
+
+  // Set committed buffer for this model
+  context->SetEnnCommittedBuffer(tmp_buf_ptr);
 
   // Set weight signatures for later release
   context->SetWeightSignatures(std::move(signatures));
@@ -426,8 +428,7 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::SetInputBuffers()
     return litert::Error(kLiteRtStatusErrorRuntimeFailure,
                          "Inputs/outputs not prepared.");
   }
-  LITERT_ASSIGN_OR_RETURN(auto committed_buf,
-                          device_context_->GetEnnCommittedBuffer());
+  LITERT_ASSIGN_OR_RETURN(auto committed_buf, GetEnnCommittedBuffer());
 
   for (int idx = 0; idx < inputs_buf_.size(); idx++) {
     auto usr_buf = inputs_buf_.at(idx);
@@ -440,8 +441,7 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::SetInputBuffers()
 
 litert::Expected<void> LiteRtDispatchInvocationContextT::SetOutputBuffers()
     const {
-  LITERT_ASSIGN_OR_RETURN(auto committed_buf,
-                          device_context_->GetEnnCommittedBuffer());
+  LITERT_ASSIGN_OR_RETURN(auto committed_buf, GetEnnCommittedBuffer());
 
   int _input_buf_size = inputs_buf_.size();
   for (int idx = 0; idx < outputs_buf_.size(); idx++) {

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
@@ -222,14 +222,6 @@ LiteRtDispatchInvocationContextT::Create(
 
   // Load model based on condition
   if (load_info.has_valid_header && load_info.use_external_weights) {
-    if (load_info.fd < 0) {
-      return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                           "Requires fd for external weights, but fd is not available.");
-    }
-
-    LITERT_LOG(LITERT_SILENT, "File descriptor: %d", load_info.fd);
-    LITERT_LOG(LITERT_SILENT, "Model offset: %u, Model size: %u", load_info.model_offset, load_info.model_size);
-
     auto& weight_mgr = litert::samsung::WeightBinaryManager::GetInstance(enn_manager);
     std::vector<EnnBufferPtr> weight_buffers;
 
@@ -246,19 +238,35 @@ LiteRtDispatchInvocationContextT::Create(
         size = load_info.separated_weights[i].end_offset -
                load_info.separated_weights[i].start_offset;
       }
-      auto buffer = weight_mgr.Acquire(sig, load_info.fd, offset, size);
+      litert::Expected<EnnBufferPtr> buffer;
+      if (load_info.fd >= 0) {
+        buffer = weight_mgr.Acquire(sig, load_info.fd, offset, size);
+      } else {
+        const void* addr = static_cast<const uint8_t*>(exec_bytecode_buffer->base_addr) + offset;
+        buffer = weight_mgr.Acquire(sig, addr, size);
+      }
+
       if (!buffer) {
         return buffer.Error();
       }
       weight_buffers.push_back(*buffer);
       signatures.push_back(sig);
     }
-
-    if (enn_manager->Api().EnnOpenModelWithFileOpenFdWeight(
-            load_info.fd, load_info.model_size, load_info.model_offset,
-            &weight_buffers[0], weight_buffers.size(), &model_id) != ENN_RET_SUCCESS)
-      return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                           "Failed to load model from fd with weights");
+    if (load_info.fd >= 0) {
+      if (enn_manager->Api().EnnOpenModelWithFileOpenFdWeight(
+              load_info.fd, load_info.model_size, load_info.model_offset,
+              &weight_buffers[0], weight_buffers.size(), &model_id) != ENN_RET_SUCCESS)
+        return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                             "Failed to load model from fd with weights");
+    } else {
+      const void* model_addr = static_cast<const uint8_t*>(exec_bytecode_buffer->base_addr) +
+                               load_info.model_offset;
+      if (enn_manager->Api().EnnOpenModelFromMemoryWithWeight(
+              reinterpret_cast<const char*>(model_addr), load_info.model_size,
+              &weight_buffers[0], weight_buffers.size(), &model_id) != ENN_RET_SUCCESS)
+        return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                             "Failed to load model from memory with weights");
+    }
   } else {
     if (exec_bytecode_buffer->fd >= 0) {
       LITERT_LOG(LITERT_SILENT, "fd: %d, Model offset: %u, Model size: %zu",

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// Copyright 2024 Google LLC.
+// Copyright (C) 2026 Samsung Electronics Co. LTD.
+// SPDX-License-Identifier: Apache-2.0
 
-#include "litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h"
+#include <memory>
+#include <fstream>
+#include <unistd.h>
 
-#include "litert/c/internal/litert_runtime_context.h"
+
 #include "litert/c/internal/litert_logging.h"
 #include "litert/c/litert_model.h"
 #include "litert/c/litert_tensor_buffer.h"
@@ -25,9 +28,135 @@
 #include "litert/cc/litert_expected.h"
 #include "litert/cc/litert_macros.h"
 #include "litert/core/util/tensor_type_util.h"
+
 #include "litert/vendors/c/litert_dispatch.h"
 #include "litert/vendors/samsung/dispatch/litert_dispatch_device_context.h"
+#include "litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h"
+#include "litert/vendors/samsung/schema/litert_samsung_header_generated.h"
+
 namespace litert::samsung {
+
+#define TO_FILE_OFFSET(header_offset, buffer_offset) ((header_offset) + (buffer_offset))
+
+struct EnnModelHandle {
+  EnnModelId id;
+  const ::litert::samsung::EnnManager* manager;
+
+  EnnModelHandle(EnnModelId id, const ::litert::samsung::EnnManager* manager)
+      : id(id), manager(manager) {}
+};
+
+// Custom deleter for EnnModelHandle
+struct EnnModelDeleter {
+  void operator()(EnnModelHandle* handle) const {
+    if (handle && handle->manager) {
+      handle->manager->Api().EnnCloseModel(handle->id);
+    }
+    delete handle;
+  }
+};
+
+using EnnModelPtr = std::unique_ptr<EnnModelHandle, EnnModelDeleter>;
+
+static EnnModelPtr MakeEnnModelPtr(const ::litert::samsung::EnnManager* manager, EnnModelId model_id) {
+  auto raw_ptr = std::make_unique<EnnModelHandle>(model_id, manager);
+  return EnnModelPtr(raw_ptr.release(), EnnModelDeleter{});
+}
+
+// Structure to hold separated weight information
+struct SeparatedWeightInfo {
+  std::string signature;
+  int64_t start_offset;
+  int64_t end_offset;
+};
+
+// Structure to hold model loading information
+struct ModelLoadInfo {
+  bool has_valid_header = false;
+  bool use_external_weights = false;
+  const void* model_addr = nullptr;
+  size_t model_size = 0;
+  int fd = -1;
+  uint32_t model_offset = 0;
+  std::vector<SeparatedWeightInfo> separated_weights;
+};
+
+static Expected<ModelLoadInfo> AnalyzeModelLoadStrategy(
+   const LiteRtMemBuffer* exec_bytecode_buffer) {
+  ModelLoadInfo info;
+
+  const void* exec_bytecode_ptr =
+      static_cast<const uint8_t*>(exec_bytecode_buffer->base_addr) +
+      exec_bytecode_buffer->offset;
+  size_t exec_bytecode_size = exec_bytecode_buffer->size;
+
+  LITERT_LOG(LITERT_INFO, "Bytecode buffer: base_addr=%p, offset=%zu, size=%zu",
+             exec_bytecode_buffer->base_addr, exec_bytecode_buffer->offset, exec_bytecode_size);
+  LITERT_LOG(LITERT_INFO, "Calculated bytecode ptr: %p, size: %zu", exec_bytecode_ptr, exec_bytecode_size);
+
+  info.fd = exec_bytecode_buffer->fd;
+
+  auto* header_buf = litert::samsung::schema::GetLiteRTSamsungHeader(exec_bytecode_ptr);
+  if (!header_buf) {
+    LITERT_LOG(LITERT_INFO, "No valid Samsung header found - using old format");
+    info.model_offset = static_cast<uint32_t>(exec_bytecode_buffer->offset);
+    info.model_size = exec_bytecode_size;
+    return info;
+  }
+
+  flatbuffers::Verifier verifier(
+      static_cast<const uint8_t*>(exec_bytecode_ptr),
+      exec_bytecode_size);
+
+  bool fb_generated = header_buf->Verify(verifier);
+  info.has_valid_header = fb_generated;
+
+  if (!fb_generated) {
+    LITERT_LOG(LITERT_INFO, "Header verification failed - using old format");
+    info.model_offset = static_cast<uint32_t>(exec_bytecode_buffer->offset);
+    info.model_size = exec_bytecode_size;
+    return info;
+  }
+
+  auto* dispatch_binary = header_buf->dispatch_binary();
+  info.use_external_weights = dispatch_binary->use_external_weights();
+
+  const auto* buf_section = dispatch_binary->buf();
+  const auto* external_weights = dispatch_binary->external_weights();
+  const auto* separated_weights = header_buf->separated_weights();
+
+  LITERT_LOG(LITERT_INFO, "Schema version: %u", header_buf->version());
+  LITERT_LOG(LITERT_VERBOSE, "Dispatch Binary Buffer: start_offset=%ld, end_offset=%ld",
+             buf_section->start_offset(), buf_section->end_offset());
+  LITERT_LOG(LITERT_VERBOSE, "Use External Weights: %s", info.use_external_weights ? "true" : "false");
+
+  if (separated_weights) {
+    for (int32_t i = 0; i < separated_weights->size(); i++) {
+      const auto* weight = separated_weights->Get(i);
+      SeparatedWeightInfo weight_info;
+      weight_info.signature = weight->signature()->str();
+      weight_info.start_offset = TO_FILE_OFFSET(weight->buf()->start_offset(), exec_bytecode_buffer->offset);
+      weight_info.end_offset = TO_FILE_OFFSET(weight->buf()->end_offset(), exec_bytecode_buffer->offset);
+      info.separated_weights.push_back(weight_info);
+      LITERT_LOG(LITERT_SILENT, "Separated Weight[%d]: signature=%s, offset=%ld-%ld",
+                 i, weight_info.signature.c_str(), weight_info.start_offset, weight_info.end_offset);
+    }
+    LITERT_LOG(LITERT_SILENT, "Total separated weights: %zu", info.separated_weights.size());
+  }
+
+  if (info.use_external_weights) {
+    LITERT_LOG(LITERT_VERBOSE, "Valid header with external weights");
+    info.model_offset = static_cast<uint32_t>(TO_FILE_OFFSET(buf_section->start_offset(), exec_bytecode_buffer->offset));
+    info.model_size = buf_section->end_offset() - buf_section->start_offset();
+    LITERT_LOG(LITERT_SILENT, "Model offset: %u, Model size: %zu", info.model_offset, info.model_size);
+  } else {
+    LITERT_LOG(LITERT_VERBOSE, "Valid header without external weights");
+    info.model_offset = static_cast<uint32_t>(TO_FILE_OFFSET(buf_section->start_offset(), exec_bytecode_buffer->offset));
+    info.model_size = buf_section->end_offset() - buf_section->start_offset();
+    LITERT_LOG(LITERT_SILENT, "Model offset: %u, Model size: %zu", info.model_offset, info.model_size);
+  }
+  return info;
+}
 
 // Require continuous memory for tensor buffer. No strides.
 Expected<LiteRtTensorBufferRequirements> GetTensorBufferRequirements(
@@ -65,6 +194,7 @@ LiteRtDispatchInvocationContextT::LiteRtDispatchInvocationContextT(
       model_id_(model_id),
       inputs_buf_(num_inputs, nullptr),
       outputs_buf_(num_outputs, nullptr) {}
+}
 
 litert::Expected<LiteRtDispatchInvocationContextT::UniquePtr>
 LiteRtDispatchInvocationContextT::Create(
@@ -73,55 +203,107 @@ LiteRtDispatchInvocationContextT::Create(
     LiteRtDispatchExecutableType exec_type,
     const LiteRtMemBuffer* exec_bytecode_buffer, const char* function_name,
     int num_inputs, int num_outputs) {
-  EnnBufferPtr* tmp_buf_ptr;
   if (!enn_manager) {
     return litert::Error(kLiteRtStatusErrorRuntimeFailure,
                          "Fail to get enn runtime.");
   }
 
-  const void* exec_bytecode_ptr =
-      static_cast<const uint8_t*>(exec_bytecode_buffer->base_addr) +
-      exec_bytecode_buffer->offset;
-  auto exec_bytecode_size = exec_bytecode_buffer->size;
+  // Analyze model loading strategy
+  LITERT_ASSIGN_OR_RETURN(auto load_info,
+    litert::samsung::AnalyzeModelLoadStrategy(exec_bytecode_buffer));
+
   EnnModelId model_id;
-  if (enn_manager->Api().EnnOpenModelFromMemory(
-          reinterpret_cast<const char*>(exec_bytecode_ptr), exec_bytecode_size,
-          &model_id) != ENN_RET_SUCCESS) {
-    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                         "Fail to load model.");
+
+  // Load model based on condition
+  if (load_info.has_valid_header && load_info.use_external_weights) {
+    if (load_info.fd < 0) {
+      return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                           "Requires fd for external weights, but fd is not available.");
+    }
+
+    LITERT_LOG(LITERT_SILENT, "File descriptor: %d", load_info.fd);
+    LITERT_LOG(LITERT_SILENT, "Model offset: %u, Model size: %u", load_info.model_offset, load_info.model_size);
+
+    std::vector<EnnBufferPtr> weight_buffers;
+    for (size_t i = 0; i < load_info.separated_weights.size(); i++) {
+      const auto& weight = load_info.separated_weights[i];
+      EnnBufferPtr weight_buffer;
+      size_t weight_size = weight.end_offset - weight.start_offset;
+
+      LITERT_LOG(LITERT_VERBOSE, "Creating weight buffer[%zu]: offset=%ld, size=%zu, signature=%s",
+                 i, weight.start_offset, weight_size, weight.signature.c_str());
+
+      if (enn_manager->Api().EnnCreateBufferCache(weight_size, &weight_buffer) != ENN_RET_SUCCESS)
+        return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                             "Failed to create weight buffer");
+
+      ssize_t bytes_read = pread(load_info.fd, weight_buffer->va, weight_size, weight.start_offset);
+      if (bytes_read != static_cast<ssize_t>(weight_size))
+        return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                             "Failed to read weight data from file");
+
+      weight_buffers.push_back(weight_buffer);
+      LITERT_LOG(LITERT_SILENT, "Weight buffer: %p, size=%d", weight_buffer->va, weight_buffer->size);
+    }
+
+    if (enn_manager->Api().EnnOpenModelWithFileOpenFdWeight(
+            load_info.fd, load_info.model_size, load_info.model_offset,
+            &weight_buffers[0], weight_buffers.size(), &model_id) != ENN_RET_SUCCESS)
+      return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                           "Failed to load model from fd with weights");
+  } else {
+    if (exec_bytecode_buffer->fd >= 0) {
+      LITERT_LOG(LITERT_SILENT, "fd: %d, Model offset: %u, Model size: %zu",
+                 exec_bytecode_buffer->fd, load_info.model_offset, load_info.model_size);
+
+      if (enn_manager->Api().EnnOpenModelWithFileOpenFd(
+              exec_bytecode_buffer->fd,
+              static_cast<uint32_t>(load_info.model_size),
+              load_info.model_offset, &model_id) != ENN_RET_SUCCESS)
+        return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                             "Fail to load model from fd.");
+    } else {
+      // Load from memory (fd not available)
+      LITERT_LOG(LITERT_INFO, "Loading model from memory");
+
+      const void* model_addr = static_cast<const uint8_t*>(exec_bytecode_buffer->base_addr) +
+                                load_info.model_offset;
+      size_t model_size = load_info.model_size;
+
+      LITERT_LOG(LITERT_SILENT, "Model addr: %p, Model size: %zu", model_addr, model_size);
+
+      if (enn_manager->Api().EnnOpenModelFromMemory(
+              reinterpret_cast<const char *>(model_addr), model_size,
+              &model_id) != ENN_RET_SUCCESS)
+        return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                             "Fail to load model from memory.");
+    }
   }
+
+  auto model_guard = MakeEnnModelPtr(enn_manager, model_id);
 
   NumberOfBuffersInfo buffer_info;
-  if (enn_manager->Api().EnnGetBuffersInfo(model_id, &buffer_info) !=
-      ENN_RET_SUCCESS) {
-    if (enn_manager->Api().EnnCloseModel(model_id) != ENN_RET_SUCCESS) {
-      return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                           "Fail to trying to Close Model");
-    }
-    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                         "Fail to get buffers information");
+  if (enn_manager->Api().EnnGetBuffersInfo(model_id, &buffer_info) != ENN_RET_SUCCESS) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure, "Fail to get buffers information");
   }
-  if (buffer_info.n_in_buf != num_inputs ||
-      buffer_info.n_out_buf != num_outputs) {
-    if (enn_manager->Api().EnnCloseModel(model_id) != ENN_RET_SUCCESS) {
-      return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                           "Fail to trying to Close Model");
-    }
-    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                         "Number of inputs/outputs is invalid");
+  LITERT_LOG(LITERT_INFO, "Buffer info - inputs: %d, outputs: %d",
+             buffer_info.n_in_buf, buffer_info.n_out_buf);
+
+  if (buffer_info.n_in_buf != num_inputs || buffer_info.n_out_buf != num_outputs) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure, "Number of inputs/outputs is invalid");
   }
 
-  if (enn_manager->Api().EnnAllocateAllBuffers(
-          model_id, &tmp_buf_ptr, &buffer_info) != ENN_RET_SUCCESS) {
-    if (enn_manager->Api().EnnCloseModel(model_id) != ENN_RET_SUCCESS) {
-      return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                           "Fail to trying to Close Model");
-    }
-    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                         "EnnAllocateAllBuffers Failed");
+  // Allocate buffers
+  EnnBufferPtr *tmp_buf_ptr;
+  if (enn_manager->Api().EnnAllocateAllBuffers(model_id, &tmp_buf_ptr, &buffer_info) != ENN_RET_SUCCESS) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure, "EnnAllocateAllBuffers Failed");
   }
+  LITERT_LOG(LITERT_INFO, "Buffers allocated successfully");
 
   device_context->SetEnnCommittedBuffer(tmp_buf_ptr);
+  LITERT_LOG(LITERT_INFO, "=== Model Loading Complete ===");
+
+  model_guard.release();
 
   return LiteRtDispatchInvocationContextT::UniquePtr(
       new LiteRtDispatchInvocationContextT(enn_manager, device_context,

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
@@ -19,7 +19,7 @@
 #include <fstream>
 #include <unistd.h>
 
-
+#include "litert/c/internal/litert_runtime_context.h"
 #include "litert/c/internal/litert_logging.h"
 #include "litert/c/litert_model.h"
 #include "litert/c/litert_tensor_buffer.h"
@@ -79,6 +79,7 @@ struct ModelLoadInfo {
   int fd = -1;
   uint32_t model_offset = 0;
   std::vector<SeparatedWeightInfo> separated_weights;
+  std::vector<std::string> signatures;
 };
 
 static Expected<ModelLoadInfo> AnalyzeModelLoadStrategy(
@@ -149,6 +150,9 @@ static Expected<ModelLoadInfo> AnalyzeModelLoadStrategy(
     info.model_offset = static_cast<uint32_t>(TO_FILE_OFFSET(buf_section->start_offset(), exec_bytecode_buffer->offset));
     info.model_size = buf_section->end_offset() - buf_section->start_offset();
     LITERT_LOG(LITERT_SILENT, "Model offset: %u, Model size: %zu", info.model_offset, info.model_size);
+    for (int32_t i = 0; i < external_weights->size(); i++) {
+      info.signatures.emplace_back(external_weights->Get(i)->str());
+    }
   } else {
     LITERT_LOG(LITERT_VERBOSE, "Valid header without external weights");
     info.model_offset = static_cast<uint32_t>(TO_FILE_OFFSET(buf_section->start_offset(), exec_bytecode_buffer->offset));
@@ -194,7 +198,6 @@ LiteRtDispatchInvocationContextT::LiteRtDispatchInvocationContextT(
       model_id_(model_id),
       inputs_buf_(num_inputs, nullptr),
       outputs_buf_(num_outputs, nullptr) {}
-}
 
 litert::Expected<LiteRtDispatchInvocationContextT::UniquePtr>
 LiteRtDispatchInvocationContextT::Create(
@@ -203,6 +206,8 @@ LiteRtDispatchInvocationContextT::Create(
     LiteRtDispatchExecutableType exec_type,
     const LiteRtMemBuffer* exec_bytecode_buffer, const char* function_name,
     int num_inputs, int num_outputs) {
+
+  counter.fetch_add(1);
   if (!enn_manager) {
     return litert::Error(kLiteRtStatusErrorRuntimeFailure,
                          "Fail to get enn runtime.");
@@ -224,26 +229,51 @@ LiteRtDispatchInvocationContextT::Create(
     LITERT_LOG(LITERT_SILENT, "File descriptor: %d", load_info.fd);
     LITERT_LOG(LITERT_SILENT, "Model offset: %u, Model size: %u", load_info.model_offset, load_info.model_size);
 
+    WeightData weightdata;
     std::vector<EnnBufferPtr> weight_buffers;
-    for (size_t i = 0; i < load_info.separated_weights.size(); i++) {
-      const auto& weight = load_info.separated_weights[i];
-      EnnBufferPtr weight_buffer;
-      size_t weight_size = weight.end_offset - weight.start_offset;
+    int shared_weight = 0;
 
-      LITERT_LOG(LITERT_VERBOSE, "Creating weight buffer[%zu]: offset=%ld, size=%zu, signature=%s",
-                 i, weight.start_offset, weight_size, weight.signature.c_str());
+    auto it = std::find_if(weightDatas.begin(), weightDatas.end(),
+      [&](const WeightData& m) {
+          return m.signature == load_info.signatures[0];
+      });
 
-      if (enn_manager->Api().EnnCreateBufferCache(weight_size, &weight_buffer) != ENN_RET_SUCCESS)
-        return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                             "Failed to create weight buffer");
+    if (it == weightDatas.end()) {
+      LITERT_LOG(LITERT_VERBOSE, "not find the signature !");
+    } else {
+      LITERT_LOG(LITERT_VERBOSE, "find the signature !");
+      weight_buffers = it->weight_buffers;
+      shared_weight = 1;
+    }
+    if (!shared_weight) {
+      for (size_t i = 0; i < load_info.separated_weights.size(); i++) {
+        const auto& weight = load_info.separated_weights[i];
+        EnnBufferPtr weight_buffer;
+        size_t weight_size = weight.end_offset - weight.start_offset;
 
-      ssize_t bytes_read = pread(load_info.fd, weight_buffer->va, weight_size, weight.start_offset);
-      if (bytes_read != static_cast<ssize_t>(weight_size))
-        return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                             "Failed to read weight data from file");
+        LITERT_LOG(LITERT_VERBOSE, "Creating weight buffer[%zu]: offset=%ld, size=%zu, signature=%s",
+                  i, weight.start_offset, weight_size, weight.signature.c_str());
 
-      weight_buffers.push_back(weight_buffer);
-      LITERT_LOG(LITERT_SILENT, "Weight buffer: %p, size=%d", weight_buffer->va, weight_buffer->size);
+        // Create empty buffer
+        if (enn_manager->Api().EnnCreateBufferCache(weight_size, &weight_buffer) != ENN_RET_SUCCESS)
+          return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                              "Failed to create weight buffer");
+
+        // Read weight data from file using pread
+        ssize_t bytes_read = pread(load_info.fd, weight_buffer->va, weight_size, weight.start_offset);
+        if (bytes_read != static_cast<ssize_t>(weight_size))
+          return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                              "Failed to read weight data from file");
+
+        if (i == 0) {
+          //only update the first weight signature
+          weightdata.signature = weight.signature;
+        }
+        weightdata.weight_buffers.push_back(weight_buffer);
+        LITERT_LOG(LITERT_SILENT, "Weight buffer: %p, size=%d", weight_buffer->va, weight_buffer->size);
+      }
+      weightDatas.push_back(weightdata);
+      weight_buffers = weightdata.weight_buffers;
     }
 
     if (enn_manager->Api().EnnOpenModelWithFileOpenFdWeight(
@@ -311,6 +341,19 @@ LiteRtDispatchInvocationContextT::Create(
 }
 
 LiteRtDispatchInvocationContextT::~LiteRtDispatchInvocationContextT() {
+  counter.fetch_sub(1);
+  if (!counter.load()) {
+    for (auto& wd : weightDatas) {
+        for (auto& buf : wd.weight_buffers) {
+            if (enn_manager_->Api().EnnReleaseBuffer(buf) != ENN_RET_SUCCESS) {
+              LITERT_LOG(LITERT_INFO, "EnnReleaseBuffer failed");
+            };
+        }
+        wd.weight_buffers.clear();
+    }
+    weightDatas.clear();
+  }
+
   enn_manager_->Api().EnnCloseModel(model_id_);
 }
 

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
@@ -32,6 +32,7 @@
 #include "litert/vendors/c/litert_dispatch.h"
 #include "litert/vendors/samsung/dispatch/litert_dispatch_device_context.h"
 #include "litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h"
+#include "litert/vendors/samsung/dispatch/litert_weight_binary_manager.h"
 #include "litert/vendors/samsung/schema/litert_samsung_header_generated.h"
 
 namespace litert::samsung {
@@ -207,7 +208,6 @@ LiteRtDispatchInvocationContextT::Create(
     const LiteRtMemBuffer* exec_bytecode_buffer, const char* function_name,
     int num_inputs, int num_outputs) {
 
-  counter.fetch_add(1);
   if (!enn_manager) {
     return litert::Error(kLiteRtStatusErrorRuntimeFailure,
                          "Fail to get enn runtime.");
@@ -218,6 +218,7 @@ LiteRtDispatchInvocationContextT::Create(
     litert::samsung::AnalyzeModelLoadStrategy(exec_bytecode_buffer));
 
   EnnModelId model_id;
+  std::vector<std::string> signatures;
 
   // Load model based on condition
   if (load_info.has_valid_header && load_info.use_external_weights) {
@@ -229,51 +230,28 @@ LiteRtDispatchInvocationContextT::Create(
     LITERT_LOG(LITERT_SILENT, "File descriptor: %d", load_info.fd);
     LITERT_LOG(LITERT_SILENT, "Model offset: %u, Model size: %u", load_info.model_offset, load_info.model_size);
 
-    WeightData weightdata;
+    auto& weight_mgr = litert::samsung::WeightBinaryManager::GetInstance(enn_manager);
     std::vector<EnnBufferPtr> weight_buffers;
-    int shared_weight = 0;
 
-    auto it = std::find_if(weightDatas.begin(), weightDatas.end(),
-      [&](const WeightData& m) {
-          return m.signature == load_info.signatures[0];
-      });
+    for (size_t i = 0; i < load_info.signatures.size(); i++) {
+      const auto& sig = load_info.signatures[i];
 
-    if (it == weightDatas.end()) {
-      LITERT_LOG(LITERT_VERBOSE, "not find the signature !");
-    } else {
-      LITERT_LOG(LITERT_VERBOSE, "find the signature !");
-      weight_buffers = it->weight_buffers;
-      shared_weight = 1;
-    }
-    if (!shared_weight) {
-      for (size_t i = 0; i < load_info.separated_weights.size(); i++) {
-        const auto& weight = load_info.separated_weights[i];
-        EnnBufferPtr weight_buffer;
-        size_t weight_size = weight.end_offset - weight.start_offset;
+      int64_t offset = 0;
+      size_t size = 0;
 
-        LITERT_LOG(LITERT_VERBOSE, "Creating weight buffer[%zu]: offset=%ld, size=%zu, signature=%s",
-                  i, weight.start_offset, weight_size, weight.signature.c_str());
-
-        // Create empty buffer
-        if (enn_manager->Api().EnnCreateBufferCache(weight_size, &weight_buffer) != ENN_RET_SUCCESS)
-          return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                              "Failed to create weight buffer");
-
-        // Read weight data from file using pread
-        ssize_t bytes_read = pread(load_info.fd, weight_buffer->va, weight_size, weight.start_offset);
-        if (bytes_read != static_cast<ssize_t>(weight_size))
-          return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                              "Failed to read weight data from file");
-
-        if (i == 0) {
-          //only update the first weight signature
-          weightdata.signature = weight.signature;
-        }
-        weightdata.weight_buffers.push_back(weight_buffer);
-        LITERT_LOG(LITERT_SILENT, "Weight buffer: %p, size=%d", weight_buffer->va, weight_buffer->size);
+      // If separated_weights has the corresponding entry, use its offset/size
+      if (!load_info.separated_weights.empty() &&
+          i < load_info.separated_weights.size()) {
+        offset = load_info.separated_weights[i].start_offset;
+        size = load_info.separated_weights[i].end_offset -
+               load_info.separated_weights[i].start_offset;
       }
-      weightDatas.push_back(weightdata);
-      weight_buffers = weightdata.weight_buffers;
+      auto buffer = weight_mgr.Acquire(sig, load_info.fd, offset, size);
+      if (!buffer) {
+        return buffer.Error();
+      }
+      weight_buffers.push_back(*buffer);
+      signatures.push_back(sig);
     }
 
     if (enn_manager->Api().EnnOpenModelWithFileOpenFdWeight(
@@ -335,23 +313,20 @@ LiteRtDispatchInvocationContextT::Create(
 
   model_guard.release();
 
-  return LiteRtDispatchInvocationContextT::UniquePtr(
+  auto context = LiteRtDispatchInvocationContextT::UniquePtr(
       new LiteRtDispatchInvocationContextT(enn_manager, device_context,
                                            model_id, num_inputs, num_outputs));
+
+  // Set weight signatures for later release
+  context->SetWeightSignatures(std::move(signatures));
+
+  return context;
 }
 
 LiteRtDispatchInvocationContextT::~LiteRtDispatchInvocationContextT() {
-  counter.fetch_sub(1);
-  if (!counter.load()) {
-    for (auto& wd : weightDatas) {
-        for (auto& buf : wd.weight_buffers) {
-            if (enn_manager_->Api().EnnReleaseBuffer(buf) != ENN_RET_SUCCESS) {
-              LITERT_LOG(LITERT_INFO, "EnnReleaseBuffer failed");
-            };
-        }
-        wd.weight_buffers.clear();
-    }
-    weightDatas.clear();
+  auto& weight_mgr = litert::samsung::WeightBinaryManager::GetInstance(enn_manager_);
+  for (const auto& sig : weight_signatures_) {
+    weight_mgr.Release(sig);
   }
 
   enn_manager_->Api().EnnCloseModel(model_id_);

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
@@ -60,6 +60,15 @@ class LiteRtDispatchInvocationContextT {
 
   litert::Expected<void> Invoke();
 
+  litert::Expected<EnnBufferPtr*> GetEnnCommittedBuffer(void) const {
+    return committed_buf_;
+  }
+
+  litert::Expected<void> SetEnnCommittedBuffer(EnnBufferPtr* update) {
+    committed_buf_ = update;
+    return {};
+  }
+
   void SetSchedulingInfo(const LiteRtSchedulingInfo* scheduling_info) {
     if (scheduling_info == nullptr) {
       scheduling_info_ = std::nullopt;
@@ -92,6 +101,7 @@ class LiteRtDispatchInvocationContextT {
   std::vector<EnnBufferPtr> inputs_buf_;
   std::vector<EnnBufferPtr> outputs_buf_;
   std::vector<std::string> weight_signatures_;
+  EnnBufferPtr* committed_buf_;
 };
 
 #endif  // ODML_LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
@@ -15,10 +15,11 @@
 // Copyright (C) 2026 Samsung Electronics Co. LTD.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_
-#define LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_
+#ifndef ODML_LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_
+#define ODML_LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_
 
 #include <optional>
+#include <atomic>
 
 #include "litert/c/internal/litert_scheduling_info.h"
 #include "litert/c/litert_model.h"
@@ -26,6 +27,11 @@
 #include "litert/cc/litert_expected.h"
 #include "litert/vendors/c/litert_dispatch.h"
 #include "litert/vendors/samsung/dispatch/enn_manager.h"
+
+struct WeightData {
+    std::vector<EnnBufferPtr> weight_buffers;
+    std::string signature;
+};
 
 class LiteRtDispatchInvocationContextT {
  public:
@@ -87,6 +93,8 @@ class LiteRtDispatchInvocationContextT {
   EnnModelId model_id_;
   std::vector<EnnBufferPtr> inputs_buf_;
   std::vector<EnnBufferPtr> outputs_buf_;
+  inline static std::vector<WeightData> weightDatas;
+  inline static std::atomic<int> counter{0};
 };
 
-#endif  // LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_
+#endif  // ODML_LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
@@ -19,7 +19,6 @@
 #define ODML_LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_
 
 #include <optional>
-#include <atomic>
 
 #include "litert/c/internal/litert_scheduling_info.h"
 #include "litert/c/litert_model.h"
@@ -27,11 +26,6 @@
 #include "litert/cc/litert_expected.h"
 #include "litert/vendors/c/litert_dispatch.h"
 #include "litert/vendors/samsung/dispatch/enn_manager.h"
-
-struct WeightData {
-    std::vector<EnnBufferPtr> weight_buffers;
-    std::string signature;
-};
 
 class LiteRtDispatchInvocationContextT {
  public:
@@ -87,14 +81,17 @@ class LiteRtDispatchInvocationContextT {
   litert::Expected<void> SetInputBuffers() const;
   litert::Expected<void> SetOutputBuffers() const;
 
+  void SetWeightSignatures(std::vector<std::string> signatures) {
+    weight_signatures_ = std::move(signatures);
+  }
+
   const ::litert::samsung::EnnManager* enn_manager_;
   LiteRtDispatchDeviceContext device_context_;
   std::optional<LiteRtSchedulingInfo> scheduling_info_;
   EnnModelId model_id_;
   std::vector<EnnBufferPtr> inputs_buf_;
   std::vector<EnnBufferPtr> outputs_buf_;
-  inline static std::vector<WeightData> weightDatas;
-  inline static std::atomic<int> counter{0};
+  std::vector<std::string> weight_signatures_;
 };
 
 #endif  // ODML_LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_

--- a/litert/vendors/samsung/dispatch/litert_weight_binary_manager.cc
+++ b/litert/vendors/samsung/dispatch/litert_weight_binary_manager.cc
@@ -1,0 +1,113 @@
+// Copyright (C) 2026 Samsung Electronics Co. LTD.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "litert/vendors/samsung/dispatch/litert_weight_binary_manager.h"
+
+#include <unistd.h>
+
+#include "litert/c/internal/litert_logging.h"
+
+namespace litert::samsung {
+
+WeightBinaryManager& WeightBinaryManager::GetInstance(
+    const EnnManager* enn_manager) {
+  static WeightBinaryManager instance(enn_manager);
+  return instance;
+}
+
+WeightBinaryManager::WeightBinaryManager(const EnnManager* enn_manager)
+    : enn_manager_(enn_manager) {}
+
+WeightBinaryManager::~WeightBinaryManager() {
+  ClearAll();
+}
+
+// Returns cached buffer if exists, otherwise creates new (from file-opened fd)
+litert::Expected<EnnBufferPtr> WeightBinaryManager::Acquire(
+    const std::string& signature, int fd, int64_t offset, size_t size) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Check cache first
+  auto it = std::find_if(
+      entries_.begin(), entries_.end(),
+      [&](const Entry& e) { return e.signature == signature; });
+
+  if (it != entries_.end()) {
+    it->ref_count++;
+    LITERT_LOG(LITERT_VERBOSE, "WeightBinaryManager: cache hit - %s",
+               signature.c_str());
+    return it->buffer;
+  }
+
+  // Cache miss - create new buffer
+  EnnBufferPtr buffer;
+  if (enn_manager_->Api().EnnCreateBufferCache(size, &buffer) != ENN_RET_SUCCESS) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                         "Failed to create weight buffer");
+  }
+
+  // Load data from file
+  ssize_t bytes_read = pread(fd, buffer->va, size, offset);
+  if (bytes_read != static_cast<ssize_t>(size)) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                         "Failed to read weight data");
+  }
+
+  entries_.push_back({signature, std::move(buffer), 1});
+  LITERT_LOG(LITERT_VERBOSE, "WeightBinaryManager: created - %s",
+             signature.c_str());
+
+  return entries_.back().buffer;
+}
+
+// Decrements ref count
+litert::Expected<void> WeightBinaryManager::Release(
+    const std::string& signature) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = std::find_if(
+      entries_.begin(), entries_.end(),
+      [&](const Entry& e) { return e.signature == signature; });
+
+  if (it == entries_.end()) {
+    return litert::Error(kLiteRtStatusErrorNotFound, "Signature not found");
+  }
+
+  it->ref_count--;
+  int new_count = it->ref_count;
+
+  if (new_count <= 0) {
+    if (it->buffer) {
+      enn_manager_->Api().EnnReleaseBuffer(it->buffer);
+    }
+    entries_.erase(it);
+  }
+
+  return {};
+}
+
+// Clears all cached weights
+void WeightBinaryManager::ClearAll() {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  for (auto& e : entries_) {
+    if (e.buffer) {
+      enn_manager_->Api().EnnReleaseBuffer(e.buffer);
+    }
+  }
+  entries_.clear();
+}
+
+}  // namespace litert::samsung

--- a/litert/vendors/samsung/dispatch/litert_weight_binary_manager.cc
+++ b/litert/vendors/samsung/dispatch/litert_weight_binary_manager.cc
@@ -16,6 +16,7 @@
 #include "litert/vendors/samsung/dispatch/litert_weight_binary_manager.h"
 
 #include <unistd.h>
+#include <cstring>
 
 #include "litert/c/internal/litert_logging.h"
 
@@ -35,7 +36,7 @@ WeightBinaryManager::~WeightBinaryManager() {
 }
 
 // Returns cached buffer if exists, otherwise creates new (from file-opened fd)
-litert::Expected<EnnBufferPtr> WeightBinaryManager::Acquire(
+litert::Expected<EnnBufferPtr> litert::samsung::WeightBinaryManager::Acquire(
     const std::string& signature, int fd, int64_t offset, size_t size) {
   std::lock_guard<std::mutex> lock(mutex_);
 
@@ -108,6 +109,44 @@ void WeightBinaryManager::ClearAll() {
     }
   }
   entries_.clear();
+}
+
+litert::Expected<EnnBufferPtr> WeightBinaryManager::Acquire(
+    const std::string& signature, const void* address, size_t size) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Check cache first
+  auto it = std::find_if(
+      entries_.begin(), entries_.end(),
+      [&](const Entry& e) { return e.signature == signature; });
+
+  if (it != entries_.end()) {
+    it->ref_count++;
+    LITERT_LOG(LITERT_VERBOSE, "WeightBinaryManager: cache hit - %s",
+               signature.c_str());
+    return it->buffer;
+  }
+
+  // Cache miss - create new buffer
+  EnnBufferPtr buffer;
+  if (enn_manager_->Api().EnnCreateBufferCache(size, &buffer) != ENN_RET_SUCCESS) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                         "Failed to create weight buffer");
+  }
+
+  // Copy data from memory address into buffer
+  if (address == nullptr) {
+    enn_manager_->Api().EnnReleaseBuffer(buffer);
+    return litert::Error(kLiteRtStatusErrorInvalidArgument,
+                         "Null address provided for weight acquisition");
+  }
+  std::memcpy(buffer->va, address, size);
+
+  entries_.push_back({signature, std::move(buffer), 1});
+  LITERT_LOG(LITERT_VERBOSE, "WeightBinaryManager: created from memory - %s",
+             signature.c_str());
+
+  return entries_.back().buffer;
 }
 
 }  // namespace litert::samsung

--- a/litert/vendors/samsung/dispatch/litert_weight_binary_manager.h
+++ b/litert/vendors/samsung/dispatch/litert_weight_binary_manager.h
@@ -38,6 +38,9 @@ class WeightBinaryManager {
   // Returns cached buffer if exists, otherwise creates new (from file-opened fd)
   litert::Expected<EnnBufferPtr> Acquire(const std::string& signature,
                                           int fd, int64_t offset, size_t size);
+  // Acquire from memory address without file descriptor
+  litert::Expected<EnnBufferPtr> Acquire(const std::string& signature,
+                                          const void* address, size_t size);
 
   // Decrements ref count
   litert::Expected<void> Release(const std::string& signature);

--- a/litert/vendors/samsung/dispatch/litert_weight_binary_manager.h
+++ b/litert/vendors/samsung/dispatch/litert_weight_binary_manager.h
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 Samsung Electronics Co. LTD.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ODML_LITERT_VENDORS_SAMSUNG_DISPATCH_LITERT_WEIGHT_BINARY_MANAGER_H_
+#define ODML_LITERT_VENDORS_SAMSUNG_DISPATCH_LITERT_WEIGHT_BINARY_MANAGER_H_
+
+#pragma once
+
+#include <string>
+#include <list>
+#include <atomic>
+#include <mutex>
+
+#include "litert/cc/litert_expected.h"
+#include "litert/vendors/samsung/dispatch/enn_manager.h"
+
+namespace litert::samsung {
+
+class WeightBinaryManager {
+ public:
+  static WeightBinaryManager& GetInstance(const EnnManager* enn_manager);
+
+  WeightBinaryManager(const WeightBinaryManager&) = delete;
+  WeightBinaryManager& operator=(const WeightBinaryManager&) = delete;
+
+  // Returns cached buffer if exists, otherwise creates new (from file-opened fd)
+  litert::Expected<EnnBufferPtr> Acquire(const std::string& signature,
+                                          int fd, int64_t offset, size_t size);
+
+  // Decrements ref count
+  litert::Expected<void> Release(const std::string& signature);
+
+  // Clears all cached weights
+  void ClearAll();
+
+ private:
+  explicit WeightBinaryManager(const EnnManager* enn_manager);
+  ~WeightBinaryManager();
+
+  struct Entry {
+    std::string signature;
+    EnnBufferPtr buffer;
+    int ref_count = 0;
+  };
+
+  const EnnManager* enn_manager_;
+  std::list<Entry> entries_;
+  std::mutex mutex_;
+};
+
+}  // namespace litert::samsung
+
+#endif  // ODML_LITERT_VENDORS_SAMSUNG_DISPATCH/LITERT_WEIGHT_BINARY_MANAGER_H_
+

--- a/litert/vendors/samsung/schema/BUILD
+++ b/litert/vendors/samsung/schema/BUILD
@@ -1,0 +1,60 @@
+# Copyright (C) 2026 Samsung Electronics Co. LTD.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@flatbuffers//:build_defs.bzl", "flatbuffer_cc_library")
+
+package(
+    # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
+    default_visibility = ["//litert/vendors/samsung:__subpackages__"],
+)
+
+flatbuffer_cc_library(
+    name = "litert_samsung_header",
+    srcs = ["litert_samsung_header.fbs"],
+    flatc_args = [
+        "--gen-mutable",
+        "--gen-object-api",
+    ],
+)
+
+cc_library(
+    name = "samsung_byte_code",
+    srcs = ["samsung_byte_code.cc"],
+    hdrs = ["samsung_byte_code.h"],
+    deps = [
+        "//litert/c/internal:litert_logging",
+        "//litert/cc:litert_expected",
+        "//litert/cc:litert_macros",
+        "//litert/vendors/samsung/schema:litert_samsung_header",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+
+
+cc_binary(
+    name = "byte_code_print",
+    srcs = ["byte_code_print.cc"],
+    deps = [
+        "//litert/c/internal:litert_logging",
+        "//litert/cc:litert_expected",
+        "//litert/cc:litert_macros",
+        "//litert/vendors/samsung/schema:litert_samsung_header",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+    ],
+)

--- a/litert/vendors/samsung/schema/CMakeLists.txt
+++ b/litert/vendors/samsung/schema/CMakeLists.txt
@@ -1,0 +1,106 @@
+# Copyright (C) 2026 Samsung Electronics Co. LTD.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Samsung Dispatch API Shared Library
+cmake_minimum_required(VERSION 3.20)
+
+set(FLATC_EXECUTABLE "")
+
+if(TFLITE_HOST_TOOLS_DIR AND EXISTS "${TFLITE_HOST_TOOLS_DIR}/flatc")
+  set(FLATC_EXECUTABLE "${TFLITE_HOST_TOOLS_DIR}/flatc")
+elseif(TFLITE_BUILD_DIR AND EXISTS "${TFLITE_BUILD_DIR}/host_flatc/_deps/flatbuffers-build/flatc")
+  set(FLATC_EXECUTABLE "${TFLITE_BUILD_DIR}/host_flatc/_deps/flatbuffers-build/flatc")
+elseif(TFLITE_BUILD_DIR AND EXISTS "${TFLITE_BUILD_DIR}/_deps/flatbuffers-build/flatc")
+  set(FLATC_EXECUTABLE "${TFLITE_BUILD_DIR}/_deps/flatbuffers-build/flatc")
+endif()
+
+if(NOT FLATC_EXECUTABLE)
+  find_program(FLATC_EXECUTABLE NAMES flatc)
+endif()
+
+if(NOT FLATC_EXECUTABLE)
+  message(STATUS "flatc not found in PATH; fetching FlatBuffers to build flatc")
+  include(FetchContent)
+  FetchContent_Declare(flatbuffers
+    GIT_REPOSITORY https://github.com/google/flatbuffers.git
+    GIT_TAG v25.9.23
+  )
+  set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(flatbuffers)
+  if(NOT TARGET flatc)
+    message(FATAL_ERROR "FlatBuffers 'flatc' target not available after fetch")
+  endif()
+  set(FLATC_EXECUTABLE $<TARGET_FILE:flatc>)
+endif()
+
+# Generate FlatBuffer C++ header from schema
+set(_samsung_gen_dir "${CMAKE_CURRENT_BINARY_DIR}/generated/include/litert/vendors/samsung/schema")
+file(MAKE_DIRECTORY "${_samsung_gen_dir}")
+
+set(_samsung_schema "${CMAKE_CURRENT_SOURCE_DIR}/litert_samsung_header.fbs")
+set(_samsung_gen_hdr "${_samsung_gen_dir}/litert_samsung_header_generated.h")
+
+add_custom_command(
+  OUTPUT "${_samsung_gen_hdr}"
+  COMMAND ${FLATC_EXECUTABLE} --cpp --gen-mutable --gen-object-api -o "${_samsung_gen_dir}" "${_samsung_schema}"
+  DEPENDS "${_samsung_schema}"
+  COMMENT "Generating Samsung litert_samsung_header_generated.h with flatc"
+  VERBATIM
+)
+
+add_custom_target(samsung_schema_gen DEPENDS "${_samsung_gen_hdr}")
+
+# Samsung byte code library
+add_library(samsung_byte_code STATIC
+    samsung_byte_code.cc
+)
+
+add_dependencies(samsung_byte_code samsung_schema_gen)
+
+target_include_directories(samsung_byte_code
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated/include>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/..>
+)
+
+target_link_libraries(samsung_byte_code
+    PUBLIC
+        flatbuffers::flatbuffers
+        absl::span
+        absl::strings
+    PRIVATE
+        litert_cc_internal
+)
+
+# Byte code print tool
+add_executable(byte_code_print byte_code_print.cc)
+
+add_dependencies(byte_code_print samsung_schema_gen)
+
+target_include_directories(byte_code_print
+    PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated/include>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/..>
+)
+
+target_link_libraries(byte_code_print
+    PRIVATE
+        samsung_byte_code
+        absl::flags
+        absl::flags_parse
+)

--- a/litert/vendors/samsung/schema/byte_code_print.cc
+++ b/litert/vendors/samsung/schema/byte_code_print.cc
@@ -1,0 +1,159 @@
+// Copyright (C) 2026 Samsung Electronics Co. LTD.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/flag.h"          // from @com_google_absl
+#include "absl/flags/parse.h"         // from @com_google_absl
+#include "absl/strings/str_format.h"  // from @com_google_absl
+#include "absl/strings/string_view.h" // from @com_google_absl
+#include "litert/cc/litert_expected.h"
+#include "litert/cc/litert_macros.h"
+#include "litert/vendors/samsung/schema/litert_samsung_header_generated.h"
+
+ABSL_FLAG(std::string, model_path, {},
+          "Please provide the bytecode path. If you don't have one,"
+          "extract_bytecode tool may help you get from tflite model.");
+
+namespace litert::samsung {
+
+static constexpr absl::string_view kStandardFormat = R"(
+    __    _ __       ____  __
+   / /   (_/ /____  / __ \/ /_
+  / /   / / __/ _ \/ /_/ / __/
+ / /___/ / /_/  __/ _, _/ /_
+/_____/_/\__/\___/_/ |_|\__/
+
+File Size  :  %d
+ ___________________________________
+ |  HEADER                          |
+ |----------------------------------|
+ |    Version:  %2d                 |
+ |----------------------------------|
+ |    Dispatch: [0]                 |
+ |      Offset:         : %8d  |
+ |      Size            : %8d  |
+ |      External Weights: %8s  |
+ |      Used Weights    :           |%s
+ |----------------------------------|%s
+ |  BINARIES   ......               |
+ |__________________________________|
+)";
+
+static constexpr absl::string_view kAuxFormat = R"(
+ |         Signature [%d]:           |
+ |           %16s        |)";
+
+static constexpr absl::string_view kWeightFormat = R"(
+ |    Weight:  [%d]                  |
+ |      Offset   :  %8d        |
+ |      Size     :  %8d        |
+ |      Signature:  %16s |
+ |----------------------------------|)";
+
+Expected<void> PrintByteCode(const std::string& model_path) {
+  std::ifstream infile(model_path, std::ios::binary | std::ios::ate);
+  if (!infile) {
+    return Unexpected(kLiteRtStatusErrorInvalidArgument,
+                      absl::StrCat("Cannot open source file: ", model_path));
+  }
+
+  std::streamsize file_size = infile.tellg();
+  infile.seekg(0, std::ios::beg);
+  std::vector<char> buffer(file_size);
+
+  if (!infile.read(buffer.data(), file_size)) {
+    return Unexpected(
+        kLiteRtStatusErrorInvalidArgument,
+        absl::StrCat("Failed to read from source file: ", model_path));
+  }
+  infile.close();
+
+  auto *header_buf = schema::GetLiteRTSamsungHeader(buffer.data());
+
+  bool is_valid_header = false;
+  if (header_buf != nullptr) {
+    // Verify the structure (without mandatory file identifier)
+    flatbuffers::Verifier verifier(
+        reinterpret_cast<const uint8_t*>(buffer.data()),
+        file_size);
+
+    is_valid_header = header_buf->Verify(verifier);
+
+    // Also check if file identifier exists
+    bool has_identifier = schema::LiteRTSamsungHeaderBufferHasIdentifier(buffer.data());
+
+    LITERT_LOG(LITERT_INFO, "Buffer: %p, Size: %d, Has valid vtable: %s, Has identifier: %s",
+               buffer.data(), file_size, is_valid_header ? "true" : "false",
+               has_identifier ? "true" : "false");
+  }
+
+  if (!is_valid_header) {
+    return Unexpected(kLiteRtStatusErrorInvalidArgument,
+                      "Invalid LiteRT Samsung Header - failed to parse or verify");
+  }
+  auto dispatch_binary = header_buf->dispatch_binary();
+
+  std::string w_signatures;
+  int32_t external_weights_size =
+      dispatch_binary->external_weights()
+          ? dispatch_binary->external_weights()->size()
+          : 0;
+  for (int32_t index = 0; index < external_weights_size; index++) {
+    w_signatures += absl::StrFormat(
+        kAuxFormat, index,
+        dispatch_binary->external_weights()->Get(index)->c_str());
+  }
+
+  std::string weights_memo;
+  if (header_buf->separated_weights()) {
+    for (int32_t index = 0; index < header_buf->separated_weights()->size();
+         index++) {
+      auto weight = header_buf->separated_weights()->Get(index);
+      weights_memo += absl::StrFormat(
+          kWeightFormat, index, weight->buf()->start_offset(),
+          weight->buf()->end_offset() - weight->buf()->start_offset(),
+          weight->signature()->c_str());
+    }
+  }
+
+  auto show =
+      absl::StrFormat(kStandardFormat, file_size, header_buf->version(),
+                      dispatch_binary->buf()->start_offset(),
+                      dispatch_binary->buf()->end_offset() -
+                          dispatch_binary->buf()->start_offset(),
+                      dispatch_binary->use_external_weights() ? "Yes" : "No",
+                      w_signatures.c_str(), weights_memo.c_str());
+
+  std::cerr << show << std::endl;
+
+  return {};
+}
+
+} // namespace litert::samsung
+
+int main(int argc, char *argv[]) {
+  absl::ParseCommandLine(argc, argv);
+
+  std::string model_path = absl::GetFlag(FLAGS_model_path);
+  auto result = litert::samsung::PrintByteCode(model_path);
+
+  return static_cast<int>(!result.HasValue());
+}

--- a/litert/vendors/samsung/schema/litert_samsung_header.fbs
+++ b/litert/vendors/samsung/schema/litert_samsung_header.fbs
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 Samsung Electronics Co. LTD.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+namespace litert.samsung.schema;
+
+// Identifier - LiteRT Schema of Samsung Header
+file_identifier "LSSH";
+
+table BufferSection {
+  start_offset: int64;
+  end_offset: int64;
+}
+
+table DispatchBinary {
+  // Buffer location of dispatch binary storage.
+  buf: BufferSection;
+
+  // When use external weights, external_weights should be filled
+  // too, and it is used to find the target weights.
+  use_external_weights: bool;
+  external_weights: [string];
+}
+
+table SeparatedWeights {
+  // Buffer location of weights storage.
+  buf: BufferSection;
+
+  // Identifier for weights.
+  signature: string;
+}
+
+table LiteRTSamsungHeader {
+  // Schema version to validate
+  version: uint;
+
+  // Output binary compiled from subgraph, used in execution of dispatch op.
+  // This is required and should not be empty.
+  dispatch_binary : DispatchBinary;
+
+  // Weight storage of model.
+  separated_weights : [SeparatedWeights];
+}
+
+root_type LiteRTSamsungHeader;

--- a/litert/vendors/samsung/schema/samsung_byte_code.cc
+++ b/litert/vendors/samsung/schema/samsung_byte_code.cc
@@ -1,0 +1,197 @@
+// Copyright (C) 2026 Samsung Electronics Co. LTD.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "litert/vendors/samsung/schema/samsung_byte_code.h"
+
+#include "litert/c/internal/litert_logging.h"
+#include "litert/cc/litert_macros.h"
+#include "litert/vendors/samsung/schema/litert_samsung_header_generated.h"
+
+namespace litert::samsung {
+
+std::string GenerateSignature(const absl::Span<const char>& weights) {
+  auto seed = weights.size();
+  for (const auto& x : weights) {
+    seed ^= x + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  }
+
+  LITERT_LOG(LITERT_INFO, "Seed %lu", seed);
+
+  static char item[] = "0123456789abcedf";
+  std::string signature;
+  for (int i = 0; i < sizeof(seed) * 2 /*= 8/4*/; i++) {
+    signature += item[int(seed & 0x0F)];
+    seed = seed >> 4;
+  }
+
+  return signature;
+}
+
+Expected<uint64_t> UpdateBufferOffset(uint64_t start_offset,
+                                      const absl::Span<const char>& data,
+                                      schema::BufferSection *const buf) {
+  start_offset = ForceAlignSize(start_offset);
+  uint64_t end_offset = start_offset + data.size();
+  if (!buf->mutate_start_offset(start_offset) ||
+      !buf->mutate_end_offset(end_offset)) {
+    return Error(kLiteRtStatusErrorRuntimeFailure,
+                 "Fail to update buffer section's offset");
+  }
+
+  return end_offset;
+}
+
+Expected<SamsungByteCode::ByteCodeT> SamsungByteCode::CreateImpl(
+    const absl::Span<const char>& dispatch_binary,
+    const std::vector<std::string>& signatures,
+    const std::vector<absl::Span<const char>> *weights) {
+  // Don't use external weight if signature not provided.
+  bool use_external_weights = !signatures.empty();
+
+  if (weights != nullptr) {
+    // Ensure valid data exist in weight
+    for (auto& weight : *weights) {
+      if (weight.data() == nullptr || weight.size() == 0) {
+        return Error(kLiteRtStatusErrorInvalidArgument,
+                     "Invalid separated weights.");
+      }
+    }
+    if (signatures.size() != weights->size()) {
+      return Error(kLiteRtStatusErrorInvalidArgument,
+                   "Require number of signatures match weights' number.");
+    }
+  }
+
+  flatbuffers::FlatBufferBuilder builder;
+  std::vector<flatbuffers::Offset<flatbuffers::String>> fb_signatures;
+  std::vector<flatbuffers::Offset<schema::SeparatedWeights>>
+      fb_separated_weights;
+  if (use_external_weights) {
+    for (auto& sig : signatures) {
+      fb_signatures.emplace_back(builder.CreateString(sig.c_str()));
+
+      if (weights != nullptr) {
+        fb_separated_weights.emplace_back(schema::CreateSeparatedWeightsDirect(
+            builder, schema::CreateBufferSection(builder, 1, 1), sig.c_str()));
+      }
+    }
+  }
+
+  auto fb_dispatch_binary = schema::CreateDispatchBinaryDirect(
+      builder, schema::CreateBufferSection(builder, 1, 1), use_external_weights,
+      use_external_weights ? &fb_signatures : nullptr);
+
+  auto header_root = schema::CreateLiteRTSamsungHeaderDirect(
+      builder, SAMSUNG_BYTE_CODE_HEADER_MAJOR_VERSION, fb_dispatch_binary,
+      !fb_separated_weights.empty() ? &fb_separated_weights : nullptr);
+  builder.Finish(header_root);
+
+  uint8_t *buffer = builder.GetBufferPointer();
+  size_t header_size = builder.GetSize();
+  // Update the offset
+  auto mutable_header = schema::GetMutableLiteRTSamsungHeader(buffer);
+
+  uint64_t cursor = header_size;
+  LITERT_ASSIGN_OR_RETURN(
+      cursor, UpdateBufferOffset(
+                  cursor, dispatch_binary,
+                  mutable_header->mutable_dispatch_binary()->mutable_buf()));
+
+  if (weights != nullptr && !weights->empty()) {
+    auto mutable_separated_weights =
+        mutable_header->mutable_separated_weights();
+    for (int32_t index = 0; index < weights->size(); index++) {
+      LITERT_ASSIGN_OR_RETURN(
+          cursor,
+          UpdateBufferOffset(cursor, weights->at(index),
+                             mutable_separated_weights->GetMutableObject(index)
+                                 ->mutable_buf()));
+    }
+  }
+
+  // Copy to buffer
+  auto byte_code_buf = ByteCodeT(cursor);
+  memcpy(byte_code_buf.data(), buffer, header_size);
+  memcpy(byte_code_buf.data() +
+             mutable_header->dispatch_binary()->buf()->start_offset(),
+         dispatch_binary.data(), dispatch_binary.size());
+  if (weights != nullptr && !weights->empty()) {
+    for (int32_t index = 0; index < weights->size(); index++) {
+      auto separated_weight = mutable_header->separated_weights()->Get(index);
+      memcpy(byte_code_buf.data() + separated_weight->buf()->start_offset(),
+             weights->at(index).data(), weights->at(index).size());
+    }
+  }
+
+  return byte_code_buf;
+}
+
+Expected<SamsungByteCode::UniquePtr>
+SamsungByteCode::Create(const absl::Span<const char>& dispatch_binary,
+                        const std::vector<absl::Span<const char>>& weights) {
+  auto dispatch_binary_size = dispatch_binary.size();
+  if (dispatch_binary.data() == nullptr || dispatch_binary_size == 0) {
+    return Error(kLiteRtStatusErrorInvalidArgument,
+                 "Dispatch binary compiled from subgraph is invalid.");
+  }
+
+  std::vector<std::string> signatures;
+  for (auto& weight : weights) {
+    signatures.emplace_back(GenerateSignature(weight));
+  }
+  LITERT_ASSIGN_OR_RETURN(auto byte_code_buf,
+                          CreateImpl(dispatch_binary, signatures, &weights));
+
+  return SamsungByteCode::UniquePtr(
+      new SamsungByteCode(std::move(byte_code_buf), signatures));
+}
+
+Expected<SamsungByteCode::UniquePtr> SamsungByteCode::Create(
+    const absl::Span<const char> &dispatch_binary,
+    const std::vector<std::string> &external_weight_signatures) {
+  auto dispatch_binary_size = dispatch_binary.size();
+  if (dispatch_binary.data() == nullptr || dispatch_binary_size == 0) {
+    return Error(kLiteRtStatusErrorInvalidArgument,
+                 "Dispatch binary compiled from subgraph is invalid.");
+  }
+
+  LITERT_ASSIGN_OR_RETURN(
+      auto byte_code_buf,
+      CreateImpl(dispatch_binary, external_weight_signatures));
+  return SamsungByteCode::UniquePtr(new SamsungByteCode(
+      std::move(byte_code_buf), external_weight_signatures));
+}
+
+SamsungByteCode::SamsungByteCode(
+    ByteCodeT&& byte_code, const std::vector<std::string>& weight_signatures)
+    : byte_code_(byte_code), external_weight_signatures_(weight_signatures) {}
+
+bool SamsungByteCode::HasExternalWeights() const {
+  return !external_weight_signatures_.empty();
+}
+
+LiteRtStatus SamsungByteCode::GetWeightSignatures(
+    std::vector<std::string>& signatures) const {
+  signatures = external_weight_signatures_;
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus SamsungByteCode::Dump(std::vector<char>& output) {
+  output.swap(byte_code_);
+  byte_code_.clear();
+
+  return kLiteRtStatusOk;
+}
+} // namespace litert::samsung

--- a/litert/vendors/samsung/schema/samsung_byte_code.h
+++ b/litert/vendors/samsung/schema/samsung_byte_code.h
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Samsung Electronics Co. LTD.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ODML_LITERT_VENDORS_SAMSUNG_SCHEMA_BYTE_CODE_H_
+#define ODML_LITERT_VENDORS_SAMSUNG_SCHEMA_BYTE_CODE_H_
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "litert/c/litert_common.h"
+#include "litert/cc/litert_expected.h"
+
+#include "absl/types/span.h"
+
+namespace litert::samsung {
+
+#define SAMSUNG_BYTE_CODE_HEADER_MAJOR_VERSION 1
+#define SAMSUNG_BYTE_CODE_HEADER_MINOR_VERSION 0
+
+#define SAMSUNG_BYTE_CODE_ALIGNMENT 64
+
+// Returns true if the content is a LiteRT-LM file.
+//
+// Args:
+//   content: The content of the file to check.
+//
+// Returns:
+//   True if the content is a LiteRT-LM file, false otherwise.
+// bool IsSamsungByteCode(absl::string_view content);
+
+inline size_t ForceAlignSize(size_t size) {
+  return ((size + SAMSUNG_BYTE_CODE_ALIGNMENT - 1) /
+          SAMSUNG_BYTE_CODE_ALIGNMENT) *
+         SAMSUNG_BYTE_CODE_ALIGNMENT;
+}
+
+class SamsungByteCode {
+public:
+  using UniquePtr = std::unique_ptr<SamsungByteCode>;
+  using ByteCodeT = std::vector<char>;
+
+  static Expected<UniquePtr>
+  Create(const absl::Span<const char>& dispatch_binary,
+         const std::vector<absl::Span<const char>>& weights);
+
+  static Expected<UniquePtr>
+  Create(const absl::Span<const char>& dispatch_binary,
+         const std::vector<std::string>& external_weight_signatures);
+
+  SamsungByteCode(SamsungByteCode &) = delete;
+  SamsungByteCode &operator=(const SamsungByteCode &) = delete;
+
+  LiteRtStatus GetWeightSignatures(std::vector<std::string>& signatures) const;
+  bool HasExternalWeights() const;
+
+  Expected<uint64_t> GetByteCodeSize() const { return byte_code_.size(); }
+
+  // Dump byte code to given vector, and byte code in the class will be
+  // expired, and no longer valid.
+  LiteRtStatus Dump(std::vector<char>& output);
+
+private:
+  SamsungByteCode(ByteCodeT&& byte_code,
+                  const std::vector<std::string>& weight_signature);
+
+  static Expected<ByteCodeT>
+  CreateImpl(const absl::Span<const char>& dispatch_binary,
+             const std::vector<std::string>& signatures,
+             const std::vector<absl::Span<const char>> *weights = nullptr);
+
+  ByteCodeT byte_code_;
+  std::vector<std::string> external_weight_signatures_;
+};
+
+} // namespace litert::samsung
+
+#endif // ODML_LITERT_VENDORS_SAMSUNG_SCHEMA_BYTE_CODE_H_


### PR DESCRIPTION
For weigh sharing between subgraphs, it should be used exynos own schema.

So it should be define Exynos Schema and used it.

- Introduce Exynos Schema
- optimized EnnOpenModel for memory efficiency
- Support weight sharing between subgraphs
- Add weight manager for Exynos


