### PR TITLE
Samsung Exynos AI LiteCore : Improve performance of samsung dispatch

### DIFF
--- a/litert/vendors/samsung/dispatch/dispatch_api.cc
+++ b/litert/vendors/samsung/dispatch/dispatch_api.cc
@@ -78,6 +78,7 @@ LiteRtStatus LiteRtSamsungInitialize(
 
   if (auto enn_manager = ::litert::samsung::EnnManager::Create(); enn_manager) {
     static_enn_manager.reset(enn_manager->release());
+    SetGenAiPerfConfigFromSoc(static_enn_manager->Api());
   } else {
     LITERT_LOG(LITERT_INFO, "Failed to initialize: %s",
                enn_manager.Error().Message().c_str());

--- a/litert/vendors/samsung/dispatch/dispatch_api.cc
+++ b/litert/vendors/samsung/dispatch/dispatch_api.cc
@@ -228,16 +228,6 @@ LiteRtStatus LiteRtSamsungInvocationContextDestroy(
   return kLiteRtStatusOk;
 }
 
-LiteRtStatus LiteRtSamsungInvocationContextSetSchedulingInfo(
-    LiteRtDispatchInvocationContext invocation_context,
-    const LiteRtSchedulingInfo* scheduling_info) {
-  if (invocation_context == nullptr) {
-    return kLiteRtStatusErrorInvalidArgument;
-  }
-  invocation_context->SetSchedulingInfo(scheduling_info);
-  return kLiteRtStatusOk;
-}
-
 LiteRtStatus LiteRtSamsungAttachInput(
     LiteRtDispatchInvocationContext invocation_context, int graph_input_index,
     LiteRtTensorBufferHandle tensor_buffer_handle) {
@@ -311,8 +301,7 @@ LiteRtDispatchInterface TheInterface = {
     /*.unregister_tensor_buffer=*/LiteRtSamsungUnregisterTensorBuffer,
     /*.invocation_context_create=*/LiteRtSamsungInvocationContextCreate,
     /*.invocation_context_destroy=*/LiteRtSamsungInvocationContextDestroy,
-    /*.invocation_context_set_scheduling_info=*/
-    LiteRtSamsungInvocationContextSetSchedulingInfo,
+    /*.invocation_context_set_scheduling_info=*/nullptr,
     /*.attach_input=*/LiteRtSamsungAttachInput,
     /*.attach_output=*/LiteRtSamsungAttachOutput,
     /*.detach_input=*/LiteRtSamsungDetachInput,

--- a/litert/vendors/samsung/dispatch/enn_manager.cc
+++ b/litert/vendors/samsung/dispatch/enn_manager.cc
@@ -91,9 +91,38 @@ LiteRtStatus EnnManager::LoadEnnRuntimeLibrary(absl::string_view path) {
   ENN_LOAD_API(enn_runtime_lib_, EnnCloseModel);
   ENN_LOAD_API(enn_runtime_lib_, EnnDeinitialize);
   ENN_LOAD_API(enn_runtime_lib_, EnnAllocateAllBuffers);
+  ENN_LOAD_API(enn_runtime_lib_, EnnSetPreferencePerfMode);
+  ENN_LOAD_API(enn_runtime_lib_, EnnSetPreferencePerfConfigId);
 
   if (api_->EnnInitialize() != ENN_RET_SUCCESS) {
     return kLiteRtStatusErrorRuntimeFailure;
+  }
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus SetGenAiPerfConfigFromSoc(const EnnManager::PublicApi& api) {
+  std::string soc_name = GetSocName();
+  if (soc_name.empty()) {
+    return kLiteRtStatusOk;
+  }
+
+  PerfConfig perfConfig = GetPerfConfigFromSoc(soc_name);
+  LITERT_LOG(LITERT_INFO, "SetGenAiPerfConfigFromSoc: SOC=%s, mode=%u, configId=%u",
+             soc_name.c_str(), static_cast<unsigned>(perfConfig.mode),
+             perfConfig.configId);
+
+  EnnReturn ret_mode = api.EnnSetPreferencePerfMode(static_cast<uint32_t>(perfConfig.mode));
+  if (ret_mode != ENN_RET_SUCCESS) {
+    LITERT_LOG(LITERT_ERROR, "SetGenAiPerfConfigFromSoc: EnnSetPreferencePerfMode failed ret=%d", ret_mode);
+    return kLiteRtStatusErrorRuntimeFailure;
+  }
+  if (perfConfig.configId != PERF_CONFIG_ID_DEFAULT) {
+    EnnReturn ret_config = api.EnnSetPreferencePerfConfigId(perfConfig.configId);
+    if (ret_config != ENN_RET_SUCCESS) {
+      LITERT_LOG(LITERT_ERROR, "SetGenAiPerfConfigFromSoc: EnnSetPreferencePerfConfigId failed ret=%d", ret_config);
+      return kLiteRtStatusErrorRuntimeFailure;
+    }
   }
 
   return kLiteRtStatusOk;

--- a/litert/vendors/samsung/dispatch/enn_manager.cc
+++ b/litert/vendors/samsung/dispatch/enn_manager.cc
@@ -57,7 +57,12 @@ Expected<EnnManager::UniquePtr> EnnManager::Create() {
 
 const EnnManager::PublicApi& EnnManager::Api() const { return *api_.get(); }
 
-EnnManager::~EnnManager() { Api().EnnDeinitialize(); }
+EnnManager::~EnnManager() {
+  if (!_enn_deinitialized_) {
+    _enn_deinitialized_ = true;
+    Api().EnnDeinitialize();
+  }
+}
 
 LiteRtStatus EnnManager::LoadEnnRuntimeLibrary(absl::string_view path) {
   auto loading_lib = SharedLibrary::Load(path, RtldFlags::Default());

--- a/litert/vendors/samsung/dispatch/enn_manager.h
+++ b/litert/vendors/samsung/dispatch/enn_manager.h
@@ -40,6 +40,11 @@ class EnnManager {
   const PublicApi& Api() const;
   ~EnnManager();
 
+  // Guard flag for cross-destructor safety.
+  // WeightBinaryManager sets this in its destructor to call EnnDeinitialize()
+  // before EnnManager is destroyed (static destruction order is unspecified).
+  bool _enn_deinitialized_ = false;
+
  private:
   EnnManager();
   // Loads and resolve compiler related api

--- a/litert/vendors/samsung/dispatch/enn_manager.h
+++ b/litert/vendors/samsung/dispatch/enn_manager.h
@@ -16,7 +16,14 @@
 #ifndef LITERT_VENDORS_SAMSUNG_ENN_MANAGER_H_
 #define LITERT_VENDORS_SAMSUNG_ENN_MANAGER_H_
 
+#include <cstring>
 #include <memory>
+#include <string>
+#include <unordered_map>
+
+#if defined(__ANDROID__)
+#include <sys/system_properties.h>
+#endif
 
 #include "litert/cc/internal/litert_shared_library.h"
 #include "litert/cc/litert_expected.h"
@@ -73,9 +80,11 @@ struct EnnManager::PublicApi {
                                           const uint32_t offset,
                                           EnnModelId* model_id);
   EnnReturn (*EnnCreateBufferFromFdWithOffset)(const uint32_t fd,
-                                               const uint32_t size,
-                                               const uint32_t offset,
-                                               EnnBufferPtr* out);
+                                                const uint32_t size,
+                                                const uint32_t offset,
+                                                EnnBufferPtr* out);
+  EnnReturn (*EnnSetPreferencePerfMode)(const uint32_t val);
+  EnnReturn (*EnnSetPreferencePerfConfigId)(uint32_t val);
   EnnReturn (*EnnCreateBufferCache)(const uint32_t req_size, EnnBufferPtr* out);
   EnnReturn (*EnnAllocateAllBuffers)(const EnnModelId model_id,
                                      EnnBufferPtr** out_buffers,
@@ -93,6 +102,105 @@ struct EnnManager::PublicApi {
   EnnReturn (*EnnCloseModel)(const EnnModelId model_id);
   EnnReturn (*EnnDeinitialize)(void);
 };
+
+static constexpr uint32_t PERF_CONFIG_ID_DEFAULT = 0;
+
+struct PerfConfig {
+  PerfModePreference mode;
+  uint32_t configId;
+};
+
+// Get hardware name from system property (primary)
+inline std::string GetHwName() {
+#if defined(__ANDROID__)
+  char prop_value[256] = {};
+
+  if (__system_property_get("ro.hardware", prop_value) > 0) {
+    return std::string(prop_value);
+  }
+#endif
+  return "";
+}
+
+// Get SOC name from system property (fallback)
+inline std::string GetSocName() {
+#if defined(__ANDROID__)
+  char prop_value[256] = {};
+
+  if (__system_property_get("ro.soc.model", prop_value) > 0) {
+    return std::string(prop_value);
+  }
+#endif
+  return "";
+}
+
+// Extract trailing digits from string (e.g., "exynos9955" -> "9955", "s5e9965" -> "9965")
+inline bool GetTrimNumber(std::string& value) {
+  const char* digits = "0123456789";
+  auto lp = value.find_last_of(digits);
+  if (lp == std::string::npos) return false;
+
+  // Find the start of the trailing digit block
+  auto fp = lp;
+  while (fp > 0 && std::strchr(digits, value[fp - 1]) != nullptr) {
+    fp--;
+  }
+
+  value = value.substr(fp, lp - fp + 1);
+  return true;
+}
+
+// SOC-to-performance-config map
+inline const std::unordered_map<std::string, PerfConfig>& GetSocPerfConfigMap() {
+  static const std::unordered_map<std::string, PerfConfig> kSocPerfConfig = {
+      {"9955", {ENN_PREF_MODE_PERFORMANCE, PERF_CONFIG_ID_DEFAULT}},
+      {"9965", {ENN_PREF_MODE_PERFORMANCE, PERF_CONFIG_ID_DEFAULT}},
+  };
+  return kSocPerfConfig;
+}
+
+inline PerfConfig GetPerfConfigFromSoc(absl::string_view soc_name) {
+  std::string key = "";
+
+  // Try ro.hardware first (primary)
+  key = GetHwName();
+  if (!key.empty()) {
+    GetTrimNumber(key);
+  }
+
+  // Fallback to ro.soc.model
+  if (key.empty()) {
+    key = GetSocName();
+    if (!key.empty()) {
+      GetTrimNumber(key);
+    }
+  }
+
+  // Lookup in map
+  const auto& map = GetSocPerfConfigMap();
+  auto it = map.find(key);
+  if (it != map.end()) {
+    return it->second;
+  }
+
+  return {ENN_PREF_MODE_PERFORMANCE, PERF_CONFIG_ID_DEFAULT};
+}
+
+inline LiteRtStatus SetGenAiPerfConfig(const EnnManager::PublicApi& api,
+                                       PerfModePreference mode,
+                                       uint32_t configId = PERF_CONFIG_ID_DEFAULT) {
+  EnnReturn ret_mode = api.EnnSetPreferencePerfMode(static_cast<uint32_t>(mode));
+  if (ret_mode != ENN_RET_SUCCESS) {
+    return kLiteRtStatusErrorRuntimeFailure;
+  }
+  EnnReturn ret_config = api.EnnSetPreferencePerfConfigId(configId);
+  if (ret_config != ENN_RET_SUCCESS) {
+    return kLiteRtStatusErrorRuntimeFailure;
+  }
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus SetGenAiPerfConfigFromSoc(const EnnManager::PublicApi& api);
 
 }  // namespace litert::samsung
 

--- a/litert/vendors/samsung/dispatch/enn_type.h
+++ b/litert/vendors/samsung/dispatch/enn_type.h
@@ -59,3 +59,10 @@ typedef struct _NumberOfBuffersInfo {
   uint32_t n_in_buf;
   uint32_t n_out_buf;
 } NumberOfBuffersInfo;
+
+typedef enum _PerfModePreference {
+  ENN_PREF_MODE_LOW_POWER = 0,
+  ENN_PREF_MODE_BALANCED = 4,
+  ENN_PREF_MODE_CUSTOM = 5,
+  ENN_PREF_MODE_PERFORMANCE = 7,
+} PerfModePreference;

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
@@ -370,25 +370,17 @@ LiteRtDispatchInvocationContextT::Create(
                          "Number of inputs/outputs is invalid");
   }
 
-  // Allocate buffers
-  EnnBufferPtr* tmp_buf_ptr;
-  if (enn_manager->Api().EnnAllocateAllBuffers(
-          model_id, &tmp_buf_ptr, &buffer_info) != ENN_RET_SUCCESS) {
-    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                         "EnnAllocateAllBuffers Failed");
-  }
-  LITERT_LOG(LITERT_INFO, "Buffers allocated successfully");
-
-  LITERT_LOG(LITERT_INFO, "=== Model Loading Complete ===");
-
+  // Release ownership since we're successfully creating the context
   model_guard.release();
 
   auto context = LiteRtDispatchInvocationContextT::UniquePtr(
       new LiteRtDispatchInvocationContextT(enn_manager, device_context,
                                            model_id, num_inputs, num_outputs));
 
-  // Set committed buffer for this model
-  context->SetEnnCommittedBuffer(tmp_buf_ptr);
+  // Initialize commit caching state
+  context->commit_state_ = CommitState::kUncommitted;
+  context->attached_input_count_ = 0;
+  context->attached_output_count_ = 0;
 
   // Set weight signatures for later release
   context->SetWeightSignatures(std::move(signatures));
@@ -397,13 +389,52 @@ LiteRtDispatchInvocationContextT::Create(
 }
 
 LiteRtDispatchInvocationContextT::~LiteRtDispatchInvocationContextT() {
-  auto& weight_mgr =
-      litert::samsung::WeightBinaryManager::GetInstance(enn_manager_);
+  // If committed, uncommit and unset buffers
+  if (commit_state_ == CommitState::kCommitted) {
+    enn_manager_->Api().EnnBufferUncommit(model_id_);
+    enn_manager_->Api().EnnUnsetBuffers(model_id_);
+  }
+
+  // Release weight buffers from global weight manager
+  auto& weight_mgr = litert::samsung::WeightBinaryManager::GetInstance(enn_manager_);
   for (const auto& sig : weight_signatures_) {
     weight_mgr.Release(sig);
   }
 
   enn_manager_->Api().EnnCloseModel(model_id_);
+}
+
+litert::Expected<void> LiteRtDispatchInvocationContextT::TransitionToCommitted() {
+  if (enn_manager_->Api().EnnBufferCommit(model_id_) != ENN_RET_SUCCESS) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure, "Fail to commit buffer");
+  }
+  commit_state_ = CommitState::kCommitted;
+  return {};
+}
+
+litert::Expected<void> LiteRtDispatchInvocationContextT::TransitionToUncommitted() {
+  if (enn_manager_->Api().EnnBufferUncommit(model_id_) != ENN_RET_SUCCESS) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure, "Fail to uncommit buffer");
+  }
+  commit_state_ = CommitState::kUncommitted;
+  return {};
+}
+
+litert::Expected<void> LiteRtDispatchInvocationContextT::UpdateStateAfterAttach() {
+  if (AreAllBuffersAttached()) {
+    // Perform actual commit
+    if (enn_manager_->Api().EnnBufferCommit(model_id_) != ENN_RET_SUCCESS) {
+      return litert::Error(kLiteRtStatusErrorRuntimeFailure, "Fail to commit buffer");
+    }
+    commit_state_ = CommitState::kCommitted;
+  } else {
+    commit_state_ = CommitState::kPartialAttach;
+  }
+  return {};
+}
+
+void LiteRtDispatchInvocationContextT::UpdateStateAfterDetach() {
+  commit_state_ = CommitState::kPartialAttach;
 }
 
 litert::Expected<LiteRtTensorBufferRequirements>
@@ -425,11 +456,33 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::AttachInput(
                          "Invalid input index");
   }
 
+  // Check if already attached
+  if (inputs_buf_[graph_input_index] != nullptr) {
+    return litert::Error(kLiteRtStatusErrorInvalidArgument,
+                         "Input already attached");
+  }
+
+  // If committed, uncommit first before modifying buffers
+  if (commit_state_ == CommitState::kCommitted) {
+    LITERT_RETURN_IF_ERROR(TransitionToUncommitted());
+  }
+
   auto enn_buffer = device_context_->GetEnnBuffer(tensor_buffer_handle);
   if (!enn_buffer) {
     return enn_buffer.Error();
   }
   inputs_buf_[graph_input_index] = enn_buffer.Value();
+
+  // Register buffer with ENN
+  if (enn_manager_->Api().EnnSetBufferByIndex(
+          model_id_, ENN_DIR_IN, graph_input_index, enn_buffer.Value()) !=
+      ENN_RET_SUCCESS) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                         "Fail to set input buffer");
+  }
+
+  attached_input_count_.fetch_add(1, std::memory_order_relaxed);
+  LITERT_RETURN_IF_ERROR(UpdateStateAfterAttach());
 
   return {};
 }
