### PR TITLE
[Intel OV] Fix compiler and dispatch test builds on Windows

### DIFF
--- a/.github/workflows/windows_x86_64.yml
+++ b/.github/workflows/windows_x86_64.yml
@@ -169,7 +169,9 @@ jobs:
         run: |
           bazel --output_base="$env:BAZEL_OUTPUT_BASE" build --disk_cache="$env:BAZEL_DISK_CACHE" --config=windows -- `
             //litert/vendors/intel_openvino/compiler:LiteRtCompilerPlugin `
-            //litert/vendors/intel_openvino/dispatch:LiteRtDispatch
+            //litert/vendors/intel_openvino/dispatch:LiteRtDispatch `
+            //litert/vendors/intel_openvino/compiler:openvino_compiler_plugin_test `
+            //litert/vendors/intel_openvino/dispatch:dispatch_api_openvino_test
 
       - name: Remove cache if cache is being refreshed.
         if: env.REFRESH_CACHE == 'true'

--- a/litert/vendors/intel_openvino/compiler/BUILD
+++ b/litert/vendors/intel_openvino/compiler/BUILD
@@ -255,12 +255,16 @@ litert_test(
     srcs = [
         "openvino_compiler_plugin_test.cc",
     ],
-    copts = ["-fexceptions"],
+    copts = ["-fexceptions"] + select({
+        "//litert:windows": ["/DLITERT_COMPILE_LIBRARY"],
+        "//conditions:default": [],
+    }),
     data = [
         "//litert/test:mlir_test_data",
         "//litert/test:tflite_test_data",
     ],
     features = ["-use_header_modules"],  # Incompatible with -fexceptions.
+    linkstatic = 1,
     tags = [
         # Tests with ungrte deps do not currently work on forge.
         "no-remote-exec",
@@ -288,6 +292,7 @@ litert_test(
         "//litert/cc/dynamic_runtime:litert_extended_model",
         "//litert/cc/dynamic_runtime:litert_model_predicates",
         "//litert/test:common",
+        "//litert/test:load_test_model_runtimecapi",
         "//litert/test:matchers_oss",
         "//litert/test:test_models",
         "//litert/vendors/cc:litert_compiler_plugin",

--- a/litert/vendors/intel_openvino/compiler/openvino_compiler_plugin_test.cc
+++ b/litert/vendors/intel_openvino/compiler/openvino_compiler_plugin_test.cc
@@ -27,6 +27,7 @@
 #include "litert/c/litert_op_code.h"
 #include "litert/cc/internal/litert_extended_model.h"
 #include "litert/test/common.h"
+#include "litert/test/load_test_model.h"
 #include "litert/test/matchers.h"
 #include "litert/test/test_models.h"
 #include "litert/vendors/c/litert_compiler_plugin.h"

--- a/litert/vendors/intel_openvino/dispatch/BUILD
+++ b/litert/vendors/intel_openvino/dispatch/BUILD
@@ -189,13 +189,19 @@ cc_test(
     srcs = [
         "dispatch_api_openvino_test.cc",
     ],
-    copts = ["-fexceptions"],
+    copts = ["-fexceptions"] + select({
+        "//litert:windows": ["/DLITERT_COMPILE_LIBRARY"],
+        "//conditions:default": [],
+    }),
     features = ["-use_header_modules"],  # Incompatible with -fexceptions.
     #TODO:Uncomment this when NPU bin test data file is added in follow-up PR
     #data = [
     #    "//litert/test:testdata/ov_model_add1d_FP32.blob",
     #],
-    linkopts = litert_android_linkopts(),
+    linkopts = litert_android_linkopts() + select({
+        "//litert:windows": ["/FORCE:MULTIPLE"],
+        "//conditions:default": [],
+    }),
     linkstatic = 1,
     tags = [
         "manual",


### PR DESCRIPTION
- Add /DLITERT_COMPILE_LIBRARY define (Windows-only) to compiler and dispatch tests to fix DLL export/import issues

- Add linkstatic=1 to compiler test to avoid flatbuffers DLL link errors

- Add /FORCE:MULTIPLE linker flag (Windows-only) for dispatch test to resolve duplicate symbols between libLiteRt.if.lib and static dispatch.lo.lib

- Add missing load_test_model dependency and include to compiler test

- No impact on Linux/Android builds (platform-specific changes are guarded by //litert:windows select)