### PR TITLE
docs: Add docstring for CreateCastOp function

### DIFF
--- a/litert/vendors/qualcomm/core/builders/cast_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/cast_op_builder.cc
@@ -13,6 +13,16 @@
 
 namespace qnn {
 
+/**
+ * @brief Creates a Cast operation wrapper.
+ *
+ * This function creates an OpWrapper representing a Cast operation
+ * with the given input and output tensors.
+ *
+ * @param input The input tensor for the cast operation.
+ * @param output The output tensor for the cast operation.
+ * @return An OpWrapper object for the Cast operation.
+ */
 OpWrapper CreateCastOp(const TensorWrapper& input,
                        const TensorWrapper& output) {
   OpWrapper op(GetUniqueOpName(QNN_OP_CAST), QNN_OP_CAST, QnnOpCode::kCast);


### PR DESCRIPTION
### 问题背景
在 LiteRT 项目中，公共函数 `CreateCastOp` 缺少文档注释，降低了代码的可读性和维护性。这使得其他开发者难以快速理解函数的功能和用法，影响了协作效率。

### 修改内容
- **修改了什么**：在 `litert/vendors/qualcomm/core/builders/cast_op_builder.cc` 文件中，为 `CreateCastOp` 函数添加了详细的文档注释，包括函数简介（@brief）、参数描述和返回值说明。
- **为什么这样改**：添加文档注释是开源项目中的最佳实践，它提高了代码的自描述性，帮助开发者快速理解函数意图，减少错误使用。这符合 LiteRT 项目对代码质量和可维护性的要求。
- **对代码质量的提升**：通过提供清晰的文档，增强了代码的可读性和可维护性，使得新贡献者更容易上手，并降低了长期维护成本。

### 验证方式
- 此修改仅涉及文档注释的添加，不改变任何代码逻辑或功能。
- 现有测试应继续通过，因为行为未变；无需添加新测试。
- 验证可以通过代码审查确保注释准确反映了函数行为，并与仓库中其他类似函数的文档风格保持一致。

### 其他信息
- **Breaking Changes**：无。此 PR 不修改任何公共 API 或外部行为。
- **文档更新**：本 PR 更新了代码内部文档，无需额外文档变更。
- **已知限制**：无。