### PR TITLE
Qualcomm AI Engine Direct - Inline the I/O arrays into the CreateOpWithSameParams() call.

### DIFF
--- a/litert/vendors/qualcomm/core/transformation/embedding_gemma.cc
+++ b/litert/vendors/qualcomm/core/transformation/embedding_gemma.cc
@@ -60,12 +60,9 @@ const TensorWrapper& BuildSingleSHA(
   new_matmul1_output_dim[2] /= num_heads;
   const auto& new_matmul1_output = tensor_pool.CloneNativeTensorFrom(
       matmul_op1_output, new_matmul1_output_dim);
-  const std::array<ConstTensorWrapperRef, 2> matmul_1_inputs = {
-      mul_output, matmul_op1.GetInputTensor(1)};
-  const std::array<ConstTensorWrapperRef, 1> matmul_1_outputs = {
-      new_matmul1_output};
-  new_ops.emplace_back(
-      CreateOpWithSameParams(matmul_op1, matmul_1_inputs, matmul_1_outputs));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      matmul_op1, {mul_output, matmul_op1.GetInputTensor(1)},
+      {new_matmul1_output}));
 
   // Add
   const auto& new_add_output = tensor_pool.CloneNativeTensorFrom(
@@ -76,22 +73,17 @@ const TensorWrapper& BuildSingleSHA(
   // Softmax
   const auto& softmax_output = tensor_pool.CloneNativeTensorFrom(
       softmax_op.GetOutputTensor(0), new_add_output.GetDimensions());
-  const std::array<ConstTensorWrapperRef, 1> softmax_inputs = {new_add_output};
-  const std::array<ConstTensorWrapperRef, 1> softmax_outputs = {softmax_output};
   new_ops.emplace_back(
-      CreateOpWithSameParams(softmax_op, softmax_inputs, softmax_outputs));
+      CreateOpWithSameParams(softmax_op, {new_add_output}, {softmax_output}));
 
   // MatMul 2
   auto matmul_op2_out_dim = matmul_op2.GetOutputTensor(0).GetDimensions();
   matmul_op2_out_dim[2] /= num_heads;
   const auto& new_matmul2_output = tensor_pool.CloneNativeTensorFrom(
       matmul_op2.GetOutputTensor(0), matmul_op2_out_dim);
-  const std::array<ConstTensorWrapperRef, 2> matmul_2_inputs = {
-      softmax_output, matmul_op2.GetInputTensor(1)};
-  const std::array<ConstTensorWrapperRef, 1> matmul_2_outputs = {
-      new_matmul2_output};
-  new_ops.emplace_back(
-      CreateOpWithSameParams(matmul_op2, matmul_2_inputs, matmul_2_outputs));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      matmul_op2, {softmax_output, matmul_op2.GetInputTensor(1)},
+      {new_matmul2_output}));
   return new_matmul2_output;
 }
 
@@ -110,11 +102,8 @@ std::vector<OpWrapper> MHA2SHA(TensorPool& tensor_pool, const OpWrapper& mul_op,
   auto transpose_out_dims = tranpose_op1.GetOutputTensor(0).GetDimensions();
   const auto& transpose_output =
       tensor_pool.CloneNativeTensorFrom(pattern_input, transpose_out_dims);
-  const std::array<ConstTensorWrapperRef, 1> transpose_inputs = {pattern_input};
-  const std::array<ConstTensorWrapperRef, 1> transpose_outputs = {
-      transpose_output};
   auto& new_transpose1 = new_ops.emplace_back(CreateOpWithSameParams(
-      tranpose_op1, transpose_inputs, transpose_outputs));
+      tranpose_op1, {pattern_input}, {transpose_output}));
 
   const uint32_t num_heads = pattern_input.GetDimension(2);
   const auto& mha_input = new_transpose1.GetOutputTensor(0);  // split_in

--- a/litert/vendors/qualcomm/core/transformation/matmul_convert.cc
+++ b/litert/vendors/qualcomm/core/transformation/matmul_convert.cc
@@ -28,12 +28,9 @@ size_t FuseMatMulConvertDecode(
   }
   // Graph transform
   QNN_LOG_INFO("[G2G] MatMul-convert fusion (Decode)");
