### PR TITLE
Add FuseSplitAttentionToSDPA pass for Intel NPU

### DIFF
--- a/litert/vendors/intel_openvino/README_options.md
+++ b/litert/vendors/intel_openvino/README_options.md
@@ -84,9 +84,18 @@ apply_plugin_main \
     --intel_openvino_configs_map="optimize_fq_after_matmul=true,INFERENCE_PRECISION_HINT=f16"
 ```
 
-The plugin recognizes `optimize_fq_after_matmul` as an internal key and consumes
-it directly; the remaining entries are forwarded to the OpenVINO Core as
-configuration properties.
+The plugin recognizes a few internal keys and consumes them directly; the
+remaining entries are forwarded to the OpenVINO Core as configuration
+properties. Internal keys (all default `false`):
+
+- `optimize_fq_after_matmul` — eliminate FakeQuantize nodes after MatMul.
+- `fuse_split_attention_to_sdpa` — fuse the Gemma-style split-cache attention
+  pattern (separate QK against the persistent KV cache and the new step's KV,
+  merged via Concat) into a single
+  `ov::op::v13::ScaledDotProductAttention`.
+- `sdpa_pad_kv_to_alignment` — only meaningful with `fuse_split_attention_to_sdpa=true`.
+  When the merged KV sequence length is not a multiple of 16, pad K/V (and the
+  mask) up to the next multiple so the block still fuses.
 
 ## Usage Example
 

--- a/litert/vendors/intel_openvino/compiler/BUILD
+++ b/litert/vendors/intel_openvino/compiler/BUILD
@@ -42,6 +42,23 @@ litert_lib(
     copts = ["-fexceptions"],
     features = ["-use_header_modules"],  # Incompatible with -fexceptions.
     deps = [
+        "//litert/c/internal:litert_logging",
+        "@intel_openvino//:openvino",
+    ],
+)
+
+litert_test(
+    name = "npu_optimizer_test",
+    srcs = ["npu_optimizer_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
+    tags = [
+        "manual",
+        "nobuilder",
+        "notap",
+    ],
+    deps = [
+        ":npu_optimizer",
         "@intel_openvino//:openvino",
     ],
 )

--- a/litert/vendors/intel_openvino/compiler/npu_optimizer.cc
+++ b/litert/vendors/intel_openvino/compiler/npu_optimizer.cc
@@ -14,17 +14,32 @@
 
 #include "litert/vendors/intel_openvino/compiler/npu_optimizer.h"
 
+#include <cstdint>
 #include <memory>
+#include <string>
+#include <vector>
 
+#include "litert/c/internal/litert_logging.h"
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/rt_info.hpp"
+#include "openvino/core/shape.hpp"
+#include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/fake_quantize.hpp"
 #include "openvino/op/matmul.hpp"
+#include "openvino/op/pad.hpp"
+#include "openvino/op/scaled_dot_product_attention.hpp"
 #include "openvino/op/sign.hpp"
+#include "openvino/op/slice.hpp"
+#include "openvino/op/softmax.hpp"
+#include "openvino/op/strided_slice.hpp"
+#include "openvino/op/transpose.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/matcher_pass.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
@@ -34,6 +49,46 @@
 
 namespace litert {
 namespace openvino {
+namespace {
+
+// The Intel NPU SDPA kernel requires the merged key/value sequence dimension
+// to be a multiple of this alignment.
+constexpr int64_t kSdpaKvSeqAlignment = 16;
+
+// Additive-mask sentinel used for padded key positions. Value taken from
+// Gemma models.
+constexpr float kSdpaPadMaskBias = -100.0f;
+
+// Returns true if |output| feeds exactly one consumer input.
+bool HasSingleConsumer(const ov::Output<ov::Node>& output) {
+  return output.get_target_inputs().size() == 1;
+}
+
+// Pads |input| at the end of the (possibly negative) |axis| by |pad_amount|
+// elements, filling with |pad_value|. |rank| is the static rank of |input|.
+// Returns the original output unchanged when |pad_amount| is zero.
+ov::Output<ov::Node> PadEndOfAxis(const ov::Output<ov::Node>& input,
+                                  int64_t rank, int64_t axis,
+                                  int64_t pad_amount, float pad_value) {
+  if (pad_amount == 0) {
+    return input;
+  }
+  const int64_t norm_axis = axis < 0 ? axis + rank : axis;
+  std::vector<int64_t> begin(rank, 0);
+  std::vector<int64_t> end(rank, 0);
+  end[norm_axis] = pad_amount;
+  auto pads_begin = ov::op::v0::Constant::create(
+      ov::element::i64, ov::Shape{static_cast<size_t>(rank)}, begin);
+  auto pads_end = ov::op::v0::Constant::create(
+      ov::element::i64, ov::Shape{static_cast<size_t>(rank)}, end);
+  auto value = ov::op::v0::Constant::create(input.get_element_type(),
+                                            ov::Shape{}, {pad_value});
+  return std::make_shared<ov::op::v1::Pad>(input, pads_begin, pads_end, value,
+                                           ov::op::PadMode::CONSTANT)
+      ->output(0);
+}
+
+}  // namespace
 
 EliminateMatMulFakeQuantize::EliminateMatMulFakeQuantize() {
   namespace pattern = ov::pass::pattern;
@@ -95,10 +150,316 @@ CastIntegerSignToFloat::CastIntegerSignToFloat() {
   register_matcher(m, callback);
 }
 
+FuseSplitAttentionToSDPA::FuseSplitAttentionToSDPA(bool pad_kv_to_alignment) {
+  namespace pattern = ov::pass::pattern;
+
+  auto q_input = pattern::any_input();
+  auto k_cache_input = pattern::any_input();
+  auto k_new_input = pattern::any_input();
+  auto v_cache_input = pattern::any_input();
+  auto v_new_input = pattern::any_input();
+  auto mask_input = pattern::any_input();
+
+  auto qk_cache = pattern::wrap_type<ov::op::v0::MatMul>(
+      {q_input, k_cache_input}, pattern::consumers_count(1));
+  auto qk_new = pattern::wrap_type<ov::op::v0::MatMul>(
+      {q_input, k_new_input}, pattern::consumers_count(1));
+
+  auto scores_concat = pattern::wrap_type<ov::op::v0::Concat>(
+      {qk_cache, qk_new}, pattern::consumers_count(1));
+  auto masked_scores = pattern::wrap_type<ov::op::v1::Add>(
+      {scores_concat, mask_input}, pattern::consumers_count(1));
+  auto softmax = pattern::wrap_type<ov::op::v8::Softmax>(
+      {masked_scores}, pattern::consumers_count(1));
+
+  auto attn_cache = pattern::wrap_type<ov::op::v0::MatMul>(
+      {pattern::any_input(), v_cache_input});
+  auto attn_new = pattern::wrap_type<ov::op::v0::MatMul>(
+      {pattern::any_input(), v_new_input});
+  auto output_add = pattern::wrap_type<ov::op::v1::Add>({attn_cache, attn_new});
+
+  ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    const std::string root_name = m.get_match_root()->get_friendly_name();
+    auto add_node =
+        std::dynamic_pointer_cast<ov::op::v1::Add>(m.get_match_root());
+    if (!add_node) {
+      LITERT_LOG(LITERT_ERROR,
+                 "FuseSplitAttentionToSDPA[%s]: reject: root is not v1::Add",
+                 root_name.c_str());
+      return false;
+    }
+
+    auto v_matmul_cache = std::dynamic_pointer_cast<ov::op::v0::MatMul>(
+        add_node->input_value(0).get_node_shared_ptr());
+    auto v_matmul_new = std::dynamic_pointer_cast<ov::op::v0::MatMul>(
+        add_node->input_value(1).get_node_shared_ptr());
+    if (!v_matmul_cache || !v_matmul_new) {
+      return false;
+    }
+
+    // Both V matmuls' first input must be a Slice / StridedSlice over a
+    // common Softmax.
+    auto cache_src_node = v_matmul_cache->input_value(0).get_node_shared_ptr();
+    auto new_src_node = v_matmul_new->input_value(0).get_node_shared_ptr();
+    const bool cache_is_slice =
+        ov::is_type<ov::op::v1::StridedSlice>(cache_src_node) ||
+        ov::is_type<ov::op::v8::Slice>(cache_src_node);
+    const bool new_is_slice =
+        ov::is_type<ov::op::v1::StridedSlice>(new_src_node) ||
+        ov::is_type<ov::op::v8::Slice>(new_src_node);
+    if (!cache_is_slice || !new_is_slice) {
+      return false;
+    }
+    auto sm_cache = std::dynamic_pointer_cast<ov::op::v8::Softmax>(
+        cache_src_node->input_value(0).get_node_shared_ptr());
+    auto sm_new = std::dynamic_pointer_cast<ov::op::v8::Softmax>(
+        new_src_node->input_value(0).get_node_shared_ptr());
+    if (!sm_cache || sm_cache != sm_new) {
+      LITERT_LOG(LITERT_DEBUG,
+                 "FuseSplitAttentionToSDPA[%s]: reject: slices do not share a "
+                 "common v8::Softmax source (cache_sm='%s', new_sm='%s')",
+                 root_name.c_str(), cache_src_node->get_type_name(),
+                 new_src_node->get_type_name());
+      return false;
+    }
+    auto softmax_node = sm_cache;
+
+    // Softmax must be on the last axis.
+    auto sm_rank = softmax_node->get_output_partial_shape(0).rank();
+    if (sm_rank.is_dynamic()) {
+      return false;
+    }
+    int64_t sm_axis = static_cast<int64_t>(softmax_node->get_axis());
+    if (sm_axis < 0) sm_axis += sm_rank.get_length();
+    if (sm_axis != sm_rank.get_length() - 1) {
+      return false;
+    }
+
+    auto mask_add_node = std::dynamic_pointer_cast<ov::op::v1::Add>(
+        softmax_node->input_value(0).get_node_shared_ptr());
+    if (!mask_add_node) {
+      return false;
+    }
+
+    auto concat_node = std::dynamic_pointer_cast<ov::op::v0::Concat>(
+        mask_add_node->input_value(0).get_node_shared_ptr());
+    if (!concat_node || concat_node->get_input_size() != 2) {
+      return false;
+    }
+    auto concat_rank = concat_node->get_output_partial_shape(0).rank();
+    if (concat_rank.is_dynamic()) {
+      return false;
+    }
+    int64_t concat_axis = concat_node->get_axis();
+    if (concat_axis < 0) concat_axis += concat_rank.get_length();
+    if (concat_axis != concat_rank.get_length() - 1) {
+      return false;
+    }
+
+    auto qk_cache_node = std::dynamic_pointer_cast<ov::op::v0::MatMul>(
+        concat_node->input_value(0).get_node_shared_ptr());
+    auto qk_new_node = std::dynamic_pointer_cast<ov::op::v0::MatMul>(
+        concat_node->input_value(1).get_node_shared_ptr());
+    if (!qk_cache_node || !qk_new_node) {
+      return false;
+    }
+
+    // Both QK matmuls must share Q and agree on transpose flags.
+    if (qk_cache_node->input_value(0) != qk_new_node->input_value(0)) {
+      return false;
+    }
+    if (qk_cache_node->get_transpose_a() || qk_new_node->get_transpose_a()) {
+      return false;
+    }
+    if (qk_cache_node->get_transpose_b() != qk_new_node->get_transpose_b()) {
+      LITERT_LOG(LITERT_DEBUG,
+                 "FuseSplitAttentionToSDPA[%s]: reject: QK MatMul transpose_b "
+                 "flags disagree (cache=%d, new=%d)",
+                 root_name.c_str(), qk_cache_node->get_transpose_b(),
+                 qk_new_node->get_transpose_b());
+      return false;
+    }
+    if (v_matmul_cache->get_transpose_a() || v_matmul_new->get_transpose_a()) {
+      return false;
+    }
+    if (v_matmul_cache->get_transpose_b() != v_matmul_new->get_transpose_b()) {
+      LITERT_LOG(LITERT_DEBUG,
+                 "FuseSplitAttentionToSDPA[%s]: reject: V MatMul transpose_b "
+                 "flags disagree (cache=%d, new=%d)",
+                 root_name.c_str(), v_matmul_cache->get_transpose_b(),
+                 v_matmul_new->get_transpose_b());
+      return false;
+    }
+
+    auto q = qk_cache_node->input_value(0);
+    auto k_cache = qk_cache_node->input_value(1);
+    auto k_new = qk_new_node->input_value(1);
+    auto v_cache = v_matmul_cache->input_value(1);
+    auto v_new = v_matmul_new->input_value(1);
+    auto mask_value = mask_add_node->input_value(1);
+
+    // KV-cache sharing guard: K_cache / V_cache must each feed exactly one
+    // consumer (the QK / attn*V MatMul we are about to fuse). If the same KV
+    // tensor is consumed elsewhere — e.g. multiple attention layers sharing
+    // the same KV cache — rewriting it as part of this fusion would alter the
+    // graph seen by the other consumer. Skip such layers.
+    if (!HasSingleConsumer(k_cache) || !HasSingleConsumer(v_cache)) {
+      LITERT_LOG(LITERT_DEBUG,
+                 "FuseSplitAttentionToSDPA[%s]: reject: K_cache or V_cache is "
+                 "shared with other consumers (K=%zu, V=%zu)",
+                 root_name.c_str(), k_cache.get_target_inputs().size(),
+                 v_cache.get_target_inputs().size());
+      return false;
+    }
+
+    // Require static 4-D ranks for predictable layout reasoning.
+    const char* const in_names[] = {"Q", "K_cache", "K_new", "V_cache",
+                                    "V_new"};
+    const ov::Output<ov::Node> ins[] = {q, k_cache, k_new, v_cache, v_new};
+    for (size_t i = 0; i < 5; ++i) {
+      const auto& ps = ins[i].get_partial_shape();
+      if (ps.rank().is_dynamic() || ps.rank().get_length() != 4) {
+        LITERT_LOG(LITERT_DEBUG,
+                   "FuseSplitAttentionToSDPA[%s]: reject: %s does not have "
+                   "static 4-D rank (rank=%s)",
+                   root_name.c_str(), in_names[i],
+                   ps.rank().is_dynamic()
+                       ? "dynamic"
+                       : std::to_string(ps.rank().get_length()).c_str());
+        return false;
+      }
+    }
+
+    // Interpret MatMul transpose flags as a physical-layout hint:
+    //   qk transpose_b == true  -> K stored as [B,H,S,D] (standard).
+    //   qk transpose_b == false -> K stored as [B,H,D,S] (already K^T).
+    //   attn transpose_b == true  -> V stored as [B,H,D,S].
+    //   attn transpose_b == false -> V stored as [B,H,S,D] (standard).
+    const bool k_is_transposed = !qk_cache_node->get_transpose_b();
+    const bool v_is_transposed = v_matmul_cache->get_transpose_b();
+
+    const int64_t k_concat_axis = k_is_transposed ? 3 : 2;
+    const int64_t v_concat_axis = v_is_transposed ? 3 : 2;
+
+    // The merged KV sequence length determines whether padding is needed.
+    // After Concat, the (logical) S_kv dim is K_cache.S + K_new.S; the NPU
+    // SDPA kernel requires this be a multiple of kSdpaKvSeqAlignment.
+    const auto& k_cache_ps = k_cache.get_partial_shape();
+    const auto& k_new_ps = k_new.get_partial_shape();
+    // The S dimension of K is at axis 2 if standard, axis 3 if pre-transposed.
+    const int64_t k_seq_axis = k_concat_axis;
+    const bool kv_len_static =
+        k_cache_ps[k_seq_axis].is_static() && k_new_ps[k_seq_axis].is_static();
+    int64_t kv_len = 0;
+    int64_t kv_pad = 0;
+    if (kv_len_static) {
+      kv_len = k_cache_ps[k_seq_axis].get_length() +
+               k_new_ps[k_seq_axis].get_length();
+      const int64_t aligned =
+          ((kv_len + kSdpaKvSeqAlignment - 1) / kSdpaKvSeqAlignment) *
+          kSdpaKvSeqAlignment;
+      kv_pad = aligned - kv_len;
+    }
+    if ((!pad_kv_to_alignment && (!kv_len_static || kv_pad != 0))) {
+      LITERT_LOG(LITERT_DEBUG,
+                 "FuseSplitAttentionToSDPA[%s]: reject: merged KV length is "
+                 "not %lld-aligned and pad_kv_to_alignment is off "
+                 "(kv_len_static=%d, kv_len=%lld, kv_pad=%lld)",
+                 root_name.c_str(), static_cast<long long>(kSdpaKvSeqAlignment),
+                 static_cast<int>(kv_len_static),
+                 static_cast<long long>(kv_len),
+                 static_cast<long long>(kv_pad));
+      return false;
+    }
+
+    auto k_concat = std::make_shared<ov::op::v0::Concat>(
+        ov::OutputVector{k_cache, k_new}, k_concat_axis);
+    auto v_concat = std::make_shared<ov::op::v0::Concat>(
+        ov::OutputVector{v_cache, v_new}, v_concat_axis);
+
+    std::shared_ptr<ov::Node> k_input = k_concat;
+    std::shared_ptr<ov::Node> v_input = v_concat;
+
+    ov::NodeVector new_nodes{k_concat, v_concat};
+    auto add_transpose = [&new_nodes](std::shared_ptr<ov::Node>& target) {
+      auto perm = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4},
+                                               {0, 1, 3, 2});
+      auto transpose = std::make_shared<ov::op::v1::Transpose>(target, perm);
+      new_nodes.push_back(perm);
+      new_nodes.push_back(transpose);
+      target = transpose;
+    };
+    if (k_is_transposed) add_transpose(k_input);
+    if (v_is_transposed) add_transpose(v_input);
+
+    // After Concat (+ optional Transpose), K and V are in standard
+    // [B,H,S_kv,D] layout. Pad the S_kv dim (axis -2) up to the alignment.
+    // PadEndOfAxis short-circuits to the original output when kv_pad == 0,
+    // so the explicit guard is unnecessary.
+    ov::Output<ov::Node> key_out =
+        PadEndOfAxis(k_input->output(0), /*rank=*/4, /*axis=*/-2, kv_pad,
+                     /*pad_value=*/0.0f);
+    ov::Output<ov::Node> val_out =
+        PadEndOfAxis(v_input->output(0), /*rank=*/4, /*axis=*/-2, kv_pad,
+                     /*pad_value=*/0.0f);
+    if (kv_pad > 0) {
+      new_nodes.push_back(key_out.get_node_shared_ptr());
+      new_nodes.push_back(val_out.get_node_shared_ptr());
+    }
+
+    // Mask. Its KV axis (-1) must match the (possibly padded) KV length, so
+    // pad it by the same amount with a large finite negative bias to mask
+    // the padded positions in softmax (kSdpaPadMaskBias is -3e4: small enough
+    // that exp underflows, large enough that fp16 stays finite, avoiding
+    // NaN in flash-attention tile rescaling).
+    const int64_t mask_rank =
+        mask_value.get_partial_shape().rank().is_static()
+            ? mask_value.get_partial_shape().rank().get_length()
+            : 4;
+    ov::Output<ov::Node> attn_mask = PadEndOfAxis(
+        mask_value, mask_rank, /*axis=*/-1, kv_pad, kSdpaPadMaskBias);
+    if (kv_pad > 0) {
+      new_nodes.push_back(attn_mask.get_node_shared_ptr());
+    }
+
+    // Scale = 1.0: any required scaling is assumed pre-applied to Q.
+    auto scale_const = ov::op::v0::Constant::create(
+        q.get_element_type(), ov::Shape{}, std::vector<float>{1.0f});
+    new_nodes.push_back(scale_const);
+
+    auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(
+        q, key_out, val_out, attn_mask, scale_const, /*is_causal=*/false);
+    new_nodes.push_back(sdpa);
+
+    sdpa->set_friendly_name(add_node->get_friendly_name());
+    ov::copy_runtime_info(m.get_matched_nodes(), new_nodes);
+    ov::replace_node(add_node, sdpa);
+    LITERT_LOG(LITERT_DEBUG,
+               "FuseSplitAttentionToSDPA: fused split-attention into "
+               "v13::ScaledDotProductAttention '%s' "
+               "(k_pre_transposed=%d, v_pre_transposed=%d, "
+               "kv_len=%lld, kv_pad=%lld)",
+               sdpa->get_friendly_name().c_str(),
+               static_cast<int>(k_is_transposed),
+               static_cast<int>(v_is_transposed),
+               static_cast<long long>(kv_len), static_cast<long long>(kv_pad));
+    return true;
+  };
+
+  auto m = std::make_shared<pattern::Matcher>(output_add,
+                                              "FuseSplitAttentionToSDPA");
+
+  register_matcher(m, callback);
+}
+
 void NpuOptimizer::Run(const std::shared_ptr<ov::Model>& model) const {
   ov::pass::Manager pass_manager;
   if (cast_integer_sign_to_float_) {
     pass_manager.register_pass<CastIntegerSignToFloat>();
+  }
+  if (fuse_split_attention_to_sdpa_) {
+    pass_manager.register_pass<FuseSplitAttentionToSDPA>(
+        sdpa_pad_kv_to_alignment_);
   }
   if (eliminate_matmul_fq_) {
     pass_manager.register_pass<EliminateMatMulFakeQuantize>();

--- a/litert/vendors/intel_openvino/compiler/npu_optimizer.h
+++ b/litert/vendors/intel_openvino/compiler/npu_optimizer.h
@@ -46,6 +46,43 @@ class CastIntegerSignToFloat : public ov::pass::MatcherPass {
   CastIntegerSignToFloat();
 };
 
+// Fuses the "split-attention" sub-graph produced by some Gemma-style models
+// (attention computed separately against the persistent KV cache and the
+// current step's KV, merged via Concat) into a single
+// `ov::op::v13::ScaledDotProductAttention`.
+//
+// Pattern matched (Q is shared between both qk MatMuls):
+//
+//   qk_cache = MatMul(Q, K_cache)
+//   qk_new   = MatMul(Q, K_new)
+//   scores   = Concat(qk_cache, qk_new, axis=-1)
+//   masked   = Add(scores, mask)
+//   probs    = Softmax(masked, axis=-1)
+//   pc       = Slice/StridedSlice(probs)        // cache half
+//   pn       = Slice/StridedSlice(probs)        // new half
+//   attn_c   = MatMul(pc, V_cache)
+//   attn_n   = MatMul(pn, V_new)
+//   output   = Add(attn_c, attn_n)              // <-- match root
+//
+// Restricted to static 4-D ranks; other shapes are left untouched. Scale is
+// set to 1.0 because the matched pattern has no explicit scale node (any
+// scaling is assumed pre-applied to Q by the model, e.g. Gemma's
+// `query_pre_attn_scalar`). When the MatMul transpose_b flags imply K or V
+// is stored as [B,H,D,S], an explicit Transpose(0,1,3,2) is inserted to
+// restore the [B,H,S,D] layout required by v13::SDPA.
+//
+// Ported from openvinotoolkit/openvino PR #36153.
+class FuseSplitAttentionToSDPA : public ov::pass::MatcherPass {
+ public:
+  OPENVINO_MATCHER_PASS_RTTI("FuseSplitAttentionToSDPA");
+  // |pad_kv_to_alignment| controls behavior when the merged KV sequence length
+  // is not a multiple of the NPU SDPA kernel's required alignment (16). When
+  // false, such blocks are left unfused. When true(default), the merged K/V
+  // is padded up to the next multiple of 16 and the mask is padded with a
+  // large negative bias so the padded key positions are excluded from softmax.
+  explicit FuseSplitAttentionToSDPA(bool pad_kv_to_alignment);
+};
+
 // Configurable runner for NPU-specific optimization passes.
 // Use the setter APIs to toggle individual optimizations, then call Run() to
 // apply the enabled passes to a model.
@@ -64,12 +101,29 @@ class NpuOptimizer {
     return *this;
   }
 
+  // Toggles the FuseSplitAttentionToSDPA pass. Disabled by default; enable
+  // via config key "fuse_split_attention_to_sdpa" = "true" to collapse the
+  // Gemma-style split-attention pattern into a single SDPA op.
+  NpuOptimizer& SetFuseSplitAttentionToSDPA(bool enable) {
+    fuse_split_attention_to_sdpa_ = enable;
+    return *this;
+  }
+
+  // Controls whether the SDPA fusion pads an unaligned merged KV sequence
+  // length up to the NPU kernel's required alignment.
+  NpuOptimizer& SetSdpaPadKvToAlignment(bool enable) {
+    sdpa_pad_kv_to_alignment_ = enable;
+    return *this;
+  }
+
   // Runs all currently-enabled passes on |model|.
   void Run(const std::shared_ptr<ov::Model>& model) const;
 
  private:
   bool eliminate_matmul_fq_ = false;
   bool cast_integer_sign_to_float_ = true;
+  bool fuse_split_attention_to_sdpa_ = false;
+  bool sdpa_pad_kv_to_alignment_ = true;
 };
 
 }  // namespace openvino

--- a/litert/vendors/intel_openvino/compiler/npu_optimizer_test.cc
+++ b/litert/vendors/intel_openvino/compiler/npu_optimizer_test.cc
@@ -1,0 +1,256 @@
+// Copyright 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "litert/vendors/intel_openvino/compiler/npu_optimizer.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "openvino/core/model.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/scaled_dot_product_attention.hpp"
+#include "openvino/op/slice.hpp"
+#include "openvino/op/softmax.hpp"
+#include "openvino/pass/manager.hpp"
+#include "openvino/runtime/core.hpp"
+#include "openvino/runtime/infer_request.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+namespace litert {
+namespace openvino {
+namespace {
+
+// Builds the "split-cache" attention pattern emitted by the LiteRT generative
+// converter (gemma4 prefill/decode), matching the layout observed in the
+// model:
+//   K_cache: [B,H,S_past,D]   K_slice: [B,H,1,D]
+//   V_cache: [B,H,D,S_past]   V_slice: [B,H,D,1]   (transposed, adj_y=true)
+//   scores = Concat[ MatMul(Q,K_cache,T), MatMul(Q,K_slice,T) ] + mask
+//   probs  = Softmax(scores)
+//   out    = Add[ MatMul(Slice(probs,past),V_cache,T),
+//                 MatMul(Slice(probs,cur),V_slice,T) ]
+// |s_past| is the cached sequence length and |s_cur| is the current chunk size
+// (the K/V slice length): decode uses s_cur=1, prefill uses s_cur=chunk (e.g.
+// 128). The query length equals s_cur in both cases.
+std::shared_ptr<ov::Model> BuildSplitCacheAttention(int64_t s_past = 8,
+                                                    int64_t s_cur = 1) {
+  using ov::op::v0::Concat;
+  using ov::op::v0::Constant;
+  using ov::op::v0::MatMul;
+  using ov::op::v0::Parameter;
+  using ov::op::v1::Add;
+  using ov::op::v8::Slice;
+  using ov::op::v8::Softmax;
+
+  constexpr int64_t kBatch = 1;
+  constexpr int64_t kHeads = 8;
+  constexpr int64_t kDim = 256;
+  const int64_t lq = s_cur;
+  const int64_t s_kv = s_past + s_cur;
+  const auto f = ov::element::f32;
+
+  auto q = std::make_shared<Parameter>(
+      f, ov::Shape{static_cast<size_t>(kBatch), static_cast<size_t>(kHeads),
+                   static_cast<size_t>(lq), static_cast<size_t>(kDim)});
+  auto k_cache = std::make_shared<Parameter>(
+      f, ov::Shape{static_cast<size_t>(kBatch), static_cast<size_t>(kHeads),
+                   static_cast<size_t>(s_past), static_cast<size_t>(kDim)});
+  auto k_slice = std::make_shared<Parameter>(
+      f, ov::Shape{static_cast<size_t>(kBatch), static_cast<size_t>(kHeads),
+                   static_cast<size_t>(s_cur), static_cast<size_t>(kDim)});
+  auto v_cache = std::make_shared<Parameter>(
+      f, ov::Shape{static_cast<size_t>(kBatch), static_cast<size_t>(kHeads),
+                   static_cast<size_t>(kDim), static_cast<size_t>(s_past)});
+  auto v_slice = std::make_shared<Parameter>(
+      f, ov::Shape{static_cast<size_t>(kBatch), static_cast<size_t>(kHeads),
+                   static_cast<size_t>(kDim), static_cast<size_t>(s_cur)});
+  auto mask = std::make_shared<Parameter>(
+      f, ov::Shape{static_cast<size_t>(kBatch), 1, static_cast<size_t>(lq),
+                   static_cast<size_t>(s_kv)});
+
+  // scores = Q * K^T (transpose_b), concatenated over the sequence axis.
+  auto qk_cache = std::make_shared<MatMul>(q, k_cache, /*transpose_a=*/false,
+                                           /*transpose_b=*/true);
+  auto qk_slice = std::make_shared<MatMul>(q, k_slice, false, true);
+  auto scores = std::make_shared<Concat>(ov::OutputVector{qk_cache, qk_slice},
+                                         /*axis=*/-1);
+  auto masked = std::make_shared<Add>(scores, mask);
+  auto probs = std::make_shared<Softmax>(masked, /*axis=*/-1);
+
+  // Split probs back into past / current, then probs * V^T (transpose_b).
+  auto start0 = Constant::create(ov::element::i64, ov::Shape{1}, {0});
+  auto stop0 = Constant::create(ov::element::i64, ov::Shape{1}, {s_past});
+  auto step = Constant::create(ov::element::i64, ov::Shape{1}, {1});
+  auto axis = Constant::create(ov::element::i64, ov::Shape{1}, {-1});
+  auto slice_past = std::make_shared<Slice>(probs, start0, stop0, step, axis);
+
+  auto start1 = Constant::create(ov::element::i64, ov::Shape{1}, {s_past});
+  auto stop1 = Constant::create(ov::element::i64, ov::Shape{1}, {s_kv});
+  auto slice_cur = std::make_shared<Slice>(probs, start1, stop1, step, axis);
+
+  auto pv_cache = std::make_shared<MatMul>(slice_past, v_cache, false, true);
+  auto pv_slice = std::make_shared<MatMul>(slice_cur, v_slice, false, true);
+  auto out = std::make_shared<Add>(pv_cache, pv_slice);
+
+  auto result = std::make_shared<ov::op::v0::Result>(out);
+  return std::make_shared<ov::Model>(
+      ov::ResultVector{result},
+      ov::ParameterVector{q, k_cache, k_slice, v_cache, v_slice, mask},
+      "split_cache_attention");
+}
+
+template <typename T>
+size_t CountOps(const std::shared_ptr<ov::Model>& model) {
+  size_t n = 0;
+  for (const auto& node : model->get_ops()) {
+    if (std::dynamic_pointer_cast<T>(node)) {
+      ++n;
+    }
+  }
+  return n;
+}
+
+std::shared_ptr<ov::op::v13::ScaledDotProductAttention> FindSdpa(
+    const std::shared_ptr<ov::Model>& model) {
+  for (const auto& node : model->get_ops()) {
+    if (auto sdpa =
+            std::dynamic_pointer_cast<ov::op::v13::ScaledDotProductAttention>(
+                node)) {
+      return sdpa;
+    }
+  }
+  return nullptr;
+}
+
+// Fills |tensor| with deterministic pseudo-random values in [-1, 1).
+void FillRandom(ov::Tensor tensor, uint32_t seed) {
+  auto* data = tensor.data<float>();
+  // Simple LCG so the test is self-contained and reproducible.
+  uint64_t state = seed * 2654435761u + 1u;
+  for (size_t i = 0; i < tensor.get_size(); ++i) {
+    state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+    data[i] = static_cast<float>((state >> 40) & 0xFFFF) / 32768.0f - 1.0f;
+  }
+}
+
+// Negative: when the K_cache (or V_cache) tensor is consumed by something
+// outside this attention block — typical of layers that share a single KV
+// cache across heads/layers — fusing in place would rewrite what the other
+// consumer sees. The pass must skip such blocks.
+TEST(FuseSplitAttentionToSDPATest, DoesNotFuseSharedKvCache) {
+  auto model = BuildSplitCacheAttention(/*s_past=*/8, /*s_cur=*/8);
+  // BuildSplitCacheAttention orders parameters as
+  //   {q, k_cache, k_slice, v_cache, v_slice, mask}.
+  // Add an extra Result that consumes k_cache directly, so K_cache now feeds
+  // two inputs (the qk_cache MatMul and this Result) — HasSingleConsumer
+  // returns false and the matcher must bail out.
+  auto k_cache = model->get_parameters()[1];
+  model->add_results({std::make_shared<ov::op::v0::Result>(k_cache)});
+
+  NpuOptimizer()
+      .SetCastIntegerSignToFloat(false)
+      .SetFuseSplitAttentionToSDPA(true)
+      .Run(model);
+
+  EXPECT_EQ(CountOps<ov::op::v13::ScaledDotProductAttention>(model), 0u);
+  EXPECT_EQ(CountOps<ov::op::v0::MatMul>(model), 4u);
+}
+
+TEST(FuseSplitAttentionToSDPATest, FusesSplitCachePattern) {
+  auto model = BuildSplitCacheAttention(/*s_past=*/8, /*s_cur=*/8);
+
+  // Precondition: 4 MatMuls, 1 Softmax, no SDPA.
+  EXPECT_EQ(CountOps<ov::op::v0::MatMul>(model), 4u);
+  EXPECT_EQ(CountOps<ov::op::v8::Softmax>(model), 1u);
+  EXPECT_EQ(CountOps<ov::op::v13::ScaledDotProductAttention>(model), 0u);
+
+  NpuOptimizer()
+      .SetCastIntegerSignToFloat(false)
+      .SetFuseSplitAttentionToSDPA(true)
+      .Run(model);
+
+  // Postcondition: the four attention MatMuls and the Softmax are gone,
+  // replaced by exactly one ScaledDotProductAttention op.
+  EXPECT_EQ(CountOps<ov::op::v13::ScaledDotProductAttention>(model), 1u);
+  EXPECT_EQ(CountOps<ov::op::v8::Softmax>(model), 0u);
+  EXPECT_EQ(CountOps<ov::op::v0::MatMul>(model), 0u);
+}
+
+// End-to-end numerical check: the fused SDPA must produce the same output as
+// the original split-cache graph for the same inputs. Uses a decode shape
+// (s_past=7, s_cur=1) so the V_cache [B,H,D,S] / V_slice [B,H,D,1] transpose
+// path is exercised.
+TEST(FuseSplitAttentionToSDPATest, NumericallyMatchesSplitCache) {
+  auto reference = BuildSplitCacheAttention(/*s_past=*/7, /*s_cur=*/1);
+  // Deep-copy before mutating so we can run both versions on identical inputs.
+  auto fused = reference->clone();
+
+  NpuOptimizer()
+      .SetCastIntegerSignToFloat(false)
+      .SetFuseSplitAttentionToSDPA(true)
+      .Run(fused);
+  ASSERT_NE(FindSdpa(fused), nullptr) << "fusion did not fire";
+
+  ov::Core core;
+  auto ref_compiled = core.compile_model(reference, "CPU");
+  auto fused_compiled = core.compile_model(fused, "CPU");
+  auto ref_req = ref_compiled.create_infer_request();
+  auto fused_req = fused_compiled.create_infer_request();
+
+  // Same input tensors fed to both. Inputs are ordered as constructed:
+  // {q, k_cache, k_slice, v_cache, v_slice, mask}.
+  const size_t num_inputs = reference->inputs().size();
+  ASSERT_EQ(num_inputs, fused->inputs().size());
+  std::vector<ov::Tensor> inputs;
+  for (size_t i = 0; i < num_inputs; ++i) {
+    const auto& port = reference->input(i);
+    ov::Tensor t(port.get_element_type(), port.get_shape());
+    FillRandom(t, static_cast<uint32_t>(i + 1));
+    inputs.push_back(t);
+    ref_req.set_input_tensor(i, t);
+    fused_req.set_input_tensor(i, t);
+  }
+
+  ref_req.infer();
+  fused_req.infer();
+
+  auto ref_out = ref_req.get_output_tensor(0);
+  auto fused_out = fused_req.get_output_tensor(0);
+  ASSERT_EQ(ref_out.get_size(), fused_out.get_size());
+  const auto* a = ref_out.data<float>();
+  const auto* b = fused_out.data<float>();
+  float max_abs_diff = 0.0f;
+  for (size_t i = 0; i < ref_out.get_size(); ++i) {
+    max_abs_diff = std::max(max_abs_diff, std::abs(a[i] - b[i]));
+    ASSERT_FALSE(std::isnan(b[i])) << "fused output has NaN at " << i;
+  }
+  EXPECT_LT(max_abs_diff, 1e-4f)
+      << "fused output diverges from split-cache reference";
+}
+
+}  // namespace
+}  // namespace openvino
+}  // namespace litert

--- a/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
+++ b/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
@@ -75,6 +75,19 @@ OpenVinoCompileContext::OpenVinoCompileContext() {
         context.eliminate_fq_after_matmul_ = (value == "true");
         continue;
       }
+      if (key == "fuse_split_attention_to_sdpa") {
+        LITERT_LOG(LITERT_INFO,
+                   "Custom config: fuse_split_attention_to_sdpa = %s",
+                   value.c_str());
+        context.fuse_split_attention_to_sdpa_ = (value == "true");
+        continue;
+      }
+      if (key == "sdpa_pad_kv_to_alignment") {
+        LITERT_LOG(LITERT_INFO, "Custom config: sdpa_pad_kv_to_alignment = %s",
+                   value.c_str());
+        context.sdpa_pad_kv_to_alignment_ = (value == "true");
+        continue;
+      }
       context.configs_map_[key] = value;
       LITERT_LOG(LITERT_INFO, "Custom config: %s = %s", key.c_str(),
                  value.c_str());
@@ -125,6 +138,8 @@ void OpenVinoCompileContext::OptimizeModel(
   if (device_ == "NPU") {
     NpuOptimizer()
         .SetEliminateMatMulFakeQuantize(eliminate_fq_after_matmul_)
+        .SetFuseSplitAttentionToSDPA(fuse_split_attention_to_sdpa_)
+        .SetSdpaPadKvToAlignment(sdpa_pad_kv_to_alignment_)
         .Run(model);
   }
 }

--- a/litert/vendors/intel_openvino/compiler/openvino_compile_context.h
+++ b/litert/vendors/intel_openvino/compiler/openvino_compile_context.h
@@ -58,6 +58,12 @@ class OpenVinoCompileContext {
   std::string device_ = "NPU";
   ov::AnyMap configs_map_;
   bool eliminate_fq_after_matmul_ = false;
+  bool fuse_split_attention_to_sdpa_ = false;
+  // `sdpa_pad_kv_to_alignment_` is only meaningful when
+  // `fuse_split_attention_to_sdpa_` is true and enabled by default. It controls
+  // whether the `FuseSplitAttentionToSDPA` pass pads KV sequences up to the NPU
+  // SDPA kernel's required alignment when fusing.
+  bool sdpa_pad_kv_to_alignment_ = true;
 };
 
 }  // namespace openvino


### PR DESCRIPTION
  Fuse Gemma-style split-attention (separate QK against KV cache and
  the new step's KV, merged via Concat) into a single
  ov::op::v13::ScaledDotProductAttention to enable the NPU NCE path.

  Disabled by default; enabled via the "fuse_split_attention_to_sdpa"
  custom config key on IntelOpenVinoOptions.

  Add test coverage for the pass.