### PR TITLE
Qualcomm AI Engine Direct - Fix Cmake for test.

### DIFF
--- a/litert/tools/CMakeLists.txt
+++ b/litert/tools/CMakeLists.txt
@@ -428,9 +428,7 @@ else()
             Threads::Threads
             "-Wl,--start-group"
             litert_tool_display
-            litert_cc_internal
-            litert_core
-            litert_core_model
+            ${LITERT_TOOL_COMMON_LIBS}
             ${ABSEIL_TOOL_LIBS}
             "-Wl,--end-group"
             ${CMAKE_DL_LIBS}

--- a/litert/vendors/qualcomm/tests/CMakeLists.txt
+++ b/litert/vendors/qualcomm/tests/CMakeLists.txt
@@ -26,6 +26,19 @@ target_link_libraries(litert_test_common PUBLIC
     flatbuffers::flatbuffers
 )
 
+add_library(litert_test_load_test_model STATIC)
+
+target_sources(litert_test_load_test_model
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../../test/load_test_model.cc
+)
+
+target_link_libraries(litert_test_load_test_model PUBLIC
+    litert_test_common
+    litert_cc_internal
+    absl::string_view
+)
+
 # Compiler plugin test
 add_executable(qnn_compiler_plugin_test)
 
@@ -38,6 +51,7 @@ target_link_libraries(qnn_compiler_plugin_test
     PRIVATE
         qnn_compiler_plugin
         litert_test_common
+        litert_test_load_test_model
         litert_runtime_c_api_shared_lib 
         GTest::gtest_main
 )

--- a/tensor/examples/segmentation/CMakeLists.txt
+++ b/tensor/examples/segmentation/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(litert_tensor_segmentation_example
         "-Wl,--start-group"
         litert_cc_api
         litert_runtime_c_api_static
+        litert_core
         litert_runtime
         litert_c_api
         litert_tensor_api_core


### PR DESCRIPTION
Summary:
- Fix circular dependency of extract_bytecode.
- Fix missed definition of qnn_compiler_plugin_test.
- Fix circular dependency of litert_tensor_segmentation_example.

Error:
```
ld.lld: error: undefined symbol: litert::testing::LoadTestFileModel(std::__ndk1::basic_string_view<char, std::__ndk1::char_traits<char>>)
>>> referenced by qnn_compiler_plugin_test.cc:238 (/local/mnt/workspace/weilhuan/LiteRT/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc:238)
>>>               CMakeFiles/qnn_compiler_plugin_test.dir/__/compiler/qnn_compiler_plugin_test.cc.o:(litert::(anonymous namespace)::TestQnnPlugin_CompileAfterGetSDKVersion_Test::TestBody())
>>> referenced by qnn_compiler_plugin_test.cc:249 (/local/mnt/workspace/weilhuan/LiteRT/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc:249)
>>>               CMakeFiles/qnn_compiler_plugin_test.dir/__/compiler/qnn_compiler_plugin_test.cc.o:(litert::(anonymous namespace)::TestQnnPlugin_PartitionMulOps_Test::TestBody())
>>> referenced by qnn_compiler_plugin_test.cc:264 (/local/mnt/workspace/weilhuan/LiteRT/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc:264)
>>>               CMakeFiles/qnn_compiler_plugin_test.dir/__/compiler/qnn_compiler_plugin_test.cc.o:(litert::(anonymous namespace)::TestQnnPlugin_CompileMulSubgraph_Test::TestBody())
>>> referenced 8 more times
```

```
/usr/bin/ld: ../../../core/liblitert_core.a(environment.cc.o): in function `LiteRtEnvironmentT::~LiteRtEnvironmentT()':
environment.cc:(.text+0x55b): undefined reference to `litert::internal::GpuEnvironment::~GpuEnvironment()'
/usr/bin/ld: ../../../core/liblitert_core.a(environment.cc.o): in function `LiteRtEnvironmentT::SetGpuEnvironment(std::unique_ptr<litert::internal::GpuEnvironment, std::default_delete<litert::internal::GpuEnvironment> >)':
environment.cc:(.text+0x742): undefined reference to `litert::internal::GpuEnvironment::~GpuEnvironment()'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[3]: *** [tensor/examples/segmentation/CMakeFiles/litert_tensor_segmentation_example.dir/build.make:233: tensor/examples/segmentation/litert_tensor_segmentation_example] Error 1
gmake[2]: *** [CMakeFiles/Makefile2:22054: tensor/examples/segmentation/CMakeFiles/litert_tensor_segmentation_example.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:22061: tensor/examples/segmentation/CMakeFiles/litert_tensor_segmentation_example.dir/rule] Error 2
gmake: *** [Makefile:4460: litert_tensor_segmentation_example] Error 2
```