### PR TITLE
MMapAllocation impelementation for TFlite on Windows

### DIFF
--- a/tflite/CMakeLists.txt
+++ b/tflite/CMakeLists.txt
@@ -127,13 +127,11 @@ set(_TFLITE_ENABLE_NNAPI "${TFLITE_ENABLE_NNAPI}")
 if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Android")
   set(_TFLITE_ENABLE_NNAPI OFF)
 endif()
+
+# mmap_allocation.cc now provides a Win32 (CreateFileMapping/MapViewOfFile)
+# implementation in addition to the POSIX mmap path, so memory mapping is
+# supported on Windows and no longer needs to be force-disabled here.
 set(_TFLITE_ENABLE_MMAP "${TFLITE_ENABLE_MMAP}")
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-  # See https://github.com/tensorflow/tensorflow/blob/\
-  # 2b96f3662bd776e277f86997659e61046b56c315/tensorflow/lite/tools/make/\
-  # Makefile#L157
-  set(_TFLITE_ENABLE_MMAP OFF)
-endif()
 # Simplifies inclusion of non-test sources and headers from a directory.
 # SOURCE_DIR: Directory to search for files.
 # SOURCES_VAR: Variable to append with all matching *.cc and *.h files.

--- a/tflite/allocation_test.cc
+++ b/tflite/allocation_test.cc
@@ -14,19 +14,74 @@ limitations under the License.
 ==============================================================================*/
 #include "tflite/converter/allocation.h"
 
+#include <fcntl.h>
+
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
+#include <string>
 
