### PR TITLE
Qualcomm AI Engine Direct - Use FloatNear in Pack and SplitV test.

### DIFF
--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/pack_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/pack_test.cc
@@ -18,7 +18,8 @@
 
 namespace litert::qnn {
 namespace {
-using testing::ElementsAre;
+using testing::FloatNear;
+using testing::Pointwise;
 
 INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
                          QnnTestPrinter);
@@ -110,8 +111,9 @@ TEST_P(QnnModelTest, PackPositiveAxisIsUnchanged) {
   ASSERT_TRUE(output_data);
   // Stacked along axis 1: [[in0_row0, in1_row0], [in0_row1, in1_row1]].
   ASSERT_THAT(output_data.value(),
-              ElementsAre(1.0f, 2.0f, 3.0f, 7.0f, 8.0f, 9.0f, 4.0f, 5.0f, 6.0f,
-                          10.0f, 11.0f, 12.0f));
+              Pointwise(FloatNear(1e-6), {1.0f, 2.0f, 3.0f, 7.0f, 8.0f, 9.0f,
+                                          4.0f, 5.0f, 6.0f, 10.0f, 11.0f,
+                                          12.0f}));
 }
 
 // A single input cannot form a valid QNN Pack, so the builder emits a Reshape

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/splitv_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/splitv_test.cc
@@ -5,16 +5,17 @@
 #include <cstdint>
 #include <vector>
 
-#include "QnnTypes.h"  // from @qairt
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "litert/vendors/qualcomm/core/builders/splitv_op_builder.h"
 #include "litert/vendors/qualcomm/core/op_code.h"
 #include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+#include "QnnTypes.h"  // from @qairt
 
 namespace litert::qnn {
 namespace {
-using testing::ElementsAre;
+using testing::FloatNear;
+using testing::Pointwise;
 
 INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
                          QnnTestPrinter);
@@ -73,16 +74,18 @@ TEST_P(QnnModelTest, SplitVTwoDimensional) {
 
   auto output0_data = qnn_model_.GetOutputData<float>(output0_idx);
   ASSERT_TRUE(output0_data);
-  ASSERT_THAT(output0_data.value(), ElementsAre(1.0f, 2.0f, 3.0f));
+  ASSERT_THAT(output0_data.value(),
+              Pointwise(FloatNear(1e-3), {1.0f, 2.0f, 3.0f}));
 
   auto output1_data = qnn_model_.GetOutputData<float>(output1_idx);
   ASSERT_TRUE(output1_data);
-  ASSERT_THAT(output1_data.value(), ElementsAre(4.0f, 5.0f, 6.0f));
+  ASSERT_THAT(output1_data.value(),
+              Pointwise(FloatNear(1e-3), {4.0f, 5.0f, 6.0f}));
 
   auto output2_data = qnn_model_.GetOutputData<float>(output2_idx);
   ASSERT_TRUE(output2_data);
   ASSERT_THAT(output2_data.value(),
-              ElementsAre(7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f));
+              Pointwise(FloatNear(1e-3), {7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f}));
 }
 
 // Mirrors tflite/kernels/split_v_test.cc FourDimensional axis=1 with -1:
@@ -136,12 +139,14 @@ TEST_P(QnnModelTest, SplitVWithNegativeOneSizeSplit) {
   auto output0_data = qnn_model_.GetOutputData<float>(output0_idx);
   ASSERT_TRUE(output0_data);
   ASSERT_THAT(output0_data.value(),
-              ElementsAre(1.0f, 2.0f, 3.0f, 4.0f, 9.0f, 10.0f, 11.0f, 12.0f));
+              Pointwise(FloatNear(1e-3),
+                        {1.0f, 2.0f, 3.0f, 4.0f, 9.0f, 10.0f, 11.0f, 12.0f}));
 
   auto output1_data = qnn_model_.GetOutputData<float>(output1_idx);
   ASSERT_TRUE(output1_data);
   ASSERT_THAT(output1_data.value(),
-              ElementsAre(5.0f, 6.0f, 7.0f, 8.0f, 13.0f, 14.0f, 15.0f, 16.0f));
+              Pointwise(FloatNear(1e-3),
+                        {5.0f, 6.0f, 7.0f, 8.0f, 13.0f, 14.0f, 15.0f, 16.0f}));
 }
 
 // Mirrors tflite/kernels/split_v_test.cc NegativeAxis:
