### PR TITLE
Qualcomm AI Engine Direct - Fix Pack Op negative axis legalization.

### DIFF
--- a/litert/vendors/qualcomm/core/builders/pack_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/pack_op_builder.cc
@@ -37,8 +37,12 @@ std::vector<OpWrapper> BuildPackOp(TensorPool& tensor_pool,
     }
     concat_op.AddOutputTensor(outputs[0]);
   } else {
+    // TFLite PACK axis is relative to the output rank (input rank + 1), since PACK
+    // inserts a new stacked dimension. For a negative axis, add the output rank.
+    // e.g. axis=-2, inputs rank=4: correct adjusted = -2+5=3; wrong (bug) = -2+4=2,
+    // which made QNN report "Expected 2 but got 32" on output[2].
     std::uint32_t adjusted_axis =
-        axis < 0 ? axis + inputs[0].get().GetRank() : axis;
+        axis < 0 ? axis + outputs[0].get().GetRank() : axis;
     res.emplace_back(CreatePackOp(
         std::vector<ConstTensorWrapperRef>(inputs.begin(), inputs.end()),
         outputs[0], adjusted_axis));

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -189,6 +189,38 @@ litert_test(
 )
 
 litert_test(
+    name = "pack_test",
+    srcs = [
+        "pack_test.cc",
+    ],
+    linkopts = select({
+        "//litert:android": [],
+        "//conditions:default": [
+            make_rpaths([
+                "//litert/c:litert_runtime_c_api_so",
+            ]),
+        ],
+    }),
+    linkstatic = True,
+    tags = [
+        # Don't build/test in OS until qnn is available.
+        "no-remote-exec",
+        "nobuilder",
+        "notap",
+        "manual",
+    ],
+    ungrte = True,
+    use_sys_malloc = True,
+    deps = [
+        "//litert/vendors/qualcomm/core/builders:pack_op_builder",
+        "//litert/vendors/qualcomm/core/utils:test_main",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+litert_test(
     name = "fully_connected_int2_test",
     srcs = [
         "fully_connected_int2_test.cc",

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/pack_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/pack_test.cc
@@ -1,0 +1,134 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "litert/vendors/qualcomm/core/builders/pack_op_builder.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+#include "QnnOpDef.h"  // from @qairt
+#include "QnnTypes.h"  // from @qairt
+
+namespace litert::qnn {
+namespace {
+using testing::ElementsAre;
+
+INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
+                         QnnTestPrinter);
+
+// Returns the value of the QNN Pack op's "axis" scalar param, or std::nullopt
+// if the op is not a Pack with an axis param.
+std::optional<std::uint32_t> GetPackAxisParam(const ::qnn::OpWrapper& op) {
+  const auto scalar_param = op.GetScalarParam(0);
+  if (!scalar_param.has_value()) return std::nullopt;
+  Qnn_Param_t qnn_param = QNN_PARAM_INIT;
+  scalar_param->CloneTo(qnn_param);
+  if (qnn_param.name == nullptr ||
+      std::string_view(qnn_param.name) != QNN_OP_PACK_PARAM_AXIS) {
+    return std::nullopt;
+  }
+  return qnn_param.scalarParam.uint32Value;
+}
+
+// Regression test for negative-axis legalization.
+// Two rank-4 inputs packed along axis=-2 produce a rank-5 output. TFLite PACK
+// axis is relative to the output rank (input + 1), so axis=-2 must resolve to
+// output index 3 (where the stacked dim of size 2 lives).
+TEST_P(QnnModelTest, PackNegativeAxisResolvesToOutputRank) {
+  const std::vector<std::uint32_t> kInputDims{1, 4, 3, 5};   // rank 4
+  const std::vector<std::uint32_t> kOutputDims{1, 4, 3, 2, 5};  // rank 5
+  static constexpr int32_t kAxis{-2};
+  // -2 normalized against the rank-5 output: -2 + 5 = 3.
+  static constexpr std::uint32_t kExpectedAxis{3};
+
+  auto& input0_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input0", QNN_DATATYPE_FLOAT_32, {}, kInputDims);
+  auto& input1_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input1", QNN_DATATYPE_FLOAT_32, {}, kInputDims);
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_FLOAT_32, {}, kOutputDims);
+
+  auto ops = ::qnn::BuildPackOp(tensor_pool_, {input0_tensor, input1_tensor},
+                                {output_tensor}, kAxis);
+  ASSERT_FALSE(ops.empty());
+
+  // The stacked dimension (size 2) lives at output index 3.
+  const auto axis_param = GetPackAxisParam(ops.front());
+  ASSERT_TRUE(axis_param.has_value());
+  EXPECT_EQ(*axis_param, kExpectedAxis);
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.Finalize());
+}
+
+// A positive axis is passed through unchanged.
+TEST_P(QnnModelTest, PackPositiveAxisIsUnchanged) {
+  const std::vector<std::uint32_t> kInputDims{2, 3};      // rank 2
+  const std::vector<std::uint32_t> kOutputDims{2, 2, 3};  // rank 3
+  static constexpr int32_t kAxis{1};
+
+  auto& input0_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input0", QNN_DATATYPE_FLOAT_32, {}, kInputDims);
+  auto& input1_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input1", QNN_DATATYPE_FLOAT_32, {}, kInputDims);
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_FLOAT_32, {}, kOutputDims);
+
+  auto ops = ::qnn::BuildPackOp(tensor_pool_, {input0_tensor, input1_tensor},
+                                {output_tensor}, kAxis);
+  ASSERT_FALSE(ops.empty());
+  const auto axis_param = GetPackAxisParam(ops.front());
+  ASSERT_TRUE(axis_param.has_value());
+  EXPECT_EQ(*axis_param, static_cast<std::uint32_t>(kAxis));
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input0_idx = qnn_model_.AddInputTensor(input0_tensor);
+  auto input1_idx = qnn_model_.AddInputTensor(input1_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+  qnn_model_.SetInputData<float>(input0_idx, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f,
+                                              6.0f});
+  qnn_model_.SetInputData<float>(input1_idx, {7.0f, 8.0f, 9.0f, 10.0f, 11.0f,
+                                              12.0f});
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<float>(output_idx);
+  ASSERT_TRUE(output_data);
+  // Stacked along axis 1: [[in0_row0, in1_row0], [in0_row1, in1_row1]].
+  ASSERT_THAT(output_data.value(),
+              ElementsAre(1.0f, 2.0f, 3.0f, 7.0f, 8.0f, 9.0f, 4.0f, 5.0f, 6.0f,
+                          10.0f, 11.0f, 12.0f));
+}
+
+// A single input cannot form a valid QNN Pack, so the builder emits a Reshape
+// instead.
+TEST_P(QnnModelTest, PackSingleInputBecomesReshape) {
+  const std::vector<std::uint32_t> kInputDims{2, 3};
+  const std::vector<std::uint32_t> kOutputDims{1, 2, 3};
+  static constexpr int32_t kAxis{0};
+
+  auto& input_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input", QNN_DATATYPE_FLOAT_32, {}, kInputDims);
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_FLOAT_32, {}, kOutputDims);
+
+  auto ops = ::qnn::BuildPackOp(tensor_pool_, {input_tensor}, {output_tensor},
+                                /*axis=*/kAxis);
+  ASSERT_EQ(ops.size(), 1);
+  EXPECT_TRUE(ops.front().IsOpCode(::qnn::QnnOpCode::kReshape));
+}
+
+}  // namespace
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/tests/CMakeLists.txt
+++ b/litert/vendors/qualcomm/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ target_sources(builder_test
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/elementwise_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/fully_connected_int2_test.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/pack_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/relu_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/topk_test.cc
 )


### PR DESCRIPTION
Summary:
  - TFLite PACK axis is relative to the output rank (input rank + 1), since PACK
    inserts a new dimension.
  - The Pack op builder compensated a negative axis with the input rank, placing
    the stacked dimension one position too early.
  - Fixed to compensate with the output rank.

#### TEST

- x86:
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all


//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.6s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.6s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 1.3s
```

- on device
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 13 tests from 9 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 15 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 33 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 16 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (12 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (633 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (1261 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1547 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1453 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (1183 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (582 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2541 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (21 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (395 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (460 ms total)
[  PASSED  ] 2 tests.
```

- [x] deverloper-verfied