### PR TITLE
Qualcomm AI Engine Direct - Plumb soc_model through run_model into compile and dispatch paths

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -57,6 +57,7 @@ struct LrtQualcommOptionsT {
   std::optional<std::string> saver_output_dir;
   std::optional<LrtQualcommOptionsGraphIOTensorMemType>
       graph_io_tensor_mem_type;
+  std::optional<std::string> soc_model;
 };
 
 LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
@@ -180,6 +181,9 @@ LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
           status = LrtQualcommOptionsSetGraphIOTensorMemType(
               parsed_options,
               static_cast<LrtQualcommOptionsGraphIOTensorMemType>(*v));
+        } else if (key == "soc_model") {
+          status = LrtQualcommOptionsSetSocModel(parsed_options,
+                                                 std::string(value).c_str());
         }
 
         return status;
@@ -296,6 +300,9 @@ LiteRtStatus LrtGetOpaqueQualcommOptionsData(LrtQualcommOptions options,
   if (options->graph_io_tensor_mem_type.has_value()) {
     toml << "graph_io_tensor_mem_type = "
          << static_cast<int>(*options->graph_io_tensor_mem_type) << "\n";
+  }
+  if (options->soc_model.has_value()) {
+    toml << "soc_model = \"" << *options->soc_model << "\"\n";
   }
   *identifier = LrtQualcommOptionsGetIdentifier();
   std::string toml_str = toml.str();
@@ -821,6 +828,29 @@ LiteRtStatus LrtQualcommOptionsGetBackend(
   }
 
   *qnn_backend = options->qnn_backend.value_or(kLiteRtQualcommBackendHtp);
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsSetSocModel(LrtQualcommOptions options,
+                                           const char* soc_model) {
+  if (options == nullptr || soc_model == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->soc_model = soc_model;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsGetSocModel(LrtQualcommOptions options,
+                                           const char** soc_model) {
+  if (options == nullptr || soc_model == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *soc_model =
+      options->soc_model.has_value() ? options->soc_model->c_str() : "";
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -334,6 +334,18 @@ LiteRtStatus LrtQualcommOptionsSetSaverOutputDir(LrtQualcommOptions options,
 
 LiteRtStatus LrtQualcommOptionsGetSaverOutputDir(LrtQualcommOptions options,
                                                  const char** saver_output_dir);
+
+// soc_model
+
+// Target SoC model name (e.g., "SM8650"). When set, this overrides the SoC
+// detected from the device or from QAIRT's default during offline preparation.
+// An empty string means "not specified" and lets the backend pick.
+
+LiteRtStatus LrtQualcommOptionsSetSocModel(LrtQualcommOptions options,
+                                           const char* soc_model);
+
+LiteRtStatus LrtQualcommOptionsGetSocModel(LrtQualcommOptions options,
+                                           const char** soc_model);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -459,6 +459,23 @@ class QualcommOptions {
     return static_cast<GraphIOTensorMemType>(val);
   }
 
+  /// @brief Target SoC model name (e.g., "SM8650").
+  ///
+  /// When set, this overrides the SoC detected from the device or QAIRT's
+  /// default during offline preparation. An empty string means "not specified"
+  /// and lets the backend pick.
+  void SetSocModel(const std::string& soc_model) {
+    LrtQualcommOptionsSetSocModel(options_, soc_model.c_str());
+  }
+  StringView GetSocModel() {
+    const char* val;
+    auto status = LrtQualcommOptionsGetSocModel(options_, &val);
+    if (status != kLiteRtStatusOk) {
+      return "";
+    }
+    return val;
+  }
+
  private:
   LrtQualcommOptions options_;
 };

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -386,6 +386,13 @@ ABSL_FLAG(std::string, qualcomm_saver_output_dir, "",
           "can be replayed on any QNN backend. See Qualcomm "
           "AI Runtime (QAIRT) SDK document for more details.");
 
+ABSL_FLAG(std::string, qualcomm_soc_model, "",
+          "Target SoC model name (e.g., 'SM8650'). When set, this overrides "
+          "the SoC detected from the device or QAIRT's default during offline "
+          "preparation. Affects both compile (graph finalize / partition) and "
+          "dispatch (deviceCreate) paths. Leave empty to let the backend "
+          "pick.");
+
 namespace litert::qualcomm {
 
 bool AbslParseFlag(absl::string_view text,
@@ -598,6 +605,9 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
   const auto graph_io_tensor_mem_type =
       absl::GetFlag(FLAGS_qualcomm_graph_io_tensor_mem_type);
   opts.SetGraphIOTensorMemType(graph_io_tensor_mem_type);
+
+  const std::string soc_model = absl::GetFlag(FLAGS_qualcomm_soc_model);
+  opts.SetSocModel(soc_model);
 
   return {};
 }

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -151,6 +151,8 @@ std::string AbslUnparseFlag(QualcommOptions::Profiling options);
 
 }  // namespace litert::qualcomm
 
+ABSL_DECLARE_FLAG(std::string, qualcomm_soc_model);
+
 // TO OBJECT (internal) ////////////////////////////////////////////////////////
 
 namespace litert::qualcomm {

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -268,6 +268,18 @@ class LiteRtCompilerPluginT {
 
   const ::qnn::Options& Options() const { return qnn_options_; }
 
+  // Returns the soc_model from the user-supplied LrtQualcommOptions, or an
+  // empty string if no Qualcomm options were provided or no soc_model was set.
+  // Used as a fallback for the JIT path, where the soc_model argument to
+  // `LiteRtCompilerPluginPartition` / `LiteRtCompilerPluginCompile` is
+  // typically nullptr.
+  absl::string_view SocModelFromOptions() {
+    if (qualcomm_options_) {
+      return qualcomm_options_.Value().GetSocModel();
+    }
+    return "";
+  }
+
   void initQnnManager(std::unique_ptr<QnnManager> qnn_manager) {
     qnn_manager_ = std::move(qnn_manager);
   }
@@ -361,9 +373,13 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
   ::litert::compiler::Subgraph graph(compiler_plugin->ctx(), subgraph);
   QnnManager* qnn_manager = compiler_plugin->QNN();
   if (!qnn_manager) {
+    absl::string_view effective_soc_model =
+        (soc_model && *soc_model) ? absl::string_view(soc_model)
+                                  : compiler_plugin->SocModelFromOptions();
     auto qnn_manager_or = QnnManager::Create(
         compiler_plugin->Options(), compiler_plugin->shared_library_dir(),
-        soc_model ? qnn::FindSocModel(soc_model) : std::nullopt);
+        !effective_soc_model.empty() ? qnn::FindSocModel(effective_soc_model)
+                                     : std::nullopt);
     if (!qnn_manager_or) {
       LITERT_LOG(LITERT_ERROR, "%s", qnn_manager_or.Error().Message().data());
       return qnn_manager_or.Error().Status();
@@ -425,15 +441,26 @@ LiteRtStatus LiteRtCompilerPluginCompile(
   litert::compiler::Model model(compiler_plugin->ctx(), partitions);
   auto num_partitions = model.NumSubgraphs();
 
+  absl::string_view effective_soc_model =
+      (soc_model && *soc_model) ? absl::string_view(soc_model)
+                                : compiler_plugin->SocModelFromOptions();
+
   LITERT_LOG(LITERT_INFO,
              "Starting QNN Compilation for %d subgraphs, soc_model=%s",
-             num_partitions, soc_model);
+             num_partitions,
+             effective_soc_model.empty()
+                 ? "<unset>"
+                 : std::string(effective_soc_model).c_str());
 
-  auto opt_soc_model = soc_model ? qnn::FindSocModel(soc_model) : std::nullopt;
+  auto opt_soc_model = !effective_soc_model.empty()
+                           ? qnn::FindSocModel(effective_soc_model)
+                           : std::nullopt;
   if (opt_soc_model) {
-    LITERT_LOG(LITERT_INFO, "Compiling QNN SoC model: %s", soc_model);
-  } else if (soc_model) {
-    LITERT_LOG(LITERT_ERROR, "Unexpected SoC model: %s", soc_model);
+    LITERT_LOG(LITERT_INFO, "Compiling QNN SoC model: %s",
+               opt_soc_model->soc_name);
+  } else if (!effective_soc_model.empty()) {
+    LITERT_LOG(LITERT_ERROR, "Unexpected SoC model: %s",
+               std::string(effective_soc_model).c_str());
     return kLiteRtStatusErrorInvalidArgument;
   }
 

--- a/litert/vendors/qualcomm/core/backends/htp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.cc
@@ -402,9 +402,7 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
     QNN_LOG_INFO("Using provided SoC info. SoC name: %s.", soc_info->soc_name);
     soc_info_ = *soc_info;
   } else {
-#if defined(__x86_64__) || defined(_M_X64)
-    // Offline compilation on desktop hosts cannot query the target device.
-#else
+    // QNN HTP use emulation on x86_64
     if (auto device_platform_info = CreateDevicePlatformInfo();
         device_platform_info) {
       auto soc_model =
@@ -421,7 +419,6 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
           "fallback for Snapdragon X Elite.");
       soc_info_ = FindSocInfo(SnapdragonModel::SC8380XP).value_or(kSocInfos[0]);
     }
-#endif
 #endif
   }
   if (soc_info_.dsp_arch == DspArch::NONE) {

--- a/litert/vendors/qualcomm/dispatch/dispatch_api.cc
+++ b/litert/vendors/qualcomm/dispatch/dispatch_api.cc
@@ -40,6 +40,7 @@
 #include "litert/vendors/c/litert_dispatch_api.h"
 #include "litert/vendors/qualcomm/common.h"
 #include "litert/vendors/qualcomm/core/common.h"
+#include "litert/vendors/qualcomm/core/utils/miscs.h"
 #include "litert/vendors/qualcomm/dispatch/litert_dispatch_device_context.h"
 #include "litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h"
 #include "litert/vendors/qualcomm/qnn_manager.h"
@@ -120,8 +121,22 @@ LiteRtStatus Initialize(const LiteRtRuntimeContext* runtime_context,
 
   // TODO(Alen): initialize qnn_options from LiteRtOptions
   ::qnn::Options qnn_options;
+  std::optional<::qnn::SocInfo> soc_info_opt = std::nullopt;
   if (qnn_opts) {
     InitQnnOptions(qnn_options, qnn_opts.Value());
+    const absl::string_view soc_model_name = qnn_opts.Value().GetSocModel();
+    if (!soc_model_name.empty()) {
+      soc_info_opt = ::qnn::FindSocModel(soc_model_name);
+      if (!soc_info_opt) {
+        LITERT_LOG(LITERT_WARNING,
+                   "Unrecognized qualcomm_soc_model '%s', falling back to "
+                   "device-detected SoC.",
+                   std::string(soc_model_name).c_str());
+      } else {
+        LITERT_LOG(LITERT_INFO, "Dispatch using user-specified SoC model: %s",
+                   soc_info_opt->soc_name);
+      }
+    }
   } else {
     LITERT_LOG(LITERT_ERROR,
                "Failed to parse qnn options, using default settings. %s",
@@ -130,7 +145,7 @@ LiteRtStatus Initialize(const LiteRtRuntimeContext* runtime_context,
   if (auto qnn_manager = QnnManager::Create(
           /*options=*/qnn_options,
           /*shared_library_dir=*/shared_library_dir_opt,
-          /*soc_model*/ std::nullopt);
+          /*soc_info=*/soc_info_opt);
       !qnn_manager) {
     LITERT_LOG(LITERT_ERROR, "%s", qnn_manager.Error().Message().c_str());
     return qnn_manager.Error().Status();


### PR DESCRIPTION
**Summary**
- run_model previously had no way to specify the target SoC for QNN, so the JIT compile path and the dispatch (deviceCreate) path both fell back to QAIRT's default (**SM8350** on **x86** host), causing arch mismatches at graphFinalize / contextCreateFromBinary when running for a different chipset.
- Added `--qualcomm_soc_model` CLI flag, plus SocModel set/get on `LrtQualcommOptions` (C API), `QualcommOptions` (C++ wrapper), and the qualcomm_flags parser.
- Wired the option into LiteRtCompilerPluginPartition and LiteRtCompilerPluginCompile as a fallback when the C-API soc_model argument is null/empty (the JIT case), and into `dispatch_api.cc` Initialize so `QnnManager::Create` receives the resolved `::qnn::SocInfo` instead of `std::nullopt`.

**TEST**
- TBD