### PR TITLE
Enable Qualcomm NPU support on Windows ARM64

### DIFF
--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -42,10 +42,18 @@ typedef QNN_INTERFACE_VER_TYPE QnnApi;
 typedef QNN_SYSTEM_INTERFACE_VER_TYPE QnnSystemApi;
 
 // QNN backend library should be on DT_RUNPATH (-rpath) (for linux).
+#if LITERT_WINDOWS_OS
+static const char kLibQnnSystemSo[] = "QnnSystem.dll";
+#else
 static const char kLibQnnSystemSo[] = "libQnnSystem.so";
+#endif
 
 // Android only library.
+#if LITERT_WINDOWS_OS
+static const char kLibQnnHtpPrepareSo[] = "QnnHtpPrepare.dll";
+#else
 static const char kLibQnnHtpPrepareSo[] = "libQnnHtpPrepare.so";
+#endif
 
 // Map LiteRT element type to Qnn counterpart.
 inline LiteRtStatus LegalizeElementType(litert::ElementType litert_type,

--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -16,7 +16,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
-load("//litert/build_common:litert_build_defs.bzl", "litert_dynamic_lib", "litert_lib", "litert_test", "make_rpaths")
+load("//litert/build_common:litert_build_defs.bzl", "litert_bin", "litert_dynamic_lib", "litert_lib", "litert_test", "make_rpaths")
 load("//litert/build_common:special_rule.bzl", "litert_android_linkopts")
 load("//litert/integration_test:litert_device.bzl", "litert_device_exec")
 
@@ -71,6 +71,61 @@ litert_dynamic_lib(
         "//litert/cc/internal:litert_options_wrapper",
         "//litert/cc/options:litert_qualcomm_options",
         "//litert/compiler/cc:litert_model",
+        "//litert/vendors/qualcomm:common",
+        "//litert/vendors/qualcomm:qnn_manager",
+        "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/schema:soc_table",
+        "//litert/vendors/qualcomm/core/utils:miscs",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+litert_bin(
+    name = "LiteRtCompilerPlugin_Qualcomm",
+    srcs = [
+        "qnn_compiler_plugin.cc",
+        "//litert/vendors/c:litert_compiler_plugin.h",
+    ],
+    copts = select({
+        "//litert:windows": [
+            "/DLITERT_COMPILE_LIBRARY",
+            "/wd4018",  # -Wno-sign-compare
+        ],
+        "//conditions:default": [],
+    }),
+    linkshared = 1,
+    linkstatic = 1,
+    target_compatible_with = select({
+        "//litert:windows": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//litert:litert_public"],
+    deps = [
+        ":qnn_compose_graph",
+        "//litert/c:litert_any",
+        "//litert/c:litert_builder",
+        "//litert/c:litert_common",
+        "//litert/c:litert_environment_options",
+        "//litert/c:litert_model_header",
+        "//litert/c:litert_opaque_options_header",
+        "//litert/c:litert_options_header",
+        "//litert/c/internal:litert_logging",
+        "//litert/c/internal:litert_logging_helper_with_compiler_context",
+        "//litert/c/options:litert_qualcomm_options",
+        "//litert/cc:litert_expected",
+        "//litert/cc:litert_macros",
+        "//litert/cc/internal:litert_context_wrapper",
+        "//litert/cc/internal:litert_handle",
+        "//litert/cc/internal:litert_options_wrapper",
+        "//litert/cc/options:litert_qualcomm_options",
+        "//litert/compiler/cc:litert_model",
+        "//litert/vendors/cc:namespace_heuristics",
         "//litert/vendors/qualcomm:common",
         "//litert/vendors/qualcomm:qnn_manager",
         "//litert/vendors/qualcomm/core:common",

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -13,7 +13,11 @@
 // limitations under the License.
 #include "litert/vendors/qualcomm/compiler/qnn_compose_graph.h"
 
+#if defined(_WIN32)
+#include <malloc.h>
+#else
 #include <alloca.h>
+#endif
 #include <stdbool.h>
 #include <stdio.h>
 

--- a/litert/vendors/qualcomm/core/backends/dsp_backend.h
+++ b/litert/vendors/qualcomm/core/backends/dsp_backend.h
@@ -18,7 +18,13 @@ namespace qnn {
 
 class DspBackend : public QnnBackend {
  public:
-  static const char* GetLibraryName() { return "libQnnDsp.so"; }
+  static const char* GetLibraryName() {
+#if defined(_WIN32)
+    return "QnnDsp.dll";
+#else
+    return "libQnnDsp.so";
+#endif
+  }
 
   static Qnn_Version_t GetExpectedBackendVersion() {
     Qnn_Version_t backend_version;

--- a/litert/vendors/qualcomm/core/backends/htp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.cc
@@ -398,20 +398,32 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
   // this API is called during offline preparation. However, it will always
   // return the default SoC info (SM8350). If user specifies a SoC, we will
   // override the default.
-#if defined(__x86_64__) || defined(_M_X64)
   if (soc_info.has_value()) {
     QNN_LOG_INFO("Using provided SoC info. SoC name: %s.", soc_info->soc_name);
     soc_info_ = *soc_info;
-  }
+  } else {
+#if defined(__x86_64__) || defined(_M_X64)
+    // Offline compilation on desktop hosts cannot query the target device.
 #else
-  if (auto device_platform_info = CreateDevicePlatformInfo();
-      device_platform_info) {
-    auto soc_model = device_platform_info->v1.hwDevices->v1.deviceInfoExtension
-                         ->onChipDevice.socModel;
-    auto soc_info_online = FindSocInfo(static_cast<SnapdragonModel>(soc_model));
-    soc_info_ = soc_info_online.value_or(kSocInfos[0]);
-  }
+    if (auto device_platform_info = CreateDevicePlatformInfo();
+        device_platform_info) {
+      auto soc_model =
+          device_platform_info->v1.hwDevices->v1.deviceInfoExtension
+              ->onChipDevice.socModel;
+      auto soc_info_online =
+          FindSocInfo(static_cast<SnapdragonModel>(soc_model));
+      soc_info_ = soc_info_online.value_or(kSocInfos[0]);
+    }
+#if defined(_WIN32) && defined(_M_ARM64)
+    if (soc_info_.dsp_arch == DspArch::NONE) {
+      QNN_LOG_WARNING(
+          "Unable to map Windows ARM64 QNN platform info; using SC8380XP "
+          "fallback for Snapdragon X Elite.");
+      soc_info_ = FindSocInfo(SnapdragonModel::SC8380XP).value_or(kSocInfos[0]);
+    }
 #endif
+#endif
+  }
   if (soc_info_.dsp_arch == DspArch::NONE) {
     QNN_LOG_ERROR("SoC info was not configured successfully.")
     return false;

--- a/litert/vendors/qualcomm/core/backends/htp_backend.h
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.h
@@ -31,7 +31,13 @@ class HtpBackend : public QnnBackend {
   using QnnDevicePlatformInfo =
       std::unique_ptr<const QnnDevice_PlatformInfo_t, PlatformInfoDeleter>;
 
-  static const char* GetLibraryName() { return "libQnnHtp.so"; }
+  static const char* GetLibraryName() {
+#if defined(_WIN32)
+    return "QnnHtp.dll";
+#else
+    return "libQnnHtp.so";
+#endif
+  }
 
   static Qnn_Version_t GetExpectedBackendVersion() {
     Qnn_Version_t backend_version;

--- a/litert/vendors/qualcomm/core/backends/ir_backend.h
+++ b/litert/vendors/qualcomm/core/backends/ir_backend.h
@@ -17,7 +17,13 @@ namespace qnn {
 
 class IrBackend : public QnnBackend {
  public:
-  static const char* GetLibraryName() { return "libQnnIr.so"; }
+  static const char* GetLibraryName() {
+#if defined(_WIN32)
+    return "QnnIr.dll";
+#else
+    return "libQnnIr.so";
+#endif
+  }
 
   static Qnn_Version_t GetExpectedBackendVersion() {
     Qnn_Version_t backend_version;

--- a/litert/vendors/qualcomm/dispatch/BUILD
+++ b/litert/vendors/qualcomm/dispatch/BUILD
@@ -16,7 +16,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
-load("//litert/build_common:litert_build_defs.bzl", "litert_dispatch_api")
+load("//litert/build_common:litert_build_defs.bzl", "litert_bin", "litert_dispatch_api")
 load("//litert/build_common:special_rule.bzl", "litert_android_linkopts")
 load("//litert/integration_test:litert_device.bzl", "litert_device_test")
 
@@ -81,6 +81,71 @@ litert_dispatch_api(
         "//litert/cc:litert_macros",
         "//litert/cc:litert_element_type",
         # TODO: Remove this dependency.
+        "//litert/core/util:tensor_type_util",
+        "//litert/vendors/c:litert_dispatch_c_api",
+        "//litert/vendors/qualcomm:common",
+        "//litert/vendors/qualcomm/core:common",
+        "//litert/vendors/qualcomm:context_binary_info",
+        "//litert/vendors/qualcomm:qnn_manager",
+        "//litert/vendors/qualcomm/core/utils:miscs",
+        "//litert/c/internal:litert_scheduling_info",
+        "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+litert_bin(
+    name = "LiteRtDispatch_Qualcomm",
+    srcs = [
+        "dispatch_api.cc",
+        "litert_dispatch_device_context.h",
+        "litert_dispatch_device_context.cc",
+        "litert_dispatch_invocation_context.h",
+        "litert_dispatch_invocation_context.cc",
+        "registry.h",
+    ],
+    copts = select({
+        "//litert:windows": [
+            "/DLITERT_COMPILE_LIBRARY",
+            "/wd4018",  # -Wno-sign-compare
+        ],
+        "//conditions:default": [],
+    }),
+    linkshared = 1,
+    linkstatic = 1,
+    target_compatible_with = select({
+        "//litert:windows": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    visibility = ["//litert:litert_public"],
+    deps = [
+        "//litert/cc/internal:litert_context_wrapper",
+        "//litert/cc/internal:litert_options_wrapper",
+        "@com_google_absl//absl/base:no_destructor",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/types:span",
+        "//litert/c/internal:litert_logging",
+        "//litert/c/internal:litert_logging_helper_with_runtime_context",
+        "//litert/c:litert_environment_options_header",
+        "//litert/c:litert_opaque_options_header",
+        "//litert/c:litert_options_header",
+        "//litert/c/options:litert_qualcomm_options",
+        "//litert/c:litert_any",
+        "//litert/c:litert_common",
+        "//litert/c:litert_environment_header",
+        "//litert/c:litert_event_header",
+        "//litert/c:litert_event_type",
+        "//litert/c:litert_model_types",
+        "//litert/c:litert_tensor_buffer_header",
+        "//litert/c:litert_tensor_buffer_types",
+        "//litert/c/internal:litert_runtime_context_header",
+        "//litert/cc:litert_expected",
+        "//litert/cc/options:litert_qualcomm_options",
+        "//litert/cc:litert_macros",
+        "//litert/cc:litert_element_type",
         "//litert/core/util:tensor_type_util",
         "//litert/vendors/c:litert_dispatch_c_api",
         "//litert/vendors/qualcomm:common",

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
@@ -26,6 +26,7 @@
 #include <fstream>
 #include <ios>
 #include <iterator>
+#include <limits>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -189,11 +190,21 @@ LiteRtDispatchInvocationContextT::GetTensorBufferRequirements(
                       "Tensor strides are not supported by QNN");
   }
 
+  static constexpr std::array<const LiteRtTensorBufferType, 1>
+      kRawTensorBufferTypes = {kLiteRtTensorBufferTypeHostMemory};
   static constexpr std::array<const LiteRtTensorBufferType, 2>
-      kSupportedTensorBufferTypes = {
+      kMemHandleTensorBufferTypes = {
           kLiteRtTensorBufferTypeFastRpc,
           kLiteRtTensorBufferTypeDmaBuf,
       };
+  const LiteRtTensorBufferType* supported_tensor_buffer_types =
+      kMemHandleTensorBufferTypes.data();
+  size_t num_supported_tensor_buffer_types = kMemHandleTensorBufferTypes.size();
+  if (qnn_manager_.GetOptions().GetGraphIOTensorMemType() ==
+      ::qnn::GraphIOTensorMemType::kRaw) {
+    supported_tensor_buffer_types = kRawTensorBufferTypes.data();
+    num_supported_tensor_buffer_types = kRawTensorBufferTypes.size();
+  }
 
   auto buffer_size = litert::internal::GetNumPackedBytes(tensor_type);
   if (!buffer_size) {
@@ -203,8 +214,8 @@ LiteRtDispatchInvocationContextT::GetTensorBufferRequirements(
   LiteRtTensorBufferRequirements requirements;
   if (auto status =
           device_context_->runtime_context()->create_tensor_buffer_requirements(
-              kSupportedTensorBufferTypes.size(),
-              kSupportedTensorBufferTypes.data(), *buffer_size,
+              num_supported_tensor_buffer_types, supported_tensor_buffer_types,
+              *buffer_size,
               /*num_strides=*/0,
               /*strides=*/nullptr, &requirements);
       status != kLiteRtStatusOk) {
@@ -275,6 +286,52 @@ Expected<void> LiteRtDispatchInvocationContextT::AttachBuffer(
     return Unexpected(tensor_buffer.Error());
   }
 
+  LiteRtTensorBufferType tensor_buffer_type;
+  LITERT_RETURN_IF_ERROR(
+      device_context_->runtime_context()->get_tensor_buffer_type(
+          *tensor_buffer, &tensor_buffer_type));
+  if (tensor_buffer_type == kLiteRtTensorBufferTypeHostMemory) {
+    void* host_memory_addr = nullptr;
+    LITERT_RETURN_IF_ERROR(
+        device_context_->runtime_context()->get_tensor_buffer_host_memory(
+            *tensor_buffer, &host_memory_addr));
+
+    size_t tensor_buffer_size = 0;
+    LITERT_RETURN_IF_ERROR(
+        device_context_->runtime_context()->get_tensor_buffer_size(
+            *tensor_buffer, &tensor_buffer_size));
+
+    size_t tensor_buffer_offset = 0;
+    LITERT_RETURN_IF_ERROR(
+        device_context_->runtime_context()->get_tensor_buffer_offset(
+            *tensor_buffer, &tensor_buffer_offset));
+
+    if (tensor_buffer_size > std::numeric_limits<uint32_t>::max()) {
+      return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                        "Host tensor buffer is too large for QNN");
+    }
+    void* data =
+        static_cast<void*>(static_cast<uint8_t*>(host_memory_addr) +
+                           tensor_buffer_offset);
+    if (tensor.version == QNN_TENSOR_VERSION_1) {
+      tensor.v1.memType = QNN_TENSORMEMTYPE_RAW;
+      tensor.v1.clientBuf.data = data;
+      tensor.v1.clientBuf.dataSize = static_cast<uint32_t>(tensor_buffer_size);
+    } else if (tensor.version == QNN_TENSOR_VERSION_2) {
+      if (tensor.v2.isDynamicDimensions != nullptr) {
+        return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                          "Dynamic dimensions not yet supported");
+      }
+      tensor.v2.memType = QNN_TENSORMEMTYPE_RAW;
+      tensor.v2.clientBuf.data = data;
+      tensor.v2.clientBuf.dataSize = static_cast<uint32_t>(tensor_buffer_size);
+    } else {
+      return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                        "Unsupported QNN tensor version");
+    }
+    return {};
+  }
+
   auto mem_handle = device_context_->GetMemHandle(tensor_buffer_handle, tensor);
   if (!mem_handle) {
     return Unexpected(mem_handle.Error());
@@ -301,6 +358,12 @@ Expected<void> LiteRtDispatchInvocationContextT::AttachBuffer(
 
 Expected<void> LiteRtDispatchInvocationContextT::DetachBuffer(
     Qnn_Tensor_t& tensor, LiteRtTensorBufferHandle tensor_buffer_handle) {
+  const auto mem_type = tensor.version == QNN_TENSOR_VERSION_1
+                            ? tensor.v1.memType
+                            : tensor.v2.memType;
+  if (mem_type == QNN_TENSORMEMTYPE_RAW) {
+    return device_context_->UnregisterTensorBuffer(tensor_buffer_handle);
+  }
   LITERT_RETURN_IF_ERROR(
       device_context_->UnregisterTensorBuffer(tensor_buffer_handle, tensor));
   return {};

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -66,6 +66,19 @@ namespace litert::qnn {
 
 namespace {
 
+LiteRtStatus SetEnvVar(const char* name, const char* value) {
+#if defined(_WIN32)
+  if (_putenv_s(name, value) != 0) {
+    return kLiteRtStatusErrorRuntimeFailure;
+  }
+#else
+  if (setenv(name, value, /*overwrite=*/1) != 0) {
+    return kLiteRtStatusErrorRuntimeFailure;
+  }
+#endif
+  return kLiteRtStatusOk;
+}
+
 RtldFlags GetRtldFlags() {
 #if defined(__ANDROID__)
   // Race condition segfault without NoDelete on android.
@@ -434,7 +447,7 @@ LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
     static constexpr char kAdsp[] = "ADSP_LIBRARY_PATH";
     const char* adsp_library_path = getenv(kAdsp);
     if (adsp_library_path == nullptr) {
-      setenv(kAdsp, shared_library_dir->data(), /*overwrite=*/1);
+      LITERT_RETURN_IF_ERROR(SetEnvVar(kAdsp, shared_library_dir->c_str()));
     } else {
       bool found = false;
       for (absl::string_view part : absl::StrSplit(adsp_library_path, ';')) {
@@ -446,7 +459,8 @@ LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
       if (!found) {
         auto new_adsp_library_path =
             absl::StrCat(shared_library_dir.value(), ";", adsp_library_path);
-        setenv(kAdsp, new_adsp_library_path.c_str(), /*overwrite=*/1);
+        LITERT_RETURN_IF_ERROR(
+            SetEnvVar(kAdsp, new_adsp_library_path.c_str()));
       }
     }
     LITERT_LOG(LITERT_DEBUG, "ADSP_LIBRARY_PATH: %s", getenv(kAdsp));

--- a/litert/vendors/qualcomm/qnn_saver_utils.h
+++ b/litert/vendors/qualcomm/qnn_saver_utils.h
@@ -12,7 +12,11 @@
 
 namespace litert::qnn {
 
+#if defined(_WIN32)
+constexpr char kSaverLibraryName[] = "QnnSaver.dll";
+#else
 constexpr char kSaverLibraryName[] = "libQnnSaver.so";
+#endif
 
 inline Qnn_Version_t GetExpectedSaverVersion() {
   Qnn_Version_t backend_version;


### PR DESCRIPTION
## Summary
- Add Windows ARM64 DLL loading support for Qualcomm QNN libraries.
- Add Windows ARM64 Bazel targets for the Qualcomm compiler plugin and dispatch library.
- Support raw host-memory graph IO in Qualcomm dispatch for Windows ARM64 NPU execution.
- Fall back to the SC8380XP SoC profile for Snapdragon X Elite when QNN platform info cannot be mapped on Windows ARM64.

## Validation
- Built on Windows ARM64:
  - `//litert/vendors/qualcomm/compiler:LiteRtCompilerPlugin_Qualcomm`
  - `//litert/vendors/qualcomm/dispatch:LiteRtDispatch_Qualcomm`
- Ran C++ benchmark smoke test with Qualcomm NPU on `mul_quant.tflite`.
- Ran ResNet152 FP32 through Qualcomm NPU with full delegation.