### PR TITLE
Qualcomm AI Engine Direct - Support Custom Op Package.

### DIFF
--- a/litert/CMakeLists.txt
+++ b/litert/CMakeLists.txt
@@ -205,19 +205,28 @@ if(EXISTS "${CMAKE_BINARY_DIR}/FP16-source/include")
 endif()
 
 # Find FlatBuffers
+#
+# TFLite is added via add_subdirectory(... "${TFLITE_BUILD_DIR}"), but its
+# FetchContent of FlatBuffers materializes under ${CMAKE_BINARY_DIR} (the
+# top-level binary dir, which does not change inside add_subdirectory), NOT
+# under ${TFLITE_BUILD_DIR}. Point at ${CMAKE_BINARY_DIR} so the headers and
+# library resolve for targets that reference FlatBuffers directly (e.g.
+# qnn_flexbuffer_helpers) rather than transitively through tensorflow-lite.
+set(LITERT_FLATBUFFERS_DIR "${CMAKE_BINARY_DIR}/flatbuffers")
+set(LITERT_FLATBUFFERS_BUILD_DIR "${CMAKE_BINARY_DIR}/_deps/flatbuffers-build")
 find_package(flatbuffers QUIET
     PATHS
-      ${TFLITE_BUILD_DIR}/_deps/flatbuffers-build
-      ${TFLITE_BUILD_DIR}/flatbuffers/CMake
-      ${TFLITE_BUILD_DIR}/flatbuffers-flatc/lib/cmake/flatbuffers
+      ${LITERT_FLATBUFFERS_BUILD_DIR}
+      ${LITERT_FLATBUFFERS_DIR}/CMake
+      ${CMAKE_BINARY_DIR}/flatbuffers-flatc/lib/cmake/flatbuffers
     NO_DEFAULT_PATH
 )
 
 if(NOT TARGET flatbuffers::flatbuffers)
   add_library(flatbuffers::flatbuffers STATIC IMPORTED)
   set_target_properties(flatbuffers::flatbuffers PROPERTIES
-    IMPORTED_LOCATION "${TFLITE_BUILD_DIR}/_deps/flatbuffers-build/libflatbuffers.a"
-    INTERFACE_INCLUDE_DIRECTORIES "${TFLITE_BUILD_DIR}/flatbuffers/include"
+    IMPORTED_LOCATION "${LITERT_FLATBUFFERS_BUILD_DIR}/libflatbuffers.a"
+    INTERFACE_INCLUDE_DIRECTORIES "${LITERT_FLATBUFFERS_DIR}/include"
   )
 endif()
 

--- a/litert/c/internal/litert_compiler_context.cc
+++ b/litert/c/internal/litert_compiler_context.cc
@@ -225,6 +225,8 @@ LiteRtCompilerContext* LrtGetCompilerContext() {
       .get_mirror_pad_mode_option = LiteRtGetMirrorPadModeOption,
 
       .get_squeeze_dims_option = LiteRtGetSqueezeDimsOption,
+
+      .get_custom_options = LiteRtGetCustomOptions,
   };
   return &ctx;
 }

--- a/litert/c/internal/litert_compiler_context.h
+++ b/litert/c/internal/litert_compiler_context.h
@@ -15,6 +15,7 @@
 #ifndef THIRD_PARTY_ODML_LITERT_LITERT_C_INTERNAL_LITERT_COMPILER_CONTEXT_H_
 #define THIRD_PARTY_ODML_LITERT_LITERT_C_INTERNAL_LITERT_COMPILER_CONTEXT_H_
 
+#include <cstdint>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -355,6 +356,10 @@ typedef struct LiteRtCompilerContext {
                                           const int32_t** squeeze_dims,
                                           int32_t* num_squeeze_dims);
 
+  // Op inspection
+  LiteRtStatus (*get_custom_options)(LiteRtOp op,
+                                     const uint8_t** custom_options,
+                                     int32_t* custom_options_size);
 } LiteRtCompilerContext;
 
 // ABI compatibility check for LiteRtCompilerContext.
