### PR TITLE
litert: honor FP16_SOURCE_DIR for the fp16 headers include path

### DIFF
--- a/litert/CMakeLists.txt
+++ b/litert/CMakeLists.txt
@@ -203,6 +203,9 @@ endif()
 if(EXISTS "${CMAKE_BINARY_DIR}/FP16-source/include")
     include_directories(${CMAKE_BINARY_DIR}/FP16-source/include)
 endif()
+if(FP16_SOURCE_DIR AND EXISTS "${FP16_SOURCE_DIR}/include")
+    include_directories(${FP16_SOURCE_DIR}/include)
+endif()
 
 # Find FlatBuffers
 #


### PR DESCRIPTION
The top-level litert/CMakeLists.txt only adds the FP16 headers to the include path when they are found at the hardcoded location ${CMAKE_BINARY_DIR}/FP16-source/include. That path is populated only when the bundled TFLite build downloads FP16 itself via its cmake/DownloadFP16.cmake ExternalProject.

When FP16 is instead provided out-of-band through the documented FP16_SOURCE_DIR variable -- which tflite/CMakeLists.txt already consumes to skip the download -- the ${CMAKE_BINARY_DIR}/FP16-source directory never exists, so the if(EXISTS ...) check is false and the FP16 include directory is never added. LiteRT sources that include "fp16.h" then fail to compile with:

    fatal error: fp16.h: No such file or directory

This is the common case for offline / air-gapped / sysroot-based / cross-compile builds that pre-provide all third-party sources and set -DFP16_SOURCE_DIR=...

Add a fallback that also adds ${FP16_SOURCE_DIR}/include to the include path when that variable is set, mirroring how the bundled TFLite build already treats FP16_SOURCE_DIR. Behaviour when FP16 is downloaded into FP16-source is unchanged.