### PR TITLE
Qualcomm AI Engine Direct - Support DLBC/DLBC_WEIGHT.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -43,6 +43,8 @@ struct LrtQualcommOptionsT {
   std::optional<bool> enable_weight_sharing;
   std::optional<bool> use_conv_hmx;
   std::optional<bool> use_fold_relu;
+  std::optional<bool> dlbc;
+  std::optional<bool> dlbc_weights;
   std::optional<LrtQualcommOptionsHtpPerformanceMode> htp_performance_mode;
   std::optional<LrtQualcommOptionsDspPerformanceMode> dsp_performance_mode;
   std::optional<std::vector<std::int32_t>> dump_tensor_ids;
@@ -111,6 +113,14 @@ LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
           auto v = litert::internal::ParseTomlBool(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
           status = LrtQualcommOptionsSetUseFoldReLU(parsed_options, *v);
+        } else if (key == "dlbc") {
+          auto v = litert::internal::ParseTomlBool(value);
+          if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
+          status = LrtQualcommOptionsSetDlbc(parsed_options, *v);
+        } else if (key == "dlbc_weights") {
+          auto v = litert::internal::ParseTomlBool(value);
+          if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
+          status = LrtQualcommOptionsSetDlbcWeights(parsed_options, *v);
         } else if (key == "htp_performance_mode") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
@@ -235,6 +245,13 @@ LiteRtStatus LrtGetOpaqueQualcommOptionsData(LrtQualcommOptions options,
   }
   if (options->use_fold_relu.has_value()) {
     toml << "use_fold_relu = " << (*options->use_fold_relu ? "true" : "false")
+         << "\n";
+  }
+  if (options->dlbc.has_value()) {
+    toml << "dlbc = " << (*options->dlbc ? "true" : "false") << "\n";
+  }
+  if (options->dlbc_weights.has_value()) {
+    toml << "dlbc_weights = " << (*options->dlbc_weights ? "true" : "false")
          << "\n";
   }
   if (options->htp_performance_mode.has_value()) {
@@ -519,6 +536,48 @@ LiteRtStatus LrtQualcommOptionsGetUseFoldReLU(LrtQualcommOptions options,
   }
 
   *use_fold_relu = options->use_fold_relu.value_or(true);
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsSetDlbc(LrtQualcommOptions options, bool dlbc) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->dlbc = dlbc;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsGetDlbc(LrtQualcommOptions options, bool* dlbc) {
+  if (dlbc == nullptr || options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *dlbc = options->dlbc.value_or(false);
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsSetDlbcWeights(LrtQualcommOptions options,
+                                              bool dlbc_weights) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->dlbc_weights = dlbc_weights;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsGetDlbcWeights(LrtQualcommOptions options,
+                                              bool* dlbc_weights) {
+  if (dlbc_weights == nullptr || options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *dlbc_weights = options->dlbc_weights.value_or(false);
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -153,6 +153,28 @@ LiteRtStatus LrtQualcommOptionsSetUseFoldReLU(LrtQualcommOptions options,
 LiteRtStatus LrtQualcommOptionsGetUseFoldReLU(LrtQualcommOptions options,
                                               bool* use_fold_relu);
 
+// dlbc
+
+// Deep Learning Bandwidth Compression (DLBC) for activations / inputs.
+// Only effective for offline (x86 AOT) preparation. Defaults to false.
+
+LiteRtStatus LrtQualcommOptionsSetDlbc(LrtQualcommOptions options, bool dlbc);
+
+LiteRtStatus LrtQualcommOptionsGetDlbc(LrtQualcommOptions options, bool* dlbc);
+
+// dlbc_weights
+
+// DLBC for weight tensors. Only effective for offline (x86 AOT) preparation.
+// Mutually exclusive with weight sharing — when both are enabled the runtime
+// will force this option off (matching QAIRT 2.36+ behavior). Defaults to
+// false.
+
+LiteRtStatus LrtQualcommOptionsSetDlbcWeights(LrtQualcommOptions options,
+                                              bool dlbc_weights);
+
+LiteRtStatus LrtQualcommOptionsGetDlbcWeights(LrtQualcommOptions options,
+                                              bool* dlbc_weights);
+
 // graph_io_tensor_mem_type
 
 // This controls whether graph inputs and outputs use MemHandle or Raw buffers

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -156,6 +156,30 @@ TEST(LiteRtQualcommOptionsTest, UseFoldReLU) {
   LrtDestroyQualcommOptions(qualcomm_options);
 }
 
+TEST(LiteRtQualcommOptionsTest, Dlbc) {
+  LrtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
+
+  LITERT_ASSERT_OK(LrtQualcommOptionsSetDlbc(qualcomm_options, true));
+
+  auto parsed = SerializeAndParse(qualcomm_options);
+  EXPECT_TRUE(parsed.GetDlbc());
+
+  LrtDestroyQualcommOptions(qualcomm_options);
+}
+
+TEST(LiteRtQualcommOptionsTest, DlbcWeights) {
+  LrtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
+
+  LITERT_ASSERT_OK(LrtQualcommOptionsSetDlbcWeights(qualcomm_options, true));
+
+  auto parsed = SerializeAndParse(qualcomm_options);
+  EXPECT_TRUE(parsed.GetDlbcWeights());
+
+  LrtDestroyQualcommOptions(qualcomm_options);
+}
+
 TEST(LiteRtQualcommOptionsTest, HtpPerformanceMode) {
   LrtQualcommOptions qualcomm_options;
   LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
@@ -394,6 +418,14 @@ TEST(QualcommOptionsTest, CppWrapper) {
   EXPECT_TRUE(options->GetUseFoldReLU());
   options->SetUseFoldReLU(false);
   EXPECT_FALSE(options->GetUseFoldReLU());
+
+  EXPECT_FALSE(options->GetDlbc());
+  options->SetDlbc(true);
+  EXPECT_TRUE(options->GetDlbc());
+
+  EXPECT_FALSE(options->GetDlbcWeights());
+  options->SetDlbcWeights(true);
+  EXPECT_TRUE(options->GetDlbcWeights());
 
   EXPECT_EQ(options->GetBackend(), QualcommOptions::Backend::kHtp);
   options->SetBackend(QualcommOptions::Backend::kDsp);

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -247,6 +247,36 @@ class QualcommOptions {
     return val;
   }
 
+  /// @brief Enable Deep Learning Bandwidth Compression (DLBC) for activations.
+  ///
+  /// Only effective for offline (x86 AOT) preparation. Defaults to false.
+  void SetDlbc(bool dlbc) { LrtQualcommOptionsSetDlbc(options_, dlbc); }
+  bool GetDlbc() {
+    bool val;
+    auto status = LrtQualcommOptionsGetDlbc(options_, &val);
+    if (status == kLiteRtStatusErrorNotFound) {
+      return false;
+    }
+    return val;
+  }
+
+  /// @brief Enable Deep Learning Bandwidth Compression (DLBC) for weights.
+  ///
+  /// Only effective for offline (x86 AOT) preparation. Mutually exclusive
+  /// with weight sharing — when both are enabled the runtime forces this
+  /// option off (matching QAIRT 2.36+ behavior). Defaults to false.
+  void SetDlbcWeights(bool dlbc_weights) {
+    LrtQualcommOptionsSetDlbcWeights(options_, dlbc_weights);
+  }
+  bool GetDlbcWeights() {
+    bool val;
+    auto status = LrtQualcommOptionsGetDlbcWeights(options_, &val);
+    if (status == kLiteRtStatusErrorNotFound) {
+      return false;
+    }
+    return val;
+  }
+
   /// @brief This option controls the profiling level.
   ///
   /// A higher level results in a more detailed report after execution.

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -475,6 +475,16 @@ ABSL_FLAG(bool, qualcomm_use_fold_relu, true,
           "optimization is correct when quantization ranges for convolution "
           "are equal to or are subset of the Relu operation.");
 
+ABSL_FLAG(bool, qualcomm_htp_use_dlbc, false,
+          "Enable Deep Learning Bandwidth Compression (DLBC) for activations "
+          "on the HTP backend. Only effective in the AOT (offline x86) "
+          "preparation flow.");
+
+ABSL_FLAG(bool, qualcomm_htp_use_dlbc_weights, false,
+          "Enable Deep Learning Bandwidth Compression (DLBC) for weight "
+          "tensors on the HTP backend. Only effective in the AOT (offline "
+          "x86) preparation flow.");
+
 ABSL_FLAG(litert::qualcomm::QualcommOptions::Backend, qualcomm_backend,
           litert::qualcomm::QualcommOptions::Backend::kHtp,
           "QNN backend to use.");
@@ -573,6 +583,13 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
 
   const auto use_fold_relu = absl::GetFlag(FLAGS_qualcomm_use_fold_relu);
   opts.SetUseFoldReLU(use_fold_relu);
+
+  const auto htp_use_dlbc = absl::GetFlag(FLAGS_qualcomm_htp_use_dlbc);
+  opts.SetDlbc(htp_use_dlbc);
+
+  const auto htp_use_dlbc_weights =
+      absl::GetFlag(FLAGS_qualcomm_htp_use_dlbc_weights);
+  opts.SetDlbcWeights(htp_use_dlbc_weights);
 
   const auto qnn_backend = absl::GetFlag(FLAGS_qualcomm_backend);
   opts.SetBackend(qnn_backend);

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -510,6 +510,8 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   EXPECT_EQ(options.Value().GetBackend(), QualcommOptions::Backend::kHtp);
   EXPECT_EQ(options.Value().GetGraphIOTensorMemType(),
             QualcommOptions::GraphIOTensorMemType::kMemHandle);
+  EXPECT_FALSE(options.Value().GetDlbc());
+  EXPECT_FALSE(options.Value().GetDlbcWeights());
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -114,6 +114,17 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetEnableWeightSharing(qualcomm_options.GetEnableWeightSharing());
   qnn_options.SetUseConvHMX(qualcomm_options.GetUseConvHMX());
   qnn_options.SetUseFoldReLU(qualcomm_options.GetUseFoldReLU());
+  qnn_options.SetDlbc(qualcomm_options.GetDlbc());
+  // DLBC weights is mutually exclusive with weight sharing (see QAIRT release
+  // notes for 2.36+). Force-off and warn when both are requested.
+  bool dlbc_weights = qualcomm_options.GetDlbcWeights();
+  if (dlbc_weights && qualcomm_options.GetEnableWeightSharing()) {
+    LITERT_LOG(LITERT_WARNING,
+               "DLBC weights cannot be combined with weight sharing; "
+               "forcing dlbc_weights = false.");
+    dlbc_weights = false;
+  }
+  qnn_options.SetDlbcWeights(dlbc_weights);
   qnn_options.SetHtpPerformanceMode(static_cast<::qnn::HtpPerformanceMode>(
       qualcomm_options.GetHtpPerformanceMode()));
   qnn_options.SetDspPerformanceMode(static_cast<::qnn::DspPerformanceMode>(

--- a/litert/vendors/qualcomm/compiler/graph_mapper.cc
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.cc
@@ -73,9 +73,9 @@ Qnn_Priority_t GetGraphPriorityValue(::qnn::GraphPriority graph_priority) {
 
 inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
     const ::qnn::Options& options) {
-  static std::array<QnnHtpGraph_CustomConfig_t, 6> graph_custom_configs;
-  static std::array<QnnGraph_Config_t, 7> graph_configs;
-  static std::array<const QnnGraph_Config_t*, 8> result;
+  static std::array<QnnHtpGraph_CustomConfig_t, 8> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 9> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 10> result;
 
   // QNN suggest always enable relax precision.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
@@ -108,14 +108,38 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
 
   // Hvx Thread
   bool has_hvx = options.GetNumHvxThreads() != 0;
+  size_t num_config = 5;
   if (has_hvx) {
-    graph_custom_configs[5] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
-    graph_custom_configs[5].option =
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
         QNN_HTP_GRAPH_CONFIG_OPTION_NUM_HVX_THREADS;
-    graph_custom_configs[5].numHvxThreads = options.GetNumHvxThreads();
+    graph_custom_configs[num_config].numHvxThreads =
+        options.GetNumHvxThreads();
+    ++num_config;
   }
 
-  size_t num_config = has_hvx ? 6 : 5;
+  // DLBC (activations / inputs). Offline-prep only — emitted only when
+  // explicitly enabled to preserve default behavior.
+  if (options.GetDlbc()) {
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+    graph_custom_configs[num_config].optimizationOption.type =
+        QNN_HTP_GRAPH_OPTIMIZATION_TYPE_ENABLE_DLBC;
+    graph_custom_configs[num_config].optimizationOption.floatValue = 1.0f;
+    ++num_config;
+  }
+  // DLBC weights. Offline-prep only.
+  if (options.GetDlbcWeights()) {
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+    graph_custom_configs[num_config].optimizationOption.type =
+        QNN_HTP_GRAPH_OPTIMIZATION_TYPE_ENABLE_DLBC_WEIGHTS;
+    graph_custom_configs[num_config].optimizationOption.floatValue = 1.0f;
+    ++num_config;
+  }
+
   for (size_t i = 0; i < num_config; ++i) {
     graph_configs[i] = QNN_GRAPH_CONFIG_INIT;
     graph_configs[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
@@ -137,9 +161,9 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
 
 inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
     const ::qnn::Options& options) {
-  static std::array<QnnHtpGraph_CustomConfig_t, 5> graph_custom_configs;
-  static std::array<QnnGraph_Config_t, 6> graph_configs;
-  static std::array<const QnnGraph_Config_t*, 7> result;
+  static std::array<QnnHtpGraph_CustomConfig_t, 7> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 8> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 9> result;
   // Default use O3 for now.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[0].option = QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
@@ -168,14 +192,37 @@ inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
 
   // Hvx Thread
   bool has_hvx = options.GetNumHvxThreads() != 0;
+  size_t num_config = 4;
   if (has_hvx) {
-    graph_custom_configs[4] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
-    graph_custom_configs[4].option =
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
         QNN_HTP_GRAPH_CONFIG_OPTION_NUM_HVX_THREADS;
-    graph_custom_configs[4].numHvxThreads = options.GetNumHvxThreads();
+    graph_custom_configs[num_config].numHvxThreads =
+        options.GetNumHvxThreads();
+    ++num_config;
   }
 
-  size_t num_config = has_hvx ? 5 : 4;
+  // DLBC (activations / inputs). Offline-prep only.
+  if (options.GetDlbc()) {
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+    graph_custom_configs[num_config].optimizationOption.type =
+        QNN_HTP_GRAPH_OPTIMIZATION_TYPE_ENABLE_DLBC;
+    graph_custom_configs[num_config].optimizationOption.floatValue = 1.0f;
+    ++num_config;
+  }
+  // DLBC weights. Offline-prep only.
+  if (options.GetDlbcWeights()) {
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+    graph_custom_configs[num_config].optimizationOption.type =
+        QNN_HTP_GRAPH_OPTIMIZATION_TYPE_ENABLE_DLBC_WEIGHTS;
+    graph_custom_configs[num_config].optimizationOption.floatValue = 1.0f;
+    ++num_config;
+  }
+
   for (size_t i = 0; i < num_config; ++i) {
     graph_configs[i] = QNN_GRAPH_CONFIG_INIT;
     graph_configs[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -122,6 +122,14 @@ void Options::SetUseFoldReLU(bool use_fold_relu) {
 
 bool Options::GetUseFoldReLU() const { return use_fold_relu_; }
 
+void Options::SetDlbc(bool dlbc) { dlbc_ = dlbc; }
+
+bool Options::GetDlbc() const { return dlbc_; }
+
+void Options::SetDlbcWeights(bool dlbc_weights) { dlbc_weights_ = dlbc_weights; }
+
+bool Options::GetDlbcWeights() const { return dlbc_weights_; }
+
 void Options::SetHtpPerformanceMode(HtpPerformanceMode htp_performance_mode) {
   htp_performance_mode_ = htp_performance_mode;
 }
@@ -207,6 +215,8 @@ UseInt64BiasAsInt32: %v\n\
 EnableWeightSharing: %v\n\
 UseConvHMX: %v\n\
 UseFoldReLU: %v\n\
+Dlbc: %v\n\
+DlbcWeights: %v\n\
 HtpPerformanceMode: %d\n\
 DspPerformanceMode: %d\n\
 DumpTensorIds: %s\n\
@@ -224,6 +234,7 @@ GraphIOTensorMemType: %d\n";  // NOLINT
   return absl::StrFormat(kQnnOptionsDumpFormat, log_level_, backend_type_,
                          profiling_, use_int64_bias_as_int32_,
                          enable_weight_sharing_, use_conv_hmx_, use_fold_relu_,
+                         dlbc_, dlbc_weights_,
                          htp_performance_mode_, dsp_performance_mode_,
                          dump_tensor_ids, ir_json_dir_, dlc_dir_, vtcm_size_,
                          num_hvx_threads_, optimization_level_, graph_priority_,

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -108,6 +108,15 @@ class Options {
   void SetUseFoldReLU(bool use_fold_relu);
   bool GetUseFoldReLU() const;
 
+  // Deep Learning Bandwidth Compression (DLBC) for activations / inputs.
+  // Offline preparation only; mutually constrained with weight sharing when
+  // combined with DLBC weights.
+  void SetDlbc(bool dlbc);
+  bool GetDlbc() const;
+
+  void SetDlbcWeights(bool dlbc_weights);
+  bool GetDlbcWeights() const;
+
   void SetHtpPerformanceMode(HtpPerformanceMode htp_performance_mode);
   HtpPerformanceMode GetHtpPerformanceMode() const;
 
@@ -152,6 +161,8 @@ class Options {
   bool enable_weight_sharing_ = false;
   bool use_conv_hmx_ = true;
   bool use_fold_relu_ = true;
+  bool dlbc_ = false;
+  bool dlbc_weights_ = false;
   HtpPerformanceMode htp_performance_mode_ = HtpPerformanceMode::kDefault;
   DspPerformanceMode dsp_performance_mode_ = DspPerformanceMode::kDefault;
   std::vector<std::int32_t> dump_tensor_ids_;

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -187,6 +187,24 @@ TEST(QnnOptionTest, UseFoldReLU) {
   EXPECT_EQ(options.GetUseFoldReLU(), false);
 }
 
+TEST(QnnOptionTest, Dlbc) {
+  Options options;
+  EXPECT_FALSE(options.GetDlbc());
+  options.SetDlbc(true);
+  EXPECT_TRUE(options.GetDlbc());
+  options.SetDlbc(false);
+  EXPECT_FALSE(options.GetDlbc());
+}
+
+TEST(QnnOptionTest, DlbcWeights) {
+  Options options;
+  EXPECT_FALSE(options.GetDlbcWeights());
+  options.SetDlbcWeights(true);
+  EXPECT_TRUE(options.GetDlbcWeights());
+  options.SetDlbcWeights(false);
+  EXPECT_FALSE(options.GetDlbcWeights());
+}
+
 TEST(QnnOptionTest, SetIrJsonDir) {
   Options options;
   options.SetIrJsonDir("tmp/");
@@ -253,6 +271,8 @@ TEST(QnnOptionTest, Default) {
   EXPECT_FALSE(options.GetEnableWeightSharing());
   EXPECT_TRUE(options.GetUseConvHMX());
   EXPECT_TRUE(options.GetUseFoldReLU());
+  EXPECT_FALSE(options.GetDlbc());
+  EXPECT_FALSE(options.GetDlbcWeights());
   EXPECT_EQ(options.GetHtpPerformanceMode(), HtpPerformanceMode::kDefault);
   EXPECT_EQ(options.GetDspPerformanceMode(), DspPerformanceMode::kDefault);
   EXPECT_TRUE(options.GetIrJsonDir().empty());


### PR DESCRIPTION
Summary:
- Enable the dlbc/dlbc_weight for HTP backend.
- These options are only for AOT flow.