@@ -363,7 +368,7 @@ typedef struct LiteRtCompilerContext {
 // changes to this struct.
 #if defined(__cplusplus) && defined(__SIZEOF_POINTER__) && \
     __SIZEOF_POINTER__ == 8
-static_assert(sizeof(LiteRtCompilerContext) == 1024,
+static_assert(sizeof(LiteRtCompilerContext) == 1032,
               "LiteRtCompilerContext size mismatch");
 static_assert(offsetof(LiteRtCompilerContext, get_num_model_subgraphs) == 0,
               "LiteRtCompilerContext get_num_model_subgraphs offset mismatch");
@@ -865,6 +870,8 @@ static_assert(
     "LiteRtCompilerContext get_mirror_pad_mode_option offset mismatch");
 static_assert(offsetof(LiteRtCompilerContext, get_squeeze_dims_option) == 1016,
               "LiteRtCompilerContext get_squeeze_dims_option offset mismatch");
+static_assert(offsetof(LiteRtCompilerContext, get_custom_options) == 1024,
+              "LiteRtCompilerContext get_custom_options offset mismatch");
 #endif  // __cplusplus
 
 LiteRtCompilerContext* LrtGetCompilerContext();

--- a/litert/c/litert_model_test.cc
+++ b/litert/c/litert_model_test.cc
@@ -379,6 +379,21 @@ TEST(LiteRtOpTest, GetCustomCodeNotCustom) {
   EXPECT_NE(LiteRtGetCustomCode(&op, &code), kLiteRtStatusOk);
 }
 
+TEST(LiteRtOpTest, GetCustomOptions) {
+  static constexpr std::array<uint8_t, 4> kOptions = {0x01, 0x02, 0x03, 0x04};
+
+  LiteRtOpT op;
+  op.SetCustomOptions(kOptions.data(), kOptions.size());
+
+  const uint8_t* options = nullptr;
+  size_t options_size = 0;
+  LITERT_ASSERT_OK(LiteRtGetCustomOptions(&op, &options, &options_size));
+
+  ASSERT_EQ(options_size, kOptions.size());
+  ASSERT_THAT(absl::MakeConstSpan(options, options_size),
+              ElementsAreArray(kOptions));
+}
+
 TEST(LiteRtSubgraphTest, GetInputs) {
   LiteRtTensorT input1;
   LiteRtTensorT input2;

--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -33,6 +33,58 @@
 
 using litert::internal::ParseToml;
 
+namespace {
+
+struct CustomOpPackage {
+  std::string name = "";
+  std::string interface_provider = "";
+  std::string compile_package_path = "";
+  std::string dispatch_package_path = "";
+  std::string target = "";
+};
+
+LiteRtStatus ParseCustomOpPackageValue(absl::string_view value,
+                                       CustomOpPackage& package) {
+  size_t start = 0;
+  while (start <= value.size()) {
+    const size_t end = value.find(';', start);
+    const size_t token_end =
+        (end == absl::string_view::npos) ? value.size() : end;
+    absl::string_view token = value.substr(start, token_end - start);
+    start = token_end + 1;
+
+    if (token.empty()) {
+      continue;
+    }
+
+    const size_t colon_pos = token.find(':');
+    if (colon_pos == absl::string_view::npos) {
+      return kLiteRtStatusErrorInvalidArgument;
+    }
+
+    const absl::string_view key = token.substr(0, colon_pos);
+    const absl::string_view val = token.substr(colon_pos + 1);
+
+    if (key == "name") {
+      package.name = val;
+    } else if (key == "interface_provider") {
+      package.interface_provider = val;
+    } else if (key == "compile_package_path") {
+      package.compile_package_path = val;
+    } else if (key == "dispatch_package_path") {
+      package.dispatch_package_path = val;
+    } else if (key == "target") {
+      package.target = val;
+    } else {
+      return kLiteRtStatusErrorInvalidArgument;
+    }
+  }
+
+  return kLiteRtStatusOk;
+}
+
+}  // namespace
+
 struct LrtQualcommOptionsT {
   std::optional<LrtQualcommOptionsLogLevel> log_level;
   std::optional<LrtQualcommOptionsProfiling> profiling;
@@ -57,6 +109,7 @@ struct LrtQualcommOptionsT {
   std::optional<std::string> saver_output_dir;
   std::optional<LrtQualcommOptionsGraphIOTensorMemType>
       graph_io_tensor_mem_type;
+  std::optional<CustomOpPackage> custom_op_package;
 };
 
 LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
@@ -180,6 +233,12 @@ LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
           status = LrtQualcommOptionsSetGraphIOTensorMemType(
               parsed_options,
               static_cast<LrtQualcommOptionsGraphIOTensorMemType>(*v));
+        } else if (key == "custom_op_package") {
+          CustomOpPackage package;
+          status = ParseCustomOpPackageValue(value, package);
+          if (status == kLiteRtStatusOk) {
+            parsed_options->custom_op_package = package;
+          }
         }
 
         return status;
@@ -297,6 +356,17 @@ LiteRtStatus LrtGetOpaqueQualcommOptionsData(LrtQualcommOptions options,
     toml << "graph_io_tensor_mem_type = "
          << static_cast<int>(*options->graph_io_tensor_mem_type) << "\n";
   }
+  if (options->custom_op_package.has_value()) {
+    const auto& package = *options->custom_op_package;
+    toml << "custom_op_package = \""
+         << "name:" << package.name << ";"
+         << "interface_provider:" << package.interface_provider << ";"
+         << "compile_package_path:" << package.compile_package_path << ";"
+         << "dispatch_package_path:" << package.dispatch_package_path << ";"
+         << "target:" << package.target << ";"
+         << "\"\n";
+  }
+
   *identifier = LrtQualcommOptionsGetIdentifier();
   std::string toml_str = toml.str();
   litert::internal::MakeCStringPayload(toml_str, payload, payload_deleter);
@@ -378,6 +448,54 @@ LiteRtStatus LrtQualcommOptionsGetSaverOutputDir(
                           ? options->saver_output_dir->c_str()
                           : "";
 
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsSetCustomOpPackage(
+    LrtQualcommOptions options, const char* name,
+    const char* interface_provider, const char* compile_package_path,
+    const char* dispatch_package_path, const char* target) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  CustomOpPackage package;
+  package.name = name;
+  package.interface_provider = interface_provider;
+  package.compile_package_path = compile_package_path;
+  package.dispatch_package_path = dispatch_package_path;
+  package.target = target;
+
+  options->custom_op_package = std::move(package);
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsGetCustomOpPackage(
+    LrtQualcommOptions options, const char** name,
+    const char** interface_provider, const char** compile_package_path,
+    const char** dispatch_package_path, const char** target) {
+  if (options == nullptr || name == nullptr || interface_provider == nullptr ||
+      compile_package_path == nullptr ||
+      dispatch_package_path == nullptr || target == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  if (!options->custom_op_package.has_value()) {
+    *name = "";
+    *interface_provider = "";
+    *compile_package_path = "";
+    *dispatch_package_path = "";
+    *target = "";
+    return kLiteRtStatusOk;
+  }
+
+  const auto& package = *options->custom_op_package;
+  *name = package.name.c_str();
+  *interface_provider = package.interface_provider.c_str();
+  *compile_package_path = package.compile_package_path.c_str();
+  *dispatch_package_path = package.dispatch_package_path.c_str();
+  *target = package.target.c_str();
   return kLiteRtStatusOk;
 }
 

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -334,6 +334,17 @@ LiteRtStatus LrtQualcommOptionsSetSaverOutputDir(LrtQualcommOptions options,
 
 LiteRtStatus LrtQualcommOptionsGetSaverOutputDir(LrtQualcommOptions options,
                                                  const char** saver_output_dir);
+
+LiteRtStatus LrtQualcommOptionsSetCustomOpPackage(
+    LrtQualcommOptions options, const char* name,
+    const char* interface_provider, const char* compile_package_path,
+    const char* dispatch_package_path, const char* target);
+
+LiteRtStatus LrtQualcommOptionsGetCustomOpPackage(
+    LrtQualcommOptions options, const char** name,
+    const char** interface_provider, const char** compile_package_path,
+    const char** dispatch_package_path, const char** target);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -316,6 +316,51 @@ TEST(LiteRtQualcommOptionsTest, DumpTensorIds) {
   LrtDestroyQualcommOptions(qualcomm_options);
 }
 
+TEST(LiteRtQualcommOptionsTest, CustomOpPackageSetGet) {
+  LrtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
+
+  LITERT_ASSERT_OK(LrtQualcommOptionsSetCustomOpPackage(
+      qualcomm_options, "pkg", "provider", "compile.so", "dispatch.so",
+      "HTP"));
+
+  const char* name = nullptr;
+  const char* interface_provider = nullptr;
+  const char* compile_package_path = nullptr;
+  const char* dispatch_package_path = nullptr;
+  const char* target = nullptr;
+  LITERT_ASSERT_OK(LrtQualcommOptionsGetCustomOpPackage(
+      qualcomm_options, &name, &interface_provider, &compile_package_path,
+      &dispatch_package_path, &target));
+
+  EXPECT_STREQ(name, "pkg");
+  EXPECT_STREQ(interface_provider, "provider");
+  EXPECT_STREQ(compile_package_path, "compile.so");
+  EXPECT_STREQ(dispatch_package_path, "dispatch.so");
+  EXPECT_STREQ(target, "HTP");
+
+  LrtDestroyQualcommOptions(qualcomm_options);
+}
+
+TEST(LiteRtQualcommOptionsTest, CustomOpPackageRoundTrip) {
+  LrtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
+
+  LITERT_ASSERT_OK(LrtQualcommOptionsSetCustomOpPackage(
+      qualcomm_options, "pkg", "provider", "compile.so", "dispatch.so",
+      "HTP"));
+
+  auto parsed = SerializeAndParse(qualcomm_options);
+  const auto custom_op_package = parsed.GetCustomOpPackage();
+  EXPECT_EQ(custom_op_package.name, "pkg");
+  EXPECT_EQ(custom_op_package.interface_provider, "provider");
+  EXPECT_EQ(custom_op_package.compile_package_path, "compile.so");
+  EXPECT_EQ(custom_op_package.dispatch_package_path, "dispatch.so");
+  EXPECT_EQ(custom_op_package.target, "HTP");
+
+  LrtDestroyQualcommOptions(qualcomm_options);
+}
+
 TEST(QualcommOptionsTest, CppWrapper) {
   auto options = QualcommOptions::Create();
   ASSERT_TRUE(options);
@@ -412,6 +457,20 @@ TEST(QualcommOptionsTest, CppWrapper) {
       QualcommOptions::GraphIOTensorMemType::kMemHandle);
   EXPECT_EQ(options->GetGraphIOTensorMemType(),
             QualcommOptions::GraphIOTensorMemType::kMemHandle);
+
+  QualcommOptions::CustomOpPackage pkg;
+  pkg.name = "pkg";
+  pkg.interface_provider = "provider";
+  pkg.compile_package_path = "compile.so";
+  pkg.dispatch_package_path = "dispatch.so";
+  pkg.target = "HTP";
+  EXPECT_EQ(options->SetCustomOpPackage(pkg), kLiteRtStatusOk);
+  const auto custom_op_package = options->GetCustomOpPackage();
+  EXPECT_EQ(custom_op_package.name, "pkg");
+  EXPECT_EQ(custom_op_package.interface_provider, "provider");
+  EXPECT_EQ(custom_op_package.compile_package_path, "compile.so");
+  EXPECT_EQ(custom_op_package.dispatch_package_path, "dispatch.so");
+  EXPECT_EQ(custom_op_package.target, "HTP");
 }
 
 }  // namespace

--- a/litert/cc/internal/litert_extended_model.h
+++ b/litert/cc/internal/litert_extended_model.h
@@ -399,6 +399,18 @@ class Op : public internal::NonOwnedHandle<LiteRtOp> {
     return absl::string_view(custom_code);
   }
 
+  /// @brief Gets the custom options.
+  /// @return The custom options if present, otherwise an error.
+  Expected<absl::Span<const uint8_t>> CustomOptions() const {
+    const uint8_t* options = nullptr;
+    int32_t options_bytes = 0;
+    auto stat = LiteRtGetCustomOptions(Get(), &options, &options_bytes);
+    if (stat != kLiteRtStatusOk) {
+      return Error(stat, "Failed to get custom options");
+    }
+    return absl::MakeConstSpan(options, options_bytes);
+  }
+
   OpInputs Inputs() const {
     LiteRtParamIndex num_inputs;
     internal::AssertOk(LiteRtGetNumOpInputs, Get(), &num_inputs);

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -459,6 +459,44 @@ class QualcommOptions {
     return static_cast<GraphIOTensorMemType>(val);
   }
 
+  struct CustomOpPackage {
+    std::string name;
+    std::string interface_provider;
+    std::string compile_package_path;
+    std::string dispatch_package_path;
+    std::string target;
+  };
+
+  LiteRtStatus SetCustomOpPackage(const CustomOpPackage& custom_op_package) {
+    return LrtQualcommOptionsSetCustomOpPackage(
+        options_, custom_op_package.name.c_str(),
+        custom_op_package.interface_provider.c_str(),
+        custom_op_package.compile_package_path.c_str(),
+        custom_op_package.dispatch_package_path.c_str(),
+        custom_op_package.target.c_str());
+  }
+
+  CustomOpPackage GetCustomOpPackage() const {
+    const char* name = "";
+    const char* interface_provider = "";
+    const char* compile_package_path = "";
+    const char* dispatch_package_path = "";
+    const char* target = "";
+    auto status = LrtQualcommOptionsGetCustomOpPackage(
+        options_, &name, &interface_provider, &compile_package_path,
+        &dispatch_package_path, &target);
+    if (status != kLiteRtStatusOk) {
+      return {};
+    }
+    CustomOpPackage custom_op_package;
+    custom_op_package.name = name;
+    custom_op_package.interface_provider = interface_provider;
+    custom_op_package.compile_package_path = compile_package_path;
+    custom_op_package.dispatch_package_path = dispatch_package_path;
+    custom_op_package.target = target;
+    return custom_op_package;
+  }
+
  private:
   LrtQualcommOptions options_;
 };

--- a/litert/compiler/cc/litert_model.h
+++ b/litert/compiler/cc/litert_model.h
@@ -296,6 +296,17 @@ class Op {
     return absl::string_view(custom_code);
   }
 
+  Expected<absl::Span<const uint8_t>> CustomOptions() const {
+    const uint8_t* custom_options_data = nullptr;
+    int32_t custom_options_size = 0;
+    auto status = ctx_->get_custom_options(Get(), &custom_options_data,
+                                           &custom_options_size);
+    if (status != kLiteRtStatusOk) {
+      return Error(status, "Failed to get custom options");
+    }
+    return absl::MakeConstSpan(custom_options_data, custom_options_size);
+  }
+
   bool Is(LiteRtOpCode code) const { return Code() == code; }
 
  private:

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -527,6 +527,84 @@ std::string AbslUnparseFlag(QualcommOptions::Backend options) {
 }
 
 }  // namespace litert::qualcomm
+
+ABSL_FLAG(
+    litert::qualcomm::QualcommOptions::CustomOpPackage,
+    qualcomm_custom_op_package, {},
+    "Custom op package settings as key:value pairs separated by ';'. "
+    "Required keys: name, interface_provider, compile_package_path, "
+    "dispatch_package_path, target. "
+    "target MUST match the chosen QNN backend (e.g., 'HTP' for the HTP "
+    "backend, 'GPU' for the GPU backend). "
+    "For compiler plugin, name/interface_provider/compile_package_path are "
+    "used. For dispatch plugin, name/interface_provider/"
+    "dispatch_package_path/target are used. Example: "
+    "\"name:TestPackage;interface_provider:Provider;compile_package_path:"
+    "libQnnTestPackage.so;dispatch_package_path:"
+    "libQnnTestPackage.so;target:HTP;\"");
+
+namespace litert::qualcomm {
+
+bool AbslParseFlag(absl::string_view text,
+                   QualcommOptions::CustomOpPackage* options,
+                   std::string* error) {
+  if (!text.empty()) {
+    size_t start = 0;
+    while (start <= text.size()) {
+      const size_t end = text.find(';', start);
+      const size_t token_end =
+          end == absl::string_view::npos ? text.size() : end;
+      const absl::string_view token = text.substr(start, token_end - start);
+      start = token_end + 1;
+
+      if (token.empty()) {
+        continue;
+      }
+
+      const size_t colon_pos = token.find(':');
+      if (colon_pos == absl::string_view::npos) {
+        *error = "Invalid custom op package flag.";
+        return false;
+      }
+
+      const absl::string_view key = token.substr(0, colon_pos);
+      const absl::string_view value = token.substr(colon_pos + 1);
+      if (key == "name") {
+        options->name = value;
+      } else if (key == "interface_provider") {
+        options->interface_provider = value;
+      } else if (key == "compile_package_path") {
+        options->compile_package_path = value;
+      } else if (key == "dispatch_package_path") {
+        options->dispatch_package_path = value;
+      } else if (key == "target") {
+        options->target = value;
+      } else {
+        *error = "Unsupported key in custom op package flag.";
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+std::string AbslUnparseFlag(QualcommOptions::CustomOpPackage options) {
+  std::string value;
+  value.reserve(256);
+  auto append_pair = [&value](absl::string_view key, absl::string_view val) {
+    value.append(key).append(":").append(val).append(";");
+  };
+
+  append_pair("name", options.name);
+  append_pair("interface_provider", options.interface_provider);
+  append_pair("compile_package_path", options.compile_package_path);
+  append_pair("dispatch_package_path", options.dispatch_package_path);
+  append_pair("target", options.target);
+  return value;
+}
+
+}  // namespace litert::qualcomm
+
 // NOLINTEND(*alien-types*)
 
 namespace litert::qualcomm {
@@ -598,6 +676,10 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
   const auto graph_io_tensor_mem_type =
       absl::GetFlag(FLAGS_qualcomm_graph_io_tensor_mem_type);
   opts.SetGraphIOTensorMemType(graph_io_tensor_mem_type);
+
+  const auto custom_op_package =
+      absl::GetFlag(FLAGS_qualcomm_custom_op_package);
+  LITERT_RETURN_IF_ERROR(opts.SetCustomOpPackage(custom_op_package));
 
   return {};
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -49,6 +49,19 @@ std::string AbslUnparseFlag(QualcommOptions::Backend options);
 
 }  // namespace litert::qualcomm
 
+ABSL_DECLARE_FLAG(litert::qualcomm::QualcommOptions::CustomOpPackage,
+                  qualcomm_custom_op_package);
+
+namespace litert::qualcomm {
+
+bool AbslParseFlag(absl::string_view text,
+                   QualcommOptions::CustomOpPackage* options,
+                   std::string* error);
+
+std::string AbslUnparseFlag(QualcommOptions::CustomOpPackage options);
+
+}  // namespace litert::qualcomm
+
 // COMPILATION OPTIONS /////////////////////////////////////////////////////////
 
 ABSL_DECLARE_FLAG(bool, qualcomm_enable_weight_sharing);

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -489,6 +489,21 @@ TEST(GraphIOTensorMemTypeTest, Parse) {
   }
 }
 
+TEST(CustomOpPackageFlagTest, ParseUnparse) {
+  std::string error;
+  QualcommOptions::CustomOpPackage value;
+  static constexpr absl::string_view kFlagValue =
+      "name:pkg;interface_provider:provider;compile_package_path:compile.so;"
+      "dispatch_package_path:dispatch.so;target:HTP;";
+  EXPECT_TRUE(AbslParseFlag(kFlagValue, &value, &error));
+  EXPECT_EQ(value.name, "pkg");
+  EXPECT_EQ(value.interface_provider, "provider");
+  EXPECT_EQ(value.compile_package_path, "compile.so");
+  EXPECT_EQ(value.dispatch_package_path, "dispatch.so");
+  EXPECT_EQ(value.target, "HTP");
+  EXPECT_EQ(AbslUnparseFlag(value), kFlagValue);
+}
+
 TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
   Expected<QualcommOptions> options = QualcommOptions::Create();
   ASSERT_TRUE(options.HasValue());

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -147,7 +147,12 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetSaverOutputDir(qualcomm_options.GetSaverOutputDir());
   qnn_options.SetGraphIOTensorMemType(static_cast<::qnn::GraphIOTensorMemType>(
       qualcomm_options.GetGraphIOTensorMemType()));
-
+  const auto custom_op_package = qualcomm_options.GetCustomOpPackage();
+  qnn_options.SetCustomOpPackage(
+      custom_op_package.name, custom_op_package.interface_provider,
+      custom_op_package.compile_package_path,
+      custom_op_package.dispatch_package_path,
+      custom_op_package.target);
   LITERT_LOG(LITERT_INFO, "\n%s", qnn_options.Dump().data());
   return kLiteRtStatusOk;
 }

--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -262,6 +262,7 @@ litert_lib(
         "//litert/vendors/qualcomm/core/builders:conv2d_op_builder",
         "//litert/vendors/qualcomm/core/builders:conv3d_op_builder",
         "//litert/vendors/qualcomm/core/builders:cumsum_op_builder",
+        "//litert/vendors/qualcomm/core/builders:custom_op_builder",
         "//litert/vendors/qualcomm/core/builders:depthwise_conv2d_op_builder",
         "//litert/vendors/qualcomm/core/builders:dynamic_update_slice_op_builder",
         "//litert/vendors/qualcomm/core/builders:elementwise_op_builder",
@@ -308,6 +309,7 @@ litert_lib(
         "//litert/vendors/qualcomm/core/builders:unpack_op_builder",
         "//litert/vendors/qualcomm/core/dump:dump_graph",
         "//litert/vendors/qualcomm/core/transformation:graph_to_graph",
+        "//litert/vendors/qualcomm/core/utils:flexbuffer_helpers",
         "//litert/vendors/qualcomm/core/utils:log",
         "//litert/vendors/qualcomm/core/utils:miscs",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
@@ -320,6 +322,7 @@ litert_lib(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@qairt//:qnn_lib_headers",
+        "@flatbuffers//:runtime_cc",
     ],
 )
 

--- a/litert/vendors/qualcomm/compiler/CMakeLists.txt
+++ b/litert/vendors/qualcomm/compiler/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(qnn_compiler_plugin
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     PRIVATE
-        ${TFLITE_BUILD_DIR}/flatbuffers/include
+        ${CMAKE_BINARY_DIR}/flatbuffers/include
 )
 
 target_link_libraries(qnn_compiler_plugin
@@ -34,6 +34,7 @@ target_link_libraries(qnn_compiler_plugin
         qnn_transformation
         qnn_dump_graph
         qnn_context_binary_info
+        qnn_flexbuffer_helpers
         tensorflow-lite
         absl::log
         absl::check

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -87,6 +87,10 @@ bool IsWeightSharingSupported(::qnn::DspArch dsp_arch) {
 #endif
 }
 
+// Compile-time custom-op packages always target the CPU backend; this is
+// the value passed to QNN's RegisterOpPackage for compilation.
+constexpr char kCustomOpPackageCompileTarget[] = "CPU";
+
 }  // namespace
 
 LiteRtStatus LiteRtGetCompilerPluginVersion(LiteRtApiVersion* api_version) {
@@ -268,8 +272,15 @@ class LiteRtCompilerPluginT {
 
   const ::qnn::Options& Options() const { return qnn_options_; }
 
-  void initQnnManager(std::unique_ptr<QnnManager> qnn_manager) {
+  LiteRtStatus initQnnManager(std::unique_ptr<QnnManager> qnn_manager) {
+    if (const auto& custom_op_package = qnn_options_.GetCustomOpPackage();
+        !custom_op_package.name.empty()) {
+      LITERT_RETURN_IF_ERROR(qnn_manager->RegisterOpPackage(
+          custom_op_package.compile_package_path,
+          custom_op_package.interface_provider, kCustomOpPackageCompileTarget));
+    }
     qnn_manager_ = std::move(qnn_manager);
+    return kLiteRtStatusOk;
   }
 
   QnnManager* QNN() { return qnn_manager_.get(); }
@@ -336,7 +347,8 @@ LiteRtStatus LiteRtGetCompilerPluginSDKVersion(
                  qnn_manager_or.Error().Message().data());
       return qnn_manager_or.Error().Status();
     }
-    compiler_plugin->initQnnManager(std::move(*qnn_manager_or));
+    LITERT_RETURN_IF_ERROR(
+        compiler_plugin->initQnnManager(std::move(*qnn_manager_or)));
     qnn_manager = compiler_plugin->QNN();
   }
 
@@ -369,7 +381,8 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
       return qnn_manager_or.Error().Status();
     }
     LITERT_LOG(LITERT_INFO, "%s", "QNN manager created");
-    compiler_plugin->initQnnManager(std::move(*qnn_manager_or));
+    LITERT_RETURN_IF_ERROR(
+        compiler_plugin->initQnnManager(std::move(*qnn_manager_or)));
     qnn_manager = compiler_plugin->QNN();
   }
 
@@ -394,7 +407,8 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
 
     std::vector<::qnn::OpWrapper> op_wrappers;
     LITERT_RETURN_IF_ERROR(litert::qnn::ConvertOp(
-        compiler_plugin->Options().GetUseInt64BiasAsInt32(), op, tensor_pool,
+        compiler_plugin->Options().GetUseInt64BiasAsInt32(),
+        compiler_plugin->Options().GetCustomOpPackage(), op, tensor_pool,
         input_tensors, output_tensors, op_wrappers));
 
     // Empty op_wrappers means the op is not supported by QNN.
@@ -483,7 +497,8 @@ LiteRtStatus LiteRtCompilerPluginCompile(
       return qnn_manager_or.Error().Status();
     }
     LITERT_LOG(LITERT_INFO, "%s", "QNN manager created");
-    compiler_plugin->initQnnManager(std::move(*qnn_manager_or));
+    LITERT_RETURN_IF_ERROR(
+        compiler_plugin->initQnnManager(std::move(*qnn_manager_or)));
     qnn_manager = compiler_plugin->QNN();
   }
 

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -58,6 +58,7 @@
 #include "litert/vendors/qualcomm/core/builders/conv2d_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/conv3d_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/cumsum_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/custom_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/depthwise_conv2d_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/dynamic_update_slice_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/elementwise_op_builder.h"
@@ -105,6 +106,7 @@
 #include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/core/dump/dump_graph.h"
 #include "litert/vendors/qualcomm/core/transformation/graph_to_graph.h"
+#include "litert/vendors/qualcomm/core/utils/flexbuffer_helpers.h"
 #include "litert/vendors/qualcomm/core/utils/log.h"
 #include "litert/vendors/qualcomm/core/utils/miscs.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
@@ -135,6 +137,7 @@ std::string SanitizeName(std::string_view name) {
   }
   return out;
 }
+
 }  // namespace
 
 LiteRtStatus ConvertPaddingType(const uint32_t litert_padding,
@@ -1407,9 +1410,139 @@ constexpr std::array<OpBuilder, kLiteRtOpCodeShloComposite + 1> kOpBuilders =
     GetOpBuilders();
 static_assert(kOpBuilders.size() == kLiteRtOpCodeShloComposite + 1);
 
+LiteRtStatus BuildCustomOp(const litert::compiler::Op& litert_op,
+                           ::qnn::TensorPool& tensor_pool,
+                           std::vector<::qnn::TensorWrapperRef>& input_tensors,
+                           std::vector<::qnn::TensorWrapperRef>& output_tensors,
+                           std::vector<::qnn::OpWrapper>& op_wrappers,
+                           const ::qnn::CustomOpPackage& custom_op_package) {
+  // Use tflite custom code as op type in QNN custom op package.
+  auto custom_code = litert_op.CustomCode();
+  if (!custom_code.HasValue() || custom_code->empty()) {
+    LITERT_LOG(LITERT_ERROR, "Custom op missing custom code.");
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  auto custom_options = litert_op.CustomOptions();
+  if (!custom_options.HasValue()) {
+    LITERT_LOG(LITERT_ERROR, "Custom op missing custom options.");
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  const char* package_name = custom_op_package.name.empty()
+                                 ? QNN_OP_PACKAGE_NAME_QTI_AISW
+                                 : custom_op_package.name.c_str();
+  auto& custom_op = op_wrappers.emplace_back(::qnn::CreateCustomOp(
+      package_name, custom_code->data(),
+      std::vector<::qnn::ConstTensorWrapperRef>(input_tensors.begin(),
+                                                input_tensors.end()),
+      std::vector<::qnn::ConstTensorWrapperRef>(output_tensors.begin(),
+                                                output_tensors.end())));
+
+  // TODO(weilhuan): Will cause seg fault if checked by flexbuffers::GetRoot().IsNull for some
+  // reason, use < 2 here to avoid this.
+  if (custom_options->size() < 2) {
+    LITERT_LOG(
+        LITERT_WARNING,
+        "Custom op custom options are too small to be a flexbuffer map, maybe "
+        "there is no custom options in custom op.");
+    return kLiteRtStatusOk;
+  }
+
+  // GetRoot trusts the buffer's internal offsets; validate first since custom
+  // options come from the .tflite (external input).
+  if (!flexbuffers::VerifyBuffer(custom_options->data(),
+                                 custom_options->size())) {
+    LITERT_LOG(LITERT_ERROR,
+               "Custom op custom options are not a valid flexbuffer.");
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  const auto root =
+      flexbuffers::GetRoot(custom_options->data(), custom_options->size());
+  if (!root.IsMap()) {
+    LITERT_LOG(LITERT_ERROR,
+               "Custom op custom options are not a flexbuffer "
+               "map.");
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  const auto map = root.AsMap();
+  const auto keys = map.Keys();
+  const auto values = map.Values();
+  for (size_t i = 0; i < map.size(); ++i) {
+    const char* key = keys[i].AsKey();
+    const auto& value = values[i];
+
+    if (value.IsUntypedVector() || value.IsTypedVector() ||
+        value.IsFixedTypedVector()) {
+      const auto dimensions = ::qnn::InferShape(value);
+      if (!dimensions.has_value()) {
+        LITERT_LOG(LITERT_ERROR,
+                   "BuildCustomOp: custom options key '%s' has ragged vector "
+                   "dimensions.",
+                   key);
+        return kLiteRtStatusErrorUnsupported;
+      }
+
+      const uint32_t num_elements =
+          std::accumulate(dimensions->begin(), dimensions->end(), uint32_t{1},
+                          std::multiplies<uint32_t>());
+
+      // Resolve the uniform scalar type once, then fill with the matching T.
+      auto fill_vector = [&](auto type_tag, Qnn_DataType_t qnn_dtype) {
+        using T = decltype(type_tag);
+        std::vector<T> data;
+        data.reserve(num_elements);
+        ::qnn::FillBuffer<T>(value, data);
+        auto& tensor = tensor_pool.CreateStaticTensor(
+            qnn_dtype, {}, dimensions.value(),
+            static_cast<uint32_t>(num_elements * sizeof(T)), data.data());
+        custom_op.AddTensorParam(key, tensor);
+      };
+
+      switch (::qnn::GetUniformScalarType(value)) {
+        case ::qnn::FlexbufferScalarType::kBool:
+          fill_vector(uint8_t{}, QNN_DATATYPE_BOOL_8);
+          break;
+        case ::qnn::FlexbufferScalarType::kInt:
+          fill_vector(int32_t{}, QNN_DATATYPE_INT_32);
+          break;
+        case ::qnn::FlexbufferScalarType::kUint:
+          fill_vector(uint32_t{}, QNN_DATATYPE_UINT_32);
+          break;
+        case ::qnn::FlexbufferScalarType::kFloat:
+          fill_vector(float{}, QNN_DATATYPE_FLOAT_32);
+          break;
+        default:
+          LITERT_LOG(LITERT_ERROR,
+                     "BuildCustomOp: unsupported scalar type for vector "
+                     "param key '%s'.",
+                     key);
+          return kLiteRtStatusErrorUnsupported;
+      }
+    } else if (value.IsBool()) {
+      custom_op.AddScalarParam<bool>(key, value.AsBool());
+    } else if (value.IsInt()) {
+      custom_op.AddScalarParam<std::int32_t>(key, value.AsInt32());
+    } else if (value.IsUInt()) {
+      custom_op.AddScalarParam<std::uint32_t>(key, value.AsUInt32());
+    } else if (value.IsFloat()) {
+      custom_op.AddScalarParam<float>(key, value.AsFloat());
+    } else {
+      LITERT_LOG(LITERT_ERROR,
+                 "BuildCustomOp: unsupported scalar type for param key '%s'.",
+                 key);
+      return kLiteRtStatusErrorUnsupported;
+    }
+  }
+  return kLiteRtStatusOk;
+}
+
 }  // namespace
 
 LiteRtStatus ConvertOp(const bool use_int64_bias_as_int32,
+                       const ::qnn::CustomOpPackage& custom_op_package,
                        const litert::compiler::Op& litert_op,
                        ::qnn::TensorPool& tensor_pool,
                        std::vector<::qnn::TensorWrapperRef>& input_tensors,
@@ -1421,6 +1554,10 @@ LiteRtStatus ConvertOp(const bool use_int64_bias_as_int32,
     return builders[op_code](litert_op, tensor_pool, input_tensors,
                              output_tensors, op_wrappers,
                              use_int64_bias_as_int32);
+  }
+  if (op_code == kLiteRtOpCodeTflCustom) {
+    return BuildCustomOp(litert_op, tensor_pool, input_tensors, output_tensors,
+                         op_wrappers, custom_op_package);
   }
   LITERT_LOG(LITERT_ERROR,
              "LiteRT Op Code: %d is not supported in Qualcomm Compiler.",
@@ -1539,9 +1676,9 @@ LiteRtStatus MapGraph(const LiteRtCompilerContext* ctx, QnnManager& qnn,
     }
 
     std::vector<::qnn::OpWrapper> op_wrappers;
-    LITERT_RETURN_IF_ERROR(ConvertOp(options.GetUseInt64BiasAsInt32(), op,
-                                     tensor_pool, input_tensors, output_tensors,
-                                     op_wrappers));
+    LITERT_RETURN_IF_ERROR(ConvertOp(
+        options.GetUseInt64BiasAsInt32(), options.GetCustomOpPackage(), op,
+        tensor_pool, input_tensors, output_tensors, op_wrappers));
     for (auto& op_wrapper : op_wrappers) {
       // Add litert op id to qnn op name to preserve op mapping
       op_wrapper.AddSuffixToName(

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
@@ -43,6 +43,7 @@ LiteRtStatus ConvertTensor(
     bool is_tensor_output = false);
 
 LiteRtStatus ConvertOp(bool use_int64_bias_as_int32,
+                       const ::qnn::CustomOpPackage& custom_op_package,
                        const litert::compiler::Op& litert_op,
                        ::qnn::TensorPool& tensor_pool,
                        std::vector<::qnn::TensorWrapperRef>& input_tensors,

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -722,3 +722,15 @@ cc_library(
         "@qairt//:qnn_lib_headers",
     ],
 )
+
+cc_library(
+    name = "custom_op_builder",
+    srcs = ["custom_op_builder.cc"],
+    hdrs = ["custom_op_builder.h"],
+    deps = [
+        ":op_builder",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@qairt//:qnn_lib_headers",
+    ],
+)

--- a/litert/vendors/qualcomm/core/builders/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/builders/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(qnn_builders
         scatter_nd_op_builder.cc
         topk_op_builder.cc
         group_norm_op_builder.cc
+        custom_op_builder.cc
 )
 
 target_include_directories(qnn_builders

--- a/litert/vendors/qualcomm/core/builders/custom_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/custom_op_builder.cc
@@ -1,0 +1,25 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "QnnOpDef.h"  // from @qairt
+
+namespace qnn {
+
+OpWrapper CreateCustomOp(const char* package_name, const char* op_type,
+                         const std::vector<ConstTensorWrapperRef>& inputs,
+                         const std::vector<ConstTensorWrapperRef>& outputs) {
+  OpWrapper op(GetUniqueOpName(op_type), package_name, op_type,
+               QnnOpCode::kUnknown);
+  for (const auto& input : inputs) {
+    op.AddInputTensor(input);
+  }
+  for (const auto& output : outputs) {
+    op.AddOutputTensor(output);
+  }
+  return op;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/custom_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/custom_op_builder.h
@@ -1,0 +1,20 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CUSTOM_OP_BUILDER_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CUSTOM_OP_BUILDER_H_
+
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+OpWrapper CreateCustomOp(const char* package_name, const char* op_type,
+                         const std::vector<ConstTensorWrapperRef>& inputs,
+                         const std::vector<ConstTensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_CUSTOM_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -208,6 +208,22 @@ GraphIOTensorMemType Options::GetGraphIOTensorMemType() const {
   return graph_io_tensor_mem_type_;
 }
 
+void Options::SetCustomOpPackage(absl::string_view name,
+                                 absl::string_view interface_provider,
+                                 absl::string_view compile_package_path,
+                                 absl::string_view dispatch_package_path,
+                                 absl::string_view target) {
+  custom_op_package_.name = name;
+  custom_op_package_.interface_provider = interface_provider;
+  custom_op_package_.compile_package_path = compile_package_path;
+  custom_op_package_.dispatch_package_path = dispatch_package_path;
+  custom_op_package_.target = target;
+}
+
+const CustomOpPackage& Options::GetCustomOpPackage() const {
+  return custom_op_package_;
+}
+
 std::string Options::Dump() const {
   static constexpr absl::string_view kQnnOptionsDumpFormat =
       "\
@@ -231,7 +247,14 @@ HvxThread: %d\n\
 OptimizationLevel: %d\n\
 GraphPriority: %d\n\
 SaverOutputDir: %s\n\
-GraphIOTensorMemType: %d\n";  // NOLINT
+GraphIOTensorMemType: %d\n\
+CustomOpPackage: {\n\
+  name: %s\n\
+  interface_provider: %s\n\
+  compile_package_path: %s\n\
+  dispatch_package_path: %s\n\
+  target: %s\n\
+}";  // NOLINT
 
   std::string dump_tensor_ids = absl::StrJoin(dump_tensor_ids_, ",");
 
@@ -241,7 +264,11 @@ GraphIOTensorMemType: %d\n";  // NOLINT
       use_conv_hmx_, use_fold_relu_, htp_p_point_, htp_performance_mode_,
       dsp_performance_mode_, dump_tensor_ids, ir_json_dir_, dlc_dir_,
       vtcm_size_, num_hvx_threads_, optimization_level_, graph_priority_,
-      saver_output_dir_, graph_io_tensor_mem_type_);
+      saver_output_dir_, graph_io_tensor_mem_type_, custom_op_package_.name,
+      custom_op_package_.interface_provider,
+      custom_op_package_.compile_package_path,
+      custom_op_package_.dispatch_package_path,
+      custom_op_package_.target);
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -83,6 +83,15 @@ enum class GraphPriority {
   kHigh = 4,
 };
 
+struct CustomOpPackage {
+  std::string name;
+  std::string interface_provider;
+  std::string compile_package_path;
+  std::string dispatch_package_path;
+  // QNN backend target at dispatch time (e.g., "HTP", "GPU").
+  std::string target;
+};
+
 class Options {
  public:
   Options() = default;
@@ -150,6 +159,13 @@ class Options {
   void SetGraphIOTensorMemType(GraphIOTensorMemType mem_type);
   GraphIOTensorMemType GetGraphIOTensorMemType() const;
 
+  void SetCustomOpPackage(absl::string_view name,
+                          absl::string_view interface_provider,
+                          absl::string_view compile_package_path,
+                          absl::string_view dispatch_package_path,
+                          absl::string_view target);
+  const CustomOpPackage& GetCustomOpPackage() const;
+
  private:
   LogLevel log_level_ = LogLevel::kInfo;
   BackendType backend_type_ = BackendType::kHtpBackend;
@@ -173,6 +189,8 @@ class Options {
   std::string saver_output_dir_;
   GraphIOTensorMemType graph_io_tensor_mem_type_ =
       GraphIOTensorMemType::kMemHandle;
+  // Currently we only support one custom op package.
+  CustomOpPackage custom_op_package_;
 };
 
 // Gets a default logger implementation to stdout.

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -253,6 +253,25 @@ TEST(QnnOptionTest, SetGraphPriority) {
   EXPECT_EQ(options.GetGraphPriority(), GraphPriority::kDefault);
 }
 
+TEST(QnnOptionTest, SetCustomOpPackage) {
+  Options options;
+  const std::string name = "TestPackage";
+  const std::string interface_provider = "TestInterfaceProvider";
+  const std::string compile_package_path = "/tmp/compile_pkg.so";
+  const std::string dispatch_package_path = "/tmp/dispatch_pkg.so";
+  const std::string target = "HTP";
+
+  options.SetCustomOpPackage(name, interface_provider, compile_package_path,
+                             dispatch_package_path, target);
+
+  const CustomOpPackage& package = options.GetCustomOpPackage();
+  EXPECT_EQ(package.name, name);
+  EXPECT_EQ(package.interface_provider, interface_provider);
+  EXPECT_EQ(package.compile_package_path, compile_package_path);
+  EXPECT_EQ(package.dispatch_package_path, dispatch_package_path);
+  EXPECT_EQ(package.target, target);
+}
+
 TEST(QnnOptionTest, Default) {
   Options options;
   EXPECT_EQ(options.GetLogLevel(), LogLevel::kInfo);
@@ -274,6 +293,12 @@ TEST(QnnOptionTest, Default) {
   EXPECT_EQ(options.GetGraphPriority(), GraphPriority::kDefault);
   EXPECT_EQ(options.GetGraphIOTensorMemType(),
             GraphIOTensorMemType::kMemHandle);
+  const CustomOpPackage& custom_op_package = options.GetCustomOpPackage();
+  EXPECT_TRUE(custom_op_package.name.empty());
+  EXPECT_TRUE(custom_op_package.interface_provider.empty());
+  EXPECT_TRUE(custom_op_package.compile_package_path.empty());
+  EXPECT_TRUE(custom_op_package.dispatch_package_path.empty());
+  EXPECT_TRUE(custom_op_package.target.empty());
 }
 
 TEST(QnnOptionTest, SetGraphIOTensorMemType) {

--- a/litert/vendors/qualcomm/core/utils/BUILD
+++ b/litert/vendors/qualcomm/core/utils/BUILD
@@ -3,6 +3,7 @@
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("//litert/build_common:litert_build_defs.bzl", "litert_test")
 load("//litert/integration_test:litert_device.bzl", "litert_device_exec")
 
 package(
@@ -100,5 +101,23 @@ cc_library(
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/types:span",
         "@qairt//:qnn_lib_headers",
+    ],
+)
+
+cc_library(
+    name = "flexbuffer_helpers",
+    srcs = ["flexbuffer_helpers.cc"],
+    hdrs = ["flexbuffer_helpers.h"],
+    deps = [
+        "@flatbuffers//:runtime_cc",
+    ],
+)
+
+litert_test(
+    name = "flexbuffer_helpers_test",
+    srcs = ["flexbuffer_helpers_test.cc"],
+    deps = [
+        ":flexbuffer_helpers",
+        "@flatbuffers",
     ],
 )

--- a/litert/vendors/qualcomm/core/utils/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/utils/CMakeLists.txt
@@ -68,3 +68,14 @@ target_link_libraries(qnn_model
         qnn_log
         qnn_wrappers
 )
+
+# flexbuffer_helpers
+add_library(qnn_flexbuffer_helpers STATIC)
+
+target_sources(qnn_flexbuffer_helpers PRIVATE flexbuffer_helpers.cc)
+
+target_include_directories(qnn_flexbuffer_helpers
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        ${CMAKE_BINARY_DIR}/flatbuffers/include
+)

--- a/litert/vendors/qualcomm/core/utils/flexbuffer_helpers.cc
+++ b/litert/vendors/qualcomm/core/utils/flexbuffer_helpers.cc
@@ -1,0 +1,172 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/utils/flexbuffer_helpers.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <type_traits>
+#include <vector>
+
+#include "flatbuffers/flexbuffers.h"  // from @flatbuffers
+
+namespace qnn {
+namespace {
+
+// Assumes the caller has already verified the tree is uniformly typed to T
+// via GetUniformScalarType. Recursively flattens scalar values into `data`,
+// row-major.
+template <typename T>
+void FillBufferRecurse(const flexbuffers::Reference& ref,
+                       std::vector<T>& data) {
+  if (ref.IsUntypedVector()) {
+    const auto vec = ref.AsVector();
+    for (size_t i = 0; i < vec.size(); ++i) {
+      FillBufferRecurse<T>(vec[i], data);
+    }
+    return;
+  }
+
+  if (ref.IsTypedVector()) {
+    const auto vec = ref.AsTypedVector();
+    for (size_t i = 0; i < vec.size(); ++i) {
+      FillBufferRecurse<T>(vec[i], data);
+    }
+    return;
+  }
+
+  if (ref.IsFixedTypedVector()) {
+    const auto vec = ref.AsFixedTypedVector();
+    for (size_t i = 0; i < vec.size(); ++i) {
+      FillBufferRecurse<T>(vec[i], data);
+    }
+    return;
+  }
+
+  if constexpr (std::is_same_v<T, uint8_t>) {
+    data.emplace_back(ref.AsBool());
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    data.emplace_back(ref.AsInt32());
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    data.emplace_back(ref.AsUInt32());
+  } else if constexpr (std::is_same_v<T, float>) {
+    data.emplace_back(ref.AsFloat());
+  }
+}
+
+// Maps a destination C++ type to the FlexbufferScalarType it represents.
+template <typename T>
+constexpr FlexbufferScalarType ScalarTypeFor() {
+  if constexpr (std::is_same_v<T, uint8_t>) {
+    return FlexbufferScalarType::kBool;
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    return FlexbufferScalarType::kInt;
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    return FlexbufferScalarType::kUint;
+  } else if constexpr (std::is_same_v<T, float>) {
+    return FlexbufferScalarType::kFloat;
+  } else {
+    return FlexbufferScalarType::kUnsupported;
+  }
+}
+
+}  // namespace
+
+FlexbufferScalarType GetUniformScalarType(const flexbuffers::Reference& ref) {
+  if (ref.IsBool()) {
+    return FlexbufferScalarType::kBool;
+  } else if (ref.IsInt()) {
+    return FlexbufferScalarType::kInt;
+  } else if (ref.IsUInt()) {
+    return FlexbufferScalarType::kUint;
+  } else if (ref.IsFloat()) {
+    return FlexbufferScalarType::kFloat;
+  } else if (ref.IsUntypedVector()) {
+    const auto& vec = ref.AsVector();
+    if (vec.size() == 0) {
+      return FlexbufferScalarType::kUnsupported;
+    } else {
+      // Recurse into the first element and ensure all others match.
+      const auto first_type = GetUniformScalarType(vec[0]);
+      for (size_t i = 1; i < vec.size(); ++i) {
+        if (GetUniformScalarType(vec[i]) != first_type) {
+          return FlexbufferScalarType::kUnsupported;
+        }
+      }
+      return first_type;
+    }
+  } else if (ref.IsTypedVector()) {
+    const auto& vec = ref.AsTypedVector();
+    if (vec.size() == 0) {
+      return FlexbufferScalarType::kUnsupported;
+    } else {
+      return GetUniformScalarType(vec[0]);
+    }
+  } else if (ref.IsFixedTypedVector()) {
+    const auto& vec = ref.AsFixedTypedVector();
+    if (vec.size() == 0) {
+      return FlexbufferScalarType::kUnsupported;
+    } else {
+      return GetUniformScalarType(vec[0]);
+    }
+  } else {
+    return FlexbufferScalarType::kUnsupported;
+  }
+}
+
+std::optional<std::vector<uint32_t>> InferShape(
+    const flexbuffers::Reference& ref) {
+  auto infer_for_vector =
+      [](const auto& vec) -> std::optional<std::vector<uint32_t>> {
+    if (vec.size() == 0) {
+      return std::vector<uint32_t>{0};
+    }
+    auto dimensions = InferShape(vec[0]);
+    if (!dimensions.has_value()) {
+      return std::nullopt;
+    }
+    for (size_t i = 1; i < vec.size(); ++i) {
+      const auto other_dimensions = InferShape(vec[i]);
+      if (!other_dimensions.has_value() ||
+          other_dimensions.value() != dimensions.value()) {
+        return std::nullopt;
+      }
+    }
+    dimensions->insert(dimensions->begin(),
+                       static_cast<uint32_t>(vec.size()));
+    return dimensions;
+  };
+
+  if (ref.IsBool() || ref.IsInt() || ref.IsUInt() || ref.IsFloat()) {
+    return std::vector<uint32_t>{};
+  }
+  if (ref.IsUntypedVector()) return infer_for_vector(ref.AsVector());
+  if (ref.IsTypedVector()) return infer_for_vector(ref.AsTypedVector());
+  if (ref.IsFixedTypedVector()) {
+    return infer_for_vector(ref.AsFixedTypedVector());
+  }
+  return std::nullopt;
+}
+
+template <typename T>
+bool FillBuffer(const flexbuffers::Reference& ref, std::vector<T>& data) {
+  const auto type = GetUniformScalarType(ref);
+  if (type == FlexbufferScalarType::kUnsupported ||
+      type != ScalarTypeFor<T>()) {
+    return false;
+  }
+  FillBufferRecurse<T>(ref, data);
+  return true;
+}
+
+template bool FillBuffer<uint8_t>(const flexbuffers::Reference&,
+                                  std::vector<uint8_t>&);
+template bool FillBuffer<int32_t>(const flexbuffers::Reference&,
+                                  std::vector<int32_t>&);
+template bool FillBuffer<uint32_t>(const flexbuffers::Reference&,
+                                   std::vector<uint32_t>&);
+template bool FillBuffer<float>(const flexbuffers::Reference&,
+                                std::vector<float>&);
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/utils/flexbuffer_helpers.h
+++ b/litert/vendors/qualcomm/core/utils/flexbuffer_helpers.h
@@ -1,0 +1,39 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_TOOLS_FLEXBUFFER_HELPERS_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_TOOLS_FLEXBUFFER_HELPERS_H_
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "flatbuffers/flexbuffers.h"  // from @flatbuffers
+
+namespace qnn {
+
+enum class FlexbufferScalarType {
+  kUnsupported = 0,
+  kBool,
+  kInt,
+  kUint,
+  kFloat,
+};
+
+// Returns the common scalar type for a scalar or vector tree.
+// Any mixed scalar types or empty vectors are treated as unsupported.
+FlexbufferScalarType GetUniformScalarType(const flexbuffers::Reference& ref);
+
+// Returns the shape for a scalar/vector tree; nullopt for ragged vectors.
+std::optional<std::vector<uint32_t>> InferShape(
+    const flexbuffers::Reference& ref);
+
+// Verifies the tree is uniformly typed to T, then flattens scalar values
+// into `data` row-major. Returns false on type mismatch or non-uniform
+// input. T must be uint8_t (bool), int32_t, uint32_t, or float.
+template <typename T>
+bool FillBuffer(const flexbuffers::Reference& ref, std::vector<T>& data);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_TOOLS_FLEXBUFFER_HELPERS_H_

--- a/litert/vendors/qualcomm/core/utils/flexbuffer_helpers_test.cc
+++ b/litert/vendors/qualcomm/core/utils/flexbuffer_helpers_test.cc
@@ -1,0 +1,268 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/utils/flexbuffer_helpers.h"
+
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "flatbuffers/flexbuffers.h"  // from @flatbuffers
+
+namespace qnn {
+namespace {
+
+// --- InferShape ---
+
+TEST(InferShapeTest, Scalar) {
+  flexbuffers::Builder fbb;
+  fbb.Int(42);
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  const auto shape = InferShape(root);
+  ASSERT_TRUE(shape.has_value());
+  EXPECT_EQ(*shape, std::vector<uint32_t>{});
+}
+
+TEST(InferShapeTest, EmptyVector) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {});
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  const auto shape = InferShape(root);
+  ASSERT_TRUE(shape.has_value());
+  EXPECT_EQ(*shape, std::vector<uint32_t>{0});
+}
+
+TEST(InferShapeTest, OneD) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {
+    fbb.Int(1);
+    fbb.Int(2);
+    fbb.Int(3);
+  });
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  const auto shape = InferShape(root);
+  ASSERT_TRUE(shape.has_value());
+  EXPECT_EQ(*shape, std::vector<uint32_t>{3});
+}
+
+TEST(InferShapeTest, TwoDRectangular) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {
+    fbb.Vector([&fbb]() {
+      fbb.Int(1);
+      fbb.Int(2);
+    });
+    fbb.Vector([&fbb]() {
+      fbb.Int(3);
+      fbb.Int(4);
+    });
+    fbb.Vector([&fbb]() {
+      fbb.Int(5);
+      fbb.Int(6);
+    });
+  });
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  const auto shape = InferShape(root);
+  ASSERT_TRUE(shape.has_value());
+  EXPECT_EQ(*shape, (std::vector<uint32_t>{3, 2}));
+}
+
+TEST(InferShapeTest, Ragged) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {
+    fbb.Vector([&fbb]() {
+      fbb.Int(1);
+      fbb.Int(2);
+    });
+    fbb.Vector([&fbb]() { fbb.Int(3); });
+  });
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  const auto shape = InferShape(root);
+  EXPECT_FALSE(shape.has_value());
+}
+
+// --- GetUniformScalarType ---
+
+TEST(GetUniformScalarTypeTest, ScalarBool) {
+  flexbuffers::Builder fbb;
+  fbb.Bool(true);
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  EXPECT_EQ(GetUniformScalarType(root), FlexbufferScalarType::kBool);
+}
+
+TEST(GetUniformScalarTypeTest, ScalarInt) {
+  flexbuffers::Builder fbb;
+  fbb.Int(-1);
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  EXPECT_EQ(GetUniformScalarType(root), FlexbufferScalarType::kInt);
+}
+
+TEST(GetUniformScalarTypeTest, ScalarUint) {
+  flexbuffers::Builder fbb;
+  fbb.UInt(42u);
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  EXPECT_EQ(GetUniformScalarType(root), FlexbufferScalarType::kUint);
+}
+
+TEST(GetUniformScalarTypeTest, ScalarFloat) {
+  flexbuffers::Builder fbb;
+  fbb.Float(1.5f);
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  EXPECT_EQ(GetUniformScalarType(root), FlexbufferScalarType::kFloat);
+}
+
+TEST(GetUniformScalarTypeTest, OneDInt) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {
+    fbb.Int(1);
+    fbb.Int(2);
+    fbb.Int(3);
+  });
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  EXPECT_EQ(GetUniformScalarType(root), FlexbufferScalarType::kInt);
+}
+
+TEST(GetUniformScalarTypeTest, TwoDFloat) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {
+    fbb.Vector([&fbb]() {
+      fbb.Float(1.0f);
+      fbb.Float(2.0f);
+    });
+    fbb.Vector([&fbb]() {
+      fbb.Float(3.0f);
+      fbb.Float(4.0f);
+    });
+  });
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  EXPECT_EQ(GetUniformScalarType(root), FlexbufferScalarType::kFloat);
+}
+
+TEST(GetUniformScalarTypeTest, EmptyVectorUnsupported) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {});
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  EXPECT_EQ(GetUniformScalarType(root), FlexbufferScalarType::kUnsupported);
+}
+
+TEST(GetUniformScalarTypeTest, MixedTypeVectorUnsupported) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {
+    fbb.Int(1);
+    fbb.Float(2.0f);
+  });
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  EXPECT_EQ(GetUniformScalarType(root), FlexbufferScalarType::kUnsupported);
+}
+
+TEST(GetUniformScalarTypeTest, NestedEmptyVectorUnsupported) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {
+    fbb.Vector([&fbb]() { fbb.Int(1); });
+    fbb.Vector([&fbb]() {});
+  });
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  EXPECT_EQ(GetUniformScalarType(root), FlexbufferScalarType::kUnsupported);
+}
+
+TEST(GetUniformScalarTypeTest, StringUnsupported) {
+  flexbuffers::Builder fbb;
+  fbb.String("hello");
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  EXPECT_EQ(GetUniformScalarType(root), FlexbufferScalarType::kUnsupported);
+}
+
+// --- FillBuffer<T> ---
+
+TEST(FillBufferTest, ScalarInt) {
+  flexbuffers::Builder fbb;
+  fbb.Int(42);
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  std::vector<int32_t> data;
+  EXPECT_TRUE(FillBuffer<int32_t>(root, data));
+  EXPECT_EQ(data, std::vector<int32_t>{42});
+}
+
+TEST(FillBufferTest, OneDInt) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {
+    fbb.Int(1);
+    fbb.Int(2);
+    fbb.Int(3);
+  });
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  std::vector<int32_t> data;
+  EXPECT_TRUE(FillBuffer<int32_t>(root, data));
+  EXPECT_EQ(data, (std::vector<int32_t>{1, 2, 3}));
+}
+
+TEST(FillBufferTest, TwoDRowMajor) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {
+    fbb.Vector([&fbb]() {
+      fbb.Int(1);
+      fbb.Int(2);
+    });
+    fbb.Vector([&fbb]() {
+      fbb.Int(3);
+      fbb.Int(4);
+    });
+  });
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  std::vector<int32_t> data;
+  EXPECT_TRUE(FillBuffer<int32_t>(root, data));
+  EXPECT_EQ(data, (std::vector<int32_t>{1, 2, 3, 4}));
+}
+
+TEST(FillBufferTest, EmptyVector) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {});
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  std::vector<int32_t> data;
+  EXPECT_FALSE(FillBuffer<int32_t>(root, data));
+  EXPECT_TRUE(data.empty());
+}
+
+TEST(FillBufferTest, TypeMismatch) {
+  flexbuffers::Builder fbb;
+  fbb.Float(1.5f);
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  std::vector<int32_t> data;
+  EXPECT_FALSE(FillBuffer<int32_t>(root, data));
+  EXPECT_TRUE(data.empty());
+}
+
+TEST(FillBufferTest, MixedTypeVectorRejected) {
+  flexbuffers::Builder fbb;
+  fbb.Vector([&fbb]() {
+    fbb.Int(1);
+    fbb.Float(2.0f);
+  });
+  fbb.Finish();
+  const auto root = flexbuffers::GetRoot(fbb.GetBuffer());
+  std::vector<int32_t> data;
+  EXPECT_FALSE(FillBuffer<int32_t>(root, data));
+}
+
+}  // namespace
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -69,7 +69,7 @@ void OpWrapper::AddTensorParam(const char* name, const TensorWrapper& tensor) {
 
 Qnn_OpConfig_t OpWrapper::GetOpConfig() {
   Qnn_OpConfig_t qnn_op = QNN_OPCONFIG_INIT;
-  qnn_op.v1.packageName = QNN_OP_PACKAGE_NAME_QTI_AISW;
+  qnn_op.v1.packageName = package_name_;
   qnn_op.v1.typeName = type_name_;
   qnn_op.v1.name = name_.data();
   // input tensors

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -20,10 +20,18 @@ namespace qnn {
 
 class OpWrapper final {
  public:
-  explicit OpWrapper() = default;
+  OpWrapper() = default;
 
-  explicit OpWrapper(std::string name, const char* op_type, QnnOpCode op_code)
-      : type_name_{op_type}, name_{std::move(name)}, op_code_{op_code} {}
+  OpWrapper(std::string name, const char* op_type, QnnOpCode op_code)
+      : OpWrapper(std::move(name), QNN_OP_PACKAGE_NAME_QTI_AISW, op_type,
+                  op_code) {}
+
+  OpWrapper(std::string name, const char* package_name,
+                     const char* op_type, QnnOpCode op_code)
+      : package_name_{package_name},
+        type_name_{op_type},
+        name_{std::move(name)},
+        op_code_{op_code} {}
 
   bool operator==(const OpWrapper& other) const;
 
@@ -70,6 +78,10 @@ class OpWrapper final {
   void AddSuffixToName(absl::string_view suffix);
 
  private:
+  // Borrowed pointer. Must point to a string that outlives this OpWrapper --
+  // in practice, the QualcommOptions instance held by LiteRtCompilerPluginT.
+  // Do not pass a stack-local or temporary string.
+  const char* package_name_{QNN_OP_PACKAGE_NAME_QTI_AISW};
   const char* type_name_{nullptr};
   std::string name_{};  // human readable name
   std::vector<std::reference_wrapper<const TensorWrapper>> input_tensors_{};

--- a/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
@@ -78,6 +78,21 @@ TEST(OpWrapperTest, SanityTest) {
   EXPECT_EQ(op_config_v1.outputTensors, nullptr);
 }
 
+TEST(OpWrapperTest, PackageNameConstructor) {
+  OpWrapper op_wrapper{"name", "custom_pkg", "OP_TYPE", QnnOpCode::kUnknown};
+  const Qnn_OpConfig_t op_config = op_wrapper.GetOpConfig();
+  EXPECT_EQ(op_config.version, QNN_OPCONFIG_VERSION_1);
+  EXPECT_STREQ(op_config.v1.packageName, "custom_pkg");
+  EXPECT_STREQ(op_config.v1.typeName, "OP_TYPE");
+  EXPECT_STREQ(op_config.v1.name, "name");
+  EXPECT_EQ(op_config.v1.numOfParams, 0);
+  EXPECT_EQ(op_config.v1.params, nullptr);
+  EXPECT_EQ(op_config.v1.numOfInputs, 0);
+  EXPECT_EQ(op_config.v1.inputTensors, nullptr);
+  EXPECT_EQ(op_config.v1.numOfOutputs, 0);
+  EXPECT_EQ(op_config.v1.outputTensors, nullptr);
+}
+
 TEST(OpWrapperTest, MoveCtorSanityTest) {
   OpWrapper op_wrapper{"name", "OP_TYPE", QnnOpCode::kUnknown};
   OpWrapper moved{std::move(op_wrapper)};

--- a/litert/vendors/qualcomm/dispatch/dispatch_api.cc
+++ b/litert/vendors/qualcomm/dispatch/dispatch_api.cc
@@ -135,6 +135,15 @@ LiteRtStatus Initialize(const LiteRtRuntimeContext* runtime_context,
     LITERT_LOG(LITERT_ERROR, "%s", qnn_manager.Error().Message().c_str());
     return qnn_manager.Error().Status();
   } else {
+    if (const auto& custom_op_package = qnn_options.GetCustomOpPackage();
+        !custom_op_package.name.empty()) {
+      LITERT_RETURN_IF_ERROR(
+          (*qnn_manager)
+              ->RegisterOpPackage(custom_op_package.dispatch_package_path,
+                                  custom_op_package.interface_provider,
+                                  custom_op_package.target));
+    }
+
     std::swap(QnnManagerStorage(), *qnn_manager);
   }
 

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -80,12 +80,13 @@ LiteRtStatus SetEnvVar(const char* name, const char* value) {
   return kLiteRtStatusOk;
 }
 
-RtldFlags GetRtldFlags() {
+RtldFlags GetRtldFlags(bool needs_global_symbols) {
 #if defined(__ANDROID__)
   // Race condition segfault without NoDelete on android.
   return RtldFlags::Lazy().Local().NoDelete();
 #else
-  return RtldFlags::Default();
+  return needs_global_symbols ? RtldFlags::Lazy().Global()
+                              : RtldFlags::Default();
 #endif
 }
 
@@ -134,10 +135,12 @@ QnnManager::~QnnManager() = default;
 
 LiteRtStatus QnnManager::LoadLib(absl::string_view path) {
   auto saver_output_dir = options_.GetSaverOutputDir();
+  const bool needs_global_symbols =
+      !options_.GetCustomOpPackage().name.empty();
   if (saver_output_dir.empty()) {
     LITERT_LOG(LITERT_INFO, "Loading qnn shared library from \"%s\"",
                path.data());
-    auto lib_or = SharedLibrary::Load(path, GetRtldFlags());
+    auto lib_or = SharedLibrary::Load(path, GetRtldFlags(needs_global_symbols));
     if (!lib_or) {
       LITERT_LOG(LITERT_ERROR,
                  "Failed to load qnn shared library from \"%s\": %s",
@@ -149,7 +152,7 @@ LiteRtStatus QnnManager::LoadLib(absl::string_view path) {
     path = kSaverLibraryName;
     LITERT_LOG(LITERT_INFO, "Loading qnn shared library from \"%s\"",
                path.data());
-    auto lib_or = SharedLibrary::Load(path, GetRtldFlags());
+    auto lib_or = SharedLibrary::Load(path, GetRtldFlags(needs_global_symbols));
     if (!lib_or) {
       LITERT_LOG(LITERT_ERROR,
                  "Failed to load qnn shared library from \"%s\": %s",
@@ -172,7 +175,10 @@ LiteRtStatus QnnManager::LoadSystemLib(absl::string_view path) {
   }
   LITERT_LOG(LITERT_INFO, "Loading qnn system shared library from \"%s\"",
              resolved_path.c_str());
-  auto lib_system_or = SharedLibrary::Load(resolved_path, GetRtldFlags());
+  const bool needs_global_symbols =
+      !options_.GetCustomOpPackage().name.empty();
+  auto lib_system_or =
+      SharedLibrary::Load(resolved_path, GetRtldFlags(needs_global_symbols));
   if (!lib_system_or) {
     LITERT_LOG(LITERT_ERROR, "%s", lib_system_or.Error().Message().data());
     return lib_system_or.Error().Status();
@@ -435,6 +441,28 @@ LiteRtStatus QnnManager::ValidateOp(::qnn::OpWrapper& op) {
     return kLiteRtStatusErrorInvalidLegalization;
   }
 
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus QnnManager::RegisterOpPackage(
+    const std::string& package_path, const std::string& interface_provider,
+    const std::string& target) {
+  if (options_.GetBackendType() == ::qnn::BackendType::kIrBackend) {
+    LITERT_LOG(LITERT_INFO,
+               "Custom op package is not supported in IrBackend. Ignore.");
+    return kLiteRtStatusOk;
+  }
+
+  if (auto status = Api()->backendRegisterOpPackage(
+          backend_->GetBackendHandle(), package_path.c_str(),
+          interface_provider.c_str(), target.c_str());
+      status != QNN_SUCCESS) {
+    LITERT_LOG(LITERT_ERROR, "Failed to register op package. Error code: %d",
+               status);
+    return kLiteRtStatusErrorRuntimeFailure;
+  }
+
+  LITERT_LOG(LITERT_INFO, "Op package loaded successfully.");
   return kLiteRtStatusOk;
 }
 

--- a/litert/vendors/qualcomm/qnn_manager.h
+++ b/litert/vendors/qualcomm/qnn_manager.h
@@ -161,6 +161,10 @@ class QnnManager {
 
   LiteRtStatus ValidateOp(::qnn::OpWrapper& op);
 
+  LiteRtStatus RegisterOpPackage(const std::string& package_path,
+                                 const std::string& interface_provider,
+                                 const std::string& target);
+
   bool IsFp16Supported() {
     // TODO(jiunkaiy): Remove this function after upgrading to stricter SDK
     // restrictions.

--- a/litert/vendors/samsung/compiler/CMakeLists.txt
+++ b/litert/vendors/samsung/compiler/CMakeLists.txt
@@ -71,7 +71,7 @@ target_include_directories(samsung_compiler_plugin
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     PRIVATE
-        ${TFLITE_BUILD_DIR}/flatbuffers/include
+        ${CMAKE_BINARY_DIR}/flatbuffers/include
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/builders>
         $<$<BOOL:${LITECORE_HEADERS_DIR}>:${LITECORE_HEADERS_DIR}>

--- a/litert/vendors/samsung/schema/CMakeLists.txt
+++ b/litert/vendors/samsung/schema/CMakeLists.txt
@@ -23,6 +23,11 @@ elseif(TFLITE_BUILD_DIR AND EXISTS "${TFLITE_BUILD_DIR}/host_flatc/_deps/flatbuf
   set(FLATC_EXECUTABLE "${TFLITE_BUILD_DIR}/host_flatc/_deps/flatbuffers-build/flatc")
 elseif(TFLITE_BUILD_DIR AND EXISTS "${TFLITE_BUILD_DIR}/_deps/flatbuffers-build/flatc")
   set(FLATC_EXECUTABLE "${TFLITE_BUILD_DIR}/_deps/flatbuffers-build/flatc")
+elseif(EXISTS "${CMAKE_BINARY_DIR}/_deps/flatbuffers-build/flatc")
+  # TFLite's FetchContent of FlatBuffers lands under ${CMAKE_BINARY_DIR}, not
+  # ${TFLITE_BUILD_DIR} (see the flatbuffers::flatbuffers target in the top
+  # CMakeLists.txt for the same path correction).
+  set(FLATC_EXECUTABLE "${CMAKE_BINARY_DIR}/_deps/flatbuffers-build/flatc")
 endif()
 
 if(NOT FLATC_EXECUTABLE)


### PR DESCRIPTION
# Qualcomm AI Engine Direct — Support Custom Op Package

## Overview

Adds end-to-end support for **QNN custom op packages** in the LiteRT Qualcomm backend for the **AOT** (compiler plugin) flow. Users supply a custom QNN op package (`.so`); TFLite custom ops are legalized to QNN custom ops, registered with QNN, and executed on the HTP.

## What's included

- **Options (C/C++/TOML/CLI):** `LrtQualcommOptionsSet/GetCustomOpPackage` carrying `interface_provider`, `compile_package_path`, `dispatch_package_path`, `target`; new `--qualcomm_custom_op_package` flag (`name:Pkg;interface_provider:Provider;compile_package_path:lib.so;dispatch_package_path:lib.so;target:HTP`). Compiler uses name/interface_provider/compile_package_path; dispatch uses name/interface_provider/dispatch_package_path/target. 
- **Registration & builder:** `core/builders/custom_op_builder` exposes `CreateCustomOp(...)`; `qnn_manager` and `dispatch_api` register the package on the compile and JIT paths. 
- **Custom options → QNN params:** new `core/utils/flexbuffer_helpers` (`InferShape`, `FillBuffer<T>`) flattens flexbuffer scalar/vector trees (bool/int32/uint32/float) with uniform-type validation; `BuildCustomOp()` in `qnn_compose_graph.cc` emits QNN scalar/tensor params. 
- **Supporting:** `op_wrapper` extended for custom params; parse/registration failures propagate `LiteRtStatus` errors; `RTLD_GLOBAL` dlopen gated behind custom-op usage; CMake targets added.

- [x] developer-verified

# Test
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all


//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 1.2s
```

```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 15 tests from 3 test suites ran. (7 ms total)
[  PASSED  ] 15 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 21 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 33 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 18 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (12 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (381 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (345 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (430 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (441 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1117 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1119 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (679 ms total)
[  PASSED  ] 10 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2057 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (13 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (457 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (432 ms total)
[  PASSED  ] 2 tests.
```