### PR TITLE
Qualcomm AI Engine Direct - Fix Data Size for Spatial Transformation Op.

### DIFF
--- a/litert/vendors/qualcomm/core/builders/spatial_transform_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/spatial_transform_op_builder.cc
@@ -35,7 +35,7 @@ std::vector<OpWrapper> BuildSpatialTransformOp(
   const std::vector<std::uint32_t> block_dims{2};
   auto& block_tensor = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_UINT_32, QuantizeParamsWrapperVariant{}, block_dims,
-      sizeof(decltype(block_dims)::value_type) * block_dims.size(),
+      sizeof(decltype(block_data)::value_type) * block_data.size(),
       block_data.data());
   spatial_transform_op.AddTensorParam(block_param, block_tensor);
 

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -335,6 +335,39 @@ litert_test(
 )
 
 litert_test(
+    name = "spatial_transform_test",
+    srcs = [
+        "spatial_transform_test.cc",
+    ],
+    linkopts = select({
+        "//litert:android": [],
+        "//conditions:default": [
+            make_rpaths([
+                "//litert/c:litert_runtime_c_api_so",
+            ]),
+        ],
+    }),
+    linkstatic = True,
+    no_main = True,
+    tags = [
+        "noasan",
+        "nomsan",
+        "nosan",
+        "notsan",
+    ],
+    target_compatible_with = _COMPATIBLE_OS,
+    ungrte = True,
+    use_sys_malloc = True,
+    deps = [
+        "//litert/vendors/qualcomm/core/builders:spatial_transform_op_builder",
+        "//litert/vendors/qualcomm/core/utils:test_main",
+        "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "@qairt//:qnn_lib_headers",
+    ] + _QNN_DEPS,
+)
+
+litert_test(
     name = "hadamard_transform_test",
     srcs = [
         "hadamard_transform_test.cc",

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/spatial_transform_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/spatial_transform_test.cc
@@ -1,0 +1,91 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <utility>
+#include <variant>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "litert/vendors/qualcomm/core/builders/spatial_transform_op_builder.h"
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+#include "QnnTypes.h"  // from @qairt
+
+namespace litert::qnn {
+namespace {
+using ::testing::ElementsAreArray;
+
+INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
+                         QnnTestPrinter);
+
+TEST_P(QnnModelTest, QuantizedDepthToSpaceValidatesWithQnn) {
+  const ::qnn::QuantizeParamsWrapperVariant quant_params{
+      std::in_place_type<::qnn::ScaleOffsetQuantizeParamsWrapper>, 0.00467028f,
+      87};
+
+  auto& input = tensor_pool_.CreateInputTensorWithName(
+      "in", QNN_DATATYPE_SFIXED_POINT_8, quant_params, {1, 1, 1, 9});
+  auto& output = tensor_pool_.CreateOutputTensorWithName(
+      "out", QNN_DATATYPE_SFIXED_POINT_8, quant_params, {1, 3, 3, 1});
+
+  auto ops = ::qnn::BuildDepthToSpaceOp(tensor_pool_, {input}, {output},
+                                        /*block_size=*/3);
+  ASSERT_FALSE(ops.empty());
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  EXPECT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "Execution requires an on-device Qualcomm HTP.";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input);
+  auto output_idx = qnn_model_.AddOutputTensor(output);
+  const std::vector<std::int8_t> input_data{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  qnn_model_.SetInputData<std::int8_t>(input_idx, input_data);
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<std::int8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  EXPECT_THAT(output_data.value(), ElementsAreArray(input_data));
+}
+
+TEST_P(QnnModelTest, QuantizedSpaceToDepthValidatesWithQnn) {
+  const ::qnn::QuantizeParamsWrapperVariant quant_params{
+      std::in_place_type<::qnn::ScaleOffsetQuantizeParamsWrapper>, 0.00467028f,
+      87};
+
+  auto& input = tensor_pool_.CreateInputTensorWithName(
+      "in", QNN_DATATYPE_SFIXED_POINT_8, quant_params, {1, 3, 3, 1});
+  auto& output = tensor_pool_.CreateOutputTensorWithName(
+      "out", QNN_DATATYPE_SFIXED_POINT_8, quant_params, {1, 1, 1, 9});
+
+  auto ops = ::qnn::BuildSpaceToDepthOp(tensor_pool_, {input}, {output},
+                                        /*block_size=*/3);
+  ASSERT_FALSE(ops.empty());
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  EXPECT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "Execution requires an on-device Qualcomm HTP.";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input);
+  auto output_idx = qnn_model_.AddOutputTensor(output);
+  const std::vector<std::int8_t> input_data{0, 1, 2, 3, 4, 5, 6, 7, 8};
+  qnn_model_.SetInputData<std::int8_t>(input_idx, input_data);
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<std::int8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  EXPECT_THAT(output_data.value(), ElementsAreArray(input_data));
+}
+
+}  // namespace
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/tests/CMakeLists.txt
+++ b/litert/vendors/qualcomm/tests/CMakeLists.txt
@@ -99,6 +99,7 @@ target_sources(builder_test
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/pack_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/pad_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/relu_test.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/spatial_transform_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/splitv_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/topk_test.cc
 )


### PR DESCRIPTION
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 31.6s
```

```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 23 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 23 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (15 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 22 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 36 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 27 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 27 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (19 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (526 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (345 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (380 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1043 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1231 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test
[==========] 2 tests from 1 test suite ran. (634 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (577 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1957 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (44 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (522 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (473 ms total)
[  PASSED  ] 2 tests.


```