### PR TITLE
Qualcomm AI Engine Direct - Support A8W2 FC.

### DIFF
--- a/litert/vendors/qualcomm/BUILD
+++ b/litert/vendors/qualcomm/BUILD
@@ -165,6 +165,7 @@ cc_library(
         "//litert/c/internal:litert_logging",
         "//litert/cc:litert_expected",
         "//litert/cc:litert_macros",
+        "//litert/vendors/qualcomm/core:common",
         "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
         "@qairt//:qnn_lib_headers",
     ],

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -458,9 +458,8 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
 
     std::vector<::qnn::OpWrapper> op_wrappers;
     LITERT_RETURN_IF_ERROR(litert::qnn::ConvertOp(
-        compiler_plugin->Options().GetUseInt64BiasAsInt32(),
-        compiler_plugin->Options().GetCustomOpPackage(), op, tensor_pool,
-        input_tensors, output_tensors, op_wrappers));
+        compiler_plugin->Options(), op, tensor_pool, input_tensors,
+        output_tensors, op_wrappers, qnn_manager->GetSdkVersion()));
 
     // Empty op_wrappers means the op is not supported by QNN.
     if (op_wrappers.empty()) {

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -371,20 +371,29 @@ using OpBuilder = LiteRtStatus (*)(
     const litert::compiler::Op& litert_op, ::qnn::TensorPool& tensor_pool,
     std::vector<::qnn::TensorWrapperRef>& input_tensors,
     std::vector<::qnn::TensorWrapperRef>& output_tensors,
-    std::vector<::qnn::OpWrapper>& op_wrappers, bool use_int64_bias_as_int32);
+    std::vector<::qnn::OpWrapper>& op_wrappers, bool use_int64_bias_as_int32,
+    ::qnn::SdkVersion sdk_version);
 
 // Wrapper to call the op builder with or without the bias parameter.
 template <auto F>
 LiteRtStatus Adapt(const litert::compiler::Op& op, ::qnn::TensorPool& tp,
                    std::vector<::qnn::TensorWrapperRef>& in,
                    std::vector<::qnn::TensorWrapperRef>& out,
-                   std::vector<::qnn::OpWrapper>& ow, bool bias) {
+                   std::vector<::qnn::OpWrapper>& ow, bool bias,
+                   ::qnn::SdkVersion sdk_version) {
   if constexpr (std::is_invocable_v<decltype(F), const litert::compiler::Op&,
                                     ::qnn::TensorPool&,
                                     std::vector<::qnn::TensorWrapperRef>&,
                                     std::vector<::qnn::TensorWrapperRef>&,
                                     std::vector<::qnn::OpWrapper>&, bool>) {
     return F(op, tp, in, out, ow, bias);
+  } else if constexpr (std::is_invocable_v<
+                           decltype(F), const litert::compiler::Op&,
+                           ::qnn::TensorPool&,
+                           std::vector<::qnn::TensorWrapperRef>&,
+                           std::vector<::qnn::TensorWrapperRef>&,
+                           std::vector<::qnn::OpWrapper>&, bool, ::qnn::SdkVersion>) {
+    return F(op, tp, in, out, ow, bias, sdk_version);
   } else {
     return F(op, tp, in, out, ow);
   }
@@ -626,7 +635,8 @@ LiteRtStatus BuildFullyConnectedOp(
     const litert::compiler::Op& litert_op, ::qnn::TensorPool& tensor_pool,
     std::vector<::qnn::TensorWrapperRef>& input_tensors,
     std::vector<::qnn::TensorWrapperRef>& output_tensors,
-    std::vector<::qnn::OpWrapper>& op_wrappers, bool use_int64_bias_as_int32) {
+    std::vector<::qnn::OpWrapper>& op_wrappers, bool use_int64_bias_as_int32,
+    ::qnn::SdkVersion sdk_version) {
   uint32_t fused_activation{};
   LITERT_RETURN_IF_ERROR(LiteRtGetFullyConnectedFusedActivationOption(
       litert_op.Get(), &fused_activation));
@@ -636,9 +646,9 @@ LiteRtStatus BuildFullyConnectedOp(
 
   auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
       tensor_pool, fused_activation, output_tensors);
-  op_wrappers = ::qnn::BuildFullyConnectedOp(tensor_pool, input_tensors,
-                                             {activation_input}, keep_num_dims,
-                                             use_int64_bias_as_int32);
+  op_wrappers = ::qnn::BuildFullyConnectedOp(
+      tensor_pool, input_tensors, {activation_input}, keep_num_dims,
+      use_int64_bias_as_int32, sdk_version);
   ::qnn::AddFusedActivationNode(op_wrappers, fused_activation, activation_input,
                                 output_tensors[0]);
   return kLiteRtStatusOk;
@@ -1562,23 +1572,23 @@ LiteRtStatus BuildCustomOp(const litert::compiler::Op& litert_op,
 
 }  // namespace
 
-LiteRtStatus ConvertOp(const bool use_int64_bias_as_int32,
-                       const ::qnn::CustomOpPackage& custom_op_package,
+LiteRtStatus ConvertOp(const ::qnn::Options& options,
                        const litert::compiler::Op& litert_op,
                        ::qnn::TensorPool& tensor_pool,
                        std::vector<::qnn::TensorWrapperRef>& input_tensors,
                        std::vector<::qnn::TensorWrapperRef>& output_tensors,
-                       std::vector<::qnn::OpWrapper>& op_wrappers) {
+                       std::vector<::qnn::OpWrapper>& op_wrappers,
+                       ::qnn::SdkVersion sdk_version) {
   const auto& builders = GetOpBuilders();
   const auto op_code = litert_op.Code();
   if (op_code < builders.size() && builders[op_code]) {
     return builders[op_code](litert_op, tensor_pool, input_tensors,
                              output_tensors, op_wrappers,
-                             use_int64_bias_as_int32);
+                             options.GetUseInt64BiasAsInt32(), sdk_version);
   }
   if (op_code == kLiteRtOpCodeTflCustom) {
     return BuildCustomOp(litert_op, tensor_pool, input_tensors, output_tensors,
-                         op_wrappers, custom_op_package);
+                         op_wrappers, options.GetCustomOpPackage());
   }
   LITERT_LOG(LITERT_ERROR,
              "LiteRT Op Code: %d is not supported in Qualcomm Compiler.",
@@ -1697,9 +1707,9 @@ LiteRtStatus MapGraph(const LiteRtCompilerContext* ctx, QnnManager& qnn,
     }
 
     std::vector<::qnn::OpWrapper> op_wrappers;
-    LITERT_RETURN_IF_ERROR(ConvertOp(
-        options.GetUseInt64BiasAsInt32(), options.GetCustomOpPackage(), op,
-        tensor_pool, input_tensors, output_tensors, op_wrappers));
+    LITERT_RETURN_IF_ERROR(ConvertOp(options, op, tensor_pool, input_tensors,
+                                     output_tensors, op_wrappers,
+                                     qnn.GetSdkVersion()));
     for (auto& op_wrapper : op_wrappers) {
       // Add litert op id to qnn op name to preserve op mapping
       op_wrapper.AddSuffixToName(

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
@@ -42,13 +42,13 @@ LiteRtStatus ConvertTensor(
     const absl::flat_hash_set<std::int32_t>& ids_to_dump = {},
     bool is_tensor_output = false);
 
-LiteRtStatus ConvertOp(bool use_int64_bias_as_int32,
-                       const ::qnn::CustomOpPackage& custom_op_package,
+LiteRtStatus ConvertOp(const ::qnn::Options& options,
                        const litert::compiler::Op& litert_op,
                        ::qnn::TensorPool& tensor_pool,
                        std::vector<::qnn::TensorWrapperRef>& input_tensors,
                        std::vector<::qnn::TensorWrapperRef>& output_tensors,
-                       std::vector<::qnn::OpWrapper>& op_wrappers);
+                       std::vector<::qnn::OpWrapper>& op_wrappers,
+                       ::qnn::SdkVersion sdk_version);
 
 // Composes a new QNN Graph from given LiteRt Graph. Qnn Graph is written to
 // context behind "qnn". Uses given graph_name to name entry point.

--- a/litert/vendors/qualcomm/context_binary_info.cc
+++ b/litert/vendors/qualcomm/context_binary_info.cc
@@ -22,6 +22,7 @@
 #include "litert/c/litert_common.h"
 #include "litert/cc/litert_expected.h"
 #include "litert/cc/litert_macros.h"
+#include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
 #include "litert/vendors/qualcomm/qnn_manager.h"
 #include "QnnCommon.h"  // from @qairt
@@ -201,10 +202,13 @@ Expected<ContextBinaryInfo> ContextBinaryInfo::Create(
   }
 
   // Compare the context binary's version against the current SDK version.
-  SdkVersion binary_version;
-  LITERT_ASSIGN_OR_RETURN(
-      binary_version,
-      QnnManager::ParseSdkVersion(binary_info->contextBinaryInfoV1.buildId));
+  auto parsed_binary_version =
+      ::qnn::ParseSdkVersion(binary_info->contextBinaryInfoV1.buildId);
+  if (!parsed_binary_version) {
+    return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                      "Failed to parse build ID");
+  }
+  const ::qnn::SdkVersion binary_version = *parsed_binary_version;
   const auto sdk_version = qnn.GetSdkVersion();
   if (binary_version > sdk_version) {
     LITERT_LOG(LITERT_ERROR,

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
     # copybara:uncomment default_applicable_licenses = ["@org_tensorflow//tensorflow:license"],
@@ -88,6 +89,7 @@ cc_library(
     hdrs = ["fully_connected_op_builder.h"],
     deps = [
         ":op_builder",
+        "//litert/vendors/qualcomm/core:common",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/utils:log",
         "//litert/vendors/qualcomm/core/utils:miscs",

--- a/litert/vendors/qualcomm/core/builders/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/builders/CMakeLists.txt
@@ -77,6 +77,7 @@ target_include_directories(qnn_builders
 
 target_link_libraries(qnn_builders
     PRIVATE
+        qnn_common
         qnn_log
         qnn_miscs
         qnn_tensor_pool

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/utils/log.h"
 #include "litert/vendors/qualcomm/core/utils/miscs.h"
@@ -27,22 +28,18 @@ constexpr int kBiasIdx = 2;
 std::vector<OpWrapper> BuildFullyConnectedOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs, const bool keep_num_dims,
-    bool use_int64_bias_as_int32) {
+    bool use_int64_bias_as_int32, SdkVersion sdk_version) {
   std::vector<OpWrapper> res;
   OpWrapper& fully_connected_op = CreateOpWrapper(res, QNN_OP_FULLY_CONNECTED);
 
-  TensorWrapper& input_tensor = inputs[0];
+  const TensorWrapper& input_tensor = inputs[0];
   fully_connected_op.AddInputTensor(input_tensor);
 
   TensorWrapper& weight_tensor = inputs[1];
-  // TODO (chunhsue-qti): Treat a8w2 as a8w4, 2-bit quant weight tensor is
-  // QNN_DATATYPE_SFIXED_POINT_8 with bitwidth 2. Remove this after a8w2 is
-  // supported.
-
-  // Check input tensor is QNN_DATATYPE_SFIXED_POINT_8 so that a16w2 will be
-  // intact.
+  // Treat a8w2 as a8w4 if sdk version < 2.47.0.
   if (input_tensor.IsQuantI8() && weight_tensor.IsQuantI8() &&
-      weight_tensor.IsQuantBitwidth(kQuantBitWidth2)) {
+      weight_tensor.IsQuantBitwidth(kQuantBitWidth2) &&
+      sdk_version < SdkVersion{2, 47, 0}) {
     QNN_LOG_WARNING(
         "Aggressively convert the a8w2 Fully Connected Op to a8w4.");
     weight_tensor.SetQuantBitwidth(kQuantBitWidth4);
@@ -50,7 +47,7 @@ std::vector<OpWrapper> BuildFullyConnectedOp(
   fully_connected_op.AddInputTensor(weight_tensor);
 
   if (inputs.size() - 1 >= kBiasIdx) {
-    TensorWrapper& bias_tensor = inputs[kBiasIdx];
+    const TensorWrapper& bias_tensor = inputs[kBiasIdx];
     if (use_int64_bias_as_int32 && bias_tensor.IsTensorStatic() &&
         bias_tensor.GetDataType() == QNN_DATATYPE_INT_64) {
       auto* converted_bias_tensor =
@@ -66,7 +63,7 @@ std::vector<OpWrapper> BuildFullyConnectedOp(
     }
   }
 
-  TensorWrapper& output_tensor = outputs[0];
+  const TensorWrapper& output_tensor = outputs[0];
   if (keep_num_dims) {
     auto& input_dims = input_tensor.GetDimensions();
     std::uint32_t input_size = std::accumulate(

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 
+#include "litert/vendors/qualcomm/core/common.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 #include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
@@ -15,7 +16,7 @@ namespace qnn {
 std::vector<OpWrapper> BuildFullyConnectedOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs, const bool keep_num_dims,
-    bool use_int64_bias_as_int32);
+    bool use_int64_bias_as_int32, ::qnn::SdkVersion sdk_version);
 
 }  // namespace qnn
 

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -6,7 +6,11 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>
+#include <charconv>
+#include <optional>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include <vector>
 
 
@@ -582,5 +586,41 @@ std::string Options::Dump() const {
 }
 
 QnnLog_Callback_t GetDefaultStdOutLogger() { return DefaultStdOutLogger; }
+
+std::optional<SdkVersion> ParseSdkVersion(const char* build_id) {
+  if (!build_id) return std::nullopt;
+
+  std::string_view version_str = build_id;
+
+  // Check for and remove the 'v' prefix.
+  if (version_str.empty() || version_str.front() != 'v') {
+    return std::nullopt;
+  }
+  version_str.remove_prefix(1);
+
+  SdkVersion version{};
+  const char* current = version_str.data();
+  const char* const end = version_str.data() + version_str.size();
+
+  auto parse_component = [&current, &end](int& component) {
+    auto [ptr, ec] = std::from_chars(current, end, component);
+    if (ec != std::errc()) {
+      return false;
+    }
+    current = ptr;
+    return true;
+  };
+
+  // Parse major, minor, and patch versions, checking for dots in between.
+  if (!parse_component(version.major)) return std::nullopt;
+
+  if (current == end || *current++ != '.') return std::nullopt;
+  if (!parse_component(version.minor)) return std::nullopt;
+
+  if (current == end || *current++ != '.') return std::nullopt;
+  if (!parse_component(version.patch)) return std::nullopt;
+
+  return version;
+}
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -5,7 +5,9 @@
 #define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_COMMON_H_
 
 #include <cstdint>
+#include <optional>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "absl/strings/string_view.h"  // from @com_google_absl
@@ -230,6 +232,43 @@ class Options {
 // Gets a default logger implementation to stdout.
 // This is used when initializing qnn logging.
 QnnLog_Callback_t GetDefaultStdOutLogger();
+
+struct SdkVersion {
+  int major = 0;
+  int minor = 0;
+  int patch = 0;
+
+  friend constexpr bool operator==(const SdkVersion& lhs,
+                                   const SdkVersion& rhs) noexcept {
+    return std::tie(lhs.major, lhs.minor, lhs.patch) ==
+           std::tie(rhs.major, rhs.minor, rhs.patch);
+  }
+  friend constexpr bool operator!=(const SdkVersion& lhs,
+                                   const SdkVersion& rhs) noexcept {
+    return !(lhs == rhs);
+  }
+  friend constexpr bool operator<(const SdkVersion& lhs,
+                                  const SdkVersion& rhs) noexcept {
+    return std::tie(lhs.major, lhs.minor, lhs.patch) <
+           std::tie(rhs.major, rhs.minor, rhs.patch);
+  }
+  friend constexpr bool operator>(const SdkVersion& lhs,
+                                  const SdkVersion& rhs) noexcept {
+    return rhs < lhs;
+  }
+  friend constexpr bool operator<=(const SdkVersion& lhs,
+                                   const SdkVersion& rhs) noexcept {
+    return !(rhs < lhs);
+  }
+  friend constexpr bool operator>=(const SdkVersion& lhs,
+                                   const SdkVersion& rhs) noexcept {
+    return !(lhs < rhs);
+  }
+};
+
+// Parses a QNN build ID string of the form "vMAJOR.MINOR.PATCH" into an
+// SdkVersion. Returns std::nullopt on parsing failure.
+std::optional<SdkVersion> ParseSdkVersion(const char* build_id);
 
 }  // namespace qnn
 

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -354,5 +354,60 @@ TEST(QnnOptionTest, Default) {
   EXPECT_EQ(options.GetGpuPerformanceMode(), GpuPerformanceMode::kHigh);
 }
 
+struct SdkVersionTest : public ::testing::Test {
+  const SdkVersion v1_0_0{1, 0, 0};
+  const SdkVersion v1_0_1{1, 0, 1};
+  const SdkVersion v1_1_0{1, 1, 0};
+  const SdkVersion v2_0_0{2, 0, 0};
+};
+
+TEST_F(SdkVersionTest, HandlesEquality) {
+  SdkVersion v1_0_0_copy = v1_0_0;
+  EXPECT_EQ(v1_0_0, v1_0_0_copy);
+  EXPECT_NE(v1_0_0, v1_0_1);
+  EXPECT_NE(v1_0_0, v1_1_0);
+  EXPECT_NE(v1_0_0, v2_0_0);
+
+  EXPECT_TRUE(v1_0_0 == v1_0_0_copy);
+  EXPECT_FALSE(v1_0_0 == v1_0_1);
+
+  EXPECT_TRUE(v1_0_0 != v1_0_1);
+  EXPECT_FALSE(v1_0_0 != v1_0_0_copy);
+}
+
+TEST_F(SdkVersionTest, HandlesLessThan) {
+  EXPECT_LT(v1_0_0, v1_0_1);
+  EXPECT_LT(v1_0_1, v1_1_0);
+  EXPECT_LT(v1_1_0, v2_0_0);
+  EXPECT_FALSE(v1_0_0 < v1_0_0);
+  EXPECT_FALSE(v1_0_1 < v1_0_0);
+}
+
+TEST_F(SdkVersionTest, HandlesGreaterThan) {
+  EXPECT_GT(v1_0_1, v1_0_0);
+  EXPECT_GT(v1_1_0, v1_0_1);
+  EXPECT_GT(v2_0_0, v1_1_0);
+  EXPECT_FALSE(v1_0_0 > v1_0_0);
+  EXPECT_FALSE(v1_0_0 > v1_0_1);
+}
+
+TEST_F(SdkVersionTest, HandlesLessThanOrEqual) {
+  SdkVersion v1_0_0_copy = v1_0_0;
+  EXPECT_LE(v1_0_0, v1_0_0_copy);
+  EXPECT_LE(v1_0_0, v1_0_1);
+  EXPECT_LE(v1_0_1, v1_1_0);
+  EXPECT_LE(v1_1_0, v2_0_0);
+  EXPECT_FALSE(v1_0_1 <= v1_0_0);
+}
+
+TEST_F(SdkVersionTest, HandlesGreaterThanOrEqual) {
+  SdkVersion v1_0_0_copy = v1_0_0;
+  EXPECT_GE(v1_0_0, v1_0_0_copy);
+  EXPECT_GE(v1_0_1, v1_0_0);
+  EXPECT_GE(v1_1_0, v1_0_1);
+  EXPECT_GE(v2_0_0, v1_1_0);
+  EXPECT_FALSE(v1_0_0 >= v1_0_1);
+}
+
 }  // namespace
 }  // namespace qnn

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/fully_connected_int2_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/fully_connected_int2_test.cc
@@ -43,8 +43,9 @@ TEST_P(QnnModelTest, FullyConnectedA16W2Sanity) {
       QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, kFilterDims,
       int2_weight_data.size(), int2_weight_data.data());
 
-  auto ops = ::qnn::BuildFullyConnectedOp(
-      tensor_pool_, {input_0, weight_tensor}, {output_0}, true, false);
+  auto ops =
+      ::qnn::BuildFullyConnectedOp(tensor_pool_, {input_0, weight_tensor},
+                                   {output_0}, true, false, {2, 46, 0});
   ASSERT_FALSE(ops.empty());
 
   qnn_model_.MoveOpsToGraph(std::move(ops));
@@ -74,7 +75,7 @@ TEST_P(QnnModelTest, FullyConnectedA16W2Sanity) {
                                 ::qnn::Quantize<int16_t>(-0.001, kScale, 0)}));
 }
 
-TEST_P(QnnModelTest, FullyConnectedA8W2Sanity) {
+TEST_P(QnnModelTest, FullyConnectedA8W2AsA8W4Sanity) {
   constexpr float kScale = 0.01;
 
   auto input_quant = ::qnn::ScaleOffsetQuantizeParamsWrapper(kScale, 0);
@@ -98,8 +99,9 @@ TEST_P(QnnModelTest, FullyConnectedA8W2Sanity) {
       QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, kFilterDims,
       int2_weight_data.size(), int2_weight_data.data());
 
-  auto ops = ::qnn::BuildFullyConnectedOp(
-      tensor_pool_, {input_0, weight_tensor}, {output_0}, true, false);
+  auto ops =
+      ::qnn::BuildFullyConnectedOp(tensor_pool_, {input_0, weight_tensor},
+                                   {output_0}, true, false, {2, 46, 0});
   ASSERT_FALSE(ops.empty());
 
   qnn_model_.MoveOpsToGraph(std::move(ops));
@@ -129,7 +131,7 @@ TEST_P(QnnModelTest, FullyConnectedA8W2Sanity) {
                                 ::qnn::Quantize<int8_t>(-0.01, kScale, 0)}));
 }
 
-TEST_P(QnnModelTest, FullyConnectedA8W2BwAxisScaleOffsetSanity) {
+TEST_P(QnnModelTest, FullyConnectedA8W2AsA8W4BwAxisScaleOffsetSanity) {
   constexpr float kScale = 0.01;
 
   auto input_quant = ::qnn::ScaleOffsetQuantizeParamsWrapper(kScale, 0);
@@ -155,8 +157,9 @@ TEST_P(QnnModelTest, FullyConnectedA8W2BwAxisScaleOffsetSanity) {
       QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, kFilterDims,
       int2_weight_data.size(), int2_weight_data.data());
 
-  auto ops = ::qnn::BuildFullyConnectedOp(
-      tensor_pool_, {input_0, weight_tensor}, {output_0}, true, false);
+  auto ops =
+      ::qnn::BuildFullyConnectedOp(tensor_pool_, {input_0, weight_tensor},
+                                   {output_0}, true, false, {2, 46, 0});
   ASSERT_FALSE(ops.empty());
 
   qnn_model_.MoveOpsToGraph(std::move(ops));
@@ -184,6 +187,96 @@ TEST_P(QnnModelTest, FullyConnectedA8W2BwAxisScaleOffsetSanity) {
       output_data.value(),
       Pointwise(testing::Eq(), {::qnn::Quantize<int8_t>(0.01, kScale, 0),
                                 ::qnn::Quantize<int8_t>(-0.02, kScale, 0)}));
+}
+
+TEST_P(QnnModelTest, FullyConnectedA8W2Sanity) {
+  static constexpr float kScale{0.01};
+
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kQuant{kScale, 0};
+  const std::vector<std::uint32_t> kInOutDims{1, 2};
+
+  auto& input_0 = tensor_pool_.CreateInputTensorWithName(
+      "in_0", QNN_DATATYPE_SFIXED_POINT_8, kQuant, kInOutDims);
+  auto& output_0 = tensor_pool_.CreateOutputTensorWithName(
+      "out_0", QNN_DATATYPE_SFIXED_POINT_8, kQuant, kInOutDims);
+
+  const std::vector<std::uint32_t> kFilterDims{2, 2};
+  const auto kWeightQuantParam =
+      ::qnn::BwScaleOffsetQuantizeParamsWrapper{2, kScale, 0};
+
+  const std::vector<int8_t> kWeightData{1, -1, -1, 1};
+  std::vector<int8_t> int2_weight_data;
+  ::qnn::ConvertDataFromInt8ToInt2(kWeightData, int2_weight_data);
+  auto& weight_tensor = tensor_pool_.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, kWeightQuantParam, kFilterDims,
+      int2_weight_data.size(), int2_weight_data.data());
+
+  auto ops =
+      ::qnn::BuildFullyConnectedOp(tensor_pool_, {input_0, weight_tensor},
+                                   {output_0}, true, false, {2, 47, 0});
+  ASSERT_FALSE(ops.empty());
+  ASSERT_TRUE(weight_tensor.IsQuantBitwidth(::qnn::kQuantBitWidth2));
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  // TODO(jiunkaiy): QAIRT 2.47 does not officially support A8W2 yet,
+  // but execution and verification work. Add ValidateOpConfig() once support is
+  // enabled.
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_0);
+  auto output_idx = qnn_model_.AddOutputTensor(output_0);
+
+  const static std::array<int8_t, 2> in_data{100, 0};
+  qnn_model_.SetInputData<int8_t>(input_idx, in_data);
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<int8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_EQ(output_data->size(), 2);
+  ASSERT_THAT(
+      output_data.value(),
+      Pointwise(testing::Eq(), {::qnn::Quantize<int8_t>(0.01, kScale, 0),
+                                ::qnn::Quantize<int8_t>(-0.01, kScale, 0)}));
+}
+
+TEST_P(QnnModelTest, FullyConnectedA8W2BwAxisScaleOffsetSanity) {
+  constexpr float kScale = 0.01;
+
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kQuant{kScale, 0};
+  const std::vector<std::uint32_t> kInDims{1, 2};
+  const std::vector<std::uint32_t> kOutDims{1, 2};
+
+  auto& input_0 = tensor_pool_.CreateInputTensorWithName(
+      "in_0", QNN_DATATYPE_SFIXED_POINT_8, kQuant, kInDims);
+  auto& output_0 = tensor_pool_.CreateOutputTensorWithName(
+      "out_0", QNN_DATATYPE_SFIXED_POINT_8, kQuant, kOutDims);
+
+  const std::vector<float> kWeightScales{kScale, 2 * kScale};
+  const std::vector<int32_t> kWeightOffsets{0, 0};
+  const ::qnn::BwAxisScaleOffsetQuantizeParamsWrapper weight_quant_param{
+      2, 0, kWeightScales, kWeightOffsets};
+
+  const std::vector<int8_t> kWeightData{1, -1, -1, 1};
+  std::vector<int8_t> int2_weight_data;
+  ::qnn::ConvertDataFromInt8ToInt2(kWeightData, int2_weight_data);
+  const std::vector<std::uint32_t> kFilterDims{2, 2};
+  auto& weight_tensor = tensor_pool_.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, weight_quant_param, kFilterDims,
+      int2_weight_data.size(), int2_weight_data.data());
+
+  const auto ops =
+      ::qnn::BuildFullyConnectedOp(tensor_pool_, {input_0, weight_tensor},
+                                   {output_0}, true, false, {2, 47, 0});
+  ASSERT_FALSE(ops.empty());
+  ASSERT_TRUE(weight_tensor.IsQuantBitwidth(::qnn::kQuantBitWidth2));
+  // TODO(jiunkaiy): Although this op passes in Gemma4, a single FC test cannot
+  // pass both validation and Finalize. Re-enable the remaining checks once this
+  // issue is fixed.
 }
 }  // namespace
 }  // namespace litert::qnn

--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -405,6 +405,7 @@ LiteRtStatus QnnManager::ValidateOp(::qnn::OpWrapper& op) {
   // TODO(jiunkaiy): Remove version check and break backward compatibility when
   // acceptable.
   const auto sdk_version = GetSdkVersion();
+  using ::qnn::SdkVersion;
   // Bypass RmsNorm OP validation.
   if (SdkVersion{2, 35, 0} <= sdk_version &&
       sdk_version < SdkVersion{2, 37, 0} &&
@@ -442,6 +443,19 @@ LiteRtStatus QnnManager::ValidateOp(::qnn::OpWrapper& op) {
         "SDK version is in [2.35.0, 2.37.0); Split OP validation is bypassed.");
     return kLiteRtStatusOk;
   }
+
+  if (op.IsOpCode(::qnn::QnnOpCode::kFullyConnected) &&
+      op.GetInputTensor(0).IsQuantI8() && op.GetInputTensor(1).IsQuantI8() &&
+      op.GetInputTensor(1).IsQuantBitwidth(::qnn::kQuantBitWidth2) &&
+      op.GetOutputTensor(0).IsQuantI8() &&
+      SdkVersion{2, 47, 0} <= sdk_version &&
+      sdk_version < SdkVersion{2, 48, 0}) {
+    LITERT_LOG(LITERT_WARNING,
+               "SDK version is in [2.47.0, 2.48.0); A8W2 FC OP validation is "
+               "bypassed.");
+    return kLiteRtStatusOk;
+  }
+
   const auto op_config = op.GetOpConfig();
   if (Qnn_ErrorHandle_t error =
           Api()->backendValidateOpConfig(BackendHandle(), op_config);
@@ -589,7 +603,12 @@ LiteRtStatus QnnManager::Init(std::optional<std::string> shared_library_dir,
   // Get SDK version from build ID.
   const char* build_id;
   Api()->backendGetBuildId(&build_id);
-  LITERT_ASSIGN_OR_RETURN(sdk_version_, ParseSdkVersion(build_id));
+  auto parsed_version = ::qnn::ParseSdkVersion(build_id);
+  if (!parsed_version) {
+    LITERT_LOG(LITERT_ERROR, "Failed to parse build ID", "");
+    return kLiteRtStatusErrorRuntimeFailure;
+  }
+  sdk_version_ = *parsed_version;
   return kLiteRtStatusOk;
 }
 
@@ -706,45 +725,6 @@ QnnManager::WeightSharingContextConfigs() {
   contextConfig.customConfig = &customConfig;
   static const QnnContext_Config_t* configs[2] = {&contextConfig, nullptr};
   return absl::MakeSpan(configs);
-}
-
-Expected<SdkVersion> QnnManager::ParseSdkVersion(const char* build_id) {
-  // A generic error to be returned on any parsing failure.
-  const auto parsing_error =
-      Unexpected(kLiteRtStatusErrorRuntimeFailure, "Failed to parse build ID");
-
-  std::string_view version_str = build_id;
-  if (!build_id) return parsing_error;
-
-  // Check for and remove the 'v' prefix.
-  if (version_str.empty() || version_str.front() != 'v') {
-    return parsing_error;
-  }
-  version_str.remove_prefix(1);
-
-  SdkVersion version{};
-  const char* current = version_str.data();
-  const char* const end = version_str.data() + version_str.size();
-
-  auto parse_component = [&current, &end](int& component) {
-    auto [ptr, ec] = std::from_chars(current, end, component);
-    if (ec != std::errc()) {
-      return false;
-    }
-    current = ptr;
-    return true;
-  };
-
-  // Parse major, minor, and patch versions, checking for dots in between.
-  if (!parse_component(version.major)) return parsing_error;
-
-  if (current == end || *current++ != '.') return parsing_error;
-  if (!parse_component(version.minor)) return parsing_error;
-
-  if (current == end || *current++ != '.') return parsing_error;
-  if (!parse_component(version.patch)) return parsing_error;
-
-  return version;
 }
 
 absl::Span<const QnnContext_Config_t*> QnnManager::GpuPerformanceContextConfigs(

--- a/litert/vendors/qualcomm/qnn_manager.h
+++ b/litert/vendors/qualcomm/qnn_manager.h
@@ -22,7 +22,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -74,37 +73,6 @@ namespace internal {
 std::string Dump(const QnnManager& qnn);
 
 }  // namespace internal
-
-struct SdkVersion {
-  int major, minor, patch;
-
-  friend constexpr bool operator==(const SdkVersion& lhs,
-                                   const SdkVersion& rhs) noexcept {
-    return std::tie(lhs.major, lhs.minor, lhs.patch) ==
-           std::tie(rhs.major, rhs.minor, rhs.patch);
-  }
-  friend constexpr bool operator!=(const SdkVersion& lhs,
-                                   const SdkVersion& rhs) noexcept {
-    return !(lhs == rhs);
-  }
-  friend constexpr bool operator<(const SdkVersion& lhs,
-                                  const SdkVersion& rhs) noexcept {
-    return std::tie(lhs.major, lhs.minor, lhs.patch) <
-           std::tie(rhs.major, rhs.minor, rhs.patch);
-  }
-  friend constexpr bool operator>(const SdkVersion& lhs,
-                                  const SdkVersion& rhs) noexcept {
-    return rhs < lhs;
-  }
-  friend constexpr bool operator<=(const SdkVersion& lhs,
-                                   const SdkVersion& rhs) noexcept {
-    return !(rhs < lhs);
-  }
-  friend constexpr bool operator>=(const SdkVersion& lhs,
-                                   const SdkVersion& rhs) noexcept {
-    return !(lhs < rhs);
-  }
-};
 
 class QnnManager {
   friend std::string internal::Dump(const QnnManager& qnn);
@@ -180,10 +148,7 @@ class QnnManager {
 
   const ::qnn::Options& GetOptions() const { return options_; }
 
-  // Gets SDK version from build ID.
-  static Expected<SdkVersion> ParseSdkVersion(const char* build_id);
-
-  SdkVersion GetSdkVersion() const { return sdk_version_; }
+  ::qnn::SdkVersion GetSdkVersion() const { return sdk_version_; }
 
   const ::qnn::SocInfo& GetSocInfo() const { return soc_info_; }
 
@@ -237,7 +202,7 @@ class QnnManager {
   ::qnn::SocInfo soc_info_ = ::qnn::kSocInfos[0];
   ::qnn::Options options_;
   std::optional<std::string> shared_library_dir_;
-  SdkVersion sdk_version_{};
+  ::qnn::SdkVersion sdk_version_{};
 };
 
 // Unfortunately we can't use std::unique_ptr with a deleter because

--- a/litert/vendors/qualcomm/qnn_manager_test.cc
+++ b/litert/vendors/qualcomm/qnn_manager_test.cc
@@ -27,7 +27,7 @@
 namespace {
 
 using ::litert::qnn::QnnManager;
-using ::litert::qnn::SdkVersion;
+using ::qnn::SdkVersion;
 using ::litert::qnn::internal::Dump;
 using ::testing::HasSubstr;
 
@@ -118,61 +118,6 @@ TEST(QnnManagerTest, GetSdkVersion) {
   const auto sdk_version = qnn.Value().get()->GetSdkVersion();
   static constexpr SdkVersion kInitSdkVersion{0, 0, 0};
   EXPECT_NE(sdk_version, kInitSdkVersion);
-}
-
-struct SdkVersionTest : public ::testing::Test {
-  const SdkVersion v1_0_0{1, 0, 0};
-  const SdkVersion v1_0_1{1, 0, 1};
-  const SdkVersion v1_1_0{1, 1, 0};
-  const SdkVersion v2_0_0{2, 0, 0};
-};
-
-TEST_F(SdkVersionTest, HandlesEquality) {
-  SdkVersion v1_0_0_copy = v1_0_0;
-  EXPECT_EQ(v1_0_0, v1_0_0_copy);
-  EXPECT_NE(v1_0_0, v1_0_1);
-  EXPECT_NE(v1_0_0, v1_1_0);
-  EXPECT_NE(v1_0_0, v2_0_0);
-
-  EXPECT_TRUE(v1_0_0 == v1_0_0_copy);
-  EXPECT_FALSE(v1_0_0 == v1_0_1);
-
-  EXPECT_TRUE(v1_0_0 != v1_0_1);
-  EXPECT_FALSE(v1_0_0 != v1_0_0_copy);
-}
-
-TEST_F(SdkVersionTest, HandlesLessThan) {
-  EXPECT_LT(v1_0_0, v1_0_1);
-  EXPECT_LT(v1_0_1, v1_1_0);
-  EXPECT_LT(v1_1_0, v2_0_0);
-  EXPECT_FALSE(v1_0_0 < v1_0_0);
-  EXPECT_FALSE(v1_0_1 < v1_0_0);
-}
-
-TEST_F(SdkVersionTest, HandlesGreaterThan) {
-  EXPECT_GT(v1_0_1, v1_0_0);
-  EXPECT_GT(v1_1_0, v1_0_1);
-  EXPECT_GT(v2_0_0, v1_1_0);
-  EXPECT_FALSE(v1_0_0 > v1_0_0);
-  EXPECT_FALSE(v1_0_0 > v1_0_1);
-}
-
-TEST_F(SdkVersionTest, HandlesLessThanOrEqual) {
-  SdkVersion v1_0_0_copy = v1_0_0;
-  EXPECT_LE(v1_0_0, v1_0_0_copy);
-  EXPECT_LE(v1_0_0, v1_0_1);
-  EXPECT_LE(v1_0_1, v1_1_0);
-  EXPECT_LE(v1_1_0, v2_0_0);
-  EXPECT_FALSE(v1_0_1 <= v1_0_0);
-}
-
-TEST_F(SdkVersionTest, HandlesGreaterThanOrEqual) {
-  SdkVersion v1_0_0_copy = v1_0_0;
-  EXPECT_GE(v1_0_0, v1_0_0_copy);
-  EXPECT_GE(v1_0_1, v1_0_0);
-  EXPECT_GE(v1_1_0, v1_0_1);
-  EXPECT_GE(v2_0_0, v1_1_0);
-  EXPECT_FALSE(v1_0_0 >= v1_0_1);
 }
 
 TEST(QnnManagerTest, AdspLibraryPathNoDuplicate) {


### PR DESCRIPTION
Summary:
- Add SDK version info to the op builder.
- Maintain backward compatibility by converting A8W2 to A8W4 FC for SDK < 2.47.0.
- Enable A8W2 FC for SDK >= 2.47.0.
- Bypass op validation for A8W2 FC in SDK 2.47.0.

x86:
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/builders:fully_connected_op_builder_test
//litert/vendors/qualcomm/core/builders:fully_connected_op_builder_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 29.8s
```
on-device:
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (12 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 21 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 33 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (4 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 27 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 27 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (16 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (343 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (387 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (346 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1027 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (986 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/builders:fully_connected_op_builder_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
[==========] 2 tests from 1 test suite ran. (685 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (681 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2164 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (20 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (495 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (467 ms total)
[  PASSED  ] 2 tests.
```
- [x] developer-verified