### PR TITLE
litert: allow find_package(flatbuffers) to use system packages

### DIFF
--- a/litert/CMakeLists.txt
+++ b/litert/CMakeLists.txt
@@ -219,7 +219,6 @@ find_package(flatbuffers QUIET
       ${LITERT_FLATBUFFERS_BUILD_DIR}
       ${LITERT_FLATBUFFERS_DIR}/CMake
       ${CMAKE_BINARY_DIR}/flatbuffers-flatc/lib/cmake/flatbuffers
-    NO_DEFAULT_PATH
 )
 
 if(NOT TARGET flatbuffers::flatbuffers)


### PR DESCRIPTION
The top-level litert/CMakeLists.txt calls
find_package(flatbuffers QUIET ... NO_DEFAULT_PATH), which restricts the search to the in-tree FlatBuffers build directories under ${CMAKE_BINARY_DIR}. In build environments where FlatBuffers is provided via CMake's default search paths -- for example through a distribution package (flatbuffers-devel, libflatbuffers-dev), a sysroot, or via CMAKE_PREFIX_PATH / flatbuffers_DIR -- this hard-coded NO_DEFAULT_PATH prevents LiteRT from picking up that package.

When no in-tree FlatBuffers is built (offline / packaged builds that disable the bundled FetchContent path), the find_package call silently fails and the fallback IMPORTED target is created pointing at ${LITERT_FLATBUFFERS_BUILD_DIR}/libflatbuffers.a, which does not exist, producing a broken flatbuffers::flatbuffers target and a link failure later.

Drop NO_DEFAULT_PATH so CMake's standard package-search fallback also applies. The explicit PATHS still take precedence, so behaviour for the bundled FetchContent build is unchanged; only environments that already provide FlatBuffers via CMake's default search paths gain the ability to reuse it.