### PR TITLE
[build] fix "changes meaning" compiler error under WSL

### DIFF
--- a/litert/CMakeLists.txt
+++ b/litert/CMakeLists.txt
@@ -41,7 +41,6 @@ add_compile_options(
   -Wno-deprecated-declarations
   -Wno-nullability-completeness
   -Wno-return-type
-  -fpermissive
 )
 add_compile_definitions(CL_TARGET_OPENCL_VERSION=300)
 

--- a/litert/cc/litert_buffer_ref.h
+++ b/litert/cc/litert_buffer_ref.h
@@ -122,7 +122,7 @@ class BufferRef {
       : end_offset_(end_offset),
         start_offset_(start_offset),
         data_(const_cast<ByteT*>(reinterpret_cast<const ByteT*>(data))) {}
-  explicit BufferRef(Span<const ByteT> data)
+  explicit BufferRef(litert::Span<const ByteT> data)
       : end_offset_(data.size()),
         start_offset_(0),
         data_(const_cast<ByteT*>(data.data())) {}
@@ -145,7 +145,7 @@ class BufferRef {
   StringView StrView() const { return StringView(StrData(), Size()); }
 
   /// @brief Returns a const span of the actual data.
-  Span<const ByteT> Span() const {
+  litert::Span<const ByteT> Span() const {
     return internal::MakeLiteRtConstSpan(Data(), Size());
   }
 
@@ -204,8 +204,8 @@ class MutableBufferRef : public BufferRef<ByteT> {
       : BufferRef<ByteT>(data, size, offset) {}
   MutableBufferRef(void* data, size_t size, size_t offset = 0)
       : BufferRef<ByteT>(data, size, offset) {}
-  explicit MutableBufferRef(Span<ByteT> data) : BufferRef<ByteT>(data) {}
-  explicit MutableBufferRef(Span<const ByteT> data) = delete;
+  explicit MutableBufferRef(litert::Span<ByteT> data) : BufferRef<ByteT>(data) {}
+  explicit MutableBufferRef(litert::Span<const ByteT> data) = delete;
   MutableBufferRef(const ByteT*, size_t, size_t) = delete;
   MutableBufferRef(const void*, size_t, size_t) = delete;
 
@@ -221,7 +221,7 @@ class MutableBufferRef : public BufferRef<ByteT> {
   }
 
   /// @brief Returns a mutable span of the actual data.
-  Span<ByteT> Span() { return internal::MakeLiteRtSpan(Data(), this->Size()); }
+  litert::Span<ByteT> Span() { return internal::MakeLiteRtSpan(Data(), this->Size()); }
 
   /// @brief Writes a string into the buffer at a specified offset.
   /// @param str The string to write.
@@ -279,7 +279,7 @@ class OwningBufferRef : public MutableBufferRef<ByteT> {
       : MutableBufferRef<ByteT>(data, size, offset) {}
   OwningBufferRef(void* data, size_t size, size_t offset = 0)
       : MutableBufferRef<ByteT>(data, size, offset) {}
-  explicit OwningBufferRef(Span<ByteT> data) : MutableBufferRef<ByteT>(data) {}
+  explicit OwningBufferRef(litert::Span<ByteT> data) : MutableBufferRef<ByteT>(data) {}
 
   /// @brief Copies the given buffer.
   OwningBufferRef(const ByteT* data, size_t size)
@@ -288,7 +288,7 @@ class OwningBufferRef : public MutableBufferRef<ByteT> {
     this->data_ = (ByteT*)Allocator()(size);
     std::memcpy(this->data_, data, size);
   }
-  explicit OwningBufferRef(Span<const ByteT> data)
+  explicit OwningBufferRef(litert::Span<const ByteT> data)
       : OwningBufferRef<ByteT, Allocator>(data.data(), data.size()) {}
 
   /// @brief Copies data from a given string.

--- a/litert/cc/litert_model_types.h
+++ b/litert/cc/litert_model_types.h
@@ -74,10 +74,10 @@ class SimpleTensor {
   SimpleTensor& operator=(SimpleTensor&&) = default;
 
   /// @brief Returns the element type of the tensor.
-  ElementType ElementType() const {
+  ::litert::ElementType ElementType() const {
     if (type_id_ == kLiteRtUnrankedTensorType) {
       LITERT_ASSIGN_OR_ABORT(auto tensor_type, UnrankedTensorType());
-      return static_cast<enum ElementType>(tensor_type.element_type);
+      return static_cast<enum ::litert::ElementType>(tensor_type.element_type);
     } else {
       LITERT_ASSIGN_OR_ABORT(auto tensor_type, RankedTensorType());
       return tensor_type.ElementType();
@@ -86,7 +86,7 @@ class SimpleTensor {
 
   /// @brief Returns whether the tensor has the given ranked tensor type.
   /// @param type The ranked tensor type to check.
-  bool HasType(const RankedTensorType& type) const {
+  bool HasType(const ::litert::RankedTensorType& type) const {
     auto t = RankedTensorType();
     return t && *t == type;
   }
@@ -114,7 +114,7 @@ class SimpleTensor {
 
   /// @brief Returns the ranked tensor type of the tensor.
   /// @return The ranked tensor type, or an error if the tensor is not ranked.
-  Expected<RankedTensorType> RankedTensorType() const {
+  Expected<::litert::RankedTensorType> RankedTensorType() const {
     if (type_id_ != kLiteRtRankedTensorType) {
       return Error(Status::kErrorInvalidArgument, "Not a ranked tensor type");
     }
@@ -208,7 +208,7 @@ class SimpleSignature {
   /// @param name The name of the input tensor.
   /// @return The ranked tensor type, or an error if the tensor is not found or
   /// not ranked.
-  Expected<RankedTensorType> InputTensorType(StringView name) const {
+  Expected<::litert::RankedTensorType> InputTensorType(StringView name) const {
     LITERT_ASSIGN_OR_RETURN(auto tensor, InputTensor(name));
     return tensor.RankedTensorType();
   }
@@ -217,7 +217,7 @@ class SimpleSignature {
   /// @param index The index of the input tensor.
   /// @return The ranked tensor type, or an error if the index is out of bounds
   /// or the tensor is not ranked.
-  Expected<RankedTensorType> InputTensorType(size_t index) const {
+  Expected<::litert::RankedTensorType> InputTensorType(size_t index) const {
     LITERT_ASSIGN_OR_RETURN(auto tensor, InputTensor(index));
     return tensor.RankedTensorType();
   }
@@ -227,7 +227,7 @@ class SimpleSignature {
   /// @param name The name of the output tensor.
   /// @return The ranked tensor type, or an error if the tensor is not found or
   /// not ranked.
-  Expected<RankedTensorType> OutputTensorType(StringView name) const {
+  Expected<::litert::RankedTensorType> OutputTensorType(StringView name) const {
     LITERT_ASSIGN_OR_RETURN(auto tensor, OutputTensor(name));
     return tensor.RankedTensorType();
   }
@@ -236,7 +236,7 @@ class SimpleSignature {
   /// @param index The index of the output tensor.
   /// @return The ranked tensor type, or an error if the index is out of bounds
   /// or the tensor is not ranked.
-  Expected<RankedTensorType> OutputTensorType(size_t index) const {
+  Expected<::litert::RankedTensorType> OutputTensorType(size_t index) const {
     LITERT_ASSIGN_OR_RETURN(auto tensor, OutputTensor(index));
     return tensor.RankedTensorType();
   }


### PR DESCRIPTION

Below errors when building the `run_model_simple` under WSL:

```
compiling  run_model_simple.cc :

    In file included from /home/dkp/LiteRT/litert/cc/litert_compiled_model.h:38,
                     from /home/dkp/LiteRT/cmake_example/run_model_simple.cc:29:
    /home/dkp/LiteRT/litert/cc/litert_buffer_ref.h:148:21: error: declaration of ‘litert::Span<const T>
  litert::BufferRef<ByteT>::Span() const’ changes meaning of ‘Span’ [-Wchanges-meaning]
      148 |   Span<const ByteT> Span() const {
          |                     ^~~~
    /home/dkp/LiteRT/litert/cc/litert_buffer_ref.h:148:3: note: used here to mean ‘using litert::Span =
  class absl::lts_20260107::Span<const T>’
      148 |   Span<const ByteT> Span() const {
          |   ^~~~~~~~~~~~~~~~~
```

Instead of adding `-fpermissive` to `run_model_simple`, this commit adds explicit namespaces to the SDK files to make it standard-compliant (which is also suggested by Gemini).