### PR TITLE
[WIP] Fix Windows ARM64 build and benchmark options

### DIFF
--- a/litert/build_common/litert_build_defs.bzl
+++ b/litert/build_common/litert_build_defs.bzl
@@ -298,6 +298,7 @@ def _litert_base(
                 ("//conditions:default", "//litert/build_common:linux_x86_64_grte"): _DEFAULT_LINK_OPTS,
                 "//litert:macos": [],
                 "//litert:ios": [],
+                "//litert:windows": [],
                 "//litert/build_common:linux_x86_64_ungrte": _UNGRTE_LINK_OPTS + _DEFAULT_LINK_OPTS,
             }),
         )
@@ -308,6 +309,7 @@ def _litert_base(
             linkopts = select({
                 "//litert:macos": [],
                 "//litert:ios": [],
+                "//litert:windows": [],
                 "//conditions:default": _DEFAULT_LINK_OPTS,
             }),
         )

--- a/litert/tensorflow_source_rules.bzl
+++ b/litert/tensorflow_source_rules.bzl
@@ -37,6 +37,9 @@ def _tensorflow_source_repo_impl(ctx):
         )
 
     _patch_xla_windows_copts(ctx)
+    _patch_xnnpack_windows_arm64(ctx)
+    _patch_farmhash_windows_arm64(ctx)
+    _patch_cpuinfo_windows_arm64(ctx)
     _apply_repo_patches(ctx)
 
 def _patch_xla_windows_copts(ctx):
@@ -47,6 +50,209 @@ def _patch_xla_windows_copts(ctx):
     new = 'clean_dep("//xla/tsl:windows"): get_win_copts(is_external, is_msvc = True),'
     if old in content:
         ctx.file(tsl_bzl, content.replace(old, new))
