### PR TITLE
Qualcomm AI Engine Direct - Enhance QC log for debugging.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -401,7 +401,9 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
     qnn_manager = compiler_plugin->QNN();
   }
 
-  for (const auto& op : graph.Ops()) {
+  const auto ops = graph.Ops();
+  for (size_t op_index = 0; op_index < ops.size(); ++op_index) {
+    const auto& op = ops[op_index];
     // default constructed, won't add tensor to QNN
     ::qnn::TensorPool tensor_pool;
     std::vector<::qnn::TensorWrapperRef> input_tensors;
@@ -424,7 +426,7 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
     LITERT_RETURN_IF_ERROR(litert::qnn::ConvertOp(
         compiler_plugin->Options().GetUseInt64BiasAsInt32(),
         compiler_plugin->Options().GetCustomOpPackage(), op, tensor_pool,
-        input_tensors, output_tensors, op_wrappers));
+        input_tensors, output_tensors, op_wrappers, op_index));
 
     // Empty op_wrappers means the op is not supported by QNN.
     if (op_wrappers.empty()) {

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -1562,6 +1562,31 @@ LiteRtStatus BuildCustomOp(const litert::compiler::Op& litert_op,
   return kLiteRtStatusOk;
 }
 
+std::string DescribeUnsupportedOp(size_t op_index,
+                                  const litert::compiler::Op& litert_op) {
+  const auto op_code = litert_op.Code();
+  std::ostringstream dump;
+  // Leading newline so this multi-line block starts on its own line and is not
+  // glued onto preceding QNN SDK stdout.
+  dump << "\nLiteRT Op #" << op_index << " ";
+  dump << "'" << GetTfliteOpName(op_code) << "' (code="
+       << static_cast<int>(op_code)
+       << ") is not supported in Qualcomm Compiler.";
+  dump << "\n  Inputs:";
+  const auto inputs = litert_op.Inputs();
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    dump << "\n    [" << i << "] name=\"" << inputs[i].Name()
+         << "\"  tensor_idx=" << inputs[i].TensorIndex();
+  }
+  dump << "\n  Outputs:";
+  const auto outputs = litert_op.Outputs();
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    dump << "\n    [" << i << "] name=\"" << outputs[i].Name()
+         << "\"  tensor_idx=" << outputs[i].TensorIndex();
+  }
+  return dump.str();
+}
+
 }  // namespace
 
 LiteRtStatus ConvertOp(const bool use_int64_bias_as_int32,
@@ -1570,7 +1595,8 @@ LiteRtStatus ConvertOp(const bool use_int64_bias_as_int32,
                        ::qnn::TensorPool& tensor_pool,
                        std::vector<::qnn::TensorWrapperRef>& input_tensors,
                        std::vector<::qnn::TensorWrapperRef>& output_tensors,
-                       std::vector<::qnn::OpWrapper>& op_wrappers) {
+                       std::vector<::qnn::OpWrapper>& op_wrappers,
+                       size_t op_index) {
   const auto& builders = GetOpBuilders();
   const auto op_code = litert_op.Code();
   if (op_code < builders.size() && builders[op_code]) {
@@ -1582,9 +1608,8 @@ LiteRtStatus ConvertOp(const bool use_int64_bias_as_int32,
     return BuildCustomOp(litert_op, tensor_pool, input_tensors, output_tensors,
                          op_wrappers, custom_op_package);
   }
-  LITERT_LOG(LITERT_ERROR,
-             "LiteRT Op Code: %d is not supported in Qualcomm Compiler.",
-             litert_op.Code());
+  LITERT_LOG(LITERT_ERROR, "%s",
+             DescribeUnsupportedOp(op_index, litert_op).c_str());
   return kLiteRtStatusOk;
 }
 
@@ -1701,7 +1726,7 @@ LiteRtStatus MapGraph(const LiteRtCompilerContext* ctx, QnnManager& qnn,
     std::vector<::qnn::OpWrapper> op_wrappers;
     LITERT_RETURN_IF_ERROR(ConvertOp(
         options.GetUseInt64BiasAsInt32(), options.GetCustomOpPackage(), op,
-        tensor_pool, input_tensors, output_tensors, op_wrappers));
+        tensor_pool, input_tensors, output_tensors, op_wrappers, id));
     for (auto& op_wrapper : op_wrappers) {
       // Add litert op id to qnn op name to preserve op mapping
       op_wrapper.AddSuffixToName(

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
@@ -15,6 +15,7 @@
 #ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_COMPILER_QNN_COMPOSE_GRAPH_H_
 #define ODML_LITERT_LITERT_VENDORS_QUALCOMM_COMPILER_QNN_COMPOSE_GRAPH_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -42,13 +43,18 @@ LiteRtStatus ConvertTensor(
     const absl::flat_hash_set<std::int32_t>& ids_to_dump = {},
     bool is_tensor_output = false);
 
+// `op_index` is the topological index of the op within its subgraph; it is
+// included in the "unsupported op" error message so a specific op can be
+// located (and cross-referenced with the "_LiteRt_OpId_<n>" suffix added to
+// the QNN op name).
 LiteRtStatus ConvertOp(bool use_int64_bias_as_int32,
                        const ::qnn::CustomOpPackage& custom_op_package,
                        const litert::compiler::Op& litert_op,
                        ::qnn::TensorPool& tensor_pool,
                        std::vector<::qnn::TensorWrapperRef>& input_tensors,
                        std::vector<::qnn::TensorWrapperRef>& output_tensors,
-                       std::vector<::qnn::OpWrapper>& op_wrappers);
+                       std::vector<::qnn::OpWrapper>& op_wrappers,
+                       size_t op_index);
 
 // Composes a new QNN Graph from given LiteRt Graph. Qnn Graph is written to
 // context behind "qnn". Uses given graph_name to name entry point.

--- a/litert/vendors/qualcomm/core/utils/miscs.cc
+++ b/litert/vendors/qualcomm/core/utils/miscs.cc
@@ -222,4 +222,43 @@ std::vector<std::int8_t> UnpackInt4Data(const void* src, size_t src_bytes) {
   }
   return dst;
 }
