### PR TITLE
[Do not land] Transformer-layer-aware partitioning prototype

### DIFF
--- a/litert/c/options/litert_compiler_options.cc
+++ b/litert/c/options/litert_compiler_options.cc
@@ -25,6 +25,8 @@
 struct LrtCompilerOptions {
   std::optional<LiteRtCompilerOptionsPartitionStrategy> partition_strategy;
   std::optional<bool> dummy_option;
+  // Per-signature layer-cut spec string (see header for grammar).
+  std::string transformer_layer_cuts;
 };
 
 LiteRtStatus LrtCreateCompilerOptions(LrtCompilerOptions** options) {
@@ -61,6 +63,12 @@ LiteRtStatus LrtGetOpaqueCompilerOptionsData(const LrtCompilerOptions* options,
     ss << "dummy_option = "
        << (options->dummy_option.value() ? "true" : "false") << "\n";
   }
+  if (!options->transformer_layer_cuts.empty()) {
+    // Quote the spec: it contains ';', '=', and ',' which the TOML reader would
+    // otherwise have to special-case. The parser strips the surrounding quotes.
+    ss << "transformer_layer_cuts = \"" << options->transformer_layer_cuts
+       << "\"\n";
+  }
 
   *identifier = LrtGetCompilerOptionsIdentifier();
   std::string toml_str = ss.str();
@@ -89,6 +97,27 @@ LiteRtStatus LrtGetCompilerOptionsPartitionStrategy(
     return kLiteRtStatusErrorNotFound;
   }
   *partition_strategy = options->partition_strategy.value();
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtSetCompilerOptionsTransformerLayerCuts(LrtCompilerOptions* options,
+                                                       const char* spec) {
+  if (!options || !spec) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+  options->transformer_layer_cuts = spec;
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtGetCompilerOptionsTransformerLayerCuts(
+    const LrtCompilerOptions* options, const char** spec) {
+  if (!options || !spec) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+  if (options->transformer_layer_cuts.empty()) {
+    return kLiteRtStatusErrorNotFound;
+  }
+  *spec = options->transformer_layer_cuts.c_str();
   return kLiteRtStatusOk;
 }
 

--- a/litert/c/options/litert_compiler_options.h
+++ b/litert/c/options/litert_compiler_options.h
@@ -15,6 +15,9 @@
 #ifndef THIRD_PARTY_ODML_LITERT_LITERT_C_OPTIONS_LITERT_COMPILER_OPTIONS_H_
 #define THIRD_PARTY_ODML_LITERT_LITERT_C_OPTIONS_LITERT_COMPILER_OPTIONS_H_
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "litert/c/litert_common.h"
 
 #ifdef __cplusplus
@@ -34,9 +37,35 @@ typedef struct LrtCompilerOptions LrtCompilerOptions;
 //   incorrect partition where there exists a path from a selected to another,
 //   where there is an unselected node in between. This feature is currently in
 //   experimental stage.
+//
+// Transformer block (experimental feature):
+//   Detects transformer-block structure (attention, feed-forward, and
+//   normalization clusters) among the ops the vendor plugin selected, and
+//   groups each detected block into a single partition before requesting
+//   compilation from the IHV delegate. This keeps a whole block self-contained
+//   so the delegate can schedule it as one unit instead of many small islands.
+//   Falls back to the default strategy when no block is found.
+//
+// Transformer layer cut (experimental feature):
+//   Like Transformer block, but instead of one partition per transformer layer,
+//   groups CONSECUTIVE layers into a single partition, breaking only at the
+//   layer indices supplied via LrtSetCompilerOptionsTransformerLayerCuts. This
+//   lets a caller carve the decoder stack into a chosen number of multi-layer
+//   chunks (e.g. cuts {16,32} on a 48-layer model -> three 16-layer
+//   partitions). With no cuts set, behaves like Transformer block.
+//
+//   Cuts are supplied as a per-signature spec string: a ';'-separated list of
+//   "signature_key=cuts" groups, where `cuts` is a ','-separated list of layer
+//   indices. A bare list (or empty key) is the default applied to signatures
+//   without an explicit group. Examples:
+//     "16"                          -> all signatures cut at layer 16
+//     "prefill_128=16,32;decode=8"  -> per-signature cuts
+//     "=16;decode=8"                -> decode at 8, all others at 16
 typedef enum LiteRtCompilerOptionsPartitionStrategy {
   kLiteRtCompilerOptionsPartitionStrategyDefault = 0,
   kLiteRtCompilerOptionsPartitionStrategyWeaklyConnected = 1,
+  kLiteRtCompilerOptionsPartitionStrategyTransformerBlock = 2,
+  kLiteRtCompilerOptionsPartitionStrategyTransformerLayerCut = 3,
 } LiteRtCompilerOptionsPartitionStrategy;
 
 // Creates a compiler options object.
@@ -68,6 +97,18 @@ LiteRtStatus LrtSetCompilerOptionsPartitionStrategy(
 LiteRtStatus LrtGetCompilerOptionsPartitionStrategy(
     const LrtCompilerOptions* options,
     LiteRtCompilerOptionsPartitionStrategy* partition_strategy);
+
+// Sets the transformer layer cut spec used by the TransformerLayerCut partition
+// strategy. `spec` is a null-terminated per-signature spec string (see the enum
+// comment above for the grammar). The string is copied.
+LiteRtStatus LrtSetCompilerOptionsTransformerLayerCuts(LrtCompilerOptions* options,
+                                                       const char* spec);
+
+// Gets the transformer layer cut spec. Returns a pointer to the internally held
+// string (valid until the options are modified or destroyed) via `*spec`.
+// Returns kLiteRtStatusErrorNotFound if no spec is set.
+LiteRtStatus LrtGetCompilerOptionsTransformerLayerCuts(
+    const LrtCompilerOptions* options, const char** spec);
 
 // Sets the dummy option for testing.
 LiteRtStatus LrtSetCompilerOptionsDummyOption(LrtCompilerOptions* options,

--- a/litert/cc/options/litert_compiler_options.h
+++ b/litert/cc/options/litert_compiler_options.h
@@ -16,6 +16,7 @@
 #define THIRD_PARTY_ODML_LITERT_LITERT_CC_OPTIONS_LITERT_COMPILER_OPTIONS_H_
 
 #include <memory>
+#include <string>
 
 #include "litert/c/options/litert_compiler_options.h"
 #include "litert/cc/litert_expected.h"
@@ -63,6 +64,29 @@ class CompilerOptions {
     LITERT_RETURN_IF_ERROR(
         LrtGetCompilerOptionsDummyOption(options_.get(), &dummy_option));
     return dummy_option;
+  }
+
+  /// @brief Sets the transformer layer cut spec (TransformerLayerCut strategy).
+  /// The spec is a per-signature string, e.g. "prefill_128=16,32;decode=8" or a
+  /// bare "16" applied to all signatures.
+  Expected<void> SetTransformerLayerCuts(const std::string& spec) {
+    LITERT_RETURN_IF_ERROR(
+        LrtSetCompilerOptionsTransformerLayerCuts(options_.get(), spec.c_str()));
+    return {};
+  }
+
+  /// @brief Gets the transformer layer cut spec. Empty if none set.
+  Expected<std::string> GetTransformerLayerCuts() const {
+    const char* spec = nullptr;
+    const LiteRtStatus status =
+        LrtGetCompilerOptionsTransformerLayerCuts(options_.get(), &spec);
+    if (status == kLiteRtStatusErrorNotFound) {
+      return std::string{};
+    }
+    if (status != kLiteRtStatusOk) {
+      return Error(status);
+    }
+    return std::string(spec);
   }
 
   /// @brief Returns the underlying C handle.

--- a/litert/compiler/plugin/BUILD
+++ b/litert/compiler/plugin/BUILD
@@ -31,6 +31,7 @@ cc_library(
     deps = [
         ":algo",
         ":litert_compiler_options",
+        ":transformer_detector",
         "//litert/c:litert_any",
         "//litert/c:litert_builder",
         "//litert/c:litert_common",
@@ -227,6 +228,43 @@ cc_test(
         "//litert/core/model:model_serialize",
         "//litert/test:common",
         "//litert/test:load_test_model",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "transformer_detector",
+    srcs = ["transformer_detector.cc"],
+    hdrs = ["transformer_detector.h"],
+    deps = [
+        "//litert/c:litert_common",
+        "//litert/c:litert_op_code",
+        "//litert/c/internal:litert_logging",
+        "//litert/cc/internal:litert_op_options",
+        "//litert/core/model",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+cc_test(
+    name = "transformer_detector_test",
+    srcs = ["transformer_detector_test.cc"],
+    data = [
+        "//litert/test:mlir_test_data",
+    ],
+    deps = [
+        ":transformer_detector",
+        "//litert/c:litert_common",
+        "//litert/c:litert_op_code",
+        "//litert/cc/internal:litert_op_options",
+        "//litert/core/model",
+        "//litert/test:common",
+        "//litert/test:load_test_model",
+        "//tflite/schema:schema_fbs",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_googletest//:gtest_main",
     ],

--- a/litert/compiler/plugin/compiler_plugin.cc
+++ b/litert/compiler/plugin/compiler_plugin.cc
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "absl/algorithm/container.h"  // from @com_google_absl
+#include "absl/container/flat_hash_map.h"  // from @com_google_absl
 #include "absl/container/flat_hash_set.h"  // from @com_google_absl
 #include "absl/log/absl_check.h"  // from @com_google_absl
 #include "absl/strings/str_cat.h"  // from @com_google_absl
@@ -50,6 +51,7 @@
 #include "litert/cc/litert_macros.h"
 #include "litert/compiler/plugin/algo.h"
 #include "litert/compiler/plugin/litert_compiler_options.h"
+#include "litert/compiler/plugin/transformer_detector.h"
 #include "litert/core/build_stamp.h"
 #include "litert/core/dynamic_loading.h"
 #include "litert/core/environment.h"
@@ -510,7 +512,8 @@ LiteRtStatus PartitionSubgraph(
     std::vector<LiteRtOpWithPartitionIndex> selected_ops,
     LiteRtSubgraphT& subgraph, std::vector<LiteRtOp>& res_ops,
     LiteRtModelT& model,
-    const LiteRtCompilerOptionsPartitionStrategy& partition_strategy_option) {
+    const LiteRtCompilerOptionsPartitionStrategy& partition_strategy_option,
+    const std::vector<int32_t>& transformer_layer_cuts = {}) {
   // Pick partition strategy based on compiler options.
   std::vector<std::vector<LiteRtOp>> (*partition_strategy_func)(
       const std::vector<LiteRtOpWithPartitionIndex>&, LiteRtSubgraph) =
@@ -520,6 +523,29 @@ LiteRtStatus PartitionSubgraph(
     partition_strategy_func = GroupPartitionsV2;
   }
   LITERT_LOG(LITERT_INFO, "Partition strategy: %d", partition_strategy_option);
+
+  // For the transformer-block / transformer-layer-cut strategies, detect
+  // transformer layers among the vendor-selected ops and rewrite their
+  // partition indices. With TransformerBlock each layer becomes its own island;
+  // with TransformerLayerCut, consecutive layers are coalesced into one island
+  // per inter-cut chunk. The resulting islands are connected sub-DAGs sharing a
+  // unique index, so the weakly-connected (union-find) grouping then emits one
+  // partition per island. If no layer is found the rewrite is a no-op.
+  if (partition_strategy_option ==
+          kLiteRtCompilerOptionsPartitionStrategyTransformerBlock ||
+      partition_strategy_option ==
+          kLiteRtCompilerOptionsPartitionStrategyTransformerLayerCut) {
+    TransformerDetectorOptions detector_options;
+    if (partition_strategy_option ==
+        kLiteRtCompilerOptionsPartitionStrategyTransformerLayerCut) {
+      detector_options.layer_cut_indices = transformer_layer_cuts;
+      // Under the layer-cut strategy, a graph with no cuts coalesces into a
+      // single partition ("cut nowhere") rather than one partition per layer.
+      detector_options.coalesce_layers = true;
+    }
+    RepartitionByTransformerBlocks(selected_ops, &subgraph, detector_options);
+    partition_strategy_func = GroupPartitions;
+  }
 
   // Group selected ops into connected islands.
   auto islands = partition_strategy_func(selected_ops, &subgraph);
@@ -619,6 +645,24 @@ Expected<PartitionResult> PartitionModel(
     }
   });
 
+  // Read partition strategy and (for the layer-cut strategy) the per-signature
+  // cut spec from the compiler options once, up front.
+  auto compiler_options = compiler_plugin.CompilerOptions();
+  LiteRtCompilerOptionsPartitionStrategy strategy =
+      kLiteRtCompilerOptionsPartitionStrategyDefault;
+  std::string layer_cut_spec;
+  if (compiler_options.HasValue()) {
+    strategy = compiler_options->partition_strategy;
+    layer_cut_spec = compiler_options->transformer_layer_cuts;
+  }
+
+  // Map each subgraph to its signature key so per-signature layer cuts can be
+  // resolved. A subgraph may be referenced by at most one signature.
+  absl::flat_hash_map<LiteRtSubgraph, std::string> subgraph_to_signature;
+  for (auto* sig : model.Signatures()) {
+    subgraph_to_signature[&sig->GetSubgraph()] = std::string(sig->Key());
+  }
+
   // Build partition result via calling plugin on non-decomposition subgraphs.
   std::vector<LiteRtOp> dispatch_ops;
   for (auto i = 0; i < input_num_sgs; ++i) {
@@ -711,15 +755,25 @@ Expected<PartitionResult> PartitionModel(
     auto num_ops = subgraph->Ops().size();
 
     auto num_partitions = dispatch_ops.size();
-    // Get partition strategy from compiler options.
-    auto compiler_options = compiler_plugin.CompilerOptions();
-    LiteRtCompilerOptionsPartitionStrategy strategy =
-        kLiteRtCompilerOptionsPartitionStrategyDefault;
-    if (compiler_options.HasValue()) {
-      strategy = compiler_options->partition_strategy;
+    // Resolve this subgraph's layer cuts from the per-signature spec.
+    std::vector<int32_t> transformer_layer_cuts;
+    if (strategy == kLiteRtCompilerOptionsPartitionStrategyTransformerLayerCut &&
+        !layer_cut_spec.empty()) {
+      absl::string_view signature_key;
+      if (auto it = subgraph_to_signature.find(subgraph);
+          it != subgraph_to_signature.end()) {
+        signature_key = it->second;
+      }
+      auto cuts = ResolveLayerCuts(layer_cut_spec, signature_key);
+      transformer_layer_cuts.assign(cuts.begin(), cuts.end());
+      LITERT_LOG(LITERT_INFO,
+                 "Subgraph<%d> signature '%s': resolved %lu layer cut(s).", i,
+                 std::string(signature_key).c_str(),
+                 transformer_layer_cuts.size());
     }
     LITERT_RETURN_IF_ERROR(PartitionSubgraph(
-        std::move(*selected_ops), *subgraph, dispatch_ops, model, strategy));
+        std::move(*selected_ops), *subgraph, dispatch_ops, model, strategy,
+        transformer_layer_cuts));
     num_partitions = dispatch_ops.size() - num_partitions;
     LITERT_LOG(LITERT_INFO,
                "Partitioned subgraph<%d>, selected %lu "

--- a/litert/compiler/plugin/litert_compiler_options.cc
+++ b/litert/compiler/plugin/litert_compiler_options.cc
@@ -15,6 +15,7 @@
 #include "litert/compiler/plugin/litert_compiler_options.h"
 
 #include <cstddef>
+#include <string>
 
 #include "absl/strings/string_view.h"  // from @com_google_absl
 #include "litert/c/litert_common.h"
@@ -37,6 +38,10 @@ LiteRtStatus ParseLiteRtCompilerOptions(const void* data, size_t size,
               static_cast<LiteRtCompilerOptionsPartitionStrategy>(strategy);
         } else if (key == "dummy_option") {
           LITERT_ASSIGN_OR_RETURN(options->dummy_option, ParseTomlBool(value));
+        } else if (key == "transformer_layer_cuts") {
+          // The value is the per-signature spec string; ParseToml has already
+          // stripped the surrounding quotes.
+          options->transformer_layer_cuts = std::string(value);
         }
         return kLiteRtStatusOk;
       });

--- a/litert/compiler/plugin/litert_compiler_options.h
+++ b/litert/compiler/plugin/litert_compiler_options.h
@@ -16,6 +16,8 @@
 #ifndef THIRD_PARTY_ODML_LITERT_LITERT_COMPILER_PLUGIN_LITERT_COMPILER_OPTIONS_H_
 #define THIRD_PARTY_ODML_LITERT_LITERT_COMPILER_PLUGIN_LITERT_COMPILER_OPTIONS_H_
 
+#include <string>
+
 #include "litert/c/litert_common.h"
 #include "litert/c/options/litert_compiler_options.h"
 
@@ -25,6 +27,11 @@ struct LiteRtCompilerOptionsT {
       kLiteRtCompilerOptionsPartitionStrategyDefault;
 
   bool dummy_option = false;
+
+  // Per-signature layer-cut spec for the TransformerLayerCut strategy (see
+  // litert/c/options/litert_compiler_options.h for the grammar). Empty means
+  // one partition per transformer layer.
+  std::string transformer_layer_cuts;
 
   static const char* Identifier() { return "compiler_options_string"; }
 };

--- a/litert/compiler/plugin/transformer_detector.cc
+++ b/litert/compiler/plugin/transformer_detector.cc
@@ -1,0 +1,812 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "litert/compiler/plugin/transformer_detector.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "absl/container/flat_hash_set.h"  // from @com_google_absl
+#include "absl/strings/match.h"  // from @com_google_absl
+#include "absl/strings/numbers.h"  // from @com_google_absl
+#include "absl/strings/str_split.h"  // from @com_google_absl
+#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "absl/strings/strip.h"  // from @com_google_absl
+#include "litert/c/internal/litert_logging.h"
+#include "litert/c/litert_common.h"
+#include "litert/c/litert_op_code.h"
+#include "litert/cc/internal/litert_op_options.h"
+#include "litert/core/model/model.h"
+
+namespace litert::internal {
+namespace {
+
+// True if `op` is a StableHLO composite normalization (odml.rms_norm /
+// odml.l2_norm / odml.group_norm). These arrive as a single composite op when
+// the vendor plugin supports the composite directly (so it is not inlined into
+// its mean/rsqrt/mul decomposition). The transformer-block detector must treat
+// such a composite as the layer's normalization signal, exactly as it treats
+// the decomposed form.
+bool IsNormCompositeOp(LiteRtOp op) {
+  if (op->OpCode() != kLiteRtOpCodeShloComposite) {
+    return false;
+  }
+  auto info = GetOptionsAs<CompositeOptions>(op);
+  if (!info) {
+    return false;
+  }
+  return info->name == CompositeOptions::kRmsNorm ||
+         info->name == CompositeOptions::kL2Norm ||
+         info->name == CompositeOptions::kGroupNorm;
+}
+
+// Op-code histogram for a connected region of selected ops. Only the codes that
+// participate in transformer-block classification are tracked; everything else
+// is rolled into `other`.
+struct OpHistogram {
+  size_t matmul = 0;       // batch_matmul / fully_connected (projections, QK^T)
+  size_t softmax = 0;      // attention probability normalization
+  size_t activation = 0;   // gelu / logistic / tanh (feed-forward non-linearity)
+  size_t norm_core = 0;    // mean / square / rsqrt / sum (layer/RMS-norm core)
+  size_t elementwise = 0;  // add / sub / mul / div (scale, residual, gate)
+  size_t reshape = 0;      // reshape / transpose (head split/merge)
+  size_t norm_composite = 0;  // odml.rms_norm / l2_norm / group_norm composite
+  size_t total = 0;
+};
+
+bool IsMatmul(LiteRtOpCode code) {
+  return code == kLiteRtOpCodeTflBatchMatmul ||
+         code == kLiteRtOpCodeTflFullyConnected;
+}
+
+bool IsActivation(LiteRtOpCode code) {
+  return code == kLiteRtOpCodeTflGelu || code == kLiteRtOpCodeTflLogistic ||
+         code == kLiteRtOpCodeTflTanh;
+}
+
+bool IsNormCore(LiteRtOpCode code) {
+  return code == kLiteRtOpCodeTflMean || code == kLiteRtOpCodeTflSquare ||
+         code == kLiteRtOpCodeTflRsqrt || code == kLiteRtOpCodeTflSum ||
+         code == kLiteRtOpCodeTflPow;
+}
+
+bool IsElementwise(LiteRtOpCode code) {
+  return code == kLiteRtOpCodeTflAdd || code == kLiteRtOpCodeTflSub ||
+         code == kLiteRtOpCodeTflMul || code == kLiteRtOpCodeTflDiv;
+}
+
+bool IsShapeOp(LiteRtOpCode code) {
+  return code == kLiteRtOpCodeTflReshape || code == kLiteRtOpCodeTflTranspose ||
+         code == kLiteRtOpCodeTflConcatenation ||
+         code == kLiteRtOpCodeTflStridedSlice || code == kLiteRtOpCodeTflCast;
+}
+
+OpHistogram Tally(const std::vector<LiteRtOp>& ops) {
+  OpHistogram h;
+  for (auto* op : ops) {
+    const auto code = op->OpCode();
+    ++h.total;
+    if (IsMatmul(code)) {
+      ++h.matmul;
+    } else if (code == kLiteRtOpCodeTflSoftmax) {
+      ++h.softmax;
+    } else if (IsActivation(code)) {
+      ++h.activation;
+    } else if (IsNormCore(code)) {
+      ++h.norm_core;
+    } else if (IsElementwise(code)) {
+      ++h.elementwise;
+    } else if (IsShapeOp(code)) {
+      ++h.reshape;
+    } else if (IsNormCompositeOp(op)) {
+      // A normalization composite is a complete norm on its own, so it counts
+      // as both a norm_core and the elementwise scale it folds in.
+      ++h.norm_composite;
+      ++h.norm_core;
+      ++h.elementwise;
+    }
+  }
+  return h;
+}
+
+// Classifies a connected region. Returns false (via the out-param staying
+// unset) for regions that do not resemble any transformer sub-structure.
+bool Classify(const OpHistogram& h,
+              const TransformerDetectorOptions& options,
+              TransformerBlock::Kind& kind_out) {
+  // Attention: at least one matmul (QK^T / *V) plus a softmax. Some delegates
+  // implement linear attention without softmax, hence the toggle.
+  const bool has_attention =
+      h.matmul >= 1 &&
+      (h.softmax >= 1 || !options.require_softmax_for_attention);
+
+  // Feed-forward: matmul projection(s) with a non-linearity. Gemma-style gated
+  // MLPs additionally carry an element-wise gate, but the activation is the
+  // discriminating signal.
+  const bool has_feed_forward = h.matmul >= 1 && h.activation >= 1;
+
+  // Normalization: either the decomposed mean/square/rsqrt core (with a
+  // scale/bias elementwise) OR a single normalization composite (odml.rms_norm
+  // etc.), which is self-contained.
+  const bool has_norm =
+      h.norm_composite >= 1 || (h.norm_core >= 1 && h.elementwise >= 1);
+
+  if (has_attention) {
+    kind_out = TransformerBlock::Kind::kAttention;
+    return true;
+  }
+  if (has_feed_forward) {
+    kind_out = TransformerBlock::Kind::kFeedForward;
+    return true;
+  }
+  if (has_norm) {
+    kind_out = TransformerBlock::Kind::kNormalization;
+    return true;
+  }
+  return false;
+}
+
+// Finds connected components among `selected` using the use-def graph,
+// restricted to ops in `selected`. This mirrors the connectivity walk in
+// algo.cc's DisjointSets but operates over the raw selected-op set rather than
+// per-vendor partition indices, since we want structural blocks regardless of
+// how the vendor numbered them.
+//
+// Returns components in deterministic execution order (the order ops appear in
+// the subgraph), so downstream partition indices are stable across runs.
+std::vector<std::vector<LiteRtOp>> ConnectedComponents(
+    const absl::flat_hash_set<LiteRtOp>& selected, LiteRtSubgraph subgraph) {
+  // Union-find over the selected set.
+  absl::flat_hash_map<LiteRtOp, LiteRtOp> parent;
+  parent.reserve(selected.size());
+  for (auto* op : selected) {
+    parent[op] = op;
+  }
+
+  std::function<LiteRtOp(LiteRtOp)> find = [&](LiteRtOp op) -> LiteRtOp {
+    auto& p = parent[op];
+    if (p != op) {
+      p = find(p);
+    }
+    return p;
+  };
+  auto unite = [&](LiteRtOp a, LiteRtOp b) {
+    auto ra = find(a);
+    auto rb = find(b);
+    if (ra != rb) {
+      parent[ra] = rb;
+    }
+  };
+
+  // Connect an op to any selected op that consumes one of its outputs.
+  for (auto* op : selected) {
+    for (auto* output : op->Outputs()) {
+      for (auto* user : output->Users()) {
+        if (selected.contains(user)) {
+          unite(op, user);
+        }
+      }
+    }
+  }
+
+  // Bucket ops by representative, preserving subgraph execution order.
+  absl::flat_hash_map<LiteRtOp, size_t> root_to_index;
+  std::vector<std::vector<LiteRtOp>> components;
+  for (auto* op : subgraph->Ops()) {
+    if (!selected.contains(op)) {
+      continue;
+    }
+    auto root = find(op);
+    auto it = root_to_index.find(root);
+    if (it == root_to_index.end()) {
+      root_to_index[root] = components.size();
+      components.push_back({op});
+    } else {
+      components[it->second].push_back(op);
+    }
+  }
+  return components;
+}
+
+// True if `op` reads a tensor whose name contains `needle`.
+bool ReadsNamed(LiteRtOp op, absl::string_view needle) {
+  for (auto* in : op->Inputs()) {
+    if (absl::StrContains(in->Name(), needle)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ReadsKvCache(LiteRtOp op) { return ReadsNamed(op, "kv_cache"); }
+
+// True if `op` reads a rotary position embedding (RoPE). RoPE is applied to Q/K
+// at the very start of a decoder layer's attention, before the KV-cache read
+// and softmax, so it is the most reliable marker of a layer's beginning.
+bool ReadsPosEmb(LiteRtOp op) { return ReadsNamed(op, "pos_emb"); }
+
+// Segments a connected component that spans multiple transformer layers into
+// one sub-component per layer. The whole decoder stack arrives as a single
+// connected component because the residual stream threads through every layer;
+// an NPU delegate, however, wants bounded per-layer partitions.
+//
+// The ops are in subgraph execution order (ConnectedComponents guarantees it).
+// The reliable per-layer landmark is the RoPE position-embedding read: it is
+// the FIRST attention op of a layer, ahead of the KV-cache read, mask and
+// softmax. The KV cache is NOT a safe boundary marker because graphs differ in
+// where the V read lands relative to the softmax (the `probs * V` matmul can
+// execute *after* softmax, e.g. Gemma4-12B), so cutting on any kv read can slice
+// a layer's own V read into the next segment.
+//
+// We therefore close the current segment when we encounter the next layer's
+// RoPE read AFTER having already seen this segment's softmax. The boundary lands
+// in the FFN gap (after softmax_N, before pos_emb_{N+1}), so every layer keeps
+// its own pos_emb, KV tensors, mask and softmax. When a graph exposes no pos_emb
+// names (e.g. the synthetic unit tests), we fall back to softmax-to-softmax
+// cuts.
+//
+// The LAST segment produced this way also contains the trailing logits head
+// (final norm + vocab projection), because no further RoPE/softmax follows to
+// trigger a cut. SplitTrailingHead (below) peels that head off so it becomes a
+// separate, non-transformer partition rather than being fused into the last
+// decoder layer.
+std::vector<std::vector<LiteRtOp>> SegmentByLayer(
+    const std::vector<LiteRtOp>& component) {
+  const bool has_pos_emb =
+      std::any_of(component.begin(), component.end(), ReadsPosEmb);
+
+  std::vector<std::vector<LiteRtOp>> layers;
+  std::vector<LiteRtOp> current;
+  bool seen_softmax = false;  // softmax seen in the current segment
+
+  auto flush = [&]() {
+    layers.push_back(std::move(current));
+    current.clear();
+    seen_softmax = false;
+  };
+
+  for (auto* op : component) {
+    const bool is_softmax = op->OpCode() == kLiteRtOpCodeTflSoftmax;
+
+    if (has_pos_emb) {
+      // Cut just before the next layer's RoPE read.
+      if (seen_softmax && ReadsPosEmb(op) && !current.empty()) {
+        flush();
+      }
+    } else if (is_softmax && seen_softmax && !current.empty()) {
+      // Fallback for graphs without pos_emb tensors.
+      flush();
+    }
+
+    current.push_back(op);
+    if (is_softmax) {
+      seen_softmax = true;
+    }
+  }
+  if (!current.empty()) {
+    layers.push_back(std::move(current));
+  }
+  return layers;
+}
+
+// Within a single segment's ordered ops, returns the index of the first op that
+// belongs to the trailing logits head, or -1 if the segment has no such tail.
+//
+// The logits head is the run of ops AFTER the segment's last self-attention
+// (softmax) that carries no further attention and ends at the model's logits
+// output. We anchor on the last softmax: everything strictly after the last
+// softmax and after the attention's output projection is the post-attention
+// FFN + final norm + LM head. We only peel when that tail actually drives a
+// non-KV subgraph output (the logits), so intermediate decoder layers — whose
+// tails feed the next layer, not an output — are never split.
+int FindLogitsHeadStart(const std::vector<LiteRtOp>& segment,
+                        const absl::flat_hash_set<LiteRtTensor>& sg_outputs) {
+  // Index of the last softmax in the segment.
+  int last_softmax = -1;
+  for (int i = 0; i < static_cast<int>(segment.size()); ++i) {
+    if (segment[i]->OpCode() == kLiteRtOpCodeTflSoftmax) {
+      last_softmax = i;
+    }
+  }
+  if (last_softmax < 0) {
+    return -1;  // not an attention segment; nothing to peel
+  }
+
+  // Does any op after the last softmax produce a large, non-KV subgraph output
+  // (the logits)? KV-cache updates are also outputs, so exclude tensors whose
+  // name marks them as KV caches.
+  auto is_logits_output = [&](LiteRtTensor t) {
+    return sg_outputs.contains(t) &&
+           !absl::StrContains(t->Name(), "kv_cache");
+  };
+  bool tail_drives_logits = false;
+  for (int i = last_softmax + 1; i < static_cast<int>(segment.size()); ++i) {
+    for (auto* out : segment[i]->Outputs()) {
+      if (is_logits_output(out)) {
+        tail_drives_logits = true;
+        break;
+      }
+    }
+    if (tail_drives_logits) break;
+  }
+  if (!tail_drives_logits) {
+    return -1;
+  }
+
+  // Peel from the final normalization that precedes the logits projection: the
+  // last norm op in the segment (RMS/L2/group composite, or the decomposed
+  // mean/rsqrt core) marks the start of the head. Fall back to "just after the
+  // attention output projection" — i.e. the first matmul after the last softmax
+  // — if no explicit norm is found.
+  int head_start = -1;
+  for (int i = last_softmax + 1; i < static_cast<int>(segment.size()); ++i) {
+    const auto code = segment[i]->OpCode();
+    if (IsNormCompositeOp(segment[i]) || IsNormCore(code)) {
+      head_start = i;  // keep advancing to the LAST norm
+    }
+  }
+  if (head_start < 0) {
+    for (int i = last_softmax + 1; i < static_cast<int>(segment.size()); ++i) {
+      if (IsMatmul(segment[i]->OpCode())) {
+        head_start = i;
+        break;
+      }
+    }
+  }
+  return head_start;
+}
+
+// Collects the set of tensors a block touches that are also subgraph
+// inputs/outputs (i.e. cross the partition boundary). KV caches, masks, and
+// position embeddings all enter the per-layer block as such boundary tensors,
+// so they are the signals we classify against.
+absl::flat_hash_set<LiteRtTensor> BoundaryTensors(
+    const std::vector<LiteRtOp>& block, LiteRtSubgraph subgraph) {
+  absl::flat_hash_set<LiteRtTensor> sg_io;
+  for (auto* t : subgraph->Inputs()) {
+    sg_io.insert(t);
+  }
+  for (auto* t : subgraph->Outputs()) {
+    sg_io.insert(t);
+  }
+  absl::flat_hash_set<LiteRtTensor> touched;
+  for (auto* op : block) {
+    for (auto* in : op->Inputs()) {
+      if (sg_io.contains(in)) {
+        touched.insert(in);
+      }
+    }
+    for (auto* out : op->Outputs()) {
+      if (sg_io.contains(out)) {
+        touched.insert(out);
+      }
+    }
+  }
+  return touched;
+}
+
+// True if `name` looks like a KV-cache tensor.
+bool IsKvCacheName(absl::string_view name) {
+  return absl::StrContains(name, "kv_cache");
+}
+
+// Annotates a block in place with attention scope, KV-cache tensors, and layer
+// index. Scope is inferred from the names of the boundary tensors the block
+// consumes: Gemma exposes distinct `mask_local`/`mask_global` and
+// `pos_emb_local_*`/`pos_emb_*` tensors per layer. Returns true if the block is
+// attention-bearing (so the caller can assign a layer index).
+bool AnnotateAttentionMetadata(TransformerBlock& block,
+                               LiteRtSubgraph subgraph) {
+  const bool is_attention = block.kind == TransformerBlock::Kind::kAttention ||
+                            block.kind == TransformerBlock::Kind::kFullBlock;
+  if (!is_attention) {
+    return false;
+  }
+
+  auto boundary = BoundaryTensors(block.ops, subgraph);
+
+  // The authoritative per-layer scope signal is the rotary position embedding:
+  // sliding-window layers read `pos_emb_local_*` (a shorter table) while
+  // full-context layers read the global `pos_emb_{cos,sin}`. Every layer reads
+  // exactly one of these in its attention preamble. The attention mask is NOT
+  // reliable: a graph may expose a single shared `mask_global`/`mask_local`
+  // tensor that several layers touch (observed on Gemma4-E2B/12B), so it is used
+  // only as a fallback tiebreak when no pos_emb signal is present.
+  bool pos_local = false;
+  bool pos_global = false;
+  bool mask_local = false;
+  bool mask_global = false;
+  for (auto* t : boundary) {
+    const absl::string_view name = t->Name();
+    if (IsKvCacheName(name)) {
+      block.kv_cache_tensors.emplace_back(name);
+    }
+    if (absl::StrContains(name, "pos_emb_local")) {
+      pos_local = true;
+    } else if (absl::StrContains(name, "pos_emb_cos") ||
+               absl::StrContains(name, "pos_emb_sin")) {
+      pos_global = true;
+    } else if (absl::StrContains(name, "mask_local")) {
+      mask_local = true;
+    } else if (absl::StrContains(name, "mask_global")) {
+      mask_global = true;
+    }
+  }
+
+  // Prefer pos_emb; fall back to mask only when pos_emb is absent/ambiguous.
+  bool is_local = pos_local;
+  bool is_global = pos_global;
+  if (pos_local == pos_global) {  // both or neither pos_emb signal
+    is_local = mask_local;
+    is_global = mask_global;
+  }
+
+  if (is_local && !is_global) {
+    block.attention_scope = TransformerBlock::AttentionScope::kLocal;
+  } else if (is_global && !is_local) {
+    block.attention_scope = TransformerBlock::AttentionScope::kGlobal;
+  } else {
+    block.attention_scope = TransformerBlock::AttentionScope::kUnknown;
+  }
+
+  std::sort(block.kv_cache_tensors.begin(), block.kv_cache_tensors.end());
+  return true;
+}
+
+// Populates `shares_kv_cache_with` by detecting layers whose KV-cache tensor
+// sets overlap. The first layer to reference a given KV-cache tensor owns it;
+// any later layer that references the same tensor is recorded as sharing with
+// the owner. This captures cross-layer KV-cache reuse without assuming a
+// particular naming convention beyond tensor identity.
+void LinkSharedKvCaches(std::vector<TransformerBlock>& blocks) {
+  // Map a KV-cache tensor name to the layer_index that first owned it.
+  absl::flat_hash_map<std::string, int> owner_of;
+  for (auto& block : blocks) {
+    if (block.layer_index < 0 || block.kv_cache_tensors.empty()) {
+      continue;
+    }
+    for (const auto& name : block.kv_cache_tensors) {
+      auto it = owner_of.find(name);
+      if (it == owner_of.end()) {
+        owner_of[name] = block.layer_index;
+      } else if (it->second != block.layer_index) {
+        // This layer reuses a cache another layer already owns.
+        block.shares_kv_cache_with = it->second;
+      }
+    }
+  }
+}
+
+}  // namespace
+
+std::vector<TransformerBlock> DetectTransformerBlocks(
+    const std::vector<LiteRtOpWithPartitionIndex>& selected_ops,
+    LiteRtSubgraph subgraph, const TransformerDetectorOptions& options) {
+  std::vector<TransformerBlock> blocks;
+  if (selected_ops.empty()) {
+    return blocks;
+  }
+
+  absl::flat_hash_set<LiteRtOp> selected;
+  selected.reserve(selected_ops.size());
+  for (const auto& [op, _] : selected_ops) {
+    selected.insert(op);
+  }
+
+  // Subgraph outputs, used to identify the trailing logits head (an op whose
+  // output is a non-KV subgraph output).
+  absl::flat_hash_set<LiteRtTensor> sg_outputs(subgraph->Outputs().begin(),
+                                               subgraph->Outputs().end());
+
+  auto components = ConnectedComponents(selected, subgraph);
+
+  // Classify each connected component.
+  LiteRtParamIndex next_index = 0;
+  for (auto& component : components) {
+    if (component.size() < options.min_block_ops) {
+      continue;
+    }
+    const auto histogram = Tally(component);
+    TransformerBlock::Kind kind;
+    if (!Classify(histogram, options, kind)) {
+      continue;
+    }
+
+    // A connected component carrying more than one self-attention (multiple
+    // softmaxes) is the whole decoder stack arriving as one component because
+    // the residual stream links every layer. Segment it into per-layer blocks
+    // so the delegate gets bounded partitions instead of one model-sized one.
+    if (options.segment_into_layers && histogram.softmax >= 2) {
+      auto layers = SegmentByLayer(component);
+
+      // Peel the trailing logits head (final norm + vocab projection) off the
+      // last segment so it becomes a separate, non-transformer partition rather
+      // than being fused into the last decoder layer. The head is emitted as a
+      // kNormalization block: it is NOT counted as a transformer layer (see
+      // AnnotateAttentionMetadata) and gets its own partition.
+      std::vector<LiteRtOp> logits_head;
+      if (!layers.empty()) {
+        auto& last = layers.back();
+        const int head_start = FindLogitsHeadStart(last, sg_outputs);
+        if (head_start > 0) {
+          logits_head.assign(last.begin() + head_start, last.end());
+          last.erase(last.begin() + head_start, last.end());
+        }
+      }
+
+      for (auto& layer : layers) {
+        if (layer.size() < options.min_block_ops) {
+          continue;
+        }
+        const auto layer_histogram = Tally(layer);
+        TransformerBlock::Kind layer_kind;
+        if (!Classify(layer_histogram, options, layer_kind)) {
+          continue;
+        }
+        if (options.fuse_adjacent_clusters) {
+          const int signals =
+              (layer_histogram.matmul >= 1 && layer_histogram.softmax >= 1) +
+              (layer_histogram.activation >= 1) +
+              (layer_histogram.norm_core >= 1);
+          if (signals >= 2) {
+            layer_kind = TransformerBlock::Kind::kFullBlock;
+          }
+        }
+        blocks.push_back(
+            TransformerBlock{layer_kind, std::move(layer), next_index++});
+      }
+
+      // Emit the logits head as its own non-transformer block (always, so its
+      // ops form one partition instead of fragmenting).
+      if (!logits_head.empty()) {
+        blocks.push_back(TransformerBlock{TransformerBlock::Kind::kNormalization,
+                                          std::move(logits_head),
+                                          next_index++});
+      }
+      continue;
+    }
+
+    // When clusters are fused, a connected component that contains more than one
+    // structural signal (attention + feed-forward, or norm + either) is a full
+    // block. Connectivity already did the fusing: a single component spanning
+    // attention and MLP means they share tensors and should ship together.
+    if (options.fuse_adjacent_clusters) {
+      const int signals = (histogram.matmul >= 1 && histogram.softmax >= 1) +
+                          (histogram.activation >= 1) +
+                          (histogram.norm_core >= 1);
+      if (signals >= 2) {
+        kind = TransformerBlock::Kind::kFullBlock;
+      }
+    }
+    blocks.push_back(TransformerBlock{kind, std::move(component), next_index++});
+  }
+
+  // Annotate attention-bearing blocks with scope / layer index / KV caches, in
+  // execution order, then link cross-layer KV-cache sharing.
+  if (options.annotate_attention_metadata) {
+    int layer_index = 0;
+    for (auto& block : blocks) {
+      if (AnnotateAttentionMetadata(block, subgraph)) {
+        block.layer_index = layer_index++;
+      }
+    }
+    LinkSharedKvCaches(blocks);
+  }
+
+  return blocks;
+}
+
+size_t RepartitionByTransformerBlocks(
+    std::vector<LiteRtOpWithPartitionIndex>& selected_ops,
+    LiteRtSubgraph subgraph, const TransformerDetectorOptions& options) {
+  auto blocks = DetectTransformerBlocks(selected_ops, subgraph, options);
+  if (blocks.empty()) {
+    LITERT_LOG(LITERT_INFO,
+               "TransformerBlockDetector: no transformer blocks found, "
+               "leaving %lu selected ops untouched.",
+               selected_ops.size());
+    return 0;
+  }
+
+  // Optionally coalesce consecutive transformer LAYERS into multi-layer
+  // partitions, breaking only at the requested cut indices. We remap each
+  // block's partition index to the index of the inter-cut "bucket" its layer
+  // falls in. Non-attention blocks (layer_index < 0) keep their own block index
+  // offset past the buckets so they are never merged into a layer group.
+  //
+  // Example: layers 0..34, cuts {12,24} -> buckets [0,12)->0, [12,24)->1,
+  // [24,35)->2. Layers in the same bucket share a partition index, so the
+  // union-find grouping (GroupPartitions) emits one partition per bucket.
+  //
+  // Coalescing runs when explicit cuts were given, OR when `coalesce_layers` is
+  // set (the TransformerLayerCut strategy) even with no cuts: an empty cut list
+  // then puts every layer in bucket 0 -> the whole stack becomes one partition
+  // ("cut nowhere"), rather than the one-partition-per-layer fallback.
+  absl::flat_hash_map<LiteRtParamIndex, LiteRtParamIndex> block_to_group;
+  if (!options.layer_cut_indices.empty() || options.coalesce_layers) {
+    // Sanitize cuts: drop <=0 and duplicates, sort ascending.
+    std::vector<int> cuts;
+    for (int c : options.layer_cut_indices) {
+      if (c > 0) {
+        cuts.push_back(c);
+      }
+    }
+    std::sort(cuts.begin(), cuts.end());
+    cuts.erase(std::unique(cuts.begin(), cuts.end()), cuts.end());
+
+    // Assign each attention layer to a bucket: bucket = number of cuts <= its
+    // layer_index. Reuse one group index per (subgraph-)distinct bucket.
+    LiteRtParamIndex next_group = 0;
+    absl::flat_hash_map<int, LiteRtParamIndex> bucket_to_group;
+    for (const auto& block : blocks) {
+      if (block.layer_index < 0) {
+        continue;  // handled below as its own group
+      }
+      int bucket = 0;
+      for (int c : cuts) {
+        if (block.layer_index >= c) {
+          ++bucket;
+        }
+      }
+      auto it = bucket_to_group.find(bucket);
+      if (it == bucket_to_group.end()) {
+        bucket_to_group[bucket] = next_group;
+        block_to_group[block.partition_index] = next_group;
+        ++next_group;
+      } else {
+        block_to_group[block.partition_index] = it->second;
+      }
+    }
+    // Non-attention blocks each get a unique trailing group so they stay
+    // separate partitions.
+    for (const auto& block : blocks) {
+      if (block.layer_index < 0) {
+        block_to_group[block.partition_index] = next_group++;
+      }
+    }
+  }
+
+  auto group_of = [&](LiteRtParamIndex block_index) -> LiteRtParamIndex {
+    if (block_to_group.empty()) {
+      return block_index;  // one partition per layer (no cuts)
+    }
+    return block_to_group[block_index];
+  };
+
+  // Map each op that belongs to a block to its assigned (possibly grouped)
+  // partition index.
+  absl::flat_hash_map<LiteRtOp, LiteRtParamIndex> op_to_block;
+  for (const auto& block : blocks) {
+    const LiteRtParamIndex group = group_of(block.partition_index);
+    for (auto* op : block.ops) {
+      op_to_block[op] = group;
+    }
+  }
+
+  LiteRtParamIndex max_group = 0;
+  for (const auto& [op, group] : op_to_block) {
+    max_group = std::max(max_group, group);
+  }
+
+  // Decide the partition index for selected ops that are NOT part of any
+  // detected block (e.g. the input-embedding preamble before layer 0, or small
+  // interstitial ops the layer segmentation did not absorb).
+  //
+  // When coalescing (the layer-cut strategy), such stray ops must NOT each
+  // become their own partition — that is what split prefill_128 into 8 when it
+  // should be 1. Instead, fold each stray op into the group of the nearest
+  // PRECEDING block in execution order (so the preamble joins the first bucket,
+  // and an op between layers N and N+1 joins layer N's group). Connectivity in
+  // GroupPartitions then merges them into the adjacent island. Strays that
+  // precede every block fall into the first group (group 0).
+  //
+  // Without coalescing (the per-layer TransformerBlock strategy, or no detector
+  // grouping at all), keep the original behavior: each stray op gets its own
+  // distinct index so it is never merged into a neighboring block.
+  absl::flat_hash_map<LiteRtOp, LiteRtParamIndex> stray_to_group;
+  if (options.coalesce_layers && !op_to_block.empty()) {
+    LiteRtParamIndex current_group = 0;  // first bucket, for leading preamble
+    for (auto* op : subgraph->Ops()) {
+      auto it = op_to_block.find(op);
+      if (it != op_to_block.end()) {
+        current_group = it->second;  // entered a block; track its group
+      } else {
+        stray_to_group[op] = current_group;
+      }
+    }
+  }
+
+  LiteRtParamIndex next_free_index =
+      op_to_block.empty() ? 0 : max_group + 1;
+  for (auto& [op, index] : selected_ops) {
+    if (auto it = op_to_block.find(op); it != op_to_block.end()) {
+      index = it->second;
+    } else if (auto sit = stray_to_group.find(op); sit != stray_to_group.end()) {
+      index = sit->second;
+    } else {
+      index = next_free_index++;
+    }
+  }
+
+  // Count distinct partition indices actually assigned across ALL selected ops
+  // (blocks + folded strays + any singleton strays).
+  absl::flat_hash_set<LiteRtParamIndex> distinct_groups;
+  for (const auto& [op, index] : selected_ops) {
+    distinct_groups.insert(index);
+  }
+  const size_t num_partitions = distinct_groups.size();
+  LITERT_LOG(LITERT_INFO,
+             "TransformerBlockDetector: grouped %lu selected ops from %lu "
+             "transformer layer(s) into %lu partition(s).",
+             selected_ops.size(), blocks.size(), num_partitions);
+  return num_partitions;
+}
+
+std::vector<int> ResolveLayerCuts(absl::string_view spec,
+                                  absl::string_view signature_key) {
+  auto parse_cut_list = [](absl::string_view list) {
+    std::vector<int> cuts;
+    for (absl::string_view tok : absl::StrSplit(list, ',', absl::SkipEmpty())) {
+      tok = absl::StripAsciiWhitespace(tok);
+      int value = 0;
+      if (absl::SimpleAtoi(tok, &value)) {
+        cuts.push_back(value);
+      }
+    }
+    return cuts;
+  };
+
+  std::vector<int> default_cuts;
+  bool have_default = false;
+  std::vector<int> matched_cuts;
+  bool have_match = false;
+
+  for (absl::string_view group : absl::StrSplit(spec, ';', absl::SkipEmpty())) {
+    group = absl::StripAsciiWhitespace(group);
+    if (group.empty()) {
+      continue;
+    }
+    const size_t eq = group.find('=');
+    if (eq == absl::string_view::npos) {
+      // Bare list: the default applied to all signatures.
+      default_cuts = parse_cut_list(group);
+      have_default = true;
+      continue;
+    }
+    absl::string_view key =
+        absl::StripAsciiWhitespace(group.substr(0, eq));
+    absl::string_view list = group.substr(eq + 1);
+    if (key.empty()) {
+      default_cuts = parse_cut_list(list);
+      have_default = true;
+    } else if (key == signature_key) {
+      matched_cuts = parse_cut_list(list);
+      have_match = true;
+    }
+  }
+
+  if (have_match) {
+    return matched_cuts;
+  }
+  if (have_default) {
+    return default_cuts;
+  }
+  return {};
+}
+
+}  // namespace litert::internal

--- a/litert/compiler/plugin/transformer_detector.h
+++ b/litert/compiler/plugin/transformer_detector.h
@@ -1,0 +1,202 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ODML_LITERT_LITERT_COMPILER_PLUGIN_TRANSFORMER_DETECTOR_H_
+#define ODML_LITERT_LITERT_COMPILER_PLUGIN_TRANSFORMER_DETECTOR_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "litert/c/litert_common.h"
+#include "litert/core/model/model.h"
+
+// Transformer-block pattern detection for the LiteRT partitioner.
+//
+// This component sits between the IHV (vendor) compiler plugin's op-selection
+// (`CompilerPlugin::Partition`) and the graph-slicing step that hands work to
+// the delegate. Vendor plugins report which individual ops they can accelerate,
+// but they have no view of the higher-level *structure* of the graph. Many NPU
+// delegates compile and schedule far more efficiently when an entire transformer
+// block (attention + feed-forward + the surrounding normalization) is presented
+// as a single, self-contained partition rather than as a scattering of small
+// per-op islands.
+//
+// `TransformerBlockDetector` scans the use-def graph of a subgraph, finds the
+// subgraphs of ops that form a transformer block, and rewrites the per-op
+// partition indices so that all ops belonging to the same block share one
+// index. The existing grouping strategies (see algo.h) then naturally outline
+// each block into its own subgraph for the delegate to compile.
+//
+// The detector is conservative: it only ever *merges* the partition indices of
+// ops the vendor already selected. It never adds an unselected op to a
+// partition, so it cannot ask a delegate to compile something it did not claim
+// to support.
+
+namespace litert::internal {
+
+// A single detected transformer block: the ordered list of ops that make it up
+// plus a coarse classification of the dominant sub-structure that triggered the
+// match. `ops` is always a subset of the ops the vendor selected.
+struct TransformerBlock {
+  enum class Kind {
+    // Self-attention core: Q*K^T -> scale -> softmax -> *V, expressed with
+    // batch_matmul/fully_connected, an optional scale mul/div, and a softmax.
+    kAttention,
+    // Gated/MLP feed-forward: two projections with a non-linearity
+    // (gelu/logistic) and an element-wise gate in between.
+    kFeedForward,
+    // Pre/post layer normalization or RMS-norm cluster
+    // (mean/sub/square/rsqrt/mul/add).
+    kNormalization,
+    // A full decoder/encoder block fused from the above when they are
+    // contiguous in execution order and connected.
+    kFullBlock,
+  };
+
+  // The attention span of a decoder layer. Gemma-style models interleave
+  // sliding-window (local) layers with full-context (global) layers; an IHV
+  // delegate may map them to different hardware paths or buffer budgets.
+  enum class AttentionScope {
+    kUnknown,
+    kLocal,   // sliding-window attention (uses the local mask / local RoPE)
+    kGlobal,  // full-context attention (uses the global mask / global RoPE)
+  };
+
+  Kind kind;
+  std::vector<LiteRtOp> ops;
+  // The partition index assigned to every op in this block.
+  LiteRtParamIndex partition_index;
+
+  // Attention span of this layer, inferred from which mask / position-embedding
+  // / KV-cache tensors the block consumes. kUnknown when the block is not an
+  // attention-bearing layer or the signals are absent.
+  AttentionScope attention_scope = AttentionScope::kUnknown;
+
+  // Zero-based layer index in execution order among attention-bearing blocks
+  // (the Nth decoder layer). -1 for non-attention blocks. Used as the identity
+  // for KV-cache-sharing relationships.
+  int layer_index = -1;
+
+  // Names of the KV-cache tensors (subgraph inputs/outputs) this layer reads or
+  // writes, e.g. "...kv_cache_k_3". Empty if none were identified.
+  std::vector<std::string> kv_cache_tensors;
+
+  // If this layer reuses the KV cache produced/consumed by an earlier layer
+  // (cross-layer KV sharing, as in some grouped/global-cache designs), this is
+  // that layer's `layer_index`. -1 when the layer owns its own KV cache.
+  int shares_kv_cache_with = -1;
+};
+
+// Tunables controlling how aggressively blocks are detected and merged. The
+// defaults are chosen for decoder-only LLMs (Gemma/Llama-style) but the knobs
+// allow vendors to adapt to their op-coverage and scheduling constraints.
+struct TransformerDetectorOptions {
+  // Minimum number of vendor-selected ops a candidate block must contain to be
+  // treated as a block. Filters out incidental matches in non-transformer
+  // graphs.
+  size_t min_block_ops = 4;
+
+  // When true, adjacent attention / feed-forward / normalization clusters that
+  // are connected in the use-def graph are fused into a single kFullBlock
+  // partition. When false, each cluster becomes its own partition.
+  bool fuse_adjacent_clusters = true;
+
+  // When true, a softmax is required for a region to be classified as
+  // attention. Disable for linear-attention variants.
+  bool require_softmax_for_attention = true;
+
+  // When true, a connected region that contains more than one self-attention
+  // (i.e. several softmaxes — the whole decoder stack arrives as a single
+  // component because the residual stream links every layer) is segmented into
+  // one block per layer, using the self-attention softmax as the per-layer
+  // anchor. This is what an NPU delegate wants: bounded, self-contained
+  // per-layer partitions rather than one partition spanning the entire model.
+  //
+  // When false, the entire connected region is emitted as one block.
+  bool segment_into_layers = true;
+
+  // When true, each attention-bearing block is annotated with its attention
+  // scope (local/global), layer index, KV-cache tensors, and any cross-layer
+  // KV-cache-sharing relationship. Inference is name- and shape-based over the
+  // subgraph I/O tensors the block touches; disable to skip the extra walk.
+  bool annotate_attention_metadata = true;
+
+  // Layer indices at which to start a new partition. A cut value `c` means
+  // "layer `c` begins a new partition". For a 35-layer model, cuts {12, 24}
+  // yield three partitions: layers [0,12), [12,24), [24,35). Out-of-range or
+  // unsorted values are sanitized (sorted, deduplicated) before use; cut 0 is
+  // ignored since every grouping already starts a partition at layer 0.
+  //
+  // How an EMPTY list is interpreted depends on `coalesce_layers`:
+  //   * coalesce_layers == false (TransformerBlock): empty -> one partition per
+  //     transformer layer.
+  //   * coalesce_layers == true (TransformerLayerCut): empty -> ALL layers
+  //     coalesced into a single partition ("cut nowhere"). Non-empty always
+  //     coalesces consecutive layers between cuts regardless of this flag.
+  std::vector<int> layer_cut_indices;
+
+  // Selects how empty `layer_cut_indices` is treated (see above). Set true for
+  // the TransformerLayerCut strategy so an unspecified graph becomes one
+  // partition rather than one-per-layer.
+  bool coalesce_layers = false;
+};
+
+// Detects transformer blocks among the vendor-selected ops of `subgraph`.
+//
+// `selected_ops` is the output of `CompilerPlugin::Partition` for `subgraph`:
+// the ops the delegate claims it can compile, each tagged with the vendor's own
+// partition index. The returned vector lists the blocks found, in execution
+// order; ops not belonging to any block are not reported.
+//
+// This call is read-only: it does not mutate the model.
+std::vector<TransformerBlock> DetectTransformerBlocks(
+    const std::vector<LiteRtOpWithPartitionIndex>& selected_ops,
+    LiteRtSubgraph subgraph, const TransformerDetectorOptions& options = {});
+
+// Rewrites the partition indices of `selected_ops` in place so that every op
+// belonging to a detected transformer block shares a single, unique partition
+// index, while ops outside any block keep distinct indices. The result is a
+// drop-in replacement for the vendor's `selected_ops` that, when passed to a
+// grouping strategy (GroupPartitions/GroupPartitionsV2), yields one partition
+// per transformer block.
+//
+// Returns the number of blocks that were re-grouped.
+size_t RepartitionByTransformerBlocks(
+    std::vector<LiteRtOpWithPartitionIndex>& selected_ops,
+    LiteRtSubgraph subgraph, const TransformerDetectorOptions& options = {});
+
+// Resolves a per-signature layer-cut spec to the cut indices for one signature.
+//
+// The spec is a ';'-separated list of groups, each "key=cuts" where `cuts` is a
+// ','-separated list of layer indices. A group with an empty key (or a bare
+// list with no '=') is the DEFAULT applied to any signature without an explicit
+// group. An explicit group for `signature_key` overrides the default.
+//
+// Examples:
+//   "16"                         -> all signatures cut at {16}
+//   "prefill_128=16,32;decode=8" -> prefill_128 {16,32}, decode {8}, others {}
+//   "=16;decode=8"               -> decode {8}, all others {16}
+//
+// Whitespace around keys and numbers is tolerated. Non-numeric cut tokens are
+// skipped. Returns the resolved (unsorted, unsanitized) cut indices for
+// `signature_key`; empty when neither an explicit group nor a default applies.
+std::vector<int> ResolveLayerCuts(absl::string_view spec,
+                                  absl::string_view signature_key);
+
+}  // namespace litert::internal
+
+#endif  // ODML_LITERT_LITERT_COMPILER_PLUGIN_TRANSFORMER_DETECTOR_H_

--- a/litert/compiler/plugin/transformer_detector_test.cc
+++ b/litert/compiler/plugin/transformer_detector_test.cc
@@ -1,0 +1,577 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "litert/compiler/plugin/transformer_detector.h"
+
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "absl/container/flat_hash_set.h"  // from @com_google_absl
+#include "litert/c/litert_common.h"
+#include "litert/c/litert_op_code.h"
+#include "litert/cc/internal/litert_op_options.h"
+#include "litert/core/model/model.h"
+#include "tflite/schema/schema_generated.h"
+
+namespace litert::internal {
+namespace {
+
+// Minimal in-memory graph builder for assembling synthetic transformer-shaped
+// subgraphs. Each AddOp appends one op whose single output feeds the next op,
+// forming a linear chain (sufficient for connectivity-based detection).
+class ChainBuilder {
+ public:
+  explicit ChainBuilder(LiteRtSubgraphT& subgraph) : subgraph_(subgraph) {
+    // Seed the chain with a subgraph input tensor.
+    prev_ = &subgraph_.EmplaceTensor();
+    subgraph_.Inputs().push_back(prev_);
+  }
+
+  // Appends an op of the given code, wiring the running tensor as its input and
+  // a fresh tensor as its output. Returns the op for selection.
+  LiteRtOp AddOp(LiteRtOpCode code) {
+    auto& op = subgraph_.EmplaceOp();
+    op.SetOpCode(code);
+    AttachInput(prev_, op);
+    auto& out = subgraph_.EmplaceTensor();
+    AttachOutput(&out, op);
+    prev_ = &out;
+    return &op;
+  }
+
+  // Appends a StableHLO composite op with the given composite name (e.g.
+  // "odml.rms_norm"), wired into the chain like AddOp.
+  LiteRtOp AddCompositeOp(const std::string& composite_name) {
+    auto& op = subgraph_.EmplaceOp();
+    op.SetOpCode(kLiteRtOpCodeShloComposite);
+    tflite::StableHLOCompositeOptionsT options;
+    options.name = composite_name;
+    options.decomposition_subgraph_index = 0;
+    litert::internal::TflOptions2 tfl_options;
+    tfl_options.type = ::tflite::BuiltinOptions2_StableHLOCompositeOptions;
+    tfl_options.Set(std::move(options));
+    litert::internal::SetTflOptions2(op, std::move(tfl_options));
+    AttachInput(prev_, op);
+    auto& out = subgraph_.EmplaceTensor();
+    AttachOutput(&out, op);
+    prev_ = &out;
+    return &op;
+  }
+
+  // Appends an op that additionally reads a named subgraph-input tensor (e.g. a
+  // KV cache, mask, or position embedding). The named tensor is registered as a
+  // subgraph input so it crosses the partition boundary.
+  LiteRtOp AddOpReading(LiteRtOpCode code, const std::string& tensor_name) {
+    auto& named = subgraph_.EmplaceTensor();
+    named.SetName(tensor_name);
+    subgraph_.Inputs().push_back(&named);
+
+    auto& op = subgraph_.EmplaceOp();
+    op.SetOpCode(code);
+    AttachInput(prev_, op);
+    AttachInput(&named, op);
+    auto& out = subgraph_.EmplaceTensor();
+    AttachOutput(&out, op);
+    prev_ = &out;
+    return &op;
+  }
+
+  // Marks the current running tensor as a named subgraph output (e.g. logits).
+  void MarkOutput(const std::string& name) {
+    prev_->SetName(name);
+    subgraph_.Outputs().push_back(prev_);
+  }
+
+ private:
+  LiteRtSubgraphT& subgraph_;
+  LiteRtTensor prev_ = nullptr;
+};
+
+// Builds one decoder layer following the real Gemma landmark order:
+//   pos_emb (RoPE) -> KV-cache read -> mask -> softmax -> FFN.
+// `scope_tag` is "local" or "global"; `idx` selects the per-layer KV cache.
+// When `kv_idx` differs from `idx`, the layer reuses another layer's cache
+// (cross-layer KV sharing).
+std::vector<LiteRtOp> BuildDecoderLayer(ChainBuilder& b, const char* scope_tag,
+                                        int idx, int kv_idx) {
+  const std::string emb = std::string("pos_emb_") +
+                          (std::string(scope_tag) == "local" ? "local_cos"
+                                                             : "cos");
+  const std::string mask = std::string("mask_") + scope_tag;
+  return {
+      b.AddOpReading(kLiteRtOpCodeTflMul, emb),  // RoPE on Q
+      b.AddOpReading(kLiteRtOpCodeTflFullyConnected,
+                     "kv_cache_k_" + std::to_string(kv_idx)),
+      b.AddOpReading(kLiteRtOpCodeTflBatchMatmul,
+                     "kv_cache_v_" + std::to_string(kv_idx)),
+      b.AddOpReading(kLiteRtOpCodeTflAdd, mask),  // mask add
+      b.AddOp(kLiteRtOpCodeTflSoftmax),
+      b.AddOp(kLiteRtOpCodeTflBatchMatmul),     // probs * V
+      b.AddOp(kLiteRtOpCodeTflFullyConnected),  // output projection
+      b.AddOp(kLiteRtOpCodeTflFullyConnected),  // FFN up
+      b.AddOp(kLiteRtOpCodeTflGelu),
+      b.AddOp(kLiteRtOpCodeTflFullyConnected),  // FFN down
+  };
+}
+
+std::vector<LiteRtOpWithPartitionIndex> SelectAll(
+    const std::vector<LiteRtOp>& ops) {
+  std::vector<LiteRtOpWithPartitionIndex> selected;
+  selected.reserve(ops.size());
+  for (auto* op : ops) {
+    // Tag every op with the same vendor partition index; the detector is
+    // expected to override these.
+    selected.push_back({op, 0});
+  }
+  return selected;
+}
+
+// Builds a single attention block: reshape -> Q*K^T -> scale -> softmax -> *V
+// -> output projection.
+std::vector<LiteRtOp> BuildAttention(ChainBuilder& b) {
+  return {
+      b.AddOp(kLiteRtOpCodeTflReshape),
+      b.AddOp(kLiteRtOpCodeTflBatchMatmul),  // Q * K^T
+      b.AddOp(kLiteRtOpCodeTflMul),          // scale by 1/sqrt(d)
+      b.AddOp(kLiteRtOpCodeTflSoftmax),      // attention probs
+      b.AddOp(kLiteRtOpCodeTflBatchMatmul),  // probs * V
+      b.AddOp(kLiteRtOpCodeTflFullyConnected),  // output projection
+  };
+}
+
+// Builds a gated feed-forward block: up-projection -> gelu -> gate mul ->
+// down-projection.
+std::vector<LiteRtOp> BuildFeedForward(ChainBuilder& b) {
+  return {
+      b.AddOp(kLiteRtOpCodeTflFullyConnected),  // up projection
+      b.AddOp(kLiteRtOpCodeTflGelu),            // activation
+      b.AddOp(kLiteRtOpCodeTflMul),             // gate
+      b.AddOp(kLiteRtOpCodeTflFullyConnected),  // down projection
+  };
+}
+
+TEST(TransformerDetectorTest, DetectsAttentionBlock) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  auto attention = BuildAttention(b);
+
+  auto selected = SelectAll(attention);
+  auto blocks = DetectTransformerBlocks(selected, &subgraph);
+
+  ASSERT_EQ(blocks.size(), 1);
+  EXPECT_EQ(blocks.front().kind, TransformerBlock::Kind::kAttention);
+  EXPECT_EQ(blocks.front().ops.size(), attention.size());
+}
+
+TEST(TransformerDetectorTest, DetectsFeedForwardBlock) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  auto ffn = BuildFeedForward(b);
+
+  auto selected = SelectAll(ffn);
+  auto blocks = DetectTransformerBlocks(selected, &subgraph);
+
+  ASSERT_EQ(blocks.size(), 1);
+  EXPECT_EQ(blocks.front().kind, TransformerBlock::Kind::kFeedForward);
+}
+
+TEST(TransformerDetectorTest, FusesContiguousAttentionAndFeedForward) {
+  // A whole decoder block: attention immediately followed by feed-forward, all
+  // connected in one chain. With fusion on (default), the single connected
+  // component carries both attention and feed-forward signals, so it is
+  // classified as a full block.
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  auto attention = BuildAttention(b);
+  auto ffn = BuildFeedForward(b);
+
+  std::vector<LiteRtOp> all = attention;
+  all.insert(all.end(), ffn.begin(), ffn.end());
+
+  auto selected = SelectAll(all);
+  auto blocks = DetectTransformerBlocks(selected, &subgraph);
+
+  ASSERT_EQ(blocks.size(), 1);
+  EXPECT_EQ(blocks.front().kind, TransformerBlock::Kind::kFullBlock);
+  EXPECT_EQ(blocks.front().ops.size(), all.size());
+}
+
+TEST(TransformerDetectorTest, RepartitionAssignsOneIndexPerBlock) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  auto attention = BuildAttention(b);
+
+  auto selected = SelectAll(attention);
+  const size_t num_blocks =
+      RepartitionByTransformerBlocks(selected, &subgraph);
+  ASSERT_EQ(num_blocks, 1);
+
+  // Every op in the block must share the same (block 0) partition index.
+  for (const auto& [op, index] : selected) {
+    EXPECT_EQ(index, 0u);
+  }
+}
+
+TEST(TransformerDetectorTest, IgnoresNonTransformerGraph) {
+  // A plain elementwise chain has no attention/ffn/norm structure.
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  std::vector<LiteRtOp> ops = {
+      b.AddOp(kLiteRtOpCodeTflAdd),
+      b.AddOp(kLiteRtOpCodeTflMul),
+      b.AddOp(kLiteRtOpCodeTflAdd),
+      b.AddOp(kLiteRtOpCodeTflMul),
+  };
+
+  auto selected = SelectAll(ops);
+  auto blocks = DetectTransformerBlocks(selected, &subgraph);
+  EXPECT_TRUE(blocks.empty());
+
+  // Repartition reports zero blocks, so downstream grouping behaves exactly as
+  // before (the selected ops are left for the normal strategy to island).
+  const size_t num_blocks =
+      RepartitionByTransformerBlocks(selected, &subgraph);
+  EXPECT_EQ(num_blocks, 0);
+}
+
+TEST(TransformerDetectorTest, RespectsMinBlockOps) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  auto attention = BuildAttention(b);  // 6 ops
+
+  auto selected = SelectAll(attention);
+  TransformerDetectorOptions options;
+  options.min_block_ops = 100;  // Larger than the block.
+  auto blocks = DetectTransformerBlocks(selected, &subgraph, options);
+  EXPECT_TRUE(blocks.empty());
+}
+
+// Builds a 3-layer stack (local, global, local), each layer owning its own KV
+// cache, and checks per-layer segmentation, scope classification, and layer
+// indexing.
+TEST(TransformerDetectorTest, SegmentsLayersAndClassifiesScope) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  std::vector<LiteRtOp> all;
+  for (auto [scope, idx] :
+       std::vector<std::pair<const char*, int>>{
+           {"local", 0}, {"global", 1}, {"local", 2}}) {
+    auto layer = BuildDecoderLayer(b, scope, idx, /*kv_idx=*/idx);
+    all.insert(all.end(), layer.begin(), layer.end());
+  }
+
+  auto selected = SelectAll(all);
+  auto blocks = DetectTransformerBlocks(selected, &subgraph);
+
+  ASSERT_EQ(blocks.size(), 3);
+  EXPECT_EQ(blocks[0].attention_scope,
+            TransformerBlock::AttentionScope::kLocal);
+  EXPECT_EQ(blocks[1].attention_scope,
+            TransformerBlock::AttentionScope::kGlobal);
+  EXPECT_EQ(blocks[2].attention_scope,
+            TransformerBlock::AttentionScope::kLocal);
+
+  EXPECT_EQ(blocks[0].layer_index, 0);
+  EXPECT_EQ(blocks[1].layer_index, 1);
+  EXPECT_EQ(blocks[2].layer_index, 2);
+
+  // Each layer owns exactly its own k_N and v_N cache (no drift into the next
+  // layer), and none share.
+  EXPECT_EQ(blocks[0].kv_cache_tensors.size(), 2);
+  EXPECT_EQ(blocks[1].kv_cache_tensors.size(), 2);
+  EXPECT_EQ(blocks[0].shares_kv_cache_with, -1);
+  EXPECT_EQ(blocks[1].shares_kv_cache_with, -1);
+  EXPECT_EQ(blocks[2].shares_kv_cache_with, -1);
+}
+
+// Two layers that read the SAME KV cache (cross-layer KV sharing): the later
+// layer must report sharing with the earlier one.
+TEST(TransformerDetectorTest, DetectsSharedKvCache) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  std::vector<LiteRtOp> all;
+  auto l0 = BuildDecoderLayer(b, "local", /*idx=*/0, /*kv_idx=*/0);
+  auto l1 = BuildDecoderLayer(b, "local", /*idx=*/1, /*kv_idx=*/0);  // reuse 0
+  all.insert(all.end(), l0.begin(), l0.end());
+  all.insert(all.end(), l1.begin(), l1.end());
+
+  auto selected = SelectAll(all);
+  auto blocks = DetectTransformerBlocks(selected, &subgraph);
+
+  ASSERT_EQ(blocks.size(), 2);
+  EXPECT_EQ(blocks[0].layer_index, 0);
+  EXPECT_EQ(blocks[1].layer_index, 1);
+  EXPECT_EQ(blocks[0].shares_kv_cache_with, -1);
+  // Layer 1 reuses layer 0's cache.
+  EXPECT_EQ(blocks[1].shares_kv_cache_with, 0);
+}
+
+// Helper: builds an `n`-layer local-attention stack and returns the flat op
+// list (each layer owns its own KV cache).
+std::vector<LiteRtOp> BuildStack(ChainBuilder& b, int n) {
+  std::vector<LiteRtOp> all;
+  for (int i = 0; i < n; ++i) {
+    auto layer = BuildDecoderLayer(b, "local", /*idx=*/i, /*kv_idx=*/i);
+    all.insert(all.end(), layer.begin(), layer.end());
+  }
+  return all;
+}
+
+// Counts the distinct partition indices assigned across selected ops.
+size_t DistinctPartitions(
+    const std::vector<LiteRtOpWithPartitionIndex>& selected) {
+  absl::flat_hash_set<LiteRtParamIndex> ids;
+  for (const auto& [op, idx] : selected) {
+    ids.insert(idx);
+  }
+  return ids.size();
+}
+
+// With layer cuts, consecutive layers are coalesced into one partition per
+// inter-cut chunk.
+TEST(TransformerDetectorTest, LayerCutsGroupConsecutiveLayers) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  auto all = BuildStack(b, /*n=*/6);  // layers 0..5
+
+  // Cuts at {2, 4} -> buckets [0,2), [2,4), [4,6) => 3 partitions.
+  auto selected = SelectAll(all);
+  TransformerDetectorOptions options;
+  options.layer_cut_indices = {2, 4};
+  const size_t num_partitions =
+      RepartitionByTransformerBlocks(selected, &subgraph, options);
+  EXPECT_EQ(num_partitions, 3);
+  EXPECT_EQ(DistinctPartitions(selected), 3);
+
+  // Layers 0 and 1 must share a partition index; layer 2 must differ.
+  // Find an op from each layer via its KV-cache input and compare indices.
+  auto index_of_layer = [&](int kv_idx) -> LiteRtParamIndex {
+    const std::string want = "kv_cache_k_" + std::to_string(kv_idx);
+    for (const auto& [op, idx] : selected) {
+      for (auto* in : op->Inputs()) {
+        if (std::string(in->Name()).find(want) != std::string::npos) {
+          return idx;
+        }
+      }
+    }
+    return std::numeric_limits<LiteRtParamIndex>::max();
+  };
+  EXPECT_EQ(index_of_layer(0), index_of_layer(1));   // same chunk
+  EXPECT_NE(index_of_layer(1), index_of_layer(2));   // crosses cut at 2
+  EXPECT_EQ(index_of_layer(2), index_of_layer(3));   // same chunk
+  EXPECT_NE(index_of_layer(3), index_of_layer(4));   // crosses cut at 4
+  EXPECT_EQ(index_of_layer(4), index_of_layer(5));   // same chunk
+}
+
+// Cuts are sanitized: out-of-order, duplicate, and out-of-range values are
+// normalized; cut 0 and cuts beyond the last layer are no-ops.
+TEST(TransformerDetectorTest, LayerCutsAreSanitized) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  auto all = BuildStack(b, /*n=*/4);  // layers 0..3
+
+  auto selected = SelectAll(all);
+  TransformerDetectorOptions options;
+  // 0 ignored; duplicates collapse; 2 is the only effective cut; 99 is past end.
+  options.layer_cut_indices = {2, 0, 2, 99};
+  const size_t num_partitions =
+      RepartitionByTransformerBlocks(selected, &subgraph, options);
+  // Effective cut {2} -> buckets [0,2), [2,4) => 2 partitions (99 adds none
+  // because no layer reaches it).
+  EXPECT_EQ(num_partitions, 2);
+}
+
+// No cuts -> one partition per layer (unchanged baseline behavior).
+TEST(TransformerDetectorTest, NoCutsIsOnePartitionPerLayer) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  auto all = BuildStack(b, /*n=*/5);
+
+  auto selected = SelectAll(all);
+  const size_t num_partitions =
+      RepartitionByTransformerBlocks(selected, &subgraph);  // default options
+  EXPECT_EQ(num_partitions, 5);
+}
+
+// coalesce_layers + empty cuts (the TransformerLayerCut "cut nowhere" case):
+// the whole stack collapses into a single partition, NOT one per layer.
+TEST(TransformerDetectorTest, CoalesceWithNoCutsIsSinglePartition) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  auto all = BuildStack(b, /*n=*/5);
+
+  auto selected = SelectAll(all);
+  TransformerDetectorOptions options;
+  options.coalesce_layers = true;  // layer_cut_indices stays empty
+  const size_t num_partitions =
+      RepartitionByTransformerBlocks(selected, &subgraph, options);
+  EXPECT_EQ(num_partitions, 1);
+  EXPECT_EQ(DistinctPartitions(selected), 1);
+}
+
+// coalesce_layers with explicit cuts behaves the same as cuts alone.
+TEST(TransformerDetectorTest, CoalesceWithCutsRespectsCuts) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  auto all = BuildStack(b, /*n=*/6);
+
+  auto selected = SelectAll(all);
+  TransformerDetectorOptions options;
+  options.coalesce_layers = true;
+  options.layer_cut_indices = {3};  // [0,3) and [3,6) => 2 partitions
+  const size_t num_partitions =
+      RepartitionByTransformerBlocks(selected, &subgraph, options);
+  EXPECT_EQ(num_partitions, 2);
+}
+
+// The trailing logits head (final norm + vocab projection producing a non-KV
+// subgraph output) is peeled into its own NON-transformer block: it does not
+// count as a layer, and a cut at index N over L layers yields N-split + head.
+TEST(TransformerDetectorTest, LogitsHeadIsSeparateNonTransformerPartition) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  // 4 decoder layers...
+  auto all = BuildStack(b, /*n=*/4);
+  // ...followed by a logits head: final RMS-norm composite + vocab projection,
+  // whose output is a (non-KV) subgraph output.
+  std::vector<LiteRtOp> head = {
+      b.AddCompositeOp(std::string(CompositeOptions::kRmsNorm)),
+      b.AddOp(kLiteRtOpCodeTflFullyConnected),  // vocab projection
+  };
+  b.MarkOutput("logits");
+  all.insert(all.end(), head.begin(), head.end());
+
+  auto selected = SelectAll(all);
+  auto blocks = DetectTransformerBlocks(selected, &subgraph);
+
+  // 4 attention layers (layer_index 0..3) + 1 non-transformer head block.
+  size_t layers = 0, non_layers = 0;
+  for (const auto& blk : blocks) {
+    if (blk.layer_index >= 0) {
+      ++layers;
+    } else {
+      ++non_layers;
+    }
+  }
+  EXPECT_EQ(layers, 4);
+  EXPECT_EQ(non_layers, 1);
+
+  // Cut at layer 2 -> [0,2) [2,4) + head = 3 partitions.
+  auto sel2 = SelectAll(all);
+  TransformerDetectorOptions options;
+  options.coalesce_layers = true;
+  options.layer_cut_indices = {2};
+  EXPECT_EQ(RepartitionByTransformerBlocks(sel2, &subgraph, options), 3);
+}
+
+// ResolveLayerCuts: per-signature spec parsing.
+TEST(TransformerDetectorTest, ResolveLayerCutsBareDefault) {
+  // A bare list applies to every signature.
+  EXPECT_EQ(ResolveLayerCuts("16", "decode"), (std::vector<int>{16}));
+  EXPECT_EQ(ResolveLayerCuts("16", "prefill_128"), (std::vector<int>{16}));
+  EXPECT_EQ(ResolveLayerCuts("8,16,24", "anything"),
+            (std::vector<int>{8, 16, 24}));
+}
+
+TEST(TransformerDetectorTest, ResolveLayerCutsPerSignature) {
+  const char* spec = "prefill_128=16,32;decode=8";
+  EXPECT_EQ(ResolveLayerCuts(spec, "prefill_128"),
+            (std::vector<int>{16, 32}));
+  EXPECT_EQ(ResolveLayerCuts(spec, "decode"), (std::vector<int>{8}));
+  // A signature not named in the spec, with no default, gets no cuts.
+  EXPECT_TRUE(ResolveLayerCuts(spec, "other").empty());
+}
+
+TEST(TransformerDetectorTest, ResolveLayerCutsDefaultPlusOverride) {
+  const char* spec = "=16;decode=8";
+  EXPECT_EQ(ResolveLayerCuts(spec, "decode"), (std::vector<int>{8}));
+  // Empty-key group is the default for everything else.
+  EXPECT_EQ(ResolveLayerCuts(spec, "prefill_128"), (std::vector<int>{16}));
+}
+
+TEST(TransformerDetectorTest, ResolveLayerCutsToleratesWhitespaceAndJunk) {
+  EXPECT_EQ(ResolveLayerCuts(" prefill_128 = 16 , 32 ; decode = 8 ",
+                             "prefill_128"),
+            (std::vector<int>{16, 32}));
+  // Non-numeric tokens are skipped.
+  EXPECT_EQ(ResolveLayerCuts("decode=8,abc,16", "decode"),
+            (std::vector<int>{8, 16}));
+  EXPECT_TRUE(ResolveLayerCuts("", "decode").empty());
+}
+
+// A normalization expressed as a single odml.rms_norm composite op must be
+// recognized as a normalization signal, the same as the decomposed form.
+TEST(TransformerDetectorTest, RecognizesNormCompositeAsNormalization) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  // rms_norm composite -> FC -> gelu -> FC: a feed-forward layer whose only
+  // norm signal is the composite. min_block_ops default is 4.
+  std::vector<LiteRtOp> ops = {
+      b.AddCompositeOp(std::string(CompositeOptions::kRmsNorm)),
+      b.AddOp(kLiteRtOpCodeTflFullyConnected),
+      b.AddOp(kLiteRtOpCodeTflGelu),
+      b.AddOp(kLiteRtOpCodeTflFullyConnected),
+  };
+
+  auto selected = SelectAll(ops);
+  auto blocks = DetectTransformerBlocks(selected, &subgraph);
+
+  // The region is detected (matmul + activation -> feed_forward, fused with the
+  // norm composite into a full block).
+  ASSERT_EQ(blocks.size(), 1);
+  EXPECT_EQ(blocks.front().kind, TransformerBlock::Kind::kFullBlock);
+  EXPECT_EQ(blocks.front().ops.size(), ops.size());
+}
+
+// A standalone normalization composite with no matmul/activation is still
+// classified as a normalization block.
+TEST(TransformerDetectorTest, NormCompositeOnlyIsNormalization) {
+  LiteRtModelT model;
+  auto& subgraph = model.EmplaceSubgraph();
+  ChainBuilder b(subgraph);
+  std::vector<LiteRtOp> ops = {
+      b.AddCompositeOp(std::string(CompositeOptions::kRmsNorm)),
+      b.AddCompositeOp(std::string(CompositeOptions::kL2Norm)),
+      b.AddCompositeOp(std::string(CompositeOptions::kGroupNorm)),
+      b.AddOp(kLiteRtOpCodeTflAdd),
+  };
+
+  auto selected = SelectAll(ops);
+  auto blocks = DetectTransformerBlocks(selected, &subgraph);
+
+  ASSERT_EQ(blocks.size(), 1);
+  EXPECT_EQ(blocks.front().kind, TransformerBlock::Kind::kNormalization);
+}
+
+}  // namespace
+}  // namespace litert::internal

