### PR TITLE
litert/qualcomm/htp: Log auto-detected on-chip SoC model id

### DIFF
--- a/litert/vendors/qualcomm/core/backends/htp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.cc
@@ -409,6 +409,8 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
       auto soc_model =
           device_platform_info->v1.hwDevices->v1.deviceInfoExtension
               ->onChipDevice.socModel;
+      QNN_LOG_INFO("Device reported on-chip SoC model id: %u",
+                   static_cast<uint32_t>(soc_model));
       auto soc_info_online =
           FindSocInfo(static_cast<SnapdragonModel>(soc_model));
       soc_info_ = soc_info_online.value_or(kSocInfos[0]);


### PR DESCRIPTION
When `HtpBackend::Init()` runs on-device (aarch64) without a caller-provided SoC, it queries QNN's `deviceGetPlatformInfo()` and looks up the reported `socModel` integer in the local SoC table. If the lookup fails, the code falls back to `kSocInfos[0]` (`UNKNOWN_SDM`, `DspArch::NONE`) and the next check errors out with "SoC info was not configured successfully." -- with no indication of what the device actually reported.

This makes triaging missing SoCs slow: silicon vendors and partners adding a new chip have to instrument the code and rebuild just to learn the on-chip id that QNN is reporting. The information is already available -- just log it before the lookup.

Example output on a Qualcomm Robotics RB3 Gen2 (QCS6490) before the SoC was added to the table:

  INFO: [Qnn] Device reported on-chip SoC model id: 93
  ERROR: [Qnn] SoC info was not configured successfully.

With this log line in place, adding the missing SoC to soc_table.h and soc_table.cc is a trivial one-line follow-up rather than a guess-and-rebuild loop.