@@ -438,7 +491,18 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::AttachOutput(
     int graph_output_index, LiteRtTensorBufferHandle tensor_buffer_handle) {
   if (graph_output_index < 0 || graph_output_index >= outputs_buf_.size()) {
     return litert::Error(kLiteRtStatusErrorInvalidArgument,
-                         "Invalid input index");
+                         "Invalid output index");
+  }
+
+  // Check if already attached
+  if (outputs_buf_[graph_output_index] != nullptr) {
+    return litert::Error(kLiteRtStatusErrorInvalidArgument,
+                         "Output already attached");
+  }
+
+  // If committed, uncommit first before modifying buffers
+  if (commit_state_ == CommitState::kCommitted) {
+    LITERT_RETURN_IF_ERROR(TransitionToUncommitted());
   }
 
   auto enn_buffer = device_context_->GetEnnBuffer(tensor_buffer_handle);
@@ -446,6 +510,17 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::AttachOutput(
     return enn_buffer.Error();
   }
   outputs_buf_[graph_output_index] = enn_buffer.Value();
+
+  // Register buffer with ENN
+  if (enn_manager_->Api().EnnSetBufferByIndex(
+          model_id_, ENN_DIR_OUT, graph_output_index, enn_buffer.Value()) !=
+      ENN_RET_SUCCESS) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                         "Fail to set output buffer");
+  }
+
+  attached_output_count_.fetch_add(1, std::memory_order_relaxed);
+  LITERT_RETURN_IF_ERROR(UpdateStateAfterAttach());
 
   return {};
 }