@@ -193,12 +198,14 @@ TEST_P(QnnModelTest, SplitVNegativeAxis) {
   auto output0_data = qnn_model_.GetOutputData<float>(output0_idx);
   ASSERT_TRUE(output0_data);
   ASSERT_THAT(output0_data.value(),
-              ElementsAre(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f));
+              Pointwise(FloatNear(1e-3),
+                        {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f}));
 
   auto output1_data = qnn_model_.GetOutputData<float>(output1_idx);
   ASSERT_TRUE(output1_data);
-  ASSERT_THAT(output1_data.value(), ElementsAre(9.0f, 10.0f, 11.0f, 12.0f,
-                                                13.0f, 14.0f, 15.0f, 16.0f));
+  ASSERT_THAT(output1_data.value(),
+              Pointwise(FloatNear(1e-3),
+                        {9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 16.0f}));
 }
 
 // QNN_OP_SPLIT requires at least one cut, so num_splits == 1 (a single output
@@ -224,9 +231,9 @@ TEST_P(QnnModelTest, SplitVSingleSplitLoweredToReshape) {
 
   ASSERT_NE(axis_tensor, nullptr);
 
-  auto ops = ::qnn::BuildSplitVOp(
-      tensor_pool_, {input_tensor, size_splits_tensor, *axis_tensor},
-      {output_tensor}, kNumSplits);
+  auto ops = ::qnn::BuildSplitVOp(tensor_pool_,
+                                  {input_tensor, size_splits_tensor, *axis_tensor},
+                                  {output_tensor}, kNumSplits);
   ASSERT_EQ(ops.size(), 1u);
   EXPECT_EQ(ops[0].GetOpCode(), ::qnn::QnnOpCode::kReshape);
 
@@ -240,15 +247,15 @@ TEST_P(QnnModelTest, SplitVSingleSplitLoweredToReshape) {
 
   auto input_idx = qnn_model_.AddInputTensor(input_tensor);
   auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
-  qnn_model_.SetInputData<float>(input_idx,
-                                 {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+  qnn_model_.SetInputData<float>(
+      input_idx, {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
 
   ASSERT_TRUE(qnn_model_.Execute());
 
   auto output_data = qnn_model_.GetOutputData<float>(output_idx);
   ASSERT_TRUE(output_data);
   ASSERT_THAT(output_data.value(),
-              ElementsAre(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f));
+              Pointwise(FloatNear(1e-3), {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}));
 }
 
 // QNN cannot handle dynamic split_index. Verify the builder rejects a


### PR DESCRIPTION
Summary:

- `PackPositiveAxisIsUnchanged` compared HTP fp32 output for exact equality via `ElementsAre`.
- On SM8650 (V75) the HTP returns values ~1 ULP off (e.g. 1.00000012 for 1.0), so the test failed there while passing on V79/V81 which happen to return bit-exact results.
- Switched to Pointwise(FloatNear(1e-3), ...), matching the sibling builder tests (relu_test, topk_test, elementwise_test) which compare on-device fp32 output with a tolerance.

## Test
- x86

```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:all


//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 26.2s
```

- on device

```
======================== Test Summary ========================
SM8750: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8750: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8750: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 16 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 21 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 33 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (0 ms total)
[  PASSED  ] 66 tests.

SM8750: //litert/vendors/qualcomm/core:common_test
[==========] 20 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8750: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (20 ms total)
[  PASSED  ] 9 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (261 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (264 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (716 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (705 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (516 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (398 ms total)
[  PASSED  ] 10 tests.

SM8750: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1278 ms total)
[  PASSED  ] 11 tests.

SM8750: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (13 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (347 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (333 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (7 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 21 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 21 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 33 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 20 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (12 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (511 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (493 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1210 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1213 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (1126 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (1103 ms total)
[  PASSED  ] 10 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2966 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (30 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (514 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (544 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 21 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 33 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (3 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 20 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 20 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (17 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (494 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (498 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (890 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1628 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (1230 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (595 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2300 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (35 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (411 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (420 ms total)
[  PASSED  ] 2 tests.
```