+
+#define QNN_DATATYPE_LIST          \
+  X(QNN_DATATYPE_INT_8)            \
+  X(QNN_DATATYPE_INT_16)           \
+  X(QNN_DATATYPE_INT_32)           \
+  X(QNN_DATATYPE_INT_64)           \
+  X(QNN_DATATYPE_UINT_8)           \
+  X(QNN_DATATYPE_UINT_16)          \
+  X(QNN_DATATYPE_UINT_32)          \
+  X(QNN_DATATYPE_UINT_64)          \
+  X(QNN_DATATYPE_FLOAT_16)         \
+  X(QNN_DATATYPE_BFLOAT_16)        \
+  X(QNN_DATATYPE_FLOAT_32)         \
+  X(QNN_DATATYPE_FLOAT_64)         \
+  X(QNN_DATATYPE_SFIXED_POINT_4)   \
+  X(QNN_DATATYPE_SFIXED_POINT_8)   \
+  X(QNN_DATATYPE_SFIXED_POINT_16)  \
+  X(QNN_DATATYPE_SFIXED_POINT_32)  \
+  X(QNN_DATATYPE_UFIXED_POINT_4)   \
+  X(QNN_DATATYPE_UFIXED_POINT_8)   \
+  X(QNN_DATATYPE_UFIXED_POINT_16)  \
+  X(QNN_DATATYPE_UFIXED_POINT_32)  \
+  X(QNN_DATATYPE_BOOL_8)           \
+  X(QNN_DATATYPE_STRING)
+
+const char* QnnDataTypeName(Qnn_DataType_t data_type) {
+  switch (data_type) {
+#define X(name) \
+  case name:    \
+    return #name;
+    QNN_DATATYPE_LIST
+#undef X
+    default:
+      return "QNN_DATATYPE_UNKNOWN";
+  }
+}
+
+#undef QNN_DATATYPE_LIST
+
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/utils/miscs.h
+++ b/litert/vendors/qualcomm/core/utils/miscs.h
@@ -35,6 +35,10 @@ inline bool IsStrEq(const char* input, const char* golden) {
 
 }  // namespace miscs
 