--- a/litert/tools/BUILD
+++ b/litert/tools/BUILD
@@ -790,6 +790,27 @@ cc_binary(
     ],
 )
 
+cc_binary(
+    name = "detect_transformer_blocks_main",
+    srcs = ["detect_transformer_blocks_main.cc"],
+    visibility = ["//litert:litert_internal_users"],
+    deps = [
+        "//litert/c:litert_common",
+        "//litert/c:litert_op_code",
+        "//litert/cc/internal:litert_op_options",
+        "//litert/compiler/plugin:transformer_detector",
+        "//litert/core/model",
+        "//litert/core/model:model_load",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/flags:parse",
+        "@com_google_absl//absl/log:absl_log",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
 # We create a library for benchmark_main.cc to faciliate the creation of a
 # customized benchmark model binary that only needs linking with extra
 # dependency, e.g., enabling creating of benchmark binaries with a custom

--- a/litert/tools/apply_plugin_main.cc
+++ b/litert/tools/apply_plugin_main.cc
@@ -135,12 +135,15 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-#if !defined(LITERT_WINDOWS_OS)
+  // Common compiler options (e.g. --partition_strategy) apply to all backends,
+  // including the OpenVINO NPU path used on Windows, so this is parsed
+  // unconditionally.
   ParseOptionsFlags(
       run->dump_out, "Compiler", [&] { return opts->GetCompilerOptions(); },
       litert::UpdateCompilerOptionsFromFlags,
       "Failed to add Compiler options to list\n ");
 
+#if !defined(LITERT_WINDOWS_OS)
   ParseOptionsFlags(
       run->dump_out, "Google Tensor",
       [&] { return opts->GetGoogleTensorOptions(); },

--- a/litert/tools/detect_transformer_blocks_main.cc
+++ b/litert/tools/detect_transformer_blocks_main.cc
@@ -1,0 +1,369 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Standalone harness that exercises the transformer-block detector against a
+// real .tflite model. It loads the model, and for each subgraph simulates an
+// IHV delegate that selects every op (the maximal-coverage case), then runs
+// `DetectTransformerBlocks` and reports the blocks found. This mirrors what the
+// partitioner does between vendor op-selection and graph slicing, without
+// requiring a vendor plugin .so.
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "absl/flags/flag.h"  // from @com_google_absl
+#include "absl/flags/parse.h"  // from @com_google_absl
+#include "absl/log/absl_log.h"  // from @com_google_absl
+#include "absl/strings/str_format.h"  // from @com_google_absl
+#include "absl/strings/string_view.h"  // from @com_google_absl
+#include "absl/container/flat_hash_map.h"  // from @com_google_absl
+#include "absl/container/flat_hash_set.h"  // from @com_google_absl
+#include "litert/c/litert_common.h"
+#include "litert/c/litert_op_code.h"
+#include "litert/cc/internal/litert_op_options.h"
+#include "litert/compiler/plugin/transformer_detector.h"
+#include "litert/core/model/model.h"
+#include "litert/core/model/model_load.h"
+
+ABSL_FLAG(std::string, model_path, "", "Path to the .tflite model to analyze.");
+ABSL_FLAG(size_t, min_block_ops, 4,
+          "Minimum ops for a region to count as a transformer block.");
+ABSL_FLAG(bool, fuse_adjacent_clusters, true,
+          "Fuse connected attention/ffn/norm clusters into full blocks.");
+ABSL_FLAG(bool, require_softmax_for_attention, true,
+          "Require a softmax for a region to classify as attention.");
+ABSL_FLAG(bool, per_block, false,
+          "Print one line per detected block (verbose).");
+ABSL_FLAG(std::string, layer_cuts, "",
+          "Per-signature layer-cut spec (e.g. --layer_cuts=16 or "
+          "--layer_cuts=\"prefill_128=16,32;decode=8\"). When set, consecutive "
+          "layers between cuts are coalesced into one partition. Cuts are "
+          "resolved per subgraph signature.");
+ABSL_FLAG(int, histogram_for_subgraph, -1,
+          "If >=0, print the op-code histogram for that subgraph and exit.");
+ABSL_FLAG(int, dump_io_for_subgraph, -1,
+          "If >=0, print the input/output tensor names+shapes for that "
+          "subgraph and exit.");
+ABSL_FLAG(int, trace_ops_for_subgraph, -1,
+          "If >=0, print the op sequence (marking softmax and kv-cache reads) "
+          "for that subgraph and exit.");
+ABSL_FLAG(int, trace_ops_limit, 60, "Max ops to print in --trace_ops mode.");
+ABSL_FLAG(int, trace_ops_from, 0,
+          "Start index for --trace_ops mode; when >0, prints every op in "
+          "[from, limit).");
+
+namespace litert::internal {
+namespace {
+
+std::string ShapeStr(const LiteRtTensorT& t) {
+  auto ranked = t.Ranked();
+  if (!ranked) {
+    return "<unranked>";
+  }
+  std::string s = "[";
+  for (int i = 0; i < ranked->layout.rank; ++i) {
+    if (i) s += ",";
+    s += std::to_string(ranked->layout.dimensions[i]);
+  }
+  s += "]";
+  return s;
+}
+
+const char* ScopeName(TransformerBlock::AttentionScope scope) {
+  switch (scope) {
+    case TransformerBlock::AttentionScope::kLocal:
+      return "local";
+    case TransformerBlock::AttentionScope::kGlobal:
+      return "global";
+    case TransformerBlock::AttentionScope::kUnknown:
+      return "-";
+  }
+  return "-";
+}
+
+const char* KindName(TransformerBlock::Kind kind) {
+  switch (kind) {
+    case TransformerBlock::Kind::kAttention:
+      return "attention";
+    case TransformerBlock::Kind::kFeedForward:
+      return "feed_forward";
+    case TransformerBlock::Kind::kNormalization:
+      return "normalization";
+    case TransformerBlock::Kind::kFullBlock:
+      return "full_block";
+  }
+  return "unknown";
+}
+
+// Simulates a permissive IHV delegate: select every op in the subgraph, all
+// tagged with partition index 0 (as a real plugin's Partition() might before
+// any structural grouping).
+std::vector<LiteRtOpWithPartitionIndex> SelectAllOps(LiteRtSubgraph subgraph) {
+  std::vector<LiteRtOpWithPartitionIndex> selected;
+  selected.reserve(subgraph->Ops().size());
+  for (auto* op : subgraph->Ops()) {
+    selected.push_back({op, 0});
+  }
+  return selected;
+}
+
+int Run(const std::string& model_path,
+        const TransformerDetectorOptions& options, bool per_block,
+        int histogram_for_subgraph, const std::string& layer_cut_spec) {
+  auto model = LoadModelFromFile(model_path);
+  if (!model) {
+    ABSL_LOG(ERROR) << "Failed to load model '" << model_path
+                    << "': " << model.Error().Message();
+    return 1;
+  }
+
+  auto& m = **model;
+  absl::PrintF("Model: %s\n", model_path);
+  absl::PrintF("Subgraphs: %lu\n\n", m.NumSubgraphs());
+
+  // Map each subgraph to its signature key for per-signature cut resolution.
+  absl::flat_hash_map<LiteRtSubgraph, std::string> subgraph_to_signature;
+  for (auto* sig : m.Signatures()) {
+    subgraph_to_signature[&sig->GetSubgraph()] = std::string(sig->Key());
+  }
+
+  const int dump_io = absl::GetFlag(FLAGS_dump_io_for_subgraph);
+  if (dump_io >= 0) {
+    if (static_cast<size_t>(dump_io) >= m.NumSubgraphs()) {
+      ABSL_LOG(ERROR) << "subgraph index out of range";
+      return 1;
+    }
+    auto* sg = m.Subgraphs()[dump_io];
+    absl::PrintF("Subgraph[%d] inputs (%lu):\n", dump_io, sg->NumInputs());
+    for (size_t i = 0; i < sg->NumInputs(); ++i) {
+      const auto& t = sg->Input(i);
+      absl::PrintF("  in[%lu] %-40s %s\n", i, std::string(t.Name()),
+                   ShapeStr(t));
+    }
+    absl::PrintF("Subgraph[%d] outputs (%lu):\n", dump_io, sg->NumOutputs());
+    for (size_t i = 0; i < sg->NumOutputs(); ++i) {
+      const auto& t = sg->Output(i);
+      absl::PrintF("  out[%lu] %-40s %s\n", i, std::string(t.Name()),
+                   ShapeStr(t));
+    }
+    return 0;
+  }
+
+  const int trace_ops = absl::GetFlag(FLAGS_trace_ops_for_subgraph);
+  if (trace_ops >= 0) {
+    if (static_cast<size_t>(trace_ops) >= m.NumSubgraphs()) {
+      ABSL_LOG(ERROR) << "subgraph index out of range";
+      return 1;
+    }
+    auto* sg = m.Subgraphs()[trace_ops];
+    const int limit = absl::GetFlag(FLAGS_trace_ops_limit);
+    const int trace_from = absl::GetFlag(FLAGS_trace_ops_from);
+    // Tensors that are subgraph outputs (for spotting the logits head).
+    absl::flat_hash_set<LiteRtTensor> sg_outputs(sg->Outputs().begin(),
+                                                 sg->Outputs().end());
+    int n = 0;
+    for (auto* op : sg->Ops()) {
+      const int idx = n++;
+      if (idx < trace_from) continue;
+      if (idx >= limit) break;
+      std::string reads;
+      for (auto* in : op->Inputs()) {
+        const auto nm = in->Name();
+        if (nm.find("kv_cache") != absl::string_view::npos ||
+            nm.find("mask") != absl::string_view::npos ||
+            nm.find("pos_emb") != absl::string_view::npos) {
+          reads += " READS:" + std::string(nm);
+        }
+      }
+      bool produces_output = false;
+      for (auto* out : op->Outputs()) {
+        if (sg_outputs.contains(out)) produces_output = true;
+      }
+      const bool is_sm = op->OpCode() == kLiteRtOpCodeTflSoftmax;
+      // In --trace_ops_from mode print every op; otherwise only landmarks.
+      if (trace_from > 0 || !reads.empty() || is_sm || produces_output) {
+        absl::PrintF("  [%4d] opcode %-4d %s%s%s\n", idx,
+                     static_cast<int>(op->OpCode()), is_sm ? "<SOFTMAX>" : "",
+                     produces_output ? " <SG_OUTPUT>" : "", reads);
+      }
+    }
+    return 0;
+  }
+
+  if (histogram_for_subgraph >= 0) {
+    if (static_cast<size_t>(histogram_for_subgraph) >= m.NumSubgraphs()) {
+      ABSL_LOG(ERROR) << "subgraph index out of range";
+      return 1;
+    }
+    auto* sg = m.Subgraphs()[histogram_for_subgraph];
+    std::map<int, size_t> by_code;
+    for (auto* op : sg->Ops()) {
+      by_code[static_cast<int>(op->OpCode())]++;
+    }
+    absl::PrintF("Subgraph[%d] op-code histogram (%lu ops):\n",
+                 histogram_for_subgraph, sg->Ops().size());
+    for (const auto& [code, count] : by_code) {
+      absl::PrintF("  opcode %-4d  x%lu\n", code, count);
+    }
+    return 0;
+  }
+
+  // Mirror PartitionModel: composite decomposition subgraphs are not passed to
+  // the partitioner (their bodies are inlined or compiled via the composite op),
+  // so they must not be analyzed as standalone graphs here.
+  absl::flat_hash_set<int> decomp_subgraphs;
+  for (size_t i = 0; i < m.NumSubgraphs(); ++i) {
+    for (auto* op : m.Subgraphs()[i]->Ops()) {
+      auto info = GetOptionsAs<CompositeOptions>(op);
+      if (info) {
+        decomp_subgraphs.insert(info->subgraph);
+      }
+    }
+  }
+  absl::PrintF("Composite decomposition subgraphs (skipped): %lu\n\n",
+               decomp_subgraphs.size());
+
+  size_t total_blocks = 0;
+  size_t total_ops_in_blocks = 0;
+  size_t total_ops = 0;
+  size_t local_layers = 0;
+  size_t global_layers = 0;
+  size_t shared_kv_layers = 0;
+  std::map<std::string, size_t> kind_counts;
+
+  for (size_t i = 0; i < m.NumSubgraphs(); ++i) {
+    if (decomp_subgraphs.contains(static_cast<int>(i))) {
+      continue;
+    }
+    auto* subgraph = m.Subgraphs()[i];
+    const size_t num_ops = subgraph->Ops().size();
+    total_ops += num_ops;
+
+    // Resolve this subgraph's layer cuts from the per-signature spec.
+    TransformerDetectorOptions sg_options = options;
+    std::string signature_key;
+    if (auto it = subgraph_to_signature.find(subgraph);
+        it != subgraph_to_signature.end()) {
+      signature_key = it->second;
+    }
+    if (!layer_cut_spec.empty()) {
+      // Mirror the TransformerLayerCut strategy: graphs without a cut coalesce
+      // into a single partition rather than one-per-layer.
+      sg_options.coalesce_layers = true;
+      sg_options.layer_cut_indices =
+          ResolveLayerCuts(layer_cut_spec, signature_key);
+    }
+
+    auto selected = SelectAllOps(subgraph);
+    auto blocks = DetectTransformerBlocks(selected, subgraph, sg_options);
+
+    size_t ops_in_blocks = 0;
+    size_t transformer_layers = 0;  // blocks that are real transformer layers
+    size_t non_transformer_blocks = 0;
+    for (const auto& block : blocks) {
+      ops_in_blocks += block.ops.size();
+      kind_counts[KindName(block.kind)]++;
+      if (block.layer_index >= 0) {
+        transformer_layers++;
+      } else {
+        non_transformer_blocks++;
+      }
+      if (block.attention_scope == TransformerBlock::AttentionScope::kLocal) {
+        local_layers++;
+      } else if (block.attention_scope ==
+                 TransformerBlock::AttentionScope::kGlobal) {
+        global_layers++;
+      }
+      if (block.shares_kv_cache_with >= 0) {
+        shared_kv_layers++;
+      }
+      if (per_block && block.layer_index >= 0) {
+        std::string shares =
+            block.shares_kv_cache_with >= 0
+                ? absl::StrFormat(", shares KV with layer %d",
+                                  block.shares_kv_cache_with)
+                : "";
+        std::string kv;
+        for (const auto& n : block.kv_cache_tensors) {
+          kv += " " + n;
+        }
+        absl::PrintF("  sg[%lu] layer %2d  %-11s  %-6s  KV{%s }%s\n", i,
+                     block.layer_index, KindName(block.kind),
+                     ScopeName(block.attention_scope), kv, shares);
+      }
+    }
+
+    total_blocks += blocks.size();
+    total_ops_in_blocks += ops_in_blocks;
+
+    // Run the actual repartition path (which applies any layer cuts) to report
+    // the number of partitions the partitioner would hand to the delegate.
+    size_t num_partitions = blocks.size();
+    if (sg_options.coalesce_layers || !sg_options.layer_cut_indices.empty()) {
+      auto selected_copy = SelectAllOps(subgraph);
+      num_partitions =
+          RepartitionByTransformerBlocks(selected_copy, subgraph, sg_options);
+    }
+
+    if (!blocks.empty()) {
+      absl::PrintF(
+          "  subgraph[%lu] (sig='%s'): %lu ops -> %lu transformer layer(s) "
+          "(+%lu non-transformer block(s)) -> %lu partition(s), %lu ops "
+          "covered (%.1f%%)\n",
+          i, signature_key, num_ops, transformer_layers, non_transformer_blocks,
+          num_partitions,
+          ops_in_blocks, num_ops ? 100.0 * ops_in_blocks / num_ops : 0.0);
+    }
+  }
+
+  absl::PrintF("\n==== Summary ====\n");
+  absl::PrintF("Total ops:               %lu\n", total_ops);
+  absl::PrintF("Total blocks detected:   %lu\n", total_blocks);
+  absl::PrintF("Ops covered by blocks:   %lu (%.1f%%)\n", total_ops_in_blocks,
+               total_ops ? 100.0 * total_ops_in_blocks / total_ops : 0.0);
+  absl::PrintF("Local attention layers:  %lu\n", local_layers);
+  absl::PrintF("Global attention layers: %lu\n", global_layers);
+  absl::PrintF("Layers sharing KV cache: %lu\n", shared_kv_layers);
+  absl::PrintF("Blocks by kind:\n");
+  for (const auto& [kind, count] : kind_counts) {
+    absl::PrintF("  %-14s %lu\n", kind, count);
+  }
+  return 0;
+}
+
+}  // namespace
+}  // namespace litert::internal
+
+int main(int argc, char* argv[]) {
+  absl::ParseCommandLine(argc, argv);
+  const auto model_path = absl::GetFlag(FLAGS_model_path);
+  if (model_path.empty()) {
+    ABSL_LOG(ERROR) << "--model_path is required.";
+    return 1;
+  }
+
+  litert::internal::TransformerDetectorOptions options;
+  options.min_block_ops = absl::GetFlag(FLAGS_min_block_ops);
+  options.fuse_adjacent_clusters = absl::GetFlag(FLAGS_fuse_adjacent_clusters);
+  options.require_softmax_for_attention =
+      absl::GetFlag(FLAGS_require_softmax_for_attention);
+
+  return litert::internal::Run(model_path, options,
+                               absl::GetFlag(FLAGS_per_block),
+                               absl::GetFlag(FLAGS_histogram_for_subgraph),
+                               absl::GetFlag(FLAGS_layer_cuts));
+}

--- a/litert/tools/flags/apply_plugin_flags.cc
+++ b/litert/tools/flags/apply_plugin_flags.cc
@@ -33,7 +33,17 @@ ABSL_FLAG(::litert::tools::IntList, subgraphs, ::litert::tools::IntList{},
 
 ABSL_FLAG(LiteRtCompilerOptionsPartitionStrategy, partition_strategy,
           kLiteRtCompilerOptionsPartitionStrategyDefault,
-          "Partition strategy for the compiler.");
+          "Partition strategy for the compiler. One of: default, "
+          "weakly_connected, transformer_block, transformer_layer_cut.");
+
+ABSL_FLAG(std::string, transformer_layer_cuts, "",
+          "Per-signature layer-cut spec for the transformer_layer_cut strategy. "
+          "Format: ';'-separated 'signature=cuts' groups, each cuts a "
+          "','-separated list of layer indices; a bare list (or empty key) is "
+          "the default for all signatures. Examples: "
+          "--transformer_layer_cuts=16  or  "
+          "--transformer_layer_cuts=\"prefill_128=16,32;decode=8\". Only used "
+          "with --partition_strategy=transformer_layer_cut.");
 
 // NOLINTBEGIN(*alien-types*)
 // TODO: Move absl parse/unparse function to same file as enum types if
@@ -51,7 +61,19 @@ bool AbslParseFlag(absl::string_view text,
         kLiteRtCompilerOptionsPartitionStrategyWeaklyConnected;
     return true;
   }
-  *error = "Unknown partition strategy";
+  if (text == "transformer_block") {
+    *partition_strategy =
+        kLiteRtCompilerOptionsPartitionStrategyTransformerBlock;
+    return true;
+  }
+  if (text == "transformer_layer_cut") {
+    *partition_strategy =
+        kLiteRtCompilerOptionsPartitionStrategyTransformerLayerCut;
+    return true;
+  }
+  *error =
+      "Unknown partition strategy (expected: default, weakly_connected, "
+      "transformer_block, transformer_layer_cut)";
   return false;
 }
 
@@ -62,7 +84,12 @@ std::string AbslUnparseFlag(
       return "default";
     case kLiteRtCompilerOptionsPartitionStrategyWeaklyConnected:
       return "weakly_connected";
+    case kLiteRtCompilerOptionsPartitionStrategyTransformerBlock:
+      return "transformer_block";
+    case kLiteRtCompilerOptionsPartitionStrategyTransformerLayerCut:
+      return "transformer_layer_cut";
   }
+  return "default";
 }
 // NOLINTEND(*alien-types*)
 
@@ -71,6 +98,11 @@ namespace litert {
 Expected<void> UpdateCompilerOptionsFromFlags(CompilerOptions& options) {
   LITERT_RETURN_IF_ERROR(
       options.SetPartitionStrategy(absl::GetFlag(FLAGS_partition_strategy)));
+
+  const auto cuts_spec = absl::GetFlag(FLAGS_transformer_layer_cuts);
+  if (!cuts_spec.empty()) {
+    LITERT_RETURN_IF_ERROR(options.SetTransformerLayerCuts(cuts_spec));
+  }
 
   return {};
 }

--- a/litert/tools/flags/apply_plugin_flags.h
+++ b/litert/tools/flags/apply_plugin_flags.h
@@ -30,6 +30,10 @@ ABSL_DECLARE_FLAG(::litert::tools::IntList, subgraphs);
 
 // Compiler plugin partition strategy flag.
 ABSL_DECLARE_FLAG(LiteRtCompilerOptionsPartitionStrategy, partition_strategy);
+
+// Per-signature layer-cut spec for the transformer_layer_cut partition strategy.
+ABSL_DECLARE_FLAG(std::string, transformer_layer_cuts);
+
 bool AbslParseFlag(absl::string_view text,
                    LiteRtCompilerOptionsPartitionStrategy* partition_strategy,
                    std::string* error);

--- a/litert/tools/flags/apply_plugin_flags_test.cc
+++ b/litert/tools/flags/apply_plugin_flags_test.cc
@@ -42,6 +42,10 @@ TEST(ApplyPluginFlagsTest, ParsePartitionStrategySuccess) {
   EXPECT_EQ(partition_strategy,
             kLiteRtCompilerOptionsPartitionStrategyWeaklyConnected);
   EXPECT_EQ(AbslUnparseFlag(partition_strategy), "weakly_connected");
+  EXPECT_TRUE(AbslParseFlag("transformer_block", &partition_strategy, &error));
+  EXPECT_EQ(partition_strategy,
+            kLiteRtCompilerOptionsPartitionStrategyTransformerBlock);
+  EXPECT_EQ(AbslUnparseFlag(partition_strategy), "transformer_block");
 }
 
 TEST(ApplyPluginFlagsTest, UnparsePartitionStrategySuccess) {
@@ -50,6 +54,9 @@ TEST(ApplyPluginFlagsTest, UnparsePartitionStrategySuccess) {
   EXPECT_EQ(
       AbslUnparseFlag(kLiteRtCompilerOptionsPartitionStrategyWeaklyConnected),
       "weakly_connected");
+  EXPECT_EQ(
+      AbslUnparseFlag(kLiteRtCompilerOptionsPartitionStrategyTransformerBlock),
+      "transformer_block");
 }
 
 TEST(ApplyPluginFlagsTest, ParseFlagsAndGetPartitionStrategySuccess) {


### PR DESCRIPTION
Add a transformer-block detector the TFLite partitioner can invoke to detect transformer-layer structure among IHV-selected ops and group the graph accordingly before requesting delegate compilation.

litert/compiler/plugin/transformer_detector.{h,cc}:
- Detect transformer layers via connected-component + op-histogram classification (attention/feed-forward/normalization/full-block), segmenting the decoder stack into one block per layer (RoPE pos_emb anchored).
- Per-layer attention metadata: local vs global attention scope (pos_emb-based), layer index, KV-cache tensors, and cross-layer KV-cache sharing.
- Recognize StableHLO norm composites (odml.rms_norm/l2_norm/group_norm) as a normalization signal.
- Peel the trailing logits head (final norm + vocab projection) into its own non-transformer partition; it is excluded from the layer count.

Partition strategies (litert/c/options + cc/options + compiler_plugin):
- kLiteRtCompilerOptionsPartitionStrategyTransformerBlock: one partition per transformer layer.
- kLiteRtCompilerOptionsPartitionStrategyTransformerLayerCut: coalesce consecutive layers into one partition per inter-cut chunk. Cuts are a per-signature spec string (e.g. "decode=10;prefill_128=4"); an unspecified graph coalesces to a single partition. Stray ops fold into the nearest preceding partition.

Tooling:
- apply_plugin_main: --partition_strategy and --transformer_layer_cuts flags (applied on the Windows/OpenVINO path).
- detect_transformer_blocks_main: standalone analysis/validation tool.

Usage examples (apply_plugin_main, Intel OpenVINO / Gemma4 E2B):

 One partition per transformer layer (no cuts):
```
  apply_plugin_main -cmd apply --model=model.tflite \
    -o out.tflite --soc_model=LNL --soc_manufacturer IntelOpenVINO \
    --libs <plugin_dir> --partition_strategy=transformer_block
```

  Cut the 35-layer decode graph at layer 10 -> 3 dispatch ops (layers [0,10), [10,35), logits head); leave prefill_128 as a single partition:
```
  apply_plugin_main -cmd apply --model=model.tflite \
    -o out.tflite --soc_model=LNL --soc_manufacturer IntelOpenVINO \
    --libs <plugin_dir> --partition_strategy=transformer_layer_cut \
    --transformer_layer_cuts="decode=10"
```

  Different cuts per signature (decode at 17, prefill_128 at 7):
```
  ...
  --partition_strategy=transformer_layer_cut
  --transformer_layer_cuts="decode=17;prefill_128=7"
```

  Same cut applied to every signature (bare list = default):
```
  ...
  --transformer_layer_cuts="16"
```

  Default for all, with one signature overridden:
```
  ...
  --transformer_layer_cuts="=16;decode=8"
````

  Inspect detected layers / partitions without a vendor plugin:
```
  detect_transformer_blocks_main --model_path=model.tflite \
    --layer_cuts="decode=10" --per_block
```