### PR TITLE
Qualcomm AI Engine Direct - Fix missing downvote handling issue.

### DIFF
--- a/litert/vendors/qualcomm/core/backends/htp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.cc
@@ -235,18 +235,34 @@ class HtpBackend::HtpPerfControl {
       case HtpPerformanceMode::kBurst:
       case HtpPerformanceMode::kSustainedHighPerformance:
       case HtpPerformanceMode::kHighPerformance:
-      case HtpPerformanceMode::kBalanced:
         SetPowerConfigs(down_vote_power_configs_, power_config_id_,
                         PowerConfig::kDcvsEnable,
                         QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_ADJUST_UP_DOWN,
-                        PowerConfig::kSleepMaxLatency,
-                        DCVS_VOLTAGE_VCORNER_SVS2, DCVS_VOLTAGE_VCORNER_SVS,
-                        DCVS_VOLTAGE_VCORNER_SVS, DCVS_VOLTAGE_VCORNER_SVS2,
-                        DCVS_VOLTAGE_VCORNER_SVS, DCVS_VOLTAGE_VCORNER_SVS);
+                        PowerConfig::kSleepHighLatency,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER);
+        break;
+      case HtpPerformanceMode::kBalanced:
+        SetPowerConfigs(down_vote_power_configs_, power_config_id_,
+                        PowerConfig::kDcvsEnable,
+                        QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_POWER_SAVER_MODE,
+                        PowerConfig::kSleepHighLatency,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
+                        DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER);
         break;
       case HtpPerformanceMode::kPowerSaver:
       case HtpPerformanceMode::kLowPowerSaver:
       case HtpPerformanceMode::kHighPowerSaver:
+      case HtpPerformanceMode::kLowBalanced:
+      case HtpPerformanceMode::kExtremePowerSaver:
         SetPowerConfigs(down_vote_power_configs_, power_config_id_,
                         PowerConfig::kDcvsEnable,
                         QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_POWER_SAVER_MODE,
@@ -257,25 +273,6 @@ class HtpBackend::HtpPerfControl {
                         DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
                         DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER,
                         DCVS_VOLTAGE_VCORNER_MIN_VOLTAGE_CORNER);
-        break;
-      case HtpPerformanceMode::kLowBalanced:
-        SetPowerConfigs(down_vote_power_configs_, power_config_id_,
-                        PowerConfig::kDcvsEnable,
-                        QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_POWER_SAVER_MODE,
-                        PowerConfig::kSleepMaxLatency,
-                        DCVS_VOLTAGE_VCORNER_SVS2, DCVS_VOLTAGE_VCORNER_SVS,
-                        DCVS_VOLTAGE_VCORNER_SVS, DCVS_VOLTAGE_VCORNER_SVS2,
-                        DCVS_VOLTAGE_VCORNER_SVS, DCVS_VOLTAGE_VCORNER_SVS);
-        break;
-      case HtpPerformanceMode::kExtremePowerSaver:
-        SetPowerConfigs(
-            down_vote_power_configs_, power_config_id_,
-            PowerConfig::kDcvsEnable,
-            QNN_HTP_PERF_INFRASTRUCTURE_POWERMODE_POWER_SAVER_MODE,
-            PowerConfig::kSleepMaxLatency, DCVS_VOLTAGE_CORNER_DISABLE,
-            DCVS_VOLTAGE_CORNER_DISABLE, DCVS_VOLTAGE_CORNER_DISABLE,
-            DCVS_VOLTAGE_CORNER_DISABLE, DCVS_VOLTAGE_CORNER_DISABLE,
-            DCVS_VOLTAGE_CORNER_DISABLE);
         break;
       default:
         QNN_LOG_ERROR(

--- a/litert/vendors/qualcomm/dispatch/dispatch_api.cc
+++ b/litert/vendors/qualcomm/dispatch/dispatch_api.cc
@@ -51,8 +51,9 @@ namespace {
 using ::litert::qnn::QnnManager;
 
 static std::unique_ptr<QnnManager>& QnnManagerStorage() {
-  static absl::NoDestructor<std::unique_ptr<QnnManager>> storage;
-  return *storage;
+  // TODO(jiunkaiy): Apply absl::NoDestructor if we can bypass the downvote.
+  static std::unique_ptr<QnnManager> storage;
+  return storage;
 }
 
 QnnManager& Qnn() { return *QnnManagerStorage(); }

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -133,8 +133,6 @@ Expected<absl::Span<const QnnSystemInterface_t*>> LoadSystemProvidersFromLib(
 
 }  // namespace
 
-QnnManager::~QnnManager() = default;
-
 LiteRtStatus QnnManager::LoadLib(absl::string_view path) {
   auto saver_output_dir = options_.GetSaverOutputDir();
   const bool needs_global_symbols = !options_.GetCustomOpPackage().name.empty();

--- a/litert/vendors/qualcomm/qnn_manager.h
+++ b/litert/vendors/qualcomm/qnn_manager.h
@@ -116,8 +116,6 @@ class QnnManager {
                       QnnSystemContext_FreeFn_t>;
   class ContextHandle;
 
-  ~QnnManager();
-
   static Expected<Ptr> Create(
       const ::qnn::Options& options,
       std::optional<std::string> shared_library_dir = std::nullopt,


### PR DESCRIPTION
Summary:
- Remove absl::NoDestructor, so the manager (and its down-vote inside ~HtpPerfControl) actually runs at process exit.
- Drop the unnecessary ~QnnManager() = default.
- Re-bucket performance modes and switch all down-vote corners to MIN_VOLTAGE_CORNER.