-  const std::array<ConstTensorWrapperRef, 2> matmul_inputs = {
-      matmul.GetInputTensor(0), matmul.GetInputTensor(1)};
-  const std::array<ConstTensorWrapperRef, 1> matmul_outputs = {
-      convert.GetOutputTensor(0)};
-  auto new_matmul =
-      CreateOpWithSameParams(matmul, matmul_inputs, matmul_outputs);
+  auto new_matmul = CreateOpWithSameParams(
+      matmul, {matmul.GetInputTensor(0), matmul.GetInputTensor(1)},
+      {convert.GetOutputTensor(0)});
   if (validate_op_config(new_matmul)) {
     ops.erase(ops.begin() + start_index,
               ops.begin() + start_index + pattern_size);
@@ -57,12 +54,9 @@ size_t FuseMatMulConvertPrefill(
   }
   // Graph transform
   QNN_LOG_INFO("[G2G] MatMul-convert fusion (Prefill)");
-  const std::array<ConstTensorWrapperRef, 2> matmul_inputs = {
-      matmul.GetInputTensor(0), matmul.GetInputTensor(1)};
-  const std::array<ConstTensorWrapperRef, 1> matmul_outputs = {
-      convert.GetOutputTensor(0)};
-  auto new_matmul =
-      CreateOpWithSameParams(matmul, matmul_inputs, matmul_outputs);
+  auto new_matmul = CreateOpWithSameParams(
+      matmul, {matmul.GetInputTensor(0), matmul.GetInputTensor(1)},
+      {convert.GetOutputTensor(0)});
   if (validate_op_config(new_matmul)) {
     ops.erase(ops.begin() + start_index + 2);
     ops.erase(ops.begin() + start_index);

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
@@ -84,35 +84,26 @@ const TensorWrapper& BuildSingleSHA(
   matmul_k1_output_dims[2] /= num_heads;
   const auto& matmul_k1_output = tensor_pool.CloneNativeTensorFrom(
       matmul_k1.GetOutputTensor(0), matmul_k1_output_dims);
-  const std::array<ConstTensorWrapperRef, 2> matmul_k1_inputs = {
-      mul_output, matmul_k1.GetInputTensor(1)};
-  const std::array<ConstTensorWrapperRef, 1> matmul_k1_outputs = {
-      matmul_k1_output};
-  new_ops.emplace_back(
-      CreateOpWithSameParams(matmul_k1, matmul_k1_inputs, matmul_k1_outputs));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      matmul_k1, {mul_output, matmul_k1.GetInputTensor(1)},
+      {matmul_k1_output}));
 
   // MatMul 2
   auto matmul_k2_output_dims = matmul_k2.GetOutputTensor(0).GetDimensions();
   matmul_k2_output_dims[2] /= num_heads;
   const auto& matmul_k2_output = tensor_pool.CloneNativeTensorFrom(
       matmul_k2.GetOutputTensor(0), matmul_k2_output_dims);
-  const std::array<ConstTensorWrapperRef, 2> matmul_k2_inputs = {
-      mul_output, matmul_k2.GetInputTensor(1)};
-  const std::array<ConstTensorWrapperRef, 1> matmul_k2_outputs = {
-      matmul_k2_output};
-  new_ops.emplace_back(
-      CreateOpWithSameParams(matmul_k2, matmul_k2_inputs, matmul_k2_outputs));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      matmul_k2, {mul_output, matmul_k2.GetInputTensor(1)},
+      {matmul_k2_output}));
 
   // Concat
   auto concat_output_dims = matmul_k1_output_dims;
   concat_output_dims[3] += matmul_k2_output_dims[3];
   const auto& concat_output = tensor_pool.CloneNativeTensorFrom(
       concat.GetOutputTensor(0), concat_output_dims);