+
+def _patch_xnnpack_windows_arm64(ctx):
+    """Patch XNNPACK's Bazel Windows ARM64 config to use MSVC C flags."""
+    patch_path = "third_party/xla/third_party/xnnpack/windows_arm64_msvc.patch"
+    ctx.file(patch_path, content = """diff --git a/BUILD.bazel b/BUILD.bazel
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -2057,6 +2057,7 @@ alias(
+     actual = select({
+         ":xnn_enable_assembly_explicit_true": ":xnn_enable_assembly_explicit_true",
+         ":xnn_enable_assembly_explicit_false": ":xnn_enable_assembly_explicit_true",
++        "//build_config:windows_aarch64": ":xnn_enable_assembly_explicit_true",
+         "//conditions:default": ":assembly_enabled_by_default",
+     }),
+ )
+diff --git a/build_config/BUILD.bazel b/build_config/BUILD.bazel
+--- a/build_config/BUILD.bazel
++++ b/build_config/BUILD.bazel
+@@ -144,6 +144,6 @@ config_setting(
+ config_setting(
+     name = "windows_aarch64",
+     values = {
+-         "cpu": "aarch64_windows",
++         "cpu": "arm64_windows",
+     },
+ )
+@@ -332,6 +332,14 @@ selects.config_setting_group(
+     ],
+ )
+@SP@
++selects.config_setting_group(
++    name = "aarch64_or_windows_aarch64",
++    match_any = [
++        ":aarch64",
++        ":windows_aarch64",
++    ],
++)
++
+ selects.config_setting_group(
+     name = "arm",
+     match_any = [
+@@ -342,6 +350,14 @@ selects.config_setting_group(
+     ],
+ )
+@SP@
++selects.config_setting_group(
++    name = "arm_or_windows_aarch64",
++    match_any = [
++        ":arm",
++        ":windows_aarch64",
++    ],
++)
++
+ selects.config_setting_group(
+     name = "x86",
+     match_any = [
+diff --git a/build_defs.bzl b/build_defs.bzl
+--- a/build_defs.bzl
++++ b/build_defs.bzl
+@@ -378,7 +378,8 @@ def xnnpack_cc_library(
+             "//build_config:windows_x86_64_clangcl": ["/clang:" + opt for opt in gcc_copts],
+             "//build_config:windows_x86_64_clang": gcc_copts,
+             "//build_config:windows_x86_64_mingw": gcc_copts,
+             "//build_config:windows_x86_64_msys": gcc_copts,
+             "//build_config:windows_x86_64": msvc_copts,
++            "//build_config:windows_aarch64": msvc_copts,
+             "//conditions:default": gcc_copts,
+         }) + select({
+diff --git a/build_params.bzl b/build_params.bzl
+--- a/build_params.bzl
++++ b/build_params.bzl
+@@ -281,7 +281,7 @@ XNNPACK_PARAMS_FOR_ARCH = {
+     ),
+     "neon": _create_params(
+-        cond = "//build_config:arm",
++        cond = "//build_config:arm_or_windows_aarch64",
+         copts = xnnpack_select_if(
+             "//build_config:aarch32",
+             [
+@@ -295,7 +295,7 @@ XNNPACK_PARAMS_FOR_ARCH = {
+         ]),
+     ),
+     "neon_aarch64": _create_params(
+-        cond = "//build_config:aarch64",
++        cond = "//build_config:aarch64_or_windows_aarch64",
+         extra_deps = xnnpack_if_kleidiai_enabled([
+             "@KleidiAI//kai/ukernels/matmul",
+         ]),
+@@ -301,7 +301,7 @@ XNNPACK_PARAMS_FOR_ARCH = {
+         ]),
+     ),
+     "neonfp16": _create_params(
+-        cond = "//build_config:arm",
++        cond = "//build_config:arm_or_windows_aarch64",
+         copts = xnnpack_select_if(
+             "//build_config:aarch32",
+             [
+@@ -312,7 +312,7 @@ XNNPACK_PARAMS_FOR_ARCH = {
+         ),
+     ),
+     "neonfma": _create_params(
+-        cond = "//build_config:arm",
++        cond = "//build_config:arm_or_windows_aarch64",
+         copts = xnnpack_select_if(
+             "//build_config:aarch32",
+             [
+@@ -323,10 +323,10 @@ XNNPACK_PARAMS_FOR_ARCH = {
+         ),
+     ),
+     "neonfma_aarch64": _create_params(
+-        cond = "//build_config:aarch64",
++        cond = "//build_config:aarch64_or_windows_aarch64",
+     ),
+     "neonv8": _create_params(
+-        cond = "//build_config:arm",
++        cond = "//build_config:arm_or_windows_aarch64",
+         copts = xnnpack_select_if(
+             "//build_config:aarch32",
+             [
+""".replace("@SP@", " "))
+
+    workspace_bzl = "third_party/xla/third_party/xnnpack/workspace.bzl"
+    content = ctx.read(workspace_bzl)
+    if "windows_arm64_msvc.patch" in content:
+        return
+
+    old = '        urls = tf_mirror_urls("https://github.com/google/XNNPACK/archive/d0004f80c78fed80c230045ee83ff34dc55be81a.zip"),'
+    new = old + '\n        patch_file = ["//third_party/xnnpack:windows_arm64_msvc.patch"],'
+    if old in content:
+        ctx.file(workspace_bzl, content.replace(old, new))
+
+def _patch_farmhash_windows_arm64(ctx):
+    """Disable FarmHash builtin-expect usage for Windows ARM64 MSVC."""
+    farmhash_build = "third_party/xla/third_party/farmhash/farmhash.BUILD"
+    content = ctx.read(farmhash_build)
+
+    if 'name = "windows_arm64"' not in content:
+        old = """config_setting(
+    name = "windows",
+    values = {
+        "cpu": "x64_windows",
+    },
+)
+"""
+        new = old + """
+config_setting(
+    name = "windows_arm64",
+    values = {
+        "cpu": "arm64_windows",
+    },
+)
+"""
+        content = content.replace(old, new)
+
+    old = """        ":windows_x86_64_clang": ["-DFARMHASH_OPTIONAL_BUILTIN_EXPECT"],
+        ":windows": ["/DFARMHASH_OPTIONAL_BUILTIN_EXPECT"],
+        "//conditions:default": [],
+"""
+    new = """        ":windows_x86_64_clang": ["-DFARMHASH_OPTIONAL_BUILTIN_EXPECT"],
+        ":windows": ["/DFARMHASH_OPTIONAL_BUILTIN_EXPECT"],
+        ":windows_arm64": ["/DFARMHASH_OPTIONAL_BUILTIN_EXPECT"],
+        "//conditions:default": [],
+"""
+    if '":windows_arm64": ["/DFARMHASH_OPTIONAL_BUILTIN_EXPECT"],' not in content:
+        content = content.replace(old, new)
+
+    ctx.file(farmhash_build, content)
+
+def _patch_cpuinfo_windows_arm64(ctx):
+    """Patch cpuinfo ARM sources to use their MSVC-safe restrict/static macro."""
+    patch_path = "third_party/xla/third_party/cpuinfo/windows_arm64_msvc.patch"
+    ctx.file(patch_path, content = """diff --git a/src/arm/cache.c b/src/arm/cache.c
+--- a/src/arm/cache.c
++++ b/src/arm/cache.c
+@@ -9,12 +9,12 @@
+@SP@void cpuinfo_arm_decode_cache(
+@SP@@TAB@enum cpuinfo_uarch uarch,
+@SP@@TAB@uint32_t cluster_cores,
+@SP@@TAB@uint32_t midr,
+-	const struct cpuinfo_arm_chipset chipset[restrict static 1],
++	const struct cpuinfo_arm_chipset chipset[RESTRICT_STATIC 1],
+@SP@@TAB@uint32_t cluster_id,
+@SP@@TAB@uint32_t arch_version,
+-	struct cpuinfo_cache l1i[restrict static 1],
+-	struct cpuinfo_cache l1d[restrict static 1],
+-	struct cpuinfo_cache l2[restrict static 1],
+-	struct cpuinfo_cache l3[restrict static 1]) {
++	struct cpuinfo_cache l1i[RESTRICT_STATIC 1],
++	struct cpuinfo_cache l1d[RESTRICT_STATIC 1],
++	struct cpuinfo_cache l2[RESTRICT_STATIC 1],
++	struct cpuinfo_cache l3[RESTRICT_STATIC 1]) {
+@SP@@TAB@switch (uarch) {
+""".replace("@SP@", " ").replace("@TAB@", "\t"))
+
+    workspace_bzl = "third_party/xla/third_party/cpuinfo/workspace.bzl"
+    content = ctx.read(workspace_bzl)
+    if "windows_arm64_msvc.patch" in content:
+        return
+
+    old = '        urls = tf_mirror_urls("https://github.com/pytorch/cpuinfo/archive/8a9210069b5a37dd89ed118a783945502a30a4ae.zip"),'
+    new = old + '\n        patch_file = ["//third_party/cpuinfo:windows_arm64_msvc.patch"],'
+    if old in content:
+        ctx.file(workspace_bzl, content.replace(old, new))
 
 def _apply_repo_patches(ctx):
     # Apply patches after extraction/symlinking.

