### PR TITLE
runtime: allow auto-resize of input tensors without dims_signature

### DIFF
--- a/litert/runtime/compiled_model.cc
+++ b/litert/runtime/compiled_model.cc
@@ -2064,8 +2064,11 @@ Expected<LiteRtMetricsT> LiteRtCompiledModelT::StopMetricsCollection() const {
 // needed.
 // 2. The input tensor has dynamic dimensions and the new shape is compatible,
 // then resize is needed.
-// 3. The input tensor has static dimensions or the new shape is not compatible,
-// then return error.
+// 3. The input tensor has no dims_signature but shapes differ: allow resize
+// (treat all dims as dynamic). This supports KV cache and other tensors in
+// LLMs that may lack explicit dynamic shape annotations.
+// 4. The input tensor has static dimensions and the new shape is not
+// compatible, then return error.
 Expected<bool> LiteRtCompiledModelT::InputTensorNeedsResize(
     const TfLiteTensor* tensor, absl::Span<const int> new_shape) {
   const TfLiteIntArray* shape_array = tensor->dims;
@@ -2083,10 +2086,32 @@ Expected<bool> LiteRtCompiledModelT::InputTensorNeedsResize(
   }
 
   if (!tensor->dims_signature || tensor->dims_signature->size == 0) {
-    return Unexpected(kLiteRtStatusErrorInvalidArgument,
-                      absl::StrCat("Cannot auto-resize tensor ",
-                                   tensor->name ? tensor->name : "<unnamed>",
-                                   ": no dims_signature exists"));
+    // No dims_signature: allow resize if the rank matches and all new
+    // dimensions are positive.  This is the common case for KV-cache tensors
+    // in LLM models that were exported without explicit dynamic-shape
+    // annotations.
+    LITERT_RETURN_IF_ERROR(
+        current_shape.size() == new_shape.size(),
+        Unexpected(
+            kLiteRtStatusErrorInvalidArgument,
+            absl::StrCat("Cannot auto-resize tensor ",
+                         tensor->name ? tensor->name : "<unnamed>",
+                         ": rank mismatch (current: ", current_shape.size(),
+                         ", new: ", new_shape.size(), ")")));
+    for (size_t i = 0; i < new_shape.size(); ++i) {
+      LITERT_RETURN_IF_ERROR(
+          new_shape[i] > 0,
+          Unexpected(kLiteRtStatusErrorInvalidArgument,
+                     absl::StrCat("Cannot auto-resize tensor ",
+                                  tensor->name ? tensor->name : "<unnamed>",
+                                  ": invalid dimension size ", new_shape[i],
+                                  " at index ", i)));
+    }
+    LITERT_LOG(LITERT_INFO,
+               "Detected shape change for tensor %s (no dims_signature) "
+               "- allowing resize",
+               tensor->name ? tensor->name : "<unnamed>");
+    return true;
   }
   // Validate that the tensor has dynamic dimensions (contains -1).
   absl::Span<const int> signature_shape = absl::MakeConstSpan(

--- a/litert/runtime/compiled_model_test.cc
+++ b/litert/runtime/compiled_model_test.cc
@@ -71,6 +71,7 @@
 #include "litert/test/matchers.h"
 #include "litert/test/testdata/simple_model_test_vectors.h"
 #include "third_party/odml/litert/ml_drift/delegate/buffer_handler_opencl.h"
+#include "tflite/c/common.h"
 #include "tflite/interpreter.h"
 
 namespace litert {
@@ -1534,6 +1535,71 @@ TEST(CompiledModelTest, CheckResizeFail) {
       InputTensorNeedsResize(compiled_model.get(), input_tensor1, {2, 128, 4}),
       IsError(kLiteRtStatusErrorInvalidArgument));
 
+  LiteRtDestroyOptions(jit_compilation_options);
+  LiteRtDestroyModel(model);
+  LiteRtDestroyEnvironment(env_ptr);
+}
+
+// Verifies auto-resize behavior for tensors that have no dims_signature (e.g.
+// KV-cache tensors in LLM models exported without dynamic-shape annotations).
+// Such tensors should be resizable as long as the rank matches and all new
+// dimensions are positive.
+TEST(CompiledModelTest, CheckResizeNoDimsSignature) {
+  // Environment setup.
+  LITERT_ASSERT_OK_AND_ASSIGN(LiteRtEnvironmentT::Ptr env,
+                              LiteRtEnvironmentT::CreateWithOptions({}));
+  LiteRtEnvironmentT* env_ptr = env.release();
+
+  // A CompiledModel instance is only needed to reach the static
+  // InputTensorNeedsResize helper via the test-only friend function.
+  std::string path = testing::GetTestFilePath(kModelFileName);
+  LiteRtModel model;
+  ASSERT_EQ(LiteRtCreateModelFromFile(env_ptr, path.c_str(), &model),
+            kLiteRtStatusOk);
+
+  LiteRtOptions jit_compilation_options;
+  ASSERT_EQ(LiteRtCreateOptions(&jit_compilation_options), kLiteRtStatusOk);
+  ASSERT_EQ(LiteRtSetOptionsHardwareAccelerators(jit_compilation_options,
+                                                 kLiteRtHwAcceleratorCpu),
+            kLiteRtStatusOk);
+  LITERT_ASSERT_OK_AND_ASSIGN(
+      LiteRtCompiledModelT::Ptr compiled_model,
+      LiteRtCompiledModelT::Create(env_ptr, model, jit_compilation_options));
+
+  // Build a synthetic tensor with static dims [1, 128, 4] but no
+  // dims_signature.
+  char tensor_name[] = "kv_cache";
+  TfLiteTensor tensor = {};
+  tensor.name = tensor_name;
+  tensor.dims = TfLiteIntArrayCreate(3);
+  tensor.dims->data[0] = 1;
+  tensor.dims->data[1] = 128;
+  tensor.dims->data[2] = 4;
+  tensor.dims_signature = nullptr;
+
+  {
+    // Same shape -> no resize needed.
+    LITERT_ASSERT_OK_AND_ASSIGN(
+        bool need_resize,
+        InputTensorNeedsResize(compiled_model.get(), &tensor, {1, 128, 4}));
+    EXPECT_FALSE(need_resize);
+  }
+  {
+    // Different shape, matching rank, positive dims -> resize allowed.
+    LITERT_ASSERT_OK_AND_ASSIGN(
+        bool need_resize,
+        InputTensorNeedsResize(compiled_model.get(), &tensor, {2, 128, 4}));
+    EXPECT_TRUE(need_resize);
+  }
+  // Rank mismatch -> error.
+  EXPECT_THAT(InputTensorNeedsResize(compiled_model.get(), &tensor, {2, 128}),
+              IsError(kLiteRtStatusErrorInvalidArgument));
+  // Non-positive dimension -> error.
+  EXPECT_THAT(
+      InputTensorNeedsResize(compiled_model.get(), &tensor, {2, -1, 4}),
+      IsError(kLiteRtStatusErrorInvalidArgument));
+
+  TfLiteIntArrayFree(tensor.dims);
   LiteRtDestroyOptions(jit_compilation_options);
   LiteRtDestroyModel(model);
   LiteRtDestroyEnvironment(env_ptr);


### PR DESCRIPTION
InputTensorNeedsResize previously refused to auto-resize any tensor that lacked a dims_signature, which blocked LLM/KV-cache inputs exported without explicit dynamic-shape annotations.

Treat a missing or empty dims_signature as fully dynamic: accept the new shape when its rank matches the current shape and all dimensions are positive. Update the case-list comment accordingly and log an INFO message when this fallback path is taken.