-  const std::array<ConstTensorWrapperRef, 2> concat_inputs = {matmul_k1_output,
-                                                              matmul_k2_output};
-  const std::array<ConstTensorWrapperRef, 1> concat_outputs = {concat_output};
-  new_ops.emplace_back(
-      CreateOpWithSameParams(concat, concat_inputs, concat_outputs));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      concat, {matmul_k1_output, matmul_k2_output}, {concat_output}));
 
   // Add
   const auto& add_1_output = tensor_pool.CloneNativeTensorFrom(
@@ -122,10 +113,8 @@ const TensorWrapper& BuildSingleSHA(
   // Softmax
   const auto& softmax_output = tensor_pool.CloneNativeTensorFrom(
       softmax.GetOutputTensor(0), add_1_output.GetDimensions());
-  const std::array<ConstTensorWrapperRef, 1> softmax_inputs = {add_1_output};
-  const std::array<ConstTensorWrapperRef, 1> softmax_outputs = {softmax_output};
   new_ops.emplace_back(
-      CreateOpWithSameParams(softmax, softmax_inputs, softmax_outputs));
+      CreateOpWithSameParams(softmax, {add_1_output}, {softmax_output}));
 
   // Slice 1
   auto slice_1_ranges = slice_1.GetTensorParam(0).GetTensor();
@@ -167,12 +156,9 @@ const TensorWrapper& BuildSingleSHA(
   matmul_v1_output_dims[2] = matmul_v1_output_dims[2] / num_heads;
   const auto& matmul_v1_output = tensor_pool.CloneNativeTensorFrom(
       matmul_v1.GetOutputTensor(0), matmul_v1_output_dims);
-  const std::array<ConstTensorWrapperRef, 2> matmul_v1_inputs = {
-      slice_1_output, matmul_v1.GetInputTensor(1)};
-  const std::array<ConstTensorWrapperRef, 1> matmul_v1_outputs = {
-      matmul_v1_output};
-  new_ops.emplace_back(
-      CreateOpWithSameParams(matmul_v1, matmul_v1_inputs, matmul_v1_outputs));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      matmul_v1, {slice_1_output, matmul_v1.GetInputTensor(1)},
+      {matmul_v1_output}));
 
   // MatMul 2
   std::vector<uint32_t> matmul_v2_output_dims =
@@ -180,12 +166,9 @@ const TensorWrapper& BuildSingleSHA(
   matmul_v2_output_dims[2] = matmul_v2_output_dims[2] / num_heads;
   const auto& matmul_v2_output = tensor_pool.CloneNativeTensorFrom(
       matmul_v2.GetOutputTensor(0), matmul_v2_output_dims);
-  const std::array<ConstTensorWrapperRef, 2> matmul_v2_inputs = {
-      slice_2_output, matmul_v2.GetInputTensor(1)};
-  const std::array<ConstTensorWrapperRef, 1> matmul_v2_outputs = {
-      matmul_v2_output};
-  new_ops.emplace_back(
-      CreateOpWithSameParams(matmul_v2, matmul_v2_inputs, matmul_v2_outputs));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      matmul_v2, {slice_2_output, matmul_v2.GetInputTensor(1)},
+      {matmul_v2_output}));
 
   // Add 2
   const auto& add_2_output = tensor_pool.CloneNativeTensorFrom(
@@ -314,12 +297,8 @@ TensorWrapper& BuildSingleSHAByUnpackAxis1(
   q_kcache_matmul_output_dims[1] /= num_attn_per_kv_heads;
   auto& q_kcache_matmul_output = tensor_pool.CloneNativeTensorFrom(
       q_kcache_matmul.GetOutputTensor(0), q_kcache_matmul_output_dims);
-  const std::array<ConstTensorWrapperRef, 2> q_kcache_matmul_inputs = {
-      mul_output, k_cache};
-  const std::array<ConstTensorWrapperRef, 1> q_kcache_matmul_outputs = {
-      q_kcache_matmul_output};
   new_ops.emplace_back(CreateOpWithSameParams(
-      q_kcache_matmul, q_kcache_matmul_inputs, q_kcache_matmul_outputs));
+      q_kcache_matmul, {mul_output, k_cache}, {q_kcache_matmul_output}));
 
   // Q KSlice Matmul
   auto q_kslice_matmul_output_dims =
