### PR TITLE
Fix parsing of Intel OpenVINO configs_map entries

### DIFF
--- a/litert/tools/flags/vendors/intel_openvino_flags.cc
+++ b/litert/tools/flags/vendors/intel_openvino_flags.cc
@@ -145,9 +145,13 @@ Expected<void> UpdateIntelOpenVinoOptionsFromFlags(
     std::vector<std::string> config_pairs =
         absl::StrSplit(configs_map_str, ',');
     for (const auto& pair : config_pairs) {
-      std::vector<std::string> key_value = absl::StrSplit(pair, '=');
-      if (key_value.size() == 2) {
-        options.SetConfigsMapOption(key_value[0].c_str(), key_value[1].c_str());
+      // Split on the first '=' only so values may themselves contain '='
+      // (e.g. NPU_COMPILATION_MODE_PARAMS=enable-flash-sdpa-conversion=true).
+      const std::pair<std::string, std::string> key_value =
+          absl::StrSplit(pair, absl::MaxSplits('=', 1));
+      if (!key_value.first.empty() && pair.find('=') != std::string::npos) {
+        options.SetConfigsMapOption(key_value.first.c_str(),
+                                    key_value.second.c_str());
       } else {
         LITERT_LOG(
             LITERT_WARNING,

--- a/litert/tools/flags/vendors/intel_openvino_flags_test.cc
+++ b/litert/tools/flags/vendors/intel_openvino_flags_test.cc
@@ -17,11 +17,12 @@
 
 #include "litert/tools/flags/vendors/intel_openvino_flags.h"
 
+#include <gtest/gtest.h>
+
 #include <string>
 
-#include <gtest/gtest.h>
-#include "absl/flags/flag.h"  // from @com_google_absl
-#include "absl/flags/marshalling.h"  // from @com_google_absl
+#include "absl/flags/flag.h"           // from @com_google_absl
+#include "absl/flags/marshalling.h"    // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
 #include "litert/c/options/litert_intel_openvino_options.h"
 #include "litert/cc/litert_expected.h"
@@ -106,7 +107,7 @@ TEST(PerformanceModeFlagTest, Parse) {
 
 TEST(UpdateIntelOpenVinoOptionsFromFlagsTest, DefaultValues) {
   LITERT_ASSERT_OK_AND_ASSIGN(IntelOpenVinoOptions options,
-                             IntelOpenVinoOptions::Create());
+                              IntelOpenVinoOptions::Create());
   ASSERT_TRUE(UpdateIntelOpenVinoOptionsFromFlags(options).HasValue());
   // With no flags set, no per-graph overrides are configured.
   EXPECT_EQ(options.GetNumGraphOverrides(), 0);
@@ -118,7 +119,7 @@ TEST(UpdateIntelOpenVinoOptionsFromFlagsTest,
      SetGraphBackendForPartition0ToCPU) {
   absl::SetFlag(&FLAGS_intel_openvino_graph_backends, "0:cpu");
   LITERT_ASSERT_OK_AND_ASSIGN(IntelOpenVinoOptions options,
-                             IntelOpenVinoOptions::Create());
+                              IntelOpenVinoOptions::Create());
 
   ASSERT_TRUE(UpdateIntelOpenVinoOptionsFromFlags(options).HasValue());
   auto graph_backend = options.GetGraphBackend(/*graph_index=*/0);
@@ -133,7 +134,7 @@ TEST(UpdateIntelOpenVinoOptionsFromFlagsTest, SetPerformanceModeToThroughput) {
   absl::SetFlag(&FLAGS_intel_openvino_performance_mode,
                 kLiteRtIntelOpenVinoPerformanceModeThroughput);
   LITERT_ASSERT_OK_AND_ASSIGN(IntelOpenVinoOptions options,
-                             IntelOpenVinoOptions::Create());
+                              IntelOpenVinoOptions::Create());
 
   ASSERT_TRUE(UpdateIntelOpenVinoOptionsFromFlags(options).HasValue());
   EXPECT_EQ(options.GetPerformanceMode(),
@@ -148,7 +149,7 @@ TEST(UpdateIntelOpenVinoOptionsFromFlagsTest, ConfigsMapSingleOption) {
   absl::SetFlag(&FLAGS_intel_openvino_configs_map,
                 "INFERENCE_PRECISION_HINT=f16");
   LITERT_ASSERT_OK_AND_ASSIGN(IntelOpenVinoOptions options,
-                             IntelOpenVinoOptions::Create());
+                              IntelOpenVinoOptions::Create());
 
   ASSERT_TRUE(UpdateIntelOpenVinoOptionsFromFlags(options).HasValue());
   // The options should be created successfully with the config map set
@@ -162,7 +163,7 @@ TEST(UpdateIntelOpenVinoOptionsFromFlagsTest, ConfigsMapMultipleOptions) {
                 "INFERENCE_PRECISION_HINT=f16,NPU_COMPILATION_MODE_PARAMS=test,"
                 "CACHE_DIR=/tmp/cache");
   LITERT_ASSERT_OK_AND_ASSIGN(IntelOpenVinoOptions options,
-                             IntelOpenVinoOptions::Create());
+                              IntelOpenVinoOptions::Create());
 
   ASSERT_TRUE(UpdateIntelOpenVinoOptionsFromFlags(options).HasValue());
   // The options should be created successfully with multiple config map entries
@@ -174,7 +175,7 @@ TEST(UpdateIntelOpenVinoOptionsFromFlagsTest, ConfigsMapMultipleOptions) {
 TEST(UpdateIntelOpenVinoOptionsFromFlagsTest, ConfigsMapEmptyValue) {
   absl::SetFlag(&FLAGS_intel_openvino_configs_map, "");
   LITERT_ASSERT_OK_AND_ASSIGN(IntelOpenVinoOptions options,
-                             IntelOpenVinoOptions::Create());
+                              IntelOpenVinoOptions::Create());
 
   ASSERT_TRUE(UpdateIntelOpenVinoOptionsFromFlags(options).HasValue());
   // Empty configs_map should work fine
@@ -184,7 +185,7 @@ TEST(UpdateIntelOpenVinoOptionsFromFlagsTest, ConfigsMapWithSpaces) {
   // Test handling of values with spaces (though typically avoided)
   absl::SetFlag(&FLAGS_intel_openvino_configs_map, "KEY1=VALUE1,KEY2=VALUE2");
   LITERT_ASSERT_OK_AND_ASSIGN(IntelOpenVinoOptions options,
-                             IntelOpenVinoOptions::Create());
+                              IntelOpenVinoOptions::Create());
 
   ASSERT_TRUE(UpdateIntelOpenVinoOptionsFromFlags(options).HasValue());
 
@@ -193,19 +194,38 @@ TEST(UpdateIntelOpenVinoOptionsFromFlagsTest, ConfigsMapWithSpaces) {
 }
 
 TEST(UpdateIntelOpenVinoOptionsFromFlagsTest, ConfigsMapMalformedPairs) {
-  // Test handling of malformed config strings (missing '=' or extra '=')
-  // Should still create options successfully, but malformed pairs are ignored
-  // with warning
+  // Test handling of malformed config strings (missing '=' or extra '=').
+  // BAD_KEY_NO_EQUALS is ignored with a warning. KEY_WITH=MULTIPLE=EQUALS is
+  // split on the first '=' only, so it parses as KEY_WITH ->
+  // MULTIPLE=EQUALS (the value retains the remaining '=').
   absl::SetFlag(
       &FLAGS_intel_openvino_configs_map,
       "GOOD_KEY=GOOD_VALUE,BAD_KEY_NO_EQUALS,KEY_WITH=MULTIPLE=EQUALS");
   LITERT_ASSERT_OK_AND_ASSIGN(IntelOpenVinoOptions options,
-                             IntelOpenVinoOptions::Create());
+                              IntelOpenVinoOptions::Create());
 
   ASSERT_TRUE(UpdateIntelOpenVinoOptionsFromFlags(options).HasValue());
-  // Only the well-formed pair should be set (BAD_KEY_NO_EQUALS will be ignored)
-  // KEY_WITH=MULTIPLE=EQUALS will be split as KEY_WITH = MULTIPLE=EQUALS (3
-  // parts, ignored)
+
+  // Reset flag to default
+  absl::SetFlag(&FLAGS_intel_openvino_configs_map, "");
+}
+
+TEST(UpdateIntelOpenVinoOptionsFromFlagsTest,
+     ConfigsMapNpuCompilationModeParams) {
+  // NPU_COMPILATION_MODE_PARAMS values are space-separated key=value pairs and
+  // therefore contain '=' inside the value. Verify the entry survives parsing.
+  absl::SetFlag(&FLAGS_intel_openvino_configs_map,
+                "NPU_COMPILATION_MODE_PARAMS=enable-decompose-sdpa=false "
+                "enable-flash-sdpa-conversion=true");
+  LITERT_ASSERT_OK_AND_ASSIGN(IntelOpenVinoOptions options,
+                              IntelOpenVinoOptions::Create());
+
+  ASSERT_TRUE(UpdateIntelOpenVinoOptionsFromFlags(options).HasValue());
+  ASSERT_EQ(options.GetNumConfigsMapOptions(), 1);
+  auto [key, value] = options.GetConfigsMapOption(0);
+  EXPECT_EQ(key, "NPU_COMPILATION_MODE_PARAMS");
+  EXPECT_EQ(value,
+            "enable-decompose-sdpa=false enable-flash-sdpa-conversion=true");
 
   // Reset flag to default
   absl::SetFlag(&FLAGS_intel_openvino_configs_map, "");


### PR DESCRIPTION
absl::StrSplit(pair, '=') split each comma-separated entry on every '=', so any pair
whose value itself contained '=' produced more than two tokens and was rejected
and dropped with a warning. This affects any property whose value embeds further
 '=' characters, e.g. nested key=value sub-lists like
NPU_COMPILATION_MODE_PARAMS=enable-flash-sdpa-conversion=true.

Split on the first '=' only so the leading delimiter separates the key from the value
and the value passes through intact. Updates the malformed-pair test for the new
splitting behavior and adds a regression test. 

Also runs clang-format (Google style) over the touched files.