### PR TITLE
Update Image Preprocessor

### DIFF
--- a/support/preprocessor/image_preprocessor.h
+++ b/support/preprocessor/image_preprocessor.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <optional>
 #include <utility>
+#include <vector>
 
 #include "absl/status/status.h"  // from @com_google_absl
 #include "absl/status/statusor.h"  // from @com_google_absl
@@ -40,6 +41,15 @@ class ImagePreprocessParameter {
     int max_num_patches;
     // The pooling kernel size.
     int pooling_kernel_size;
+    // use position tensor.
+    bool emit_positions = true;
+  };
+
+  // The config for normalization
+  struct NormalizationConfig {
+    std::vector<float> mean;
+    std::vector<float> std;
+    float rescale_factor = 1.0;
   };
 
   // Gets the target dimensions for preprocessing.
@@ -60,9 +70,20 @@ class ImagePreprocessParameter {
     patchify_config_ = patchify_config;
   }
 
+  // Gets the Normalization config for preprocessing.
+  const std::optional<NormalizationConfig>& GetNormalizationConfig() const {
+    return normalization_config_;
+  }
+
+  // Sets the Normalization config for preprocessing
+  void SetNormalizationConfig(const NormalizationConfig& normalization_config) {
+      normalization_config_ = normalization_config;
+  }
+
  private:
   Dimensions dimensions_;
   std::optional<PatchifyConfig> patchify_config_;
+  std::optional<NormalizationConfig> normalization_config_;
 };
 
 // Preprocessor for image.

--- a/support/preprocessor/image_preprocessor_utils.cc
+++ b/support/preprocessor/image_preprocessor_utils.cc
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <cstdint>
 #include <string>
+#include <optional>
 #include <utility>
 
 #include "absl/container/flat_hash_map.h"  // from @com_google_absl
@@ -137,6 +138,9 @@ absl::StatusOr<InputImage> PatchifyImage(
   }
 
   const int patch_dim = patch_width * patch_height * channels;
+  // Transformer (ViT) encoders consume a per-patch "positions_xy" tensor, while
+  // single input encoders (e.g. LFM2 VL) only consume the "images" tensor.
+  const bool emit_positions = patchify_config->emit_positions;
 
   LITERT_ASSIGN_OR_RETURN(
       auto patches_buffer,
@@ -145,22 +149,27 @@ absl::StatusOr<InputImage> PatchifyImage(
           batch_size * num_patches * patch_dim * sizeof(float)));
 
   LITERT_ASSIGN_OR_RETURN(
-      auto positions_buffer,
-      ::litert::TensorBuffer::CreateManagedHostMemory(
-          MakeRankedTensorType<int32_t>({batch_size, num_patches, 2}),
-          batch_size * num_patches * 2 * sizeof(int32_t)));
-
-  LITERT_ASSIGN_OR_RETURN(
       auto patches_lock,
       ::litert::TensorBufferScopedLock::Create(
           patches_buffer, ::litert::TensorBuffer::LockMode::kWrite));
   float* patches_ptr = reinterpret_cast<float*>(patches_lock.second);
 
