### PR TITLE
Samsung Exynos AI LiteCore : Update LiteCore SDK and fixing wrong soc

### DIFF
--- a/ci/tools/python/vendor_sdk/samsung/setup.py
+++ b/ci/tools/python/vendor_sdk/samsung/setup.py
@@ -46,7 +46,7 @@ IS_X86_ARCHITECTURE = platform.machine() in ('x86_64', 'i386', 'i686')
 
 # --- Configuration for samsung SDK Download ---
 EXYNOS_AI_LITECORE_URL = 'https://soc-developer.semiconductor.samsung.com/api/v1/resource/download-file/ai-litecore-ubuntu2404-v1.2.0.tar.gz'  # pylint: disable=line-too-long
-EXYNOS_AI_LITECORE_CONTENT_DIR = f'exynos-ai-litecore-v{PACKAGE_VERSION}'
+EXYNOS_AI_LITECORE_CONTENT_DIR = f'exynos-ai-litecore-v1.2.0'
 EXYNOS_AI_LITECORE_TARGET_DIR = 'ai_edge_litert_sdk_samsung/data'
 # ---
 

--- a/litert/python/aot/ai_pack/export_lib.py
+++ b/litert/python/aot/ai_pack/export_lib.py
@@ -222,6 +222,16 @@ def _target_to_ai_pack_info(target: aot_types.Target) -> str | None:
         device_group_name=group_name, device_selectors=device_selector
     )
     return device_group
+  elif isinstance(target, exynos_target.Target):
+    group_name = str(target)
+    selector = _process_exynos_target(target)
+    device_selector = _DEVICE_SELECTOR_TEMPLATE.format(
+        soc_man=selector[0], soc_model=selector[1]
+    )
+    device_group = _DEVICE_GROUP_TEMPLATE.format(
+        device_group_name=group_name, device_selectors=device_selector
+    )
+    return device_group
   elif isinstance(target, fallback_backend.FallbackTarget):
     # Don't need to have device selector for fallback target.
     return None
@@ -256,6 +266,13 @@ def _process_google_tensor_target(
 ) -> tuple[str, str]:
   """Returns tuple of (manufacturer, model) for the given Google Tensor target."""
   return str(target.soc_manufacturer), str(target.soc_model).replace('_', ' ')
+
+
+def _process_exynos_target(
+    target: exynos_target.Target,
+) -> tuple[str, str]:
+  """Returns tuple of (manufacturer, model) for the given ENN target."""
+  return str(target.soc_manufacturer), str(target.soc_model)
 
 
 def _write_targeting_config(


### PR DESCRIPTION
- Remove invalidate SoC Name in Non Mobile Device
- Add Exynos AI LiteCore Version