@@ -328,12 +307,8 @@ TensorWrapper& BuildSingleSHAByUnpackAxis1(
   q_kslice_matmul_output_dims[1] /= num_attn_per_kv_heads;
   auto& q_kslice_matmul_output = tensor_pool.CloneNativeTensorFrom(
       q_kslice_matmul.GetOutputTensor(0), q_kslice_matmul_output_dims);
-  const std::array<ConstTensorWrapperRef, 2> q_kslice_matmul_inputs = {
-      mul_output, k_slice};
-  const std::array<ConstTensorWrapperRef, 1> q_kslice_matmul_outputs = {
-      q_kslice_matmul_output};
   new_ops.emplace_back(CreateOpWithSameParams(
-      q_kslice_matmul, q_kslice_matmul_inputs, q_kslice_matmul_outputs));
+      q_kslice_matmul, {mul_output, k_slice}, {q_kslice_matmul_output}));
 
   // QK Concat
   std::uint32_t adjusted_axis = 2;
@@ -372,11 +347,8 @@ TensorWrapper& BuildSingleSHAByUnpackAxis1(
   softmax_output_dims[1] /= num_attn_per_kv_heads;
   auto& softmax_output = tensor_pool.CloneNativeTensorFrom(
       softmax.GetOutputTensor(0), softmax_output_dims);
-  const std::array<ConstTensorWrapperRef, 1> softmax_inputs = {
-      post_mask_reshape_output};
-  const std::array<ConstTensorWrapperRef, 1> softmax_outputs = {softmax_output};
-  new_ops.emplace_back(
-      CreateOpWithSameParams(softmax, softmax_inputs, softmax_outputs));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      softmax, {post_mask_reshape_output}, {softmax_output}));
 
   // QK VCache Slice
   auto qk_vcache_slice_param = qk_vcache_slice.GetTensorParam(0).GetTensor();
@@ -437,12 +409,9 @@ TensorWrapper& BuildSingleSHAByUnpackAxis1(
   qk_vcache_matmul_output_dims[1] /= num_attn_per_kv_heads;
   auto& qk_vcache_matmul_output = tensor_pool.CloneNativeTensorFrom(
       qk_vcache_matmul.GetOutputTensor(0), qk_vcache_matmul_output_dims);
-  const std::array<ConstTensorWrapperRef, 2> qk_vcache_matmul_inputs = {
-      qk_vcache_slice_output, v_cache};
-  const std::array<ConstTensorWrapperRef, 1> qk_vcache_matmul_outputs = {
-      qk_vcache_matmul_output};
-  new_ops.emplace_back(CreateOpWithSameParams(
-      qk_vcache_matmul, qk_vcache_matmul_inputs, qk_vcache_matmul_outputs));
+  new_ops.emplace_back(CreateOpWithSameParams(qk_vcache_matmul,
+                                              {qk_vcache_slice_output, v_cache},
+                                              {qk_vcache_matmul_output}));
 
   // QK VSlice Matmul
   auto qk_vslice_matmul_output_dims =
@@ -451,12 +420,9 @@ TensorWrapper& BuildSingleSHAByUnpackAxis1(
   qk_vslice_matmul_output_dims[1] /= num_attn_per_kv_heads;
   auto& qk_vslice_matmul_output = tensor_pool.CloneNativeTensorFrom(
       qk_vslice_matmul.GetOutputTensor(0), qk_vslice_matmul_output_dims);
-  const std::array<ConstTensorWrapperRef, 2> qk_vslice_matmul_inputs = {
-      qk_vslice_slice_output, v_slice};
-  const std::array<ConstTensorWrapperRef, 1> qk_vslice_matmul_outputs = {
-      qk_vslice_matmul_output};
-  new_ops.emplace_back(CreateOpWithSameParams(
-      qk_vslice_matmul, qk_vslice_matmul_inputs, qk_vslice_matmul_outputs));
+  new_ops.emplace_back(CreateOpWithSameParams(qk_vslice_matmul,
+                                              {qk_vslice_slice_output, v_slice},
+                                              {qk_vslice_matmul_output}));
 
   // QKV Add
   auto qkv_add_output_dims = qkv_add.GetOutputTensor(0).GetDimensions();
@@ -512,12 +478,9 @@ size_t OptimizeMHAPrefill(std::function<bool(OpWrapper&)> validate_op_config,
                                    .GetDimensions();
   const auto& transpose_output =
       tensor_pool.CloneNativeTensorFrom(pattern_input, transpose_output_dims);
-  const std::array<ConstTensorWrapperRef, 1> transpose_inputs = {pattern_input};
-  const std::array<ConstTensorWrapperRef, 1> transpose_outputs = {
-      transpose_output};
   new_ops.emplace_back(
       CreateOpWithSameParams(ops[start_index + kTransposePrefillIndex],
-                             transpose_inputs, transpose_outputs));
+                             {pattern_input}, {transpose_output}));
 
   // Reshape
   const auto& reshape_output = tensor_pool.CloneNativeTensorFrom(
@@ -1020,11 +983,8 @@ bool OptimizeMHATinyGemmaPrefill(
   auto transpose_output_dims = transpoe_0.GetOutputTensor(0).GetDimensions();
   const auto& transpose_output =
       tensor_pool.CloneNativeTensorFrom(pattern_input, transpose_output_dims);
-  const std::array<ConstTensorWrapperRef, 1> transpose_inputs = {pattern_input};
-  const std::array<ConstTensorWrapperRef, 1> transpose_outputs = {
-      transpose_output};
   auto& new_transpose_0 = new_ops.emplace_back(
-      CreateOpWithSameParams(transpoe_0, transpose_inputs, transpose_outputs));
+      CreateOpWithSameParams(transpoe_0, {pattern_input}, {transpose_output}));
 
   // Process MHA to SHA transformation.
   const int num_heads = pattern_input.GetDimension(2);
@@ -1464,12 +1424,8 @@ size_t OptimizeMHAAttn(std::function<bool(OpWrapper&)> validate_op_config,
           matmul_qk_out,
           {q_matmul_in.GetDimension(0), q_matmul_in.GetDimension(1),
            k_matmul_in.GetDimension(2)});
-      const std::array<ConstTensorWrapperRef, 2> matmul_qk_inputs = {
-          q_matmul_in, k_matmul_in};
-      const std::array<ConstTensorWrapperRef, 1> matmul_qk_outputs = {
-          select_in};
       new_ops.emplace_back(CreateOpWithSameParams(
-          ops[matmul_qk_index], matmul_qk_inputs, matmul_qk_outputs));
+          ops[matmul_qk_index], {q_matmul_in, k_matmul_in}, {select_in}));
 
       // Change Select to Add.
       const auto& softmax_in =