@@ -456,7 +531,15 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::DetachInput(
     return litert::Error(kLiteRtStatusErrorInvalidArgument,
                          "Invalid input index");
   }
+
+  // If committed, uncommit first
+  if (commit_state_ == CommitState::kCommitted) {
+    LITERT_RETURN_IF_ERROR(TransitionToUncommitted());
+  }
+
   inputs_buf_[graph_input_index] = nullptr;
+  attached_input_count_.fetch_sub(1, std::memory_order_relaxed);
+  UpdateStateAfterDetach();
 
   return {};
 }
@@ -465,61 +548,34 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::DetachOutput(
     int graph_output_index, LiteRtTensorBufferHandle tensor_buffer_handle) {
   if (graph_output_index < 0 || graph_output_index >= outputs_buf_.size()) {
     return litert::Error(kLiteRtStatusErrorInvalidArgument,
-                         "Invalid input index");
+                         "Invalid output index");
   }
+
+  // If committed, uncommit first
+  if (commit_state_ == CommitState::kCommitted) {
+    LITERT_RETURN_IF_ERROR(TransitionToUncommitted());
+  }
+
   outputs_buf_[graph_output_index] = nullptr;
+  attached_output_count_.fetch_sub(1, std::memory_order_relaxed);
+  UpdateStateAfterDetach();
 
   return {};
 }
 
 litert::Expected<void> LiteRtDispatchInvocationContextT::Invoke() {
-  if (auto status = SetInputBuffers(); !status) {
-    return status.Error();
+  // Check if buffers are committed
+  if (commit_state_ != CommitState::kCommitted) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
+                         "Buffers not committed. Attach all buffers first.");
   }
 
