### PR TITLE
litert/c: add version/soversion to the C API shared library

### DIFF
--- a/litert/c/CMakeLists.txt
+++ b/litert/c/CMakeLists.txt
@@ -15,6 +15,11 @@
 # LiteRT C API
 cmake_minimum_required(VERSION 3.20)
 
+set(LITERT_MAJOR_VERSION "" CACHE STRING "LiteRt major version")
+set(LITERT_MINOR_VERSION "" CACHE STRING "LiteRt minor version")
+set(LITERT_PATCH_VERSION "" CACHE STRING "LiteRt patch version")
+set(LITERT_VERSION "${LITERT_MAJOR_VERSION}.${LITERT_MINOR_VERSION}.${LITERT_PATCH_VERSION}")
+
 add_subdirectory(internal)
 
 set(LITERT_C_PUBLIC_HEADERS
@@ -246,6 +251,40 @@ set_target_properties(litert_runtime_c_api_shared_lib PROPERTIES
     POSITION_INDEPENDENT_CODE ON
 )
 set_target_properties(litert_runtime_c_api_shared_lib PROPERTIES INTERFACE_LINK_LIBRARIES "")
+if(LITERT_MAJOR_VERSION)
+    set_target_properties(litert_runtime_c_api_shared_lib PROPERTIES
+        VERSION   "${LITERT_VERSION}"
+        SOVERSION "${LITERT_MAJOR_VERSION}"
+    )
+endif()
+
+install(TARGETS litert_runtime_c_api_shared_lib
+    LIBRARY
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT   Runtime
+    NAMELINK_COMPONENT Development
+)
+
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/litert/c/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/litert/c
+    COMPONENT   Development
+    FILES_MATCHING PATTERN "*.h"
+)
+
+install(FILES ${LITERT_BUILD_COMMON_GENERATED_DIR}/build_config.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/litert/build_common
+    COMPONENT   Development
+)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/litert.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/litert.pc
+    @ONLY
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/litert.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    COMPONENT   Development
+)
 target_compile_options(litert_runtime_c_api_shared_lib PRIVATE
     -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables
     -ffunction-sections -fdata-sections

--- a/litert/c/litert.pc.in
+++ b/litert/c/litert.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: litert
+Description: LiteRT (Google AI Edge runtime) shared library
+Version: @LITERT_VERSION@
+Libs: -L${libdir} -lLiteRt
+Cflags: -I${includedir}
+


### PR DESCRIPTION
The LiteRT C API shared library (libLiteRt.so) is built with no version information, so it installs as an unversioned libLiteRt.so carrying a plain "libLiteRt.so" SONAME. Distributions expect a versioned shared object (libLiteRt.so.MAJOR.MINOR.PATCH with a libLiteRt.so.MAJOR SONAME and a libLiteRt.so development symlink), matching the convention already used by the TensorFlow Lite C API (libtensorflowlite_c).

Introduce LITERT_{MAJOR,MINOR,PATCH}_VERSION cache variables and set the VERSION and SOVERSION target properties on
litert_runtime_c_api_shared_lib so CMake emits the versioned shared object together with its SONAME and development symlinks. The versions default to empty, which preserves the previous unversioned behaviour unless they are supplied at configure time, so the change is opt-in and backwards compatible.