### PR TITLE
Make LiteRtLayout ABI identical across MSVC and GCC/Clang (#7459)

### DIFF
--- a/litert/c/litert_layout.h
+++ b/litert/c/litert_layout.h
@@ -33,7 +33,16 @@ extern "C" {
 /// @note This concrete type is part of the public API and is ABI stable.
 typedef struct {
   unsigned int rank : 7;  // The number of dimensions.
-  bool has_strides : 1;   // Whether the layout has strides.
+  // Whether the layout has strides.
+  //
+  // NOTE: This bit-field uses `unsigned int` (matching `rank` above) rather
+  // than `bool` on purpose. MSVC does not coalesce adjacent bit-fields with
+  // different underlying types into the same storage unit, so a `bool` field
+  // here would open a fresh 4-byte unit and shift `dimensions`/`strides`,
+  // making this public struct binary-incompatible between MSVC and GCC/Clang
+  // builds. Keeping the underlying type identical packs both fields together
+  // on every compiler. See https://github.com/google-ai-edge/LiteRT/issues/7459
+  unsigned int has_strides : 1;
 
   // Dimension sizes, array of length `rank`. Dynamic dimensions are anything
   // less than 0. Everything from [rank, LITERT_MAX_RANK) is undefined.
@@ -43,21 +52,18 @@ typedef struct {
   uint32_t strides[LITERT_TENSOR_MAX_RANK];
 } LiteRtLayout;
 
+// The layout below is now identical across MSVC and GCC/Clang because `rank`
+// and `has_strides` share an underlying type and pack into a single storage
+// unit on every compiler. These asserts intentionally have no `_MSC_VER`
+// branch so any future change that reintroduces cross-compiler divergence
+// fails the build.
 #if defined(__cplusplus) && defined(__SIZEOF_POINTER__) && \
     __SIZEOF_POINTER__ == 8
-#if !defined(_MSC_VER)
 static_assert(sizeof(LiteRtLayout) == 68, "LiteRtLayout size mismatch");
 static_assert(offsetof(LiteRtLayout, dimensions) == 4,
               "LiteRtLayout dimensions offset mismatch");
 static_assert(offsetof(LiteRtLayout, strides) == 36,
               "LiteRtLayout strides offset mismatch");
-#else   // !defined(_MSC_VER)
-static_assert(sizeof(LiteRtLayout) == 72, "LiteRtLayout size mismatch");
-static_assert(offsetof(LiteRtLayout, dimensions) == 8,
-              "LiteRtLayout dimensions offset mismatch");
-static_assert(offsetof(LiteRtLayout, strides) == 40,
-              "LiteRtLayout strides offset mismatch");
-#endif  // !defined(_MSC_VER)
 #endif  // __cplusplus
 
 // Return the number of scalar elements in the provided tensor layout. Return an

--- a/litert/c/litert_model_types.h
+++ b/litert/c/litert_model_types.h
@@ -81,15 +81,14 @@ typedef struct {
   LiteRtLayout layout;
 } LiteRtRankedTensorType;
 
+// `LiteRtRankedTensorType` embeds `LiteRtLayout`, whose layout is now identical
+// across MSVC and GCC/Clang (see litert/c/litert_layout.h), so this size no
+// longer diverges by compiler. The assert intentionally has no `_MSC_VER`
+// branch.
 #if defined(__cplusplus) && defined(__SIZEOF_POINTER__) && \
     __SIZEOF_POINTER__ == 8
-#if !defined(_MSC_VER)
 static_assert(sizeof(LiteRtRankedTensorType) == 72,
               "LiteRtRankedTensorType size mismatch");
-#else   // !defined(_MSC_VER)
-static_assert(sizeof(LiteRtRankedTensorType) == 76,
-              "LiteRtRankedTensorType size mismatch");
-#endif  // !defined(_MSC_VER)
 static_assert(offsetof(LiteRtRankedTensorType, layout) == 4,
               "LiteRtRankedTensorType layout offset mismatch");
 #endif  // __cplusplus


### PR DESCRIPTION
## What

Fixes #7459.

The public `LiteRtLayout` struct in `litert/c/litert_layout.h` declares:

```c
unsigned int rank : 7;
bool         has_strides : 1;
```

MSVC does not coalesce adjacent bit-fields with **different underlying types** into the same storage unit. So on MSVC the `bool` field opens a fresh 4-byte storage unit, making the struct **72 bytes with `dimensions` at offset 8**, versus **68 bytes / offset 4** on GCC/Clang. `LiteRtRankedTensorType` (which embeds `LiteRtLayout`) diverges the same way: 76 vs 72 bytes.

| Compiler | `sizeof(LiteRtLayout)` | `offsetof(dimensions)` |
|---|---|---|
| Clang / GCC | 68 | 4 |
| MSVC | 72 | 8 |

Because this is a documented **non-opaque, ABI-stable public type**, any consumer that reads a struct produced by a differently-compiled `LiteRt.dll` (Dart FFI, Rust bindings, MinGW builds) sees every dimension shifted by 4 bytes. The current header (commit `edc801ec1`) only *documents* the divergence via per-compiler `static_assert` branches; it does not fix the incompatibility.

## Change

Give `has_strides` the same underlying type as `rank` so both pack into a single storage unit on every compiler:

```c
unsigned int rank : 7;
unsigned int has_strides : 1;
```

- **No-op for the GCC/Clang ABI** — still 68 bytes, `dimensions` at offset 4.
- **Unifies MSVC** to the same 68-byte layout.
- Collapses the per-compiler `static_assert` branches in `litert_layout.h` and `litert_model_types.h` into a single expectation, so any future reintroduction of cross-compiler divergence fails the build.

This is the minimal, lowest-risk option from the issue's suggested fixes (no public API surface added, no behavior change). Assigning `bool` values to / reading the field as `bool` continues to work (the `litert/cc` wrapper is unaffected).

## Verification

Compiled the real headers under clang with the asserts active:

```
LiteRtLayout sizeof=68 off(dim)=4 off(str)=36
LiteRtRankedTensorType sizeof=72 off(layout)=4
```

Confirmed identical layout before and after the change on clang, and that a `true` assigned to the 1-bit `unsigned int` field reads back as `1`.

Note: I don't have an MSVC environment to reproduce the 72→68 unification directly; that follows from the documented MSVC bit-field packing rule and the measurements in #7459. The in-header `static_assert`s serve as the compile-time regression guard across CI toolchains.