### PR TITLE
Allow benchmark_model to enable NPU profiling via PERF_COUNT

### DIFF
--- a/litert/tools/BUILD
+++ b/litert/tools/BUILD
@@ -838,6 +838,7 @@ cc_library(
         ":benchmark_litert_model",
         "//tflite/c:c_api_types",
         "//tflite/tools:logging",
+        "@com_google_absl//absl/flags:parse",
         "@com_google_absl//absl/flags:reflection",
         "@com_google_absl//absl/strings",
     ],

--- a/litert/tools/benchmark_litert_model_main.cc
+++ b/litert/tools/benchmark_litert_model_main.cc
@@ -15,7 +15,9 @@ limitations under the License.
 
 #include <cstdlib>
 #include <iostream>
+#include <vector>
 
+#include "absl/flags/parse.h"       // from @com_google_absl
 #include "absl/flags/reflection.h"  // from @com_google_absl
 #include "absl/strings/match.h"  // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
@@ -45,6 +47,17 @@ int Main(int argc, char** argv) {
       }
     }
     std::cout << std::endl;
+  }
+
+  // Populate ABSL_FLAG values (e.g. --intel_openvino_configs_map) from argv.
+  // Must use ParseAbseilFlagsOnly, not ParseCommandLine: tflite's
+  // BenchmarkModel owns flags such as --graph and --use_npu and parses them
+  // itself from argv below. ParseCommandLine would abort on those as
+  // "unknown"; ParseAbseilFlagsOnly leaves them in argv for tflite.
+  {
+    std::vector<char*> positional_args;
+    std::vector<absl::UnrecognizedFlag> unrecognized_flags;
+    absl::ParseAbseilFlagsOnly(argc, argv, positional_args, unrecognized_flags);
   }
 
   TFLITE_LOG(INFO) << "STARTING!";

--- a/litert/vendors/intel_openvino/dispatch/invocation_context.cc
+++ b/litert/vendors/intel_openvino/dispatch/invocation_context.cc
@@ -199,6 +199,25 @@ LiteRtDispatchInvocationContextT::Create(
   }
   LITERT_LOG(LITERT_INFO, "Using Intel OpenVINO device: %s", device.c_str());
 
+  // Forward configs_map entries to OV Core. Runtime-only properties such
+  // as PERF_COUNT must be set here (at import_model time) — they are not
+  // baked into the exported NPU blob by the AOT compile path.
+  ov::AnyMap import_configs;
+  bool perf_count_enabled = false;
+  const int num_options = intel_openvino_opts != nullptr ?
+                          intel_openvino_opts->GetNumConfigsMapOptions() : 0;
+  for (int i = 0; i < num_options; ++i) {
+    auto [key, value] = intel_openvino_opts->GetConfigsMapOption(i);
+    if (key.empty()) continue;
+    if (key == "PERF_COUNT" && (value == "YES" || value == "true")) {
+      perf_count_enabled = true;
+    }
+
+    import_configs[key] = value;
+    LITERT_LOG(LITERT_INFO, "Dispatch: OpenVINO config '%s'='%s'", key.c_str(),
+               value.c_str());
+  }
+
   OpenVINOSharedCore::GetInstance()->SetDevice(device);
 
   if (!exec_bytecode_ptr || exec_bytecode_size == 0) {
@@ -214,7 +233,7 @@ LiteRtDispatchInvocationContextT::Create(
   }
   ov::CompiledModel compiled_model;
   try {
-    compiled_model = core->import_model(model_stream, device);
+    compiled_model = core->import_model(model_stream, device, import_configs);
   } catch (const std::exception& e) {
     return litert::Error(kLiteRtStatusErrorRuntimeFailure, e.what());
   }
@@ -223,7 +242,8 @@ LiteRtDispatchInvocationContextT::Create(
   LITERT_LOG(LITERT_INFO, "Openvino InvocationContext Initialize SUCCESS");
   // TODO: add support for loading cached model
   return Ptr(new LiteRtDispatchInvocationContextT(infer_request, device_context,
-                                                  num_inputs, num_outputs));
+                                                  num_inputs, num_outputs,
+                                                  perf_count_enabled));
 }
 
 litert::Expected<LiteRtTensorBufferRequirements>
@@ -296,5 +316,14 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::Invoke() {
     return litert::Unexpected(
         kLiteRtStatusErrorRuntimeFailure,
         "Failed to execute inference request due to timeout");
+
+  if (perf_count_enabled_) {
+    try {
+      (void)infer_request_.get_profiling_info();
+    } catch (const std::exception& e) {
+      LITERT_LOG(LITERT_WARNING, "Failed to read OpenVINO profiling info: %s",
+                 e.what());
+    }
+  }
   return {};
 }

--- a/litert/vendors/intel_openvino/dispatch/invocation_context.h
+++ b/litert/vendors/intel_openvino/dispatch/invocation_context.h
@@ -83,14 +83,23 @@ class LiteRtDispatchInvocationContextT {
  private:
   LiteRtDispatchInvocationContextT(ov::InferRequest& infer_request,
                                    LiteRtDispatchDeviceContextT& device_context,
-                                   int num_inputs, int num_outputs)
-      : device_context_(device_context), infer_request_(infer_request) {}
+                                   int num_inputs, int num_outputs,
+                                   bool perf_count_enabled)
+      : device_context_(device_context),
+        infer_request_(infer_request),
+        perf_count_enabled_(perf_count_enabled) {}
   LiteRtDispatchDeviceContextT& device_context_;
   ov::InferRequest infer_request_;
   // Timeout is in milliseconds
   static constexpr int kInferRequestTimeoutMs = 10000;
 
   std::optional<LiteRtSchedulingInfo> scheduling_info_;
+  // When the user passes PERF_COUNT=YES via IntelOpenVinoOptions::ConfigsMap
+  // we must call infer_request_.get_profiling_info() after each Invoke().
+  // The call itself is what causes the OpenVINO NPU plugin to flush the
+  // per-op trace to NPU_PROFILING_OUTPUT_FILE — without pulling the data
+  // back to host the plugin never writes the file.
+  bool perf_count_enabled_ = false;
 };
 
 #endif  // ODML_LITERT_LITERT_VENDORS_OPENVINO_DISPATCH_LITERT_DISPATCH_INVOCATION_CONTEXT_H_


### PR DESCRIPTION
To collect NPU per-layer profiling with benchmark_model, the user must
be able to pass PERF_COUNT=YES to OpenVINO at runtime.

Two gaps blocked this:
  1. benchmark_litert_model_main never parsed ABSL_FLAGs,
      so --intel_openvino_configs_map silently stayed empty. 
      Use absl::ParseAbseilFlagsOnly so absl flags are populated
      and tflite-owned flags (--graph, --use_npu) stay in argv for tflite.

  2. The OpenVINO dispatch called import_model without a config map.
      PERF_COUNT is runtime-only and never reached the plugin. Pass
      IntelOpenVinoOptions::ConfigsMap as the third argument, and when
      PERF_COUNT is set, call get_profiling_info() after each Invoke() so the
     plugin flushes its trace to the output file.

Example:
  set NPU_PROFILING_OUTPUT_FILE=npu_prof.json
  set NPU_PRINT_PROFILING=JSON
  benchmark_model --intel_openvino_configs_map="PERF_COUNT=YES"