-#if defined(__linux__)
-#include <fcntl.h>
-#endif
-
+#if defined(_WIN32)
+#include <io.h>
+#else
 #include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 #include <gtest/gtest.h>
 #include "tflite/testing/util.h"
 
 namespace tflite {
+namespace {
+
+// The file-descriptor / offset tests below run on both POSIX and Windows so
+// that the Win32 CreateFileMapping/MapViewOfFile path in mmap_allocation.cc is
+// exercised. These helpers wrap the small platform differences (MSVC's CRT
+// uses `_open`/`_close`/`_filelengthi64` and needs the `_O_BINARY` flag).
+int OpenReadOnly(const char* path) {
+#if defined(_WIN32)
+  return _open(path, _O_RDONLY | _O_BINARY);
+#else
+  return open(path, O_RDONLY);
+#endif
+}
+
+void CloseFd(int fd) {
+#if defined(_WIN32)
+  _close(fd);
+#else
+  close(fd);
+#endif
+}
+
+// Returns the file size in bytes, or -1 on failure.
+int64_t FileSize(int fd) {
+#if defined(_WIN32)
+  return _filelengthi64(fd);
+#else
+  struct stat fd_stat;
+  if (fstat(fd, &fd_stat) != 0) {
+    return -1;
+  }
+  return fd_stat.st_size;
+#endif
+}
+
+// Writes `contents` to a fresh temporary file and returns its path. Used by the
+// copy-on-write test so it never mutates checked-in testdata even if the
+// map_private mapping is (incorrectly) backed by the file.
+std::string WriteTempFile(const std::string& contents) {
+  std::string path = ::testing::TempDir() + "/mmap_alloc_private_test.bin";
+  FILE* f = fopen(path.c_str(), "wb");
+  EXPECT_NE(f, nullptr);
+  if (f != nullptr) {
+    fwrite(contents.data(), 1, contents.size(), f);
+    fclose(f);
+  }
+  return path;
+}
+
+}  // namespace
 
 TEST(MMAPAllocation, TestInvalidFile) {
   if (!MMAPAllocation::IsSupported()) {
@@ -53,7 +108,6 @@ TEST(MMAPAllocation, TestValidFile) {
   EXPECT_NE(allocation.base(), nullptr);
 }
 
-#if defined(__linux__)
 TEST(MMAPAllocation, TestInvalidFileDescriptor) {
   if (!MMAPAllocation::IsSupported()) {
     return;
@@ -69,14 +123,11 @@ TEST(MMAPAllocation, TestInvalidSizeAndOffset) {
     return;
   }
 
-  int fd =
-      open("tflite/testdata/empty_model.bin", O_RDONLY);
+  int fd = OpenReadOnly("tflite/testdata/empty_model.bin");
   ASSERT_GT(fd, 0);
 
-  struct stat fd_stat;
-  ASSERT_EQ(fstat(fd, &fd_stat), 0);
-
-  size_t file_size = fd_stat.st_size;
+  int64_t file_size = FileSize(fd);
+  ASSERT_GT(file_size, 0);
 
   TestErrorReporter error_reporter;
   MMAPAllocation allocation_invalid_offset(fd, /*offset=*/file_size + 100,
@@ -96,11 +147,13 @@ TEST(MMAPAllocation, TestInvalidSizeAndOffset) {
       fd, /*offset=*/10, /*length=*/file_size, &error_reporter);
   EXPECT_FALSE(allocation_excessive_length_with_offset.valid());
 
+  // offset + length overflows size_t; the CheckedInt bounds guard must reject
+  // this rather than wrapping to a small in-range value.
   MMAPAllocation allocation_integer_overflow(
       fd, /*offset=*/10, /*length=*/SIZE_MAX - 5, &error_reporter);
   EXPECT_FALSE(allocation_integer_overflow.valid());
 
-  close(fd);
+  CloseFd(fd);
 }
 
 TEST(MMAPAllocation, TestValidFileDescriptor) {
@@ -108,8 +161,7 @@ TEST(MMAPAllocation, TestValidFileDescriptor) {
     return;
   }
 
-  int fd =
-      open("tflite/testdata/empty_model.bin", O_RDONLY);
+  int fd = OpenReadOnly("tflite/testdata/empty_model.bin");
   ASSERT_GT(fd, 0);
 
   TestErrorReporter error_reporter;
@@ -119,7 +171,7 @@ TEST(MMAPAllocation, TestValidFileDescriptor) {
   EXPECT_GT(allocation.bytes(), 0);
   EXPECT_NE(allocation.base(), nullptr);
 
-  close(fd);
+  CloseFd(fd);
 }
 
 TEST(MMAPAllocation, TestValidFileDescriptorWithOffset) {
@@ -127,24 +179,71 @@ TEST(MMAPAllocation, TestValidFileDescriptorWithOffset) {
     return;
   }
 
-  int fd =
-      open("tflite/testdata/empty_model.bin", O_RDONLY);
+  int fd = OpenReadOnly("tflite/testdata/empty_model.bin");
   ASSERT_GT(fd, 0);
 
-  struct stat fd_stat;
-  ASSERT_EQ(fstat(fd, &fd_stat), 0);
-  size_t file_size = fd_stat.st_size;
+  int64_t file_size = FileSize(fd);
+  ASSERT_GT(file_size, 0);
 
   TestErrorReporter error_reporter;
   MMAPAllocation allocation(fd, /*offset=*/10, /*length=*/file_size - 10,
                             &error_reporter);
   EXPECT_TRUE(allocation.valid());
   EXPECT_GT(allocation.fd(), 0);
-  EXPECT_GT(allocation.bytes(), 0);
+  EXPECT_EQ(allocation.bytes(), static_cast<size_t>(file_size - 10));
   EXPECT_NE(allocation.base(), nullptr);
 
-  close(fd);
+  // A non-zero offset that is smaller than the mapping granularity (page size
+  // on POSIX, dwAllocationGranularity on Windows) cannot start the mapped view
+  // exactly at the requested byte. The implementation rounds the view down to
+  // the granularity boundary and exposes the requested byte via base(), which
+  // is mmapped_buffer() advanced by offset_in_buffer(). Verify base() lands
+  // `offset` bytes past the granularity-aligned start of the file.
+  EXPECT_EQ(allocation.mmapped_buffer_offset_in_file(), 0u);
+  EXPECT_EQ(
+      static_cast<const char*>(allocation.base()) -
+          static_cast<const char*>(allocation.mmapped_buffer()),
+      10);
+  EXPECT_EQ(allocation.mmapped_buffer_size(), static_cast<size_t>(file_size));
+
+  CloseFd(fd);
 }
-#endif  // defined(__linux__)
+
+// The default (map_private == false) mapping is read-only and shared. The
+// map_private == true mapping is copy-on-write and writable: edits must be
+// visible through the mapping but must NOT be flushed back to the file on
+// disk. This exercises the PAGE_WRITECOPY / FILE_MAP_COPY Win32 path (and
+// MAP_PRIVATE|PROT_WRITE on POSIX).
+TEST(MMAPAllocation, TestMapPrivateIsWritableAndDoesNotModifyFile) {
+  if (!MMAPAllocation::IsSupported()) {
+    return;
+  }
+
+  const char original_first_byte = 0x11;
+  const std::string contents(64, original_first_byte);
+  const std::string path = WriteTempFile(contents);
+
+  int fd = OpenReadOnly(path.c_str());
+  ASSERT_GT(fd, 0);
+
+  TestErrorReporter error_reporter;
+  MMAPAllocation writable(fd, &error_reporter, /*map_private=*/true);
+  ASSERT_TRUE(writable.valid());
+
+  char* data = const_cast<char*>(static_cast<const char*>(writable.base()));
+  const char kSentinel = static_cast<char>(original_first_byte ^ 0x5A);
+  data[0] = kSentinel;
+  // The write is visible through the copy-on-write mapping.
+  EXPECT_EQ(data[0], kSentinel);
+
+  // Re-map the file read-only and confirm the on-disk byte is unchanged (the
+  // copy-on-write page was never flushed back to the file).
+  TestErrorReporter verify_reporter;
+  MMAPAllocation verify(fd, &verify_reporter);
+  ASSERT_TRUE(verify.valid());
+  EXPECT_EQ(static_cast<const char*>(verify.base())[0], original_first_byte);
+
+  CloseFd(fd);
+}
 
 }  // namespace tflite

--- a/tflite/converter/BUILD
+++ b/tflite/converter/BUILD
@@ -2182,7 +2182,12 @@ cc_library(
     srcs = [
         "allocation.cc",
     ] + select({
-        ":tflite_mmap_disabled": [
+        # Note: this uses ":mmap_allocation_disabled" (NOT ":tflite_mmap_disabled")
+        # so that Windows compiles the real mmap_allocation.cc -- it has a Win32
+        # (CreateFileMapping/MapViewOfFile) path. The -DTFLITE_MMAP_DISABLED copt
+        # is still defined on Windows for other code (e.g. the 4bit kernel's
+        # anonymous-mmap prepack cache), but file mapping itself is supported.
+        ":mmap_allocation_disabled": [
             "mmap_allocation_disabled.cc",
         ],
         "//conditions:default": [
@@ -2277,6 +2282,17 @@ selects.config_setting_group(
         ":fuchsia_mmap_disabled",
         ":tflite_mmap_disabled_true",
         "@org_tensorflow//tensorflow:windows",
+    ],
+)
+
+# Selects whether the no-op mmap_allocation_disabled.cc is compiled instead of
+# the real mmap_allocation.cc. Unlike ":tflite_mmap_disabled", this does NOT
+# include Windows, because mmap_allocation.cc has a Win32 file-mapping path.
+selects.config_setting_group(
+    name = "mmap_allocation_disabled",
+    match_any = [
+        ":fuchsia_mmap_disabled",
+        ":tflite_mmap_disabled_true",
     ],
 )
 # LINT.ThenChange(//tflite/BUILD)

--- a/tflite/converter/mmap_allocation.cc
+++ b/tflite/converter/mmap_allocation.cc
@@ -13,13 +13,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include <fcntl.h>
 #include <stddef.h>
+
+#include <cerrno>
+
+#if defined(_WIN32)
+#include <fcntl.h>
+#include <io.h>
+#include <windows.h>
+#else
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
-#include <cerrno>
+#endif
 
 #include "tflite/converter/allocation.h"
 #include "tflite/converter/core/api/error_reporter.h"
@@ -27,6 +34,64 @@ limitations under the License.
 
 namespace tflite {
 namespace {
+
+#if defined(_WIN32)
+
+// On Windows a mapped view of a file is represented by the address returned
+// from MapViewOfFile(). A failed mapping is reported as nullptr (there is no
+// MAP_FAILED sentinel), and the open file descriptor uses the MSVC CRT.
+constexpr void* kFailedMmap = nullptr;
+
+// Returns the platform allocation granularity. On Windows the file offset
+// passed to MapViewOfFile() must be a multiple of dwAllocationGranularity
+// (typically 64KB), which is coarser than the page size used on POSIX.
+size_t GetMapOffsetAlignment() {
+  SYSTEM_INFO sys_info;
+  ::GetSystemInfo(&sys_info);
+  return sys_info.dwAllocationGranularity;
+}
+
+// Splits a 64-bit value into the high/low 32-bit parts expected by the
+// Win32 file-mapping APIs.
+struct HighLow {
+  DWORD high;
+  DWORD low;
+
+  static HighLow From(uint64_t value) {
+    return HighLow{static_cast<DWORD>(value >> 32),
+                   static_cast<DWORD>(value & 0xFFFFFFFFULL)};
+  }
+};
+
+// _dup(-1) (and other negative fds) trips the MSVC CRT invalid-parameter
+// handler, which aborts the process by default. Guard so a bad fd is reported
+// as an error the same way it is on POSIX, where dup(-1) simply returns -1.
+int DupFd(int fd) { return fd < 0 ? -1 : _dup(fd); }
+int CloseFd(int fd) { return _close(fd); }
+int OpenReadOnly(const char* filename) {
+  return _open(filename, _O_RDONLY | _O_BINARY);
+}
+
+size_t GetFdSizeBytes(int fd) {
+  if (fd < 0) {
+    return 0;
+  }
+  int64_t size = _filelengthi64(fd);
+  if (size < 0) {
+    return 0;
+  }
+  return static_cast<size_t>(size);
+}
+
+#else  // !_WIN32
+
+void* const kFailedMmap = MAP_FAILED;
+
+size_t GetMapOffsetAlignment() { return sysconf(_SC_PAGE_SIZE); }
+
+int DupFd(int fd) { return dup(fd); }
+int CloseFd(int fd) { return close(fd); }
+int OpenReadOnly(const char* filename) { return open(filename, O_RDONLY); }
 
 size_t GetFdSizeBytes(int fd) {
   if (fd < 0) {
@@ -41,11 +106,13 @@ size_t GetFdSizeBytes(int fd) {
   return fd_stat.st_size;
 }
 
+#endif  // _WIN32
+
 }  // namespace
 
 MMAPAllocation::MMAPAllocation(const char* filename,
                                ErrorReporter* error_reporter, bool map_private)
-    : MMAPAllocation(error_reporter, open(filename, O_RDONLY), map_private) {
+    : MMAPAllocation(error_reporter, OpenReadOnly(filename), map_private) {
   if (mmap_fd_ == -1) {
     TF_LITE_REPORT_ERROR(error_reporter, "Could not open '%s'.", filename);
   }
@@ -53,7 +120,7 @@ MMAPAllocation::MMAPAllocation(const char* filename,
 
 MMAPAllocation::MMAPAllocation(int fd, ErrorReporter* error_reporter,
                                bool map_private)
-    : MMAPAllocation(error_reporter, dup(fd), map_private) {
+    : MMAPAllocation(error_reporter, DupFd(fd), map_private) {
   if (mmap_fd_ == -1) {
     TF_LITE_REPORT_ERROR(error_reporter, "Failed to dup '%d' file descriptor.",
                          fd);
@@ -63,7 +130,7 @@ MMAPAllocation::MMAPAllocation(int fd, ErrorReporter* error_reporter,
 MMAPAllocation::MMAPAllocation(const char* filename, size_t offset,
                                size_t length, ErrorReporter* error_reporter,
                                bool map_private)
-    : MMAPAllocation(error_reporter, open(filename, O_RDONLY), offset, length,
+    : MMAPAllocation(error_reporter, OpenReadOnly(filename), offset, length,
                      map_private) {
   if (mmap_fd_ == -1) {
     TF_LITE_REPORT_ERROR(error_reporter, "Could not open '%s'.", filename);
@@ -72,7 +139,7 @@ MMAPAllocation::MMAPAllocation(const char* filename, size_t offset,
 
 MMAPAllocation::MMAPAllocation(int fd, size_t offset, size_t length,
                                ErrorReporter* error_reporter, bool map_private)
-    : MMAPAllocation(error_reporter, dup(fd), offset, length, map_private) {
+    : MMAPAllocation(error_reporter, DupFd(fd), offset, length, map_private) {
   if (mmap_fd_ == -1) {
     TF_LITE_REPORT_ERROR(error_reporter, "Failed to dup '%d' file descriptor.",
                          fd);
@@ -88,21 +155,23 @@ MMAPAllocation::MMAPAllocation(ErrorReporter* error_reporter, int owned_fd,
                                size_t offset, size_t length, bool map_private)
     : Allocation(error_reporter, Allocation::Type::kMMap),
       mmap_fd_(owned_fd),
-      mmapped_buffer_(MAP_FAILED),
+      mmapped_buffer_(kFailedMmap),
       buffer_size_bytes_(length) {
   if (owned_fd < 0) {
     return;
   }
 
-  static int pagesize = sysconf(_SC_PAGE_SIZE);
-
-  offset_in_buffer_ = offset % pagesize;
+  const size_t alignment = GetMapOffsetAlignment();
+  offset_in_buffer_ = offset % alignment;
   offset_of_buffer_in_file_ = offset - offset_in_buffer_;
 
   size_t file_size = GetFdSizeBytes(mmap_fd_);
   CheckedInt<size_t> checked_length_offset =
       CheckedInt<size_t>(length) + offset;
-  if (checked_length_offset.Overflow() ||
+  // A zero-length mapping is rejected on both platforms: POSIX mmap(len=0)
+  // fails with EINVAL, and on Windows MapViewOfFile(size=0) would instead map
+  // to the end of the file -- an inconsistency, so reject it explicitly.
+  if (length == 0 || checked_length_offset.Overflow() ||
       checked_length_offset.Value() > file_size) {
     TF_LITE_REPORT_ERROR(error_reporter,
                          "Asked to mmap '%d' bytes from fd '%d' at offset "
@@ -111,6 +180,47 @@ MMAPAllocation::MMAPAllocation(ErrorReporter* error_reporter, int owned_fd,
     return;
   }
 
+#if defined(_WIN32)
+  HANDLE osf_handle = reinterpret_cast<HANDLE>(_get_osfhandle(mmap_fd_));
+  if (osf_handle == INVALID_HANDLE_VALUE) {
+    TF_LITE_REPORT_ERROR(error_reporter,
+                         "Failed to obtain file handle for fd '%d'.", mmap_fd_);
+    return;
+  }
+
+  // map_private => copy-on-write writable mapping; otherwise read-only shared.
+  const DWORD protect = map_private ? PAGE_WRITECOPY : PAGE_READONLY;
+  const DWORD access = map_private ? FILE_MAP_COPY : FILE_MAP_READ;
+
+  // A maximum size of 0 maps the whole file; the view below restricts the
+  // window that is actually mapped into the address space.
+  HANDLE file_mapping = ::CreateFileMappingA(osf_handle, /*attributes=*/nullptr,
+                                             protect, /*sizeHigh=*/0,
+                                             /*sizeLow=*/0, /*name=*/nullptr);
+  if (file_mapping == nullptr) {
+    TF_LITE_REPORT_ERROR(error_reporter,
+                         "CreateFileMapping of fd '%d' failed with error '%lu'.",
+                         mmap_fd_, ::GetLastError());
+    return;
+  }
+
+  HighLow file_offset = HighLow::From(offset_of_buffer_in_file_);
+  mmapped_buffer_ = ::MapViewOfFile(file_mapping, access, file_offset.high,
+                                    file_offset.low,
+                                    /*dwNumberOfBytesToMap=*/length +
+                                        offset_in_buffer_);
+  // The view holds its own reference to the section object, so the mapping
+  // handle can be released immediately; the view stays valid until unmapped.
+  ::CloseHandle(file_mapping);
+
+  if (mmapped_buffer_ == nullptr) {
+    TF_LITE_REPORT_ERROR(error_reporter,
+                         "MapViewOfFile of fd '%d' at offset '%d' failed with "
+                         "error '%lu'.",
+                         mmap_fd_, offset, ::GetLastError());
+    return;
+  }
+#else   // !_WIN32
   mmapped_buffer_ = mmap(nullptr, /*__len=*/length + offset_in_buffer_,
                          map_private ? (PROT_READ | PROT_WRITE) : PROT_READ,
                          map_private ? MAP_PRIVATE : MAP_SHARED, mmap_fd_,
@@ -121,15 +231,20 @@ MMAPAllocation::MMAPAllocation(ErrorReporter* error_reporter, int owned_fd,
                          mmap_fd_, offset, errno);
     return;
   }
+#endif  // _WIN32
 }
 
 MMAPAllocation::~MMAPAllocation() {
   if (valid()) {
+#if defined(_WIN32)
+    ::UnmapViewOfFile(const_cast<void*>(mmapped_buffer_));
+#else
     munmap(const_cast<void*>(mmapped_buffer_),
            buffer_size_bytes_ + offset_in_buffer_);
+#endif
   }
   if (mmap_fd_ >= 0) {
-    close(mmap_fd_);
+    CloseFd(mmap_fd_);
   }
 }
 
@@ -140,7 +255,7 @@ const void* MMAPAllocation::base() const {
 
 size_t MMAPAllocation::bytes() const { return buffer_size_bytes_; }
 
-bool MMAPAllocation::valid() const { return mmapped_buffer_ != MAP_FAILED; }
+bool MMAPAllocation::valid() const { return mmapped_buffer_ != kFailedMmap; }
 
 bool MMAPAllocation::IsSupported() { return true; }
 


### PR DESCRIPTION
Implement MMapAllocation for TFlite so the file backed model loading can utilize this.