+  // Execute model (no memcpy needed)
   if (enn_manager_->Api().EnnExecuteModel(model_id_) != ENN_RET_SUCCESS) {
     return litert::Error(kLiteRtStatusErrorRuntimeFailure, "Fail to execute");
   }
 
-  if (auto status = SetOutputBuffers(); !status) {
-    return status.Error();
-  }
-
   return {};
 }
 
-litert::Expected<void> LiteRtDispatchInvocationContextT::SetInputBuffers()
-    const {
-  bool input_prepared =
-      std::all_of(inputs_buf_.begin(), inputs_buf_.end(),
-                  [](const EnnBufferPtr& val) { return val != nullptr; });
-  bool output_prepared =
-      std::all_of(outputs_buf_.begin(), outputs_buf_.end(),
-                  [](const EnnBufferPtr& val) { return val != nullptr; });
-  if (!input_prepared || !output_prepared) {
-    return litert::Error(kLiteRtStatusErrorRuntimeFailure,
-                         "Inputs/outputs not prepared.");
-  }
-  LITERT_ASSIGN_OR_RETURN(auto committed_buf, GetEnnCommittedBuffer());
-
-  for (int idx = 0; idx < inputs_buf_.size(); idx++) {
-    auto usr_buf = inputs_buf_.at(idx);
-    auto target_buf = committed_buf[idx];
-    memcpy(target_buf->va, usr_buf->va, usr_buf->size);
-  }
-
-  return {};
-}
-
-litert::Expected<void> LiteRtDispatchInvocationContextT::SetOutputBuffers()
-    const {
-  LITERT_ASSIGN_OR_RETURN(auto committed_buf, GetEnnCommittedBuffer());
-
-  int _input_buf_size = inputs_buf_.size();
-  for (int idx = 0; idx < outputs_buf_.size(); idx++) {
-    auto usr_buf = outputs_buf_.at(idx);
-    auto target_buf = committed_buf[idx + _input_buf_size];
-    memcpy(usr_buf->va, target_buf->va, usr_buf->size);
-  }
-  return {};
-}
+// SetInputBuffers and SetOutputBuffers removed - no longer needed with commit caching

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
@@ -233,7 +233,7 @@ Expected<LiteRtTensorBufferRequirements> GetTensorBufferRequirements(
 }  // namespace litert::samsung
 
 LiteRtDispatchInvocationContextT::LiteRtDispatchInvocationContextT(
-    const ::litert::samsung::EnnManager* enn_manager,
+    ::litert::samsung::EnnManager* enn_manager,
     LiteRtDispatchDeviceContext device_context, const EnnModelId& model_id,
     int num_inputs, int num_outputs)
     : enn_manager_(enn_manager),