@@ -1480,18 +1436,13 @@ size_t OptimizeMHAAttn(std::function<bool(OpWrapper&)> validate_op_config,
       // Softmax
       const auto& qk_softmax =
           tensor_pool.CloneNativeTensorFrom(softmax_in, select_out_dims);
-      const std::array<ConstTensorWrapperRef, 1> softmax_inputs = {softmax_in};
-      const std::array<ConstTensorWrapperRef, 1> softmax_outputs = {qk_softmax};
       new_ops.emplace_back(CreateOpWithSameParams(
-          ops[select_index + kAttnSoftmax], softmax_inputs, softmax_outputs));
+          ops[select_index + kAttnSoftmax], {softmax_in}, {qk_softmax}));
 
       // MatMul
-      const std::array<ConstTensorWrapperRef, 2> matmul_out_inputs = {
-          qk_softmax, v_sha_inputs[i]};
-      const std::array<ConstTensorWrapperRef, 1> matmul_out_outputs = {
-          sha_outputs[i]};
-      new_ops.emplace_back(CreateOpWithSameParams(
-          ops[matmul_qk_index], matmul_out_inputs, matmul_out_outputs));
+      new_ops.emplace_back(CreateOpWithSameParams(ops[matmul_qk_index],
+                                                  {qk_softmax, v_sha_inputs[i]},
+                                                  {sha_outputs[i]}));
     }
     // Pack
     new_ops.emplace_back(CreatePackOp(sha_outputs, mha_out, 2));


### PR DESCRIPTION
x86:
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test       PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 0.2s
```

on-device:
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 13 tests from 9 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 15 tests from 3 test suites ran. (14 ms total)
[  PASSED  ] 15 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 33 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (14 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (340 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (349 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (380 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1066 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1004 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (700 ms total)
[  PASSED  ] 10 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2146 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (8 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (6 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (526 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (448 ms total)
[  PASSED  ] 2 tests.
```