+// Returns the enum name for a Qnn_DataType_t (e.g. "QNN_DATATYPE_FLOAT_32"),
+// or "QNN_DATATYPE_UNKNOWN" for unrecognized values. For logging.
+const char* QnnDataTypeName(Qnn_DataType_t data_type);
+
 constexpr uint32_t kQuantBitWidth4 = 4;
 constexpr uint32_t kQuantBitWidth2 = 2;
 

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <functional>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -166,6 +167,21 @@ void OpWrapper::AddPrefixToName(absl::string_view prefix) {
 
 void OpWrapper::AddSuffixToName(absl::string_view suffix) {
   name_ = absl::StrCat(name_, suffix);
+}
+
+std::string OpWrapper::ToString() const {
+  std::ostringstream out;
+  out << "'" << GetName() << "' (type="
+      << (GetTypeName() ? GetTypeName() : "<null>") << ")";
+  out << "\n  Inputs:";
+  for (size_t i = 0; i < input_tensors_.size(); ++i) {
+    out << "\n    [" << i << "] " << input_tensors_[i].get().ToString();
+  }
+  out << "\n  Outputs:";
+  for (size_t i = 0; i < output_tensors_.size(); ++i) {
+    out << "\n    [" << i << "] " << output_tensors_[i].get().ToString();
+  }
+  return out.str();
 }
 
 namespace {

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.h
@@ -77,6 +77,10 @@ class OpWrapper final {
 
   void AddSuffixToName(absl::string_view suffix);
 
+  // Multi-line description (name, type, and every input/output tensor), for
+  // logging.
+  std::string ToString() const;
+
  private:
   // Borrowed pointer. Must point to a string that outlives this OpWrapper --
   // in practice, the QualcommOptions instance held by LiteRtCompilerPluginT.

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -12,6 +12,7 @@
 #include <iterator>
 #include <limits>
 #include <numeric>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <variant>
@@ -362,5 +363,26 @@ void TensorWrapper::SetQuantBitwidth(std::uint32_t bitwidth) {
   }
 
   UpdateQnnQuantParams();
+}
+
+std::string TensorWrapper::ToString() const {
+  std::ostringstream out;
+  out << "name=\"" << GetName() << "\" dtype=" << QnnDataTypeName(GetDataType());
+  out << " dims=[";
+  for (size_t i = 0; i < dimensions_.size(); ++i) {
+    out << (i == 0 ? "" : ",") << dimensions_[i];
+  }
+  out << "]";
+  // Quantization kind, stated factually without diagnosing any failure.
+  if (IsPerChannelQuant()) {
+    out << " per-channel-quant";
+  } else if (IsPerTensorQuant()) {
+    out << " per-tensor-quant";
+  } else if (IsQuant()) {
+    out << " quant";
+  } else {
+    out << " (no quantization)";
+  }
+  return out.str();
 }
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -56,6 +56,9 @@ class TensorWrapper final {
 
   void CloneTo(Qnn_Tensor_t& dst) const;
 
+  // Single-line description (name / dtype / dims / quant kind), for logging.
+  std::string ToString() const;
+
   // Accessors /////////////////////////////////////////////////////////
 
   template <typename T>

--- a/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
@@ -9,9 +9,11 @@
 #include <functional>
 #include <numeric>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "litert/vendors/qualcomm/core/op_code.h"
 #include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
@@ -498,6 +500,26 @@ TEST(OpWrapperTest, IsElementWiseTest) {
       QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION,
       QNN_OP_ELEMENT_WISE_UNARY_OPERATION_NOT);
   EXPECT_TRUE(IsElementWiseNot(not_op));
+}
+
+TEST(OpWrapperTest, ToString) {
+  std::vector<uint32_t> dims = {1, 1, 3};
+  auto input = CreateTensor(dims, QNN_TENSOR_TYPE_NATIVE);
+  auto output = CreateTensor(dims, QNN_TENSOR_TYPE_APP_READ);
+  OpWrapper op{"my_op", "OP_TYPE", QnnOpCode::kUnknown};
+  op.AddInputTensor(input);
+  op.AddOutputTensor(output);
+
+  const std::string str = op.ToString();
+  EXPECT_EQ(
+      str,
+      "'my_op' (type=OP_TYPE)"
+      "\n  Inputs:"
+      "\n    [0] name=\"\" dtype=QNN_DATATYPE_UFIXED_POINT_8 dims=[1,1,3] "
+      "(no quantization)"
+      "\n  Outputs:"
+      "\n    [0] name=\"\" dtype=QNN_DATATYPE_UFIXED_POINT_8 dims=[1,1,3] "
+      "(no quantization)");
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -406,6 +406,47 @@ TEST(TensorWrapperTest, SameTensorWrapperTest) {
   EXPECT_EQ(tensor_wrapper_1, tensor_wrapper_ref);
 }
 
+TEST(TensorWrapperTest, ToStringNoQuant) {
+  TensorWrapper tensor_wrapper{"my_tensor",
+                               QNN_TENSOR_TYPE_NATIVE,
+                               QNN_DATATYPE_FLOAT_32,
+                               QuantizeParamsWrapperVariant(),
+                               {1, 2, 3}};
+  const std::string str = tensor_wrapper.ToString();
+  EXPECT_EQ(str,
+            "name=\"my_tensor\" dtype=QNN_DATATYPE_FLOAT_32 dims=[1,2,3] "
+            "(no quantization)");
+}
+
+TEST(TensorWrapperTest, ToStringPerTensorQuant) {
+  ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
+  TensorWrapper tensor_wrapper{"q_tensor",
+                               QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_UFIXED_POINT_8,
+                               q_param,
+                               {1, 1, 3}};
+  const std::string str = tensor_wrapper.ToString();
+  EXPECT_EQ(str,
+            "name=\"q_tensor\" dtype=QNN_DATATYPE_UFIXED_POINT_8 dims=[1,1,3] "
+            "per-tensor-quant");
+}
+
+TEST(TensorWrapperTest, ToStringPerChannelQuant) {
+  std::vector<float> scales = {1.0, 1.0};
+  std::vector<std::int32_t> zero_points = {0, 0};
+  AxisScaleOffsetQuantizeParamsWrapper q_param(
+      0, absl::Span<float>(scales.data(), scales.size()),
+      absl::Span<std::int32_t>(zero_points.data(), zero_points.size()));
+  TensorWrapper tensor_wrapper{"pc_tensor",
+                               QNN_TENSOR_TYPE_STATIC,
+                               QNN_DATATYPE_UFIXED_POINT_8,
+                               q_param,
+                               {1, 1, 3}};
+  EXPECT_EQ(tensor_wrapper.ToString(),
+            "name=\"pc_tensor\" dtype=QNN_DATATYPE_UFIXED_POINT_8 dims=[1,1,3] "
+            "per-channel-quant");
+}
+
 TEST(TensorWrapperTest, QnnTensorIdAndName) {
   ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
   TensorWrapper tensor_wrapper{"tensor_name",

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -446,8 +446,13 @@ LiteRtStatus QnnManager::ValidateOp(::qnn::OpWrapper& op) {
   if (Qnn_ErrorHandle_t error =
           Api()->backendValidateOpConfig(BackendHandle(), op_config);
       QNN_SUCCESS != error) {
-    LITERT_LOG(LITERT_ERROR, "Failed to validate op %s\n, error: %lld",
-               op_config.v1.name, static_cast<long long>(error));
+    // Detailed message on the failure path only: which op failed, the QNN
+    // error code, and every operand's dtype / dims / quantization kind.
+    LITERT_LOG(LITERT_ERROR,
+               "\nQNN op validation failed: %s\n"
+               "  QNN error=%lld. See the QNN validator log lines above for the "
+               "specific reason.",
+               op.ToString().c_str(), static_cast<long long>(error));
     return kLiteRtStatusErrorInvalidLegalization;
   }
 


### PR DESCRIPTION
# What
- Add detailed log for unsupported op and validation failure.

## Verification

- [x] Developer-Verified
- Validation failed log update:
```
QNN op validation failed: 'Pack_17' (type=Pack)
  Inputs:
    [0] name="0_litert_43" dtype=QNN_DATATYPE_SFIXED_POINT_8 dims=[1,100,4,32] per-tensor-quant
    [1] name="1_litert_46" dtype=QNN_DATATYPE_SFIXED_POINT_8 dims=[1,100,4,32] per-tensor-quant
  Outputs:
    [0] name="2_litert_47" dtype=QNN_DATATYPE_SFIXED_POINT_8 dims=[1,100,4,2,32] per-tensor-quant
  Reasons (QNN error=3110):
    see QNN validator lines below: "Op specific validation failed" / "Incorrect ..." before "validateNativeOps master op validator Pack_17 ... failed".
```
- Unsupported op log update:
```
LiteRT Op #44 'SplitV' (code=102) is not supported in Qualcomm Compiler.
  Inputs:
    [0] name="mobile_sam_5m_image_encoder/tf_op_layer_Reshape_2/Reshape_2"  tensor_idx=403
    [1] name="mobile_sam_5m_image_encoder/tf_op_layer_split/Const"  tensor_idx=8
    [2] name="mobile_sam_5m_image_encoder/tf_op_layer_split/split/split_dim"  tensor_idx=9
  Outputs:
    [0] name="mobile_sam_5m_image_encoder/tf_op_layer_split/split;mobile_sam_5m_image_encoder/tf_op_layer_split/split1;mobile_sam_5m_image_encoder/tf_op_layer_split/split2"  tensor_idx=404
    [1] name="mobile_sam_5m_image_encoder/tf_op_layer_split/split;mobile_sam_5m_image_encoder/tf_op_layer_split/split1;mobile_sam_5m_image_encoder/tf_op_layer_split/split21"  tensor_idx=405
    [2] name="mobile_sam_5m_image_encoder/tf_op_layer_split/split;mobile_sam_5m_image_encoder/tf_op_layer_split/split1;mobile_sam_5m_image_encoder/tf_op_layer_split/split22"  tensor_idx=406
```

# Test

- Passed x86 unit test. 
- Passed android unit test.

======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all


//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 28.9s

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 20 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 13 tests from 9 test suites ran. (0 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 15 tests from 3 test suites ran. (23 ms total)
[  PASSED  ] 15 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 20 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 33 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (3 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (3 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 17 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (21 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (583 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (595 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1403 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1019 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (4 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (706 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2435 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (60 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (588 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (510 ms total)
[  PASSED  ] 2 tests.