@@ -244,7 +244,7 @@ LiteRtDispatchInvocationContextT::LiteRtDispatchInvocationContextT(
 
 litert::Expected<LiteRtDispatchInvocationContextT::UniquePtr>
 LiteRtDispatchInvocationContextT::Create(
-    const ::litert::samsung::EnnManager* enn_manager,
+    ::litert::samsung::EnnManager* enn_manager,
     LiteRtDispatchDeviceContext device_context,
     LiteRtDispatchExecutableType exec_type,
     const LiteRtMemBuffer* exec_bytecode_buffer, const char* function_name,

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.cc
@@ -578,4 +578,13 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::Invoke() {
   return {};
 }
 
+void LiteRtDispatchInvocationContextT::SetSchedulingInfo(
+    const LiteRtSchedulingInfo* scheduling_info) {
+  if (scheduling_info != nullptr) {
+    scheduling_info_ = *scheduling_info;
+  } else {
+    scheduling_info_.reset();
+  }
+}
+
 // SetInputBuffers and SetOutputBuffers removed - no longer needed with commit caching

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
@@ -64,7 +64,9 @@ class LiteRtDispatchInvocationContextT {
 
   litert::Expected<void> Invoke();
 
-private:
+  void SetSchedulingInfo(const LiteRtSchedulingInfo* scheduling_info);
+
+ private:
   // Commit state for caching
   enum class CommitState {
     kUncommitted,     // Initial state or all buffers detached

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
@@ -36,7 +36,7 @@ class LiteRtDispatchInvocationContextT {
   using UniquePtr = std::unique_ptr<LiteRtDispatchInvocationContextT>;
 
   static litert::Expected<UniquePtr> Create(
-      const ::litert::samsung::EnnManager* enn_manager,
+      ::litert::samsung::EnnManager* enn_manager,
       LiteRtDispatchDeviceContext device_context,
       LiteRtDispatchExecutableType exec_type,
       const LiteRtMemBuffer* exec_bytecode_buffer, const char* function_name,
@@ -73,7 +73,7 @@ private:
   };
 
   LiteRtDispatchInvocationContextT(
-      const ::litert::samsung::EnnManager* enn_manager,
+      ::litert::samsung::EnnManager* enn_manager,
       LiteRtDispatchDeviceContext device_context, const EnnModelId& model_id,
       int num_inputs, int num_outputs);
 
@@ -92,7 +92,7 @@ private:
     weight_signatures_ = std::move(signatures);
   }
 
-  const ::litert::samsung::EnnManager* enn_manager_;
+  ::litert::samsung::EnnManager* enn_manager_;
   LiteRtDispatchDeviceContext device_context_;
   std::optional<LiteRtSchedulingInfo> scheduling_info_;
   EnnModelId model_id_;

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
@@ -30,7 +30,6 @@
 
 // Note: This class is NOT thread-safe.
 // Caller must ensure that only one thread accesses a given instance at a time.
-// For concurrent access, external synchronization is required.
 class LiteRtDispatchInvocationContextT {
  public:
   using UniquePtr = std::unique_ptr<LiteRtDispatchInvocationContextT>;

--- a/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
+++ b/litert/vendors/samsung/dispatch/litert_dispatch_invocation_context.h
@@ -18,6 +18,7 @@
 #ifndef ODML_LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_
 #define ODML_LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_
 
+#include <atomic>
 #include <optional>
 
 #include "litert/c/internal/litert_scheduling_info.h"
@@ -27,6 +28,9 @@
 #include "litert/vendors/c/litert_dispatch.h"
 #include "litert/vendors/samsung/dispatch/enn_manager.h"
 
+// Note: This class is NOT thread-safe.
+// Caller must ensure that only one thread accesses a given instance at a time.
+// For concurrent access, external synchronization is required.
 class LiteRtDispatchInvocationContextT {
  public:
   using UniquePtr = std::unique_ptr<LiteRtDispatchInvocationContextT>;
@@ -60,35 +64,29 @@ class LiteRtDispatchInvocationContextT {
 
   litert::Expected<void> Invoke();
 
-  litert::Expected<EnnBufferPtr*> GetEnnCommittedBuffer(void) const {
-    return committed_buf_;
-  }
+private:
+  // Commit state for caching
+  enum class CommitState {
+    kUncommitted,     // Initial state or all buffers detached
+    kCommitted,       // All buffers attached and committed
+    kPartialAttach,   // Some buffers attached, waiting for commit
+  };
 
-  litert::Expected<void> SetEnnCommittedBuffer(EnnBufferPtr* update) {
-    committed_buf_ = update;
-    return {};
-  }
-
-  void SetSchedulingInfo(const LiteRtSchedulingInfo* scheduling_info) {
-    if (scheduling_info == nullptr) {
-      scheduling_info_ = std::nullopt;
-      return;
-    }
-    scheduling_info_ = *scheduling_info;
-  }
-
-  const LiteRtSchedulingInfo* GetSchedulingInfo() const {
-    return scheduling_info_.has_value() ? &scheduling_info_.value() : nullptr;
-  }
-
- private:
   LiteRtDispatchInvocationContextT(
       const ::litert::samsung::EnnManager* enn_manager,
       LiteRtDispatchDeviceContext device_context, const EnnModelId& model_id,
       int num_inputs, int num_outputs);
 
-  litert::Expected<void> SetInputBuffers() const;
-  litert::Expected<void> SetOutputBuffers() const;
+  bool AreAllBuffersAttached() const {
+    return attached_input_count_.load(std::memory_order_relaxed) == inputs_buf_.size() &&
+           attached_output_count_.load(std::memory_order_relaxed) == outputs_buf_.size();
+  }
+
+  // Helper methods for state transitions
+  litert::Expected<void> TransitionToCommitted();
+  litert::Expected<void> TransitionToUncommitted();
+  litert::Expected<void> UpdateStateAfterAttach();
+  void UpdateStateAfterDetach();
 
   void SetWeightSignatures(std::vector<std::string> signatures) {
     weight_signatures_ = std::move(signatures);
@@ -101,7 +99,11 @@ class LiteRtDispatchInvocationContextT {
   std::vector<EnnBufferPtr> inputs_buf_;
   std::vector<EnnBufferPtr> outputs_buf_;
   std::vector<std::string> weight_signatures_;
-  EnnBufferPtr* committed_buf_;
+
+  // Commit caching state
+  CommitState commit_state_ = CommitState::kUncommitted;
+  std::atomic<int> attached_input_count_{0};
+  std::atomic<int> attached_output_count_{0};
 };
 
 #endif  // ODML_LITERT_VENDORS_SAMSUNG_DISPATCH_INVOCATION_CONTEXT_H_

--- a/litert/vendors/samsung/dispatch/litert_weight_binary_manager.cc
+++ b/litert/vendors/samsung/dispatch/litert_weight_binary_manager.cc
@@ -23,16 +23,21 @@
 
 namespace litert::samsung {
 
-WeightBinaryManager& WeightBinaryManager::GetInstance(
-    const EnnManager* enn_manager) {
+WeightBinaryManager& WeightBinaryManager::GetInstance(EnnManager* enn_manager) {
   static WeightBinaryManager instance(enn_manager);
   return instance;
 }
 
-WeightBinaryManager::WeightBinaryManager(const EnnManager* enn_manager)
+WeightBinaryManager::WeightBinaryManager(EnnManager* enn_manager)
     : enn_manager_(enn_manager) {}
 
-WeightBinaryManager::~WeightBinaryManager() { ClearAll(); }
+WeightBinaryManager::~WeightBinaryManager() {
+  ClearAll();
+  if (!enn_manager_->_enn_deinitialized_) {
+    enn_manager_->_enn_deinitialized_ = true;
+    enn_manager_->Api().EnnDeinitialize();
+  }
+}
 
 // Returns cached buffer if exists, otherwise creates new (from file-opened fd)
 litert::Expected<EnnBufferPtr> litert::samsung::WeightBinaryManager::Acquire(
@@ -102,6 +107,11 @@ litert::Expected<void> WeightBinaryManager::Release(
 // Clears all cached weights
 void WeightBinaryManager::ClearAll() {
   std::lock_guard<std::mutex> lock(mutex_);
+
+  // enn_manager_ may be dangling if EnnManager was destroyed first
+  // (static destruction order across TUs is unspecified).
+  // In that case, ENN runtime is already shutting down -- no-op is safe.
+  if (!enn_manager_) return;
 
   for (auto& e : entries_) {
     if (e.buffer) {

--- a/litert/vendors/samsung/dispatch/litert_weight_binary_manager.h
+++ b/litert/vendors/samsung/dispatch/litert_weight_binary_manager.h
@@ -30,7 +30,7 @@ namespace litert::samsung {
 
 class WeightBinaryManager {
  public:
-  static WeightBinaryManager& GetInstance(const EnnManager* enn_manager);
+  static WeightBinaryManager& GetInstance(EnnManager* enn_manager);
 
   WeightBinaryManager(const WeightBinaryManager&) = delete;
   WeightBinaryManager& operator=(const WeightBinaryManager&) = delete;
@@ -50,7 +50,7 @@ class WeightBinaryManager {
   void ClearAll();
 
  private:
-  explicit WeightBinaryManager(const EnnManager* enn_manager);
+  explicit WeightBinaryManager(EnnManager* enn_manager);
   ~WeightBinaryManager();
 
   struct Entry {
@@ -59,7 +59,7 @@ class WeightBinaryManager {
     int ref_count = 0;
   };
 
-  const EnnManager* enn_manager_;
+  EnnManager* enn_manager_;
   std::list<Entry> entries_;
   std::mutex mutex_;
 };


### PR DESCRIPTION
Summary : 
      1. Implement commit caching for buffer management
        - Remove allocate Enn Buffer from Create phase
        -  Implement auto-commit/uncommit when buffers are attach/detach
        - Remove memory copy overhead
     2. Add performance config for GenAI
        - According to SoC, apply property perf configuration for inferencing Samsung dispatch

