### PR TITLE
tflite: fix uint64 addition overflow in external-offset bounds checks (interpreter_builder.cc)

### DIFF
--- a/tflite/core/interpreter_builder.cc
+++ b/tflite/core/interpreter_builder.cc
@@ -668,7 +668,8 @@ TfLiteStatus InterpreterBuilder::ParseTensors(
           *buffer_data = reinterpret_cast<const char*>(array->data());
           return kTfLiteOk;
         } else if (offset > 1 && allocation_) {
-          if (offset + buffer->size() > allocation_->bytes()) {
+          if (offset > allocation_->bytes() ||
+              buffer->size() > allocation_->bytes() - offset) {
             TF_LITE_REPORT_ERROR(
                 error_reporter_,
                 "Constant buffer %d specified an out of range offset.\n",

--- a/tflite/core/interpreter_builder.cc
+++ b/tflite/core/interpreter_builder.cc
@@ -375,9 +375,9 @@ TfLiteStatus InterpreterBuilder::ParseNodes(
         init_data = reinterpret_cast<const char*>(op->custom_options()->data());
         init_data_size = op->custom_options()->size();
       } else if (op->large_custom_options_offset() > 1 && allocation_) {
-        if (op->large_custom_options_offset() +
-                op->large_custom_options_size() >
-            allocation_->bytes()) {
+        if (op->large_custom_options_offset() > allocation_->bytes() ||
+            op->large_custom_options_size() >
+                allocation_->bytes() - op->large_custom_options_offset()) {
           TF_LITE_REPORT_ERROR(
               error_reporter_,
               "Custom Option Offset for opcode_index %d is out of bound\n",


### PR DESCRIPTION
### Summary
The external-offset bounds checks in `tflite/core/interpreter_builder.cc` add two `uint64_t` values (`offset + size`) and compare against `allocation_->bytes()`. The addition can wrap on overflow, so a crafted model passes the check, and the subsequent `allocation_->base() + offset` pointer computation also wraps, producing an out-of-bounds access on the default model-load path.

I was advised to resubmit this in LiteRT: the original TensorFlow report (tensorflow/tensorflow#116632) was closed with the TFLite-to-LiteRT migration redirect ("All active development has shifted to LiteRT ... please open a new issue in the LiteRT Repository"). The original fix is tensorflow/tensorflow#116631. This PR applies the same fix here, where the code is confirmed present and unfixed. Tracking issue: #8180.

### Criticality and impact
- Memory safety, reachable on the default load path (`Interpreter(model_path=...).allocate_tensors()`) with an attacker-supplied `.tflite`. No special flags or APIs are required.
- Out-of-bounds access: `allocation_->base() + offset` resolves outside the model's mmap region. Demonstrated as a reproducible SIGSEGV at invoke.
- Same class as CVE-2021-29605, CVE-2022-23558, and CVE-2022-23559 in this component. Those fixes addressed int-based arithmetic; this is the 64-bit external-offset feature (`Buffer.offset/size`, `Operator.large_custom_options_offset/size`) added after those patches.
- All four fields are `ulong` (uint64_t) in `schema.fbs`.

### Fix
Overflow-safe comparison (no addition that can wrap) at both sites (`ParseTensors` Buffer.offset, `ParseNodes` large_custom_options):
```cpp
if (offset > allocation_->bytes() ||
    size > allocation_->bytes() - offset) {
  return kTfLiteError;
}
```

### Validation (uint64 smoke test of the arithmetic)
```
case                             current  fixed
malicious offset wrap (~2^64)    accept   reject
malicious size wrap              accept   reject
legit in-range                   accept   accept
legit edge (offset+size==bytes)  accept   accept
out-of-range, no overflow        reject   reject
```
The fix rejects both overflow cases and is behavior-identical to the current code on every legitimate case.

### Reproduction (full PoC on Google OSS VRP 505514642)
Build a valid `.tflite`, set the weight Buffer `offset=0xFFFFFFFFFFFFFF00` and `size=0x100`, then load and invoke. Without the fix the load succeeds (bypass) and invoke SIGSEGVs; with the fix the load returns `kTfLiteError` ("Constant buffer N specified an out of range offset.").

### Regression test
Porting `TestBufferOffsetOverflowRejected` from tensorflow/tensorflow#116631 to `tflite/core/model_test.cc`.

### References
- #8180 (LiteRT tracking issue)
- tensorflow/tensorflow#116632 (closed, redirected here)
- tensorflow/tensorflow#116631 (original fix)
- Google OSS VRP issue 505514642