-  LITERT_ASSIGN_OR_RETURN(
-      auto positions_lock,
-      ::litert::TensorBufferScopedLock::Create(
-          positions_buffer, ::litert::TensorBuffer::LockMode::kWrite));
-  int32_t* positions_ptr = reinterpret_cast<int32_t*>(positions_lock.second);
+  std::optional<::litert::TensorBuffer> positions_buffer;
+  std::optional<::litert::TensorBufferScopedLock> positions_lock;
+  int32_t* positions_ptr = nullptr;
+  if (emit_positions) {
+    LITERT_ASSIGN_OR_RETURN(
+        positions_buffer,
+        ::litert::TensorBuffer::CreateManagedHostMemory(
+            MakeRankedTensorType<int32_t>({batch_size, num_patches, 2}),
+            batch_size * num_patches * 2 * sizeof(int32_t)));
+    LITERT_ASSIGN_OR_RETURN(
+        auto positions_lock_and_addr,
+        ::litert::TensorBufferScopedLock::Create(
+            *positions_buffer, ::litert::TensorBuffer::LockMode::kWrite));
+    positions_lock = std::move(positions_lock_and_addr.first);
+    positions_ptr = reinterpret_cast<int32_t*>(positions_lock_and_addr.second);
+  }
 
   for (int b = 0; b < batch_size; ++b) {
     for (int h = 0; h < num_patches_h; ++h) {
@@ -168,8 +177,10 @@ absl::StatusOr<InputImage> PatchifyImage(
         int patch_idx = h * num_patches_w + w;
         int global_patch_idx = b * num_patches + patch_idx;
 
-        positions_ptr[global_patch_idx * 2] = w;
-        positions_ptr[global_patch_idx * 2 + 1] = h;
+        if (positions_ptr != nullptr) {
+          positions_ptr[global_patch_idx * 2] = w;
+          positions_ptr[global_patch_idx * 2 + 1] = h;
+        }
 
         for (int ph = 0; ph < patch_height; ++ph) {
           for (int pw = 0; pw < patch_width; ++pw) {
@@ -190,8 +201,11 @@ absl::StatusOr<InputImage> PatchifyImage(
 
   absl::flat_hash_map<std::string, TensorBuffer> tensor_map;
   tensor_map["images"] = std::move(patches_buffer);
-  tensor_map["positions_xy"] = std::move(positions_buffer);
-
+  if (emit_positions) {
+    // Release the write lock before handing the buffer off.
+    positions_lock.reset();
+    tensor_map["positions_xy"] = std::move(*positions_buffer);
+  }
   return InputImage(std::move(tensor_map));
 }
 

--- a/support/preprocessor/stb_image_preprocessor.cc
+++ b/support/preprocessor/stb_image_preprocessor.cc
@@ -180,32 +180,27 @@ absl::StatusOr<InputImage> StbImagePreprocessor::Preprocess(
   std::unique_ptr<unsigned char[], void (*)(void*)> decoded_image_ptr(
       decoded_image, stbi_image_free);
 
-  if (parameter.GetPatchifyConfig().has_value()) {
-    // Patchify the image if patchify config is set.
+  std::vector<unsigned char> resized_image;
+  ImagePreprocessParameter updated_parameter = parameter;
+  if (parameter.GetTargetDimensions().empty()) {
+    // No fixed target dimensions: resize while preserving the aspect ratio so
+    // the image fits the patchify constraints (used by patchifying encoders).
     const size_t num_elements = static_cast<size_t>(original_width) *
                                 original_height * kDesiredChannels;
-    // Resize the image if needed.
-    ImagePreprocessParameter updated_parameter = parameter;
     updated_parameter.SetTargetDimensions(
         {1, original_height, original_width, kDesiredChannels});
     std::vector<unsigned char> image_data(decoded_image,
                                           decoded_image + num_elements);
-    std::vector<unsigned char> resized_image_data;
     RETURN_IF_ERROR(MaybeResizeImageWithSameAspectRatio(
-        image_data, resized_image_data, updated_parameter));
-    // Convert the image to float.
-    std::vector<float> float_image(resized_image_data.size());
-    for (size_t i = 0; i < resized_image_data.size(); ++i) {
-      float_image[i] = static_cast<float>(resized_image_data[i]) / 255.0f;
-    }
-    return PatchifyImage(float_image, updated_parameter);
+        image_data, resized_image, updated_parameter));
   } else {
-    const int batch_size = target_dimensions.at(0);
+    // Fixed target dimensions: resize directly to the requested size.
     const int target_height = target_dimensions.at(1);
     const int target_width = target_dimensions.at(2);
     const int target_channels = target_dimensions.at(3);
-    std::vector<uint8_t> resized_image(static_cast<size_t>(target_width) *
-                                       target_height * target_channels);
+
+    resized_image.resize(static_cast<size_t>(target_width) * target_height *
+                         target_channels);
 
     int alpha_channel = -1;
     if (target_channels == 4) {
@@ -231,33 +226,69 @@ absl::StatusOr<InputImage> StbImagePreprocessor::Preprocess(
                      STBIR_FILTER_CATMULLROM) == 0) {
       return absl::InternalError("Failed to resize image.");
     }
-    // copybara:comment_end
-    const int num_elements =
-        batch_size * target_height * target_width * target_channels;
-    const size_t buffer_size = num_elements * sizeof(float);
-
-    LITERT_ASSIGN_OR_RETURN(
-        auto processed_tensor_buffer,
-        ::litert::TensorBuffer::CreateManagedHostMemory(
-            MakeRankedTensorType<float>(
-                {batch_size, target_height, target_width, target_channels}),
-            buffer_size));
-
-    LITERT_ASSIGN_OR_RETURN(
-        auto processed_tensor_lock_and_addr,
-        ::litert::TensorBufferScopedLock::Create(
-            processed_tensor_buffer, ::litert::TensorBuffer::LockMode::kWrite));
-    float* float_buffer_ptr =
-        reinterpret_cast<float*>(processed_tensor_lock_and_addr.second);
-    // Normalize pixel values from [0, 255] to [0.0f, 1.0f].
-    for (size_t i = 0; i < resized_image.size(); ++i) {
-      float_buffer_ptr[i] = static_cast<float>(resized_image[i]) / 255.0f;
-    }
-
-    InputImage processed_image(std::move(processed_tensor_buffer));
-
-    return processed_image;
   }
+
+  const Dimensions &final_dimensions = updated_parameter.GetTargetDimensions();
+  const int batch_size = final_dimensions.at(0);
+  const int target_height = final_dimensions.at(1);
+  const int target_width = final_dimensions.at(2);
+  const int target_channels = final_dimensions.at(3);
+
+  // Rescale the pixel values into floats. Defaults to the [0, 255] -> [0, 1]
+  // mapping unless an explicit rescale factor is provided.
+  const float rescale_factor =
+      updated_parameter.GetNormalizationConfig().has_value()
+          ? updated_parameter.GetNormalizationConfig()->rescale_factor
+          : (1.0f / 255.0f);
+  std::vector<float> float_image(resized_image.size());
+  for (size_t i = 0; i < resized_image.size(); ++i) {
+    float_image[i] = static_cast<float>(resized_image[i]) * rescale_factor;
+  }
+
+    // Optionally apply per-channel mean/std normalization.
+  if (updated_parameter.GetNormalizationConfig().has_value()) {
+    const auto& normalization_config =
+        *updated_parameter.GetNormalizationConfig();
+    if (normalization_config.mean.size() !=
+            static_cast<size_t>(desired_channels) ||
+        normalization_config.std.size() !=
+            static_cast<size_t>(desired_channels)) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Normalization mean/std size does not match the number of channels (",
+          desired_channels, ")."));
+    }
+    for (size_t index = 0; index < float_image.size(); ++index) {
+      const int ch = index % desired_channels;
+      float_image[index] = (float_image[index] - normalization_config.mean[ch]) /
+                           normalization_config.std[ch];
+     }
+  }
+
+  if (updated_parameter.GetPatchifyConfig().has_value()) {
+    return PatchifyImage(std::move(float_image), updated_parameter);
+  }
+
+  const size_t num_elements = static_cast<size_t>(batch_size) * target_height *
+                              target_width * target_channels;
+  const size_t buffer_size = num_elements * sizeof(float);
+  LITERT_ASSIGN_OR_RETURN(
+      auto processed_tensor_buffer,
+      ::litert::TensorBuffer::CreateManagedHostMemory(
+          MakeRankedTensorType<float>(
+              {batch_size, target_height, target_width, target_channels}),
+          buffer_size));
+  LITERT_ASSIGN_OR_RETURN(
+      auto processed_tensor_lock_and_addr,
+      ::litert::TensorBufferScopedLock::Create(
+          processed_tensor_buffer, ::litert::TensorBuffer::LockMode::kWrite));
+  float* float_buffer_ptr =
+      reinterpret_cast<float*>(processed_tensor_lock_and_addr.second);
+  for (size_t i = 0; i < float_image.size(); ++i) {
+    float_buffer_ptr[i] = float_image[i];
+  }
+  InputImage processed_image(std::move(processed_tensor_buffer));
+
+  return processed_image;
 }
 
 }  // namespace litert::support


### PR DESCRIPTION
- Add an optional NormalizationConfig (rescale factor + per-channel mean/std) to the image preprocessor so encoders with custom normalization (e.g. LFM2 VL) are supported.
- Make the patchify positions_xy tensor optional via an emit_positions flag, since single-input encoders consume only the images tensor while ViT encoders also need positions.
- Unify the resize/rescale/normalize path in the STB preprocessor and branch on target dimensions instead of patchify config, keeping existing ViT and fixed-size models unchanged.