--- a/litert/tools/benchmark_litert_model.cc
+++ b/litert/tools/benchmark_litert_model.cc
@@ -88,6 +88,8 @@ Options CreateCompiledModelOptions(const BenchmarkParams& params) {
   auto num_threads = params.Get<int>("num_threads");
   auto enable_weight_sharing = params.Get<bool>("enable_weight_sharing");
   auto convert_weights_on_gpu = params.Get<bool>("convert_weights_on_gpu");
+  auto qualcomm_graph_io_tensor_mem_type =
+      params.Get<std::string>("qualcomm_graph_io_tensor_mem_type");
   auto mediatek_nerun_pilot_version =
       params.Get<std::string>("mediatek_nerun_pilot_version");
   LITERT_ASSIGN_OR_ABORT(Options compilation_options,
@@ -139,6 +141,18 @@ Options CreateCompiledModelOptions(const BenchmarkParams& params) {
     if (!status) {
       LITERT_LOG(LITERT_ERROR, "Failed to run options parsers: %s",
                  status.Error().Message().c_str());
+      std::abort();
+    }
+    if (qualcomm_graph_io_tensor_mem_type == "raw") {
+      qnn_opts.SetGraphIOTensorMemType(
+          litert::qualcomm::QualcommOptions::GraphIOTensorMemType::kRaw);
+    } else if (qualcomm_graph_io_tensor_mem_type == "memhandle") {
+      qnn_opts.SetGraphIOTensorMemType(
+          litert::qualcomm::QualcommOptions::GraphIOTensorMemType::kMemHandle);
+    } else {
+      LITERT_LOG(LITERT_ERROR,
+                 "Invalid qualcomm_graph_io_tensor_mem_type: %s",
+                 qualcomm_graph_io_tensor_mem_type.c_str());
       std::abort();
     }
   }

--- a/litert/tools/benchmark_litert_model.h
+++ b/litert/tools/benchmark_litert_model.h
@@ -241,6 +241,8 @@ class BenchmarkLiteRtModel : public BenchmarkModel {
                             BenchmarkParam::Create<std::string>(""));
     default_params.AddParam("compiler_cache_path",
                             BenchmarkParam::Create<std::string>(""));
+    default_params.AddParam("qualcomm_graph_io_tensor_mem_type",
+                            BenchmarkParam::Create<std::string>("memhandle"));
     default_params.AddParam("require_full_delegation",
                             BenchmarkParam::Create<bool>(false));
     default_params.AddParam("use_profiler",
@@ -377,6 +379,9 @@ class BenchmarkLiteRtModel : public BenchmarkModel {
     flags.push_back(tflite::benchmark::CreateFlag<std::string>(
         "compiler_cache_path", &params_,
         "Compiler plugin cache path, used to store JIT-compiled models."));
+    flags.push_back(tflite::benchmark::CreateFlag<std::string>(
+        "qualcomm_graph_io_tensor_mem_type", &params_,
+        "Qualcomm graph IO tensor memory type [raw|memhandle]."));
     flags.push_back(tflite::benchmark::CreateFlag<bool>(
         "require_full_delegation", &params_,
         "Whether to require full delegation."));


### PR DESCRIPTION
## Summary
- Fix Windows ARM64 Bazel build issues outside `litert/vendors` now that vendor changes are upstream.
- Patch TensorFlow external deps for Windows ARM64: XNNPACK config/flags, FarmHash builtin-expect define, and cpuinfo MSVC restrict/static handling.
- Add `--qualcomm_graph_io_tensor_mem_type=raw|memhandle` to the C++ LiteRT benchmark path.

