### PR TITLE
Qualcomm AI Engine Direct - Support DLBC/DLBC_WEIGHT.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -118,6 +118,10 @@ LiteRtStatus LrtQualcommOptionsGetUseInt64BiasAsInt32(
 
 // Weight sharing indicates whether different subgraphs may share weight
 // tensors. This is only supported on x86 AOT. Defaults to false.
+//
+// Note: weight sharing is mutually exclusive with HTP DLBC weights (QAIRT
+// 2.36+). When both are requested, weight sharing wins and DLBC weights is
+// forced off.
 
 LiteRtStatus LrtQualcommOptionsSetEnableWeightSharing(
     LrtQualcommOptions options, bool enable_weight_sharing);

--- a/litert/vendors/qualcomm/compiler/graph_mapper.cc
+++ b/litert/vendors/qualcomm/compiler/graph_mapper.cc
@@ -90,9 +90,9 @@ QnnGpu_Precision_t GetGpuPrecisionValue(::qnn::GpuPrecision precision) {
 
 inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
     const ::qnn::Options& options) {
-  static std::array<QnnHtpGraph_CustomConfig_t, 7> graph_custom_configs;
-  static std::array<QnnGraph_Config_t, 8> graph_configs;
-  static std::array<const QnnGraph_Config_t*, 9> result;
+  static std::array<QnnHtpGraph_CustomConfig_t, 9> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 10> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 11> result;
   size_t num_config = 5;
 
   // QNN suggest always enable relax precision.
@@ -151,6 +151,27 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
     num_config++;
   }
 
+  // DLBC
+  if (options.GetHtpDlbc()) {
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+    graph_custom_configs[num_config].optimizationOption.type =
+        QNN_HTP_GRAPH_OPTIMIZATION_TYPE_ENABLE_DLBC;
+    graph_custom_configs[num_config].optimizationOption.floatValue = 1.0f;
+    num_config++;
+  }
+  // DLBC weights
+  if (options.GetHtpDlbcWeights()) {
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+    graph_custom_configs[num_config].optimizationOption.type =
+        QNN_HTP_GRAPH_OPTIMIZATION_TYPE_ENABLE_DLBC_WEIGHTS;
+    graph_custom_configs[num_config].optimizationOption.floatValue = 1.0f;
+    num_config++;
+  }
+
   for (size_t i = 0; i < num_config; ++i) {
     graph_configs[i] = QNN_GRAPH_CONFIG_INIT;
     graph_configs[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;
@@ -172,9 +193,9 @@ inline absl::Span<const QnnGraph_Config_t*> GetDefaultGraphConfigs(
 
 inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
     const ::qnn::Options& options) {
-  static std::array<QnnHtpGraph_CustomConfig_t, 5> graph_custom_configs;
-  static std::array<QnnGraph_Config_t, 6> graph_configs;
-  static std::array<const QnnGraph_Config_t*, 7> result;
+  static std::array<QnnHtpGraph_CustomConfig_t, 7> graph_custom_configs;
+  static std::array<QnnGraph_Config_t, 8> graph_configs;
+  static std::array<const QnnGraph_Config_t*, 9> result;
   // Default use O3 for now.
   graph_custom_configs[0] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
   graph_custom_configs[0].option = QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
@@ -203,14 +224,37 @@ inline absl::Span<const QnnGraph_Config_t*> GetLegacyGraphConfigs(
 
   // Hvx Thread
   bool has_hvx = options.GetNumHvxThreads() != 0;
+  size_t num_config = 4;
   if (has_hvx) {
-    graph_custom_configs[4] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
-    graph_custom_configs[4].option =
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
         QNN_HTP_GRAPH_CONFIG_OPTION_NUM_HVX_THREADS;
-    graph_custom_configs[4].numHvxThreads = options.GetNumHvxThreads();
+    graph_custom_configs[num_config].numHvxThreads =
+        options.GetNumHvxThreads();
+    ++num_config;
   }
 
-  size_t num_config = has_hvx ? 5 : 4;
+  // DLBC (activations / inputs). Offline-prep only.
+  if (options.GetHtpDlbc()) {
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+    graph_custom_configs[num_config].optimizationOption.type =
+        QNN_HTP_GRAPH_OPTIMIZATION_TYPE_ENABLE_DLBC;
+    graph_custom_configs[num_config].optimizationOption.floatValue = 1.0f;
+    ++num_config;
+  }
+  // DLBC weights. Offline-prep only.
+  if (options.GetHtpDlbcWeights()) {
+    graph_custom_configs[num_config] = QNN_HTP_GRAPH_CUSTOM_CONFIG_INIT;
+    graph_custom_configs[num_config].option =
+        QNN_HTP_GRAPH_CONFIG_OPTION_OPTIMIZATION;
+    graph_custom_configs[num_config].optimizationOption.type =
+        QNN_HTP_GRAPH_OPTIMIZATION_TYPE_ENABLE_DLBC_WEIGHTS;
+    graph_custom_configs[num_config].optimizationOption.floatValue = 1.0f;
+    ++num_config;
+  }
+
   for (size_t i = 0; i < num_config; ++i) {
     graph_configs[i] = QNN_GRAPH_CONFIG_INIT;
     graph_configs[i].option = QNN_GRAPH_CONFIG_OPTION_CUSTOM;

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -13,8 +13,10 @@
 #include <android/log.h>
 #endif  // defined(__ANDROID__)
 
+#include "absl/strings/str_cat.h"  // from @com_google_absl
 #include "absl/strings/str_format.h"  // from @com_google_absl
 #include "absl/strings/str_join.h"  // from @com_google_absl
+#include "absl/strings/str_replace.h"  // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
 
 namespace qnn {
@@ -84,6 +86,250 @@ void DefaultStdOutLogger(const char* fmt, QnnLog_Level_t level,
 
 }  // namespace
 
+// AbslStringify overloads so %v renders these enums as "Name(N)" in Dump().
+// In namespace qnn, not the anonymous namespace above -- ADL skips anonymous
+// namespaces, so %v would silently print the integer instead. Kept out of
+// common.h so the rendering stays local to this TU. No default case: a new
+// enumerator then trips -Werror=switch.
+template <typename Sink>
+void AbslStringify(Sink& sink, LogLevel v) {
+  absl::string_view name = "Unknown";
+  switch (v) {
+    case LogLevel::kOff:
+      name = "Off";
+      break;
+    case LogLevel::kError:
+      name = "Error";
+      break;
+    case LogLevel::kWarn:
+      name = "Warn";
+      break;
+    case LogLevel::kInfo:
+      name = "Info";
+      break;
+    case LogLevel::kVerbose:
+      name = "Verbose";
+      break;
+    case LogLevel::kDebug:
+      name = "Debug";
+      break;
+  }
+  absl::Format(&sink, "%s(%d)", name, static_cast<int>(v));
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, BackendType v) {
+  absl::string_view name = "Unknown";
+  switch (v) {
+    case BackendType::kUndefinedBackend:
+      name = "Undefined";
+      break;
+    case BackendType::kGpuBackend:
+      name = "Gpu";
+      break;
+    case BackendType::kHtpBackend:
+      name = "Htp";
+      break;
+    case BackendType::kDspBackend:
+      name = "Dsp";
+      break;
+    case BackendType::kIrBackend:
+      name = "Ir";
+      break;
+  }
+  absl::Format(&sink, "%s(%d)", name, static_cast<int>(v));
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, Profiling v) {
+  absl::string_view name = "Unknown";
+  switch (v) {
+    case Profiling::kOff:
+      name = "Off";
+      break;
+    case Profiling::kBasic:
+      name = "Basic";
+      break;
+    case Profiling::kDetailed:
+      name = "Detailed";
+      break;
+    case Profiling::kLinting:
+      name = "Linting";
+      break;
+    case Profiling::kOptrace:
+      name = "Optrace";
+      break;
+  }
+  absl::Format(&sink, "%s(%d)", name, static_cast<int>(v));
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, HtpPerformanceMode v) {
+  absl::string_view name = "Unknown";
+  switch (v) {
+    case HtpPerformanceMode::kDefault:
+      name = "Default";
+      break;
+    case HtpPerformanceMode::kSustainedHighPerformance:
+      name = "SustainedHighPerformance";
+      break;
+    case HtpPerformanceMode::kBurst:
+      name = "Burst";
+      break;
+    case HtpPerformanceMode::kHighPerformance:
+      name = "HighPerformance";
+      break;
+    case HtpPerformanceMode::kPowerSaver:
+      name = "PowerSaver";
+      break;
+    case HtpPerformanceMode::kLowPowerSaver:
+      name = "LowPowerSaver";
+      break;
+    case HtpPerformanceMode::kHighPowerSaver:
+      name = "HighPowerSaver";
+      break;
+    case HtpPerformanceMode::kLowBalanced:
+      name = "LowBalanced";
+      break;
+    case HtpPerformanceMode::kBalanced:
+      name = "Balanced";
+      break;
+    case HtpPerformanceMode::kExtremePowerSaver:
+      name = "ExtremePowerSaver";
+      break;
+  }
+  absl::Format(&sink, "%s(%d)", name, static_cast<int>(v));
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, DspPerformanceMode v) {
+  absl::string_view name = "Unknown";
+  switch (v) {
+    case DspPerformanceMode::kDefault:
+      name = "Default";
+      break;
+    case DspPerformanceMode::kSustainedHighPerformance:
+      name = "SustainedHighPerformance";
+      break;
+    case DspPerformanceMode::kBurst:
+      name = "Burst";
+      break;
+    case DspPerformanceMode::kHighPerformance:
+      name = "HighPerformance";
+      break;
+    case DspPerformanceMode::kPowerSaver:
+      name = "PowerSaver";
+      break;
+    case DspPerformanceMode::kLowPowerSaver:
+      name = "LowPowerSaver";
+      break;
+    case DspPerformanceMode::kHighPowerSaver:
+      name = "HighPowerSaver";
+      break;
+    case DspPerformanceMode::kLowBalanced:
+      name = "LowBalanced";
+      break;
+    case DspPerformanceMode::kBalanced:
+      name = "Balanced";
+      break;
+  }
+  absl::Format(&sink, "%s(%d)", name, static_cast<int>(v));
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, OptimizationLevel v) {
+  absl::string_view name = "Unknown";
+  switch (v) {
+    case OptimizationLevel::kHtpOptimizeForInference:
+      name = "HtpOptimizeForInference";
+      break;
+    case OptimizationLevel::kHtpOptimizeForPrepare:
+      name = "HtpOptimizeForPrepare";
+      break;
+    case OptimizationLevel::kHtpOptimizeForInferenceO3:
+      name = "HtpOptimizeForInferenceO3";
+      break;
+  }
+  absl::Format(&sink, "%s(%d)", name, static_cast<int>(v));
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, GraphPriority v) {
+  absl::string_view name = "Unknown";
+  switch (v) {
+    case GraphPriority::kDefault:
+      name = "Default";
+      break;
+    case GraphPriority::kLow:
+      name = "Low";
+      break;
+    case GraphPriority::kNormal:
+      name = "Normal";
+      break;
+    case GraphPriority::kNormalHigh:
+      name = "NormalHigh";
+      break;
+    case GraphPriority::kHigh:
+      name = "High";
+      break;
+  }
+  absl::Format(&sink, "%s(%d)", name, static_cast<int>(v));
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, GpuPrecision v) {
+  absl::string_view name = "Unknown";
+  switch (v) {
+    case GpuPrecision::kUserProvided:
+      name = "UserProvided";
+      break;
+    case GpuPrecision::kFp32:
+      name = "Fp32";
+      break;
+    case GpuPrecision::kFp16:
+      name = "Fp16";
+      break;
+    case GpuPrecision::kHybrid:
+      name = "Hybrid";
+      break;
+  }
+  absl::Format(&sink, "%s(%d)", name, static_cast<int>(v));
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, GpuPerformanceMode v) {
+  absl::string_view name = "Unknown";
+  switch (v) {
+    case GpuPerformanceMode::kDefault:
+      name = "Default";
+      break;
+    case GpuPerformanceMode::kHigh:
+      name = "High";
+      break;
+    case GpuPerformanceMode::kNormal:
+      name = "Normal";
+      break;
+    case GpuPerformanceMode::kLow:
+      name = "Low";
+      break;
+  }
+  absl::Format(&sink, "%s(%d)", name, static_cast<int>(v));
+}
+
+template <typename Sink>
+void AbslStringify(Sink& sink, GraphIOTensorMemType v) {
+  absl::string_view name = "Unknown";
+  switch (v) {
+    case GraphIOTensorMemType::kRaw:
+      name = "Raw";
+      break;
+    case GraphIOTensorMemType::kMemHandle:
+      name = "MemHandle";
+      break;
+  }
+  absl::Format(&sink, "%s(%d)", name, static_cast<int>(v));
+}
+
 void Options::SetLogLevel(LogLevel log_level) { log_level_ = log_level; }
 
 LogLevel Options::GetLogLevel() const { return log_level_; }
@@ -108,6 +354,11 @@ bool Options::GetUseInt64BiasAsInt32() const {
 
 void Options::SetEnableWeightSharing(bool enable_weight_sharing) {
   enable_weight_sharing_ = enable_weight_sharing;
+  // Mutually exclusive with DLBC weights (QAIRT 2.36+); weight sharing wins.
+  // Enforced here too so the outcome is order-independent.
+  if (enable_weight_sharing_) {
+    htp_dlbc_weights_ = false;
+  }
 }
 
 bool Options::GetEnableWeightSharing() const { return enable_weight_sharing_; }
@@ -133,6 +384,17 @@ void Options::SetHtpPPoint(std::int32_t htp_p_point) {
 }
 
 std::int32_t Options::GetHtpPPoint() const { return htp_p_point_; }
+
+void Options::SetHtpDlbc(bool htp_dlbc) { htp_dlbc_ = htp_dlbc; }
+
+bool Options::GetHtpDlbc() const { return htp_dlbc_; }
+
+void Options::SetHtpDlbcWeights(bool htp_dlbc_weights) {
+  // DLBC weights is mutually exclusive with weight sharing (QAIRT 2.36+).
+  htp_dlbc_weights_ = htp_dlbc_weights && !enable_weight_sharing_;
+}
+
+bool Options::GetHtpDlbcWeights() const { return htp_dlbc_weights_; }
 
 void Options::SetHtpPerformanceMode(HtpPerformanceMode htp_performance_mode) {
   htp_performance_mode_ = htp_performance_mode;
@@ -239,52 +501,76 @@ const CustomOpPackage& Options::GetCustomOpPackage() const {
 }
 
 std::string Options::Dump() const {
-  static constexpr absl::string_view kQnnOptionsDumpFormat =
-      "\
-::qnn::Options:\n\
-LogLevel: %d\n\
-BackendType: %d\n\
-Profiling: %d\n\
-UseInt64BiasAsInt32: %v\n\
-EnableWeightSharing: %v\n\
-EnableJustInTime: %v\n\
-UseConvHMX: %v\n\
-UseFoldReLU: %v\n\
-HtpPPoint: %d\n\
-HtpPerformanceMode: %d\n\
-DspPerformanceMode: %d\n\
-GpuPerformanceMode: %d\n\
-GpuPrecision: %d\n\
-DumpTensorIds: %s\n\
-IrJsonDir: %s\n\
-DlcDir: %s\n\
-VtcmSize: %d\n\
-HvxThread: %d\n\
-OptimizationLevel: %d\n\
-GraphPriority: %d\n\
-SaverOutputDir: %s\n\
-GraphIOTensorMemType: %d\n\
-CustomOpPackage: {\n\
-  name: %s\n\
-  interface_provider: %s\n\
-  compile_package_path: %s\n\
-  dispatch_package_path: %s\n\
-  target: %s\n\
-}";  // NOLINT
+  // Grouped by category; append a field() line to the right section to add one.
+  std::string out =
+      "\n"
+      "+------------------------------------------+\n"
+      "|              ::qnn::Options              |\n"
+      "+------------------------------------------+\n";
 
-  std::string dump_tensor_ids = absl::StrJoin(dump_tensor_ids_, ",");
+  // Renders "<indent><name> : <value>". indent is 2 for top-level options, 4
+  // for nested struct members; the name width (26 - indent) keeps the " : "
+  // aligned across both. %v renders enums as "Name(N)" via the overloads above.
+  // One option per line keeps edits conflict-free.
+  const auto field = [&out](int indent, absl::string_view name,
+                            const auto& value) {
+    absl::StrAppendFormat(&out, "%*s%-*s : %v\n", indent, "", 26 - indent, name,
+                          value);
+  };
 
-  return absl::StrFormat(
-      kQnnOptionsDumpFormat, log_level_, backend_type_, profiling_,
-      use_int64_bias_as_int32_, enable_weight_sharing_, enable_just_in_time_,
-      use_conv_hmx_, use_fold_relu_, htp_p_point_, htp_performance_mode_,
-      dsp_performance_mode_, gpu_performance_mode_, gpu_precision_,
-      dump_tensor_ids, ir_json_dir_, dlc_dir_, vtcm_size_, num_hvx_threads_,
-      optimization_level_, graph_priority_, saver_output_dir_,
-      graph_io_tensor_mem_type_, custom_op_package_.name,
-      custom_op_package_.interface_provider,
-      custom_op_package_.compile_package_path,
-      custom_op_package_.dispatch_package_path, custom_op_package_.target);
+  // --- GENERAL ---
+  absl::StrAppend(&out, "[GENERAL]\n");
+  field(2, "LogLevel", log_level_);
+  field(2, "BackendType", backend_type_);
+  field(2, "Profiling", profiling_);
+  field(2, "UseInt64BiasAsInt32", use_int64_bias_as_int32_);
+  field(2, "EnableWeightSharing", enable_weight_sharing_);
+  field(2, "EnableJustInTime", enable_just_in_time_);
+  field(2, "GraphPriority", graph_priority_);
+  field(2, "GraphIOTensorMemType", graph_io_tensor_mem_type_);
+  field(2, "CustomOpPackage", absl::string_view());
+  field(4, "name", custom_op_package_.name);
+  field(4, "interface_provider", custom_op_package_.interface_provider);
+  field(4, "compile_package_path", custom_op_package_.compile_package_path);
+  field(4, "dispatch_package_path", custom_op_package_.dispatch_package_path);
+  field(4, "target", custom_op_package_.target);
+
+  // --- HTP ---
+  absl::StrAppend(&out, "[HTP]\n");
+  field(2, "UseConvHMX", use_conv_hmx_);
+  field(2, "UseFoldReLU", use_fold_relu_);
+  field(2, "HtpDlbc", htp_dlbc_);
+  field(2, "HtpDlbcWeights", htp_dlbc_weights_);
+  field(2, "HtpPPoint", htp_p_point_);
+  field(2, "HtpPerformanceMode", htp_performance_mode_);
+  field(2, "VtcmSize", vtcm_size_);
+  field(2, "NumHvxThreads", num_hvx_threads_);
+  field(2, "OptimizationLevel", optimization_level_);
+
+  // --- IR ---
+  absl::StrAppend(&out, "[IR]\n");
+  field(2, "IrJsonDir", ir_json_dir_);
+  field(2, "DlcDir", dlc_dir_);
+
+  // --- SAVER ---
+  absl::StrAppend(&out, "[SAVER]\n");
+  field(2, "SaverOutputDir", saver_output_dir_);
+
+  // --- DSP ---
+  absl::StrAppend(&out, "[DSP]\n");
+  field(2, "DspPerformanceMode", dsp_performance_mode_);
+
+  // --- GPU ---
+  absl::StrAppend(&out, "[GPU]\n");
+  field(2, "GpuPerformanceMode", gpu_performance_mode_);
+  field(2, "GpuPrecision", gpu_precision_);
+
+  // --- DEBUG ---
+  absl::StrAppend(&out, "[DEBUG]\n");
+  field(2, "DumpTensorIds", absl::StrJoin(dump_tensor_ids_, ","));
+
+  // Strip the trailing space empty values leave after " : ".
+  return absl::StrReplaceAll(out, {{" \n", "\n"}});
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -137,6 +137,12 @@ class Options {
   void SetHtpPPoint(std::int32_t htp_p_point);
   std::int32_t GetHtpPPoint() const;
 
+  void SetHtpDlbc(bool htp_dlbc);
+  bool GetHtpDlbc() const;
+
+  void SetHtpDlbcWeights(bool htp_dlbc_weights);
+  bool GetHtpDlbcWeights() const;
+
   void SetHtpPerformanceMode(HtpPerformanceMode htp_performance_mode);
   HtpPerformanceMode GetHtpPerformanceMode() const;
 
@@ -196,6 +202,8 @@ class Options {
   bool use_conv_hmx_ = true;
   bool use_fold_relu_ = true;
   std::int32_t htp_p_point_ = 0;
+  bool htp_dlbc_ = false;
+  bool htp_dlbc_weights_ = false;
   HtpPerformanceMode htp_performance_mode_ = HtpPerformanceMode::kDefault;
   DspPerformanceMode dsp_performance_mode_ = DspPerformanceMode::kDefault;
   std::vector<std::int32_t> dump_tensor_ids_;

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -196,6 +196,24 @@ TEST(QnnOptionTest, HtpPPoint) {
   EXPECT_EQ(options.GetHtpPPoint(), 0);
 }
 
+TEST(QnnOptionTest, HtpDlbc) {
+  Options options;
+  EXPECT_FALSE(options.GetHtpDlbc());
+  options.SetHtpDlbc(true);
+  EXPECT_TRUE(options.GetHtpDlbc());
+  options.SetHtpDlbc(false);
+  EXPECT_FALSE(options.GetHtpDlbc());
+}
+
+TEST(QnnOptionTest, HtpDlbcWeights) {
+  Options options;
+  EXPECT_FALSE(options.GetHtpDlbcWeights());
+  options.SetHtpDlbcWeights(true);
+  EXPECT_TRUE(options.GetHtpDlbcWeights());
+  options.SetHtpDlbcWeights(false);
+  EXPECT_FALSE(options.GetHtpDlbcWeights());
+}
+
 TEST(QnnOptionTest, SetIrJsonDir) {
   Options options;
   options.SetIrJsonDir("tmp/");
@@ -313,6 +331,8 @@ TEST(QnnOptionTest, Default) {
   EXPECT_TRUE(options.GetUseConvHMX());
   EXPECT_TRUE(options.GetUseFoldReLU());
   EXPECT_EQ(options.GetHtpPPoint(), 0);
+  EXPECT_FALSE(options.GetHtpDlbc());
+  EXPECT_FALSE(options.GetHtpDlbcWeights());
   EXPECT_EQ(options.GetHtpPerformanceMode(), HtpPerformanceMode::kDefault);
   EXPECT_EQ(options.GetDspPerformanceMode(), DspPerformanceMode::kDefault);
   EXPECT_TRUE(options.GetIrJsonDir().empty());

--- a/litert/vendors/qualcomm/qnn_manager_test.cc
+++ b/litert/vendors/qualcomm/qnn_manager_test.cc
@@ -208,4 +208,42 @@ TEST(QnnManagerTest, AdspLibraryPathNoDuplicate) {
   }
 }
 
+// Tests that ::qnn::Options correctly enforces the DLBC weights vs.
+// weight_sharing mutual exclusivity rule (QAIRT 2.36+ requirement). The
+// mutual exclusion is now enforced inside SetHtpDlbcWeights at the internal
+// layer.
+TEST(InitQnnOptionsDlbcTest, HtpDlbcWeightsAlonePropagates) {
+  ::qnn::Options qnn_options;
+  qnn_options.SetEnableWeightSharing(false);
+  qnn_options.SetHtpDlbcWeights(true);
+  EXPECT_TRUE(qnn_options.GetHtpDlbcWeights());
+}
+
+TEST(InitQnnOptionsDlbcTest, WeightSharingAloneLeavesHtpDlbcDefault) {
+  ::qnn::Options qnn_options;
+  qnn_options.SetEnableWeightSharing(true);
+  EXPECT_TRUE(qnn_options.GetEnableWeightSharing());
+  EXPECT_FALSE(qnn_options.GetHtpDlbcWeights());
+}
+
+TEST(InitQnnOptionsDlbcTest, BothEnabledForcesHtpDlbcWeightsOff) {
+  ::qnn::Options qnn_options;
+  qnn_options.SetEnableWeightSharing(true);
+  qnn_options.SetHtpDlbcWeights(true);
+  EXPECT_TRUE(qnn_options.GetEnableWeightSharing());
+  // SetHtpDlbcWeights silently force-offs to match QAIRT 2.36+ behavior.
+  EXPECT_FALSE(qnn_options.GetHtpDlbcWeights());
+}
+
+// DLBC (activations) is independent of weight_sharing — no mutex enforcement
+// needed there. Sanity-check that it propagates regardless and does not bleed
+// into htp_dlbc_weights.
+TEST(InitQnnOptionsDlbcTest, HtpDlbcUnaffectedByWeightSharing) {
+  ::qnn::Options qnn_options;
+  qnn_options.SetEnableWeightSharing(true);
+  qnn_options.SetHtpDlbc(true);
+  EXPECT_TRUE(qnn_options.GetHtpDlbc());
+  EXPECT_FALSE(qnn_options.GetHtpDlbcWeights());
+}
+
 }  // namespace


### PR DESCRIPTION
# What
- DLBC/DLBC_WEIGHT are some qnn-context-binary-genereator supported options.
- Enable the dlbc/dlbc_weight for HTP backend.
- These options are only for AOT flow.

## Verification

- [x] Developer-Verified
- E2E test with DLBC/DLBC_WEIGHT
- For Gemma4-2B:
  - A → B (dlbc)
  - A → C (weights
  - A → D (both)

## Subgraph 0

| Quadrant | dlbc | weights | First (μs) | Fastest (μs) | Avg (μs) | Δ vs A |
|----------|:----:|:-------:|-----------:|-------------:|---------:|-------:|
| A | ❌ | ❌ | 34,850 | 16,457 | 18,106 | — |
| B | ✅ | ❌ | 33,663 | 16,427 | 18,072 | −0.2% |
| C | ❌ | ✅ | 33,954 | 16,672 | 18,365 | +1.4% |
| D | ✅ | ✅ | 34,095 | 16,643 | 18,389 | +1.6% |

## Subgraph 1

| Quadrant | dlbc | weights | First (μs) | Fastest (μs) | Avg (μs) | Δ vs A |
|----------|:----:|:-------:|-----------:|-------------:|---------:|-------:|
| A | ❌ | ❌ | 30,069 | 10,280 | 10,691 | — |
| B | ✅ | ❌ | 27,043 | 10,176 | 10,528 | −1.5% |
| C | ❌ | ✅ | 27,015 | 10,350 | 10,699 | +0.07% |
| D | ✅ | ✅ | 25,510 | 10,231 | 10,570 | −1.1% |

- Options visualization
```
+------------------------------------------+
|              ::qnn::Options              |
+------------------------------------------+
[GENERAL]
  LogLevel                 : Info(3)
  BackendType              : Ir(4)
  Profiling                : Off(0)
  UseInt64BiasAsInt32      : true
  EnableWeightSharing      : false
  EnableJustInTime         : false
  GraphPriority            : Default(0)
  GraphIOTensorMemType     : MemHandle(1)
  CustomOpPackage          :
    name                   :
    interface_provider     :
    compile_package_path   :
    dispatch_package_path  :
    target                 :
[HTP]
  UseConvHMX               : true
  UseFoldReLU              : true
  HtpDlbc                  : false
  HtpDlbcWeights           : false
  HtpPPoint                : 0
  HtpPerformanceMode       : Default(0)
  VtcmSize                 : 0
  NumHvxThreads            : 0
  OptimizationLevel        : HtpOptimizeForInferenceO3(2)
[IR]
  IrJsonDir                :
  DlcDir                   : /local/mnt/workspace/chuntl/liteRT/qti/claude/resnet_quant/dlc
[SAVER]
  SaverOutputDir           :
[DSP]
  DspPerformanceMode       : Default(0)
[GPU]
  GpuPerformanceMode       : High(1)
  GpuPrecision             : Fp16(2)
[DEBUG]
  DumpTensorIds            :
```
# Test

- Passed x86 unit test. 
- Passed android unit test.

======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test       PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all


//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test                 PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test                  PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 30.9s

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 13 tests from 9 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 15 tests from 3 test suites ran. (30 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 33 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 19 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (22 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (571 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (433 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (968 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (914 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (719 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2441 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (57 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (5 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (557 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (496 ms total)
[  PASSED  ] 2 tests.