### PR TITLE
[Not for Landing] OV NPU: support DUS in-graph for prefill/decode

### DIFF
--- a/litert/runtime/compiled_model.cc
+++ b/litert/runtime/compiled_model.cc
@@ -24,6 +24,7 @@
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <set>
 #include <memory>
 #include <optional>
 #include <string>
@@ -474,6 +475,13 @@ Expected<void> LiteRtCompiledModelT::InitializeRuntime(
       std::make_unique<LiteRtExternalLiteRtBufferContextT>(env, get_tensor_id);
   interp_->SetExternalContext(kTfLiteLiteRtBufferContext,
                               buffer_context_.get());
+
+  // Record in-place DUS operand/output pairs now, while ops still carry their
+  // original subgraph indices (delegation below outlines partitions and would
+  // obscure the pairing). Consumed by the delegate kernel (Prepare) and the
+  // boundary-buffer drain to co-alias NPU<->CPU<->NPU boundaries onto one host
+  // buffer.
+  BuildDusInplaceMap();
 
   // Check if the external weights is provided by the client.
   if (jit_compilation_options == nullptr) {
@@ -993,6 +1001,14 @@ LiteRtCompiledModelT::Create(LiteRtEnvironmentT* env, LiteRtModel model,
       !(hardware_accelerators & kLiteRtHwAcceleratorCpu) &&
       !has_non_delegated_ops;
   compiled_model->CheckCpuTensors();
+  // Attach OpenVINO host buffers to internal NPU<->CPU boundary tensors now
+  // (once), while the graph is otherwise untouched -- before any per-run I/O
+  // buffer registration in Run(). Custom allocations persist across the
+  // AllocateTensors calls Run() makes later, so the boundary stays zero-copy.
+  if (auto attached = compiled_model->AttachHostBoundaryBuffers(); !attached) {
+    return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                      attached.Error().Message());
+  }
   return compiled_model;
 }
 
@@ -1057,6 +1073,174 @@ void LiteRtCompiledModelT::CheckCpuTensors() {
       }
     }
   }
+}
+
+void LiteRtCompiledModelT::BuildDusInplaceMap() {
+  if (buffer_context_ == nullptr) {
+    return;
+  }
+  // A DYNAMIC_UPDATE_SLICE writes its operand (input 0) in place. The reference
+  // TFLite kernel declares kTfLiteInplaceOpInput0Shared and skips the whole-
+  // tensor copy when operand and output share one buffer -- but only when the
+  // operand is not read by any other op (a second reader of the pre-update
+  // buffer would see corrupted data). Record only single-consumer operands so
+  // the kernel + drain can safely co-alias the DUS operand and output onto one
+  // OpenVINO host buffer (killing both the NPU<->CPU boundary memcpy AND the
+  // in-kernel 33MB copy). Runs before delegation, so operand/output tensor
+  // indices are still the original subgraph indices the kernel will report.
+  int pairs = 0;
+  for (int subgraph_no = 0; subgraph_no < interp_->subgraphs_size();
+       ++subgraph_no) {
+    auto* subgraph = interp_->subgraph(subgraph_no);
+    auto& execution_plan = subgraph->execution_plan();
+    auto& nodes_and_registration = subgraph->nodes_and_registration();
+    // Count how many nodes consume each tensor in this subgraph.
+    absl::flat_hash_map<int, int> consumer_count;
+    for (int node_index : execution_plan) {
+      const TfLiteNode& node = nodes_and_registration[node_index].first;
+      for (int i = 0; i < node.inputs->size; ++i) {
+        int t = node.inputs->data[i];
+        if (t != kTfLiteOptionalTensor) ++consumer_count[t];
+      }
+    }
+    for (int node_index : execution_plan) {
+      const TfLiteNode& node = nodes_and_registration[node_index].first;
+      const TfLiteRegistration& registration =
+          nodes_and_registration[node_index].second;
+      if (registration.builtin_code != kTfLiteBuiltinDynamicUpdateSlice) {
+        continue;
+      }
+      if (node.inputs->size < 1 || node.outputs->size < 1) continue;
+      int operand_index = node.inputs->data[0];
+      int output_index = node.outputs->data[0];
+      if (operand_index == kTfLiteOptionalTensor ||
+          output_index == kTfLiteOptionalTensor) {
+        continue;
+      }
+      // Operand must be consumed only by this DUS for in-place to be safe.
+      auto it = consumer_count.find(operand_index);
+      if (it == consumer_count.end() || it->second != 1) {
+        continue;
+      }
+      buffer_context_->AddDusInplacePair({subgraph_no, output_index},
+                                         {subgraph_no, operand_index});
+      ++pairs;
+    }
+  }
+  LITERT_LOG(LITERT_INFO,
+             "BuildDusInplaceMap: recorded %d in-place DUS operand/output "
+             "pair(s) for zero-copy boundary co-aliasing",
+             pairs);
+}
+
+litert::Expected<void> LiteRtCompiledModelT::AttachHostBoundaryBuffers() {
+  if (host_boundary_buffers_attached_ || buffer_context_ == nullptr) {
+    return {};
+  }
+  // Kill-switch for A/B testing: LITERT_DISABLE_ZEROCOPY_BOUNDARY=1 skips the
+  // whole host-boundary attach so the runtime falls back to the sync-copy path.
+  if (const char* env = std::getenv("LITERT_DISABLE_ZEROCOPY_BOUNDARY");
+      env != nullptr && env[0] == '1') {
+    LITERT_LOG(LITERT_INFO,
+               "Zero-copy boundary attach DISABLED via "
+               "LITERT_DISABLE_ZEROCOPY_BOUNDARY=1 (sync-copy fallback)");
+    host_boundary_buffers_attached_ = true;
+    return {};
+  }
+  // Run an initial allocation so the dispatch delegate's Prepare
+  // (PreallocateHostBoundaryBuffers) pre-allocates OpenVINO host buffers for
+  // internal NPU<->CPU boundary tensors and records them as custom-allocation
+  // requests on buffer_context_. Requests only exist AFTER this first
+  // AllocateTensors runs the delegate Prepare.
+  if (interp_->AllocateTensors() != kTfLiteOk) {
+    return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                      "AttachHostBoundaryBuffers: initial AllocateTensors "
+                      "failed");
+  }
+  if (buffer_context_->HostCustomAllocationRequests().empty()) {
+    // No internal boundaries need host buffers (e.g. fully delegated model);
+    // leave the graph as-is. Mark done so we don't retry the probe each Run.
+    host_boundary_buffers_attached_ = true;
+    return {};
+  }
+  // Point each boundary tensor's TFLite storage at the OpenVINO host buffer the
+  // kernel pre-allocated, so the un-offloaded CPU consumer (e.g. an in-graph
+  // DynamicUpdateSlice) reads/writes that memory in place -- no per-inference
+  // sync memcpy at the boundary. Custom allocations persist across subsequent
+  // AllocateTensors calls, so doing this once here is enough for all Runs.
+  int applied = 0;
+  std::set<int> affected_subgraphs;
+  for (const auto& req : buffer_context_->HostCustomAllocationRequests()) {
+    // Only tensors a CPU op ACTUALLY reads need a host CustomAllocation. A
+    // dispatch output that feeds another NPU partition (NPU<->NPU boundary) is
+    // already zero-copy via buffer_context_ registration; forcing a CPU custom
+    // allocation onto it corrupts the memory plan and crashes Invoke. cpu_tensors_
+    // (from CheckCpuTensors) is exactly the set of tensors consumed by a
+    // non-delegated CPU op (e.g. the in-graph DynamicUpdateSlice / Cast).
+    TfLiteTensorIdentifier tid{req.subgraph_index, req.tensor_index};
+    // Allow the custom allocation if a CPU op reads this tensor directly (the
+    // DUS operand), OR if it is the OUTPUT of an in-place DUS whose operand a
+    // CPU op reads. The DUS output feeds an NPU BMM (so it is NOT in
+    // cpu_tensors_), but it must still be custom-allocated onto the SAME host
+    // buffer as its operand so the reference DUS kernel sees operand.data ==
+    // output.data and takes its in-place fast path (skips the 33MB copy). All
+    // other non-CPU tensors stay untouched (NPU<->NPU boundaries are already
+    // zero-copy via buffer_context_; forcing a custom allocation there corrupts
+    // the memory plan).
+    const bool is_cpu_read = cpu_tensors_.find(tid) != cpu_tensors_.end();
+    bool is_inplace_dus_output = false;
+    if (!is_cpu_read) {
+      if (const auto* operand_tid =
+              buffer_context_->DusInplaceOperandFor(tid)) {
+        is_inplace_dus_output =
+            cpu_tensors_.find(*operand_tid) != cpu_tensors_.end();
+      }
+    }
+    if (!is_cpu_read && !is_inplace_dus_output) {
+      LITERT_LOG(LITERT_INFO,
+                 "Skipping host custom allocation for boundary tensor (sg %d, "
+                 "idx %d): not consumed by a CPU op (NPU<->NPU, stays zero-copy)",
+                 req.subgraph_index, req.tensor_index);
+      continue;
+    }
+    TfLiteCustomAllocation custom_allocation{req.host_addr, req.size};
+    // Route to the owning subgraph: interp_->SetCustomAllocationForTensor()
+    // only touches the primary subgraph, so decode-subgraph boundary tensors
+    // must go through interp_->subgraph(idx) directly.
+    auto* subgraph = interp_->subgraph(req.subgraph_index);
+    if (subgraph == nullptr ||
+        subgraph->SetCustomAllocationForTensor(
+            req.tensor_index, custom_allocation,
+            kTfLiteCustomAllocationFlagsSkipAlignCheck) != kTfLiteOk) {
+      LITERT_LOG(LITERT_WARNING,
+                 "Failed to set host custom allocation for boundary tensor "
+                 "(sg %d, idx %d); falling back to sync copy",
+                 req.subgraph_index, req.tensor_index);
+      continue;
+    }
+    ++applied;
+    affected_subgraphs.insert(req.subgraph_index);
+    LITERT_LOG(LITERT_INFO,
+               "Attached OpenVINO host buffer to boundary tensor (sg %d, "
+               "idx %d) (zero-copy NPU<->CPU)",
+               req.subgraph_index, req.tensor_index);
+  }
+  buffer_context_->ClearHostCustomAllocationRequests();
+  // Re-allocate EACH subgraph we touched (SetCustomAllocationForTensor requires
+  // a following AllocateTensors on that subgraph to take effect).
+  for (int sg_idx : affected_subgraphs) {
+    if (interp_->subgraph(sg_idx)->AllocateTensors() != kTfLiteOk) {
+      return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                        "AttachHostBoundaryBuffers: re-allocation after "
+                        "attaching host boundary buffers failed");
+    }
+  }
+  LITERT_LOG(LITERT_INFO,
+             "Re-allocated %zu subgraph(s) after attaching %d host boundary "
+             "buffer(s) (zero-copy)",
+             affected_subgraphs.size(), applied);
+  host_boundary_buffers_attached_ = true;
+  return {};
 }
 
 #if !defined(LITERT_DISABLE_NPU)

--- a/litert/runtime/compiled_model.h
+++ b/litert/runtime/compiled_model.h
@@ -394,6 +394,13 @@ class LiteRtCompiledModelT {
   // Checks the CPU Tensors and stores them in the `cpu_tensors_` set.
   void CheckCpuTensors();
 
+  // Scans every subgraph for in-place DYNAMIC_UPDATE_SLICE ops (single-consumer
+  // operand) and records their operand/output identifier pairs on
+  // `buffer_context_`, so the delegate kernel and the boundary-buffer drain can
+  // co-alias both partition boundaries onto one host buffer. Must run before
+  // ModifyGraphWithDelegate (delegation reindexes/outlines ops).
+  void BuildDusInplaceMap();
+
   litert::Expected<void> ResizeInputTensorImpl(size_t signature_index,
                                                size_t input_index,
                                                absl::Span<const int> dims,
@@ -561,8 +568,22 @@ class LiteRtCompiledModelT {
   bool (*check_cancelled_func_)(void*) = nullptr;
   absl::AnyInvocable<bool()> check_cancelled_func_cpp_;
 
+  // One-time setup (called from Create, after the delegate is applied): runs an
+  // initial AllocateTensors so the dispatch delegate's Prepare pre-allocates
+  // host buffers for internal NPU<->CPU boundary tensors, attaches them as
+  // TFLite CustomAllocations, and re-allocates once so they take effect. Doing
+  // this at Create (not in Run) keeps the graph stable before any per-run I/O
+  // buffer registration. No-op when there are no such boundaries.
+  litert::Expected<void> AttachHostBoundaryBuffers();
+
   // Indicates whether the model is fully delegated on GPU or NPU.
   bool non_cpu_fully_delegated_ = false;
+
+  // Set once the internal NPU<->CPU boundary host buffers have been attached as
+  // TFLite CustomAllocations (zero-copy). One-shot: after the first successful
+  // attach + re-AllocateTensors, subsequent Run() calls skip the drain so they
+  // don't re-allocate and invalidate per-run I/O buffer registrations.
+  bool host_boundary_buffers_attached_ = false;
 };
 
 #endif  // ODML_LITERT_LITERT_RUNTIME_COMPILED_MODEL_H_

--- a/litert/runtime/dispatch/dispatch_delegate_kernel.cc
+++ b/litert/runtime/dispatch/dispatch_delegate_kernel.cc
@@ -15,8 +15,10 @@
 #include "litert/runtime/dispatch/dispatch_delegate_kernel.h"
 
 #include <algorithm>
+#include <chrono>  // NOLINT(build/c++11)
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <iterator>
 #include <memory>
@@ -92,6 +94,21 @@ Expected<LiteRtMemBuffer> BuildExecutableBytecodeBuffer(
 }
 
 DispatchDelegateKernel::~DispatchDelegateKernel() {
+  if (profile_boundary_ && eval_count_ > 0) {
+    const double n = static_cast<double>(eval_count_);
+    LITERT_LOG(
+        LITERT_INFO,
+        "BOUNDARY-PROFILE graph '%s' over %llu run(s): "
+        "input_sync=%.1f us/run (%llu B/run), "
+        "npu_dispatch=%.1f us/run, "
+        "output_sync=%.1f us/run (%llu B/run) "
+        "[sync bytes ~0 => in-place/zero-copy engaged]",
+        graph_name_.c_str(), static_cast<unsigned long long>(eval_count_),
+        input_sync_us_ / n,
+        static_cast<unsigned long long>(input_sync_bytes_ / eval_count_),
+        dispatch_invoke_us_ / n, output_sync_us_ / n,
+        static_cast<unsigned long long>(output_sync_bytes_ / eval_count_));
+  }
   // Detach all buffer handles from invocation contexts.
   {
     for (const auto& [tensor_id, tensor_info] : tensor_buffer_infos_) {
@@ -322,6 +339,10 @@ Expected<LiteRtMetricsT> DispatchDelegateKernel::StopMetricsCollection() {
 
 Expected<void> DispatchDelegateKernel::InitHelper(
     TfLiteOpaqueContext* context, const TfLiteOpaqueDelegateParams& params) {
+  if (const char* env = std::getenv("LITERT_PROFILE_BOUNDARY");
+      env != nullptr && env[0] == '1') {
+    profile_boundary_ = true;
+  }
   LITERT_ASSIGN_OR_RETURN(
       auto buffer_context,
       LiteRtExternalLiteRtBufferContextT::GetInstance(context));
@@ -431,13 +452,271 @@ Expected<void> DispatchDelegateKernel::InitHelper(
 
 Expected<void> DispatchDelegateKernel::PrepareHelper(
     TfLiteOpaqueContext* context, TfLiteOpaqueNode* node) {
+  LITERT_RETURN_IF_ERROR(PreallocateHostBoundaryBuffers(context));
   return {};
+}
+
+Expected<void> DispatchDelegateKernel::PreallocateHostBoundaryBuffers(
+    TfLiteOpaqueContext* context) {
+  if (const char* env = std::getenv("LITERT_DISABLE_ZEROCOPY_BOUNDARY");
+      env != nullptr && env[0] == '1') {
+    // A/B kill-switch: skip pre-allocation entirely so boundaries fall back to
+    // the normal sync-copy path.
+    return {};
+  }
+  LITERT_LOG(LITERT_INFO,
+             "PreallocateHostBoundaryBuffers[v3]: %zu inputs, %zu outputs",
+             input_tensor_ids_.size(), output_tensor_ids_.size());
+
+  // Collect model I/O ids: those are custom-allocated by the normal binding
+  // path, so we must NOT touch them here. Only INTERNAL partition boundaries
+  // that touch an un-offloaded CPU op are handled.
+  absl::flat_hash_set<int> model_output_ids;
+  {
+    const int* ids = nullptr;
+    int n = 0;
+    if (TfLiteOpaqueContextGetOutputs(context, &ids, &n) == kTfLiteOk && ids) {
+      for (int i = 0; i < n; ++i) model_output_ids.insert(ids[i]);
+    }
+  }
+  absl::flat_hash_set<int> model_input_ids;
+  {
+    const int* ids = nullptr;
+    int n = 0;
+    if (TfLiteOpaqueContextGetInputs(context, &ids, &n) == kTfLiteOk && ids) {
+      for (int i = 0; i < n; ++i) model_input_ids.insert(ids[i]);
+    }
+  }
+
+  // A tensor that is ANY model I/O (input or output) is bound by the runtime's
+  // per-run RegisterBuffer path, which flips its allocation_type to
+  // kTfLiteNonCpu -- incompatible with a kTfLiteCustom custom allocation. Skip
+  // all model I/O in BOTH directions (e.g. the fp16 KV cache is simultaneously
+  // an internal boundary AND an exported model output).
+  auto is_model_io = [&](int id) {
+    return model_output_ids.contains(id) || model_input_ids.contains(id);
+  };
+
+  // OUTPUT side: an NPU-produced tensor consumed by a CPU op (e.g. the K/V
+  // "new slice" feeding the CPU DynamicUpdateSlice). NPU -> CPU.
+  for (int tensor_id : output_tensor_ids_) {
+    if (is_model_io(tensor_id)) {
+      LITERT_LOG(LITERT_INFO, "  out boundary skip tensor %d: model I/O",
+                 tensor_id);
+      continue;
+    }
+    LITERT_ASSIGN_OR_RETURN(
+        bool done, PreallocateOneHostBoundary(context, tensor_id,
+                                              /*is_input=*/false));
+    (void)done;
+  }
+
+  // INPUT side: a tensor produced by a CPU op and consumed by THIS NPU
+  // partition (e.g. the DynamicUpdateSlice's merged full-cache output feeding
+  // the next transformer layer's attention). CPU -> NPU. A tensor that another
+  // NPU partition produced is already registered in buffer_context_ and stays
+  // zero-copy via that path -- skip it here (it is not CPU-touched). A model
+  // input is bound by the normal I/O path -- skip. What remains is exactly the
+  // CPU-op-produced inputs.
+  for (int tensor_id : input_tensor_ids_) {
+    if (is_model_io(tensor_id)) {
+      LITERT_LOG(LITERT_INFO, "  in boundary skip tensor %d: model I/O",
+                 tensor_id);
+      continue;
+    }
+    auto* tfl_tensor = TfLiteOpaqueContextGetOpaqueTensor(context, tensor_id);
+    if (tfl_tensor) {
+      if (auto existing = buffer_context_->GetTensorBuffer(tfl_tensor);
+          existing) {
+        LITERT_LOG(LITERT_INFO,
+                   "  in boundary skip tensor %d: already backed by an "
+                   "upstream NPU partition (NPU<->NPU, zero-copy)",
+                   tensor_id);
+        continue;
+      }
+    }
+    LITERT_ASSIGN_OR_RETURN(
+        bool done, PreallocateOneHostBoundary(context, tensor_id,
+                                              /*is_input=*/true));
+    (void)done;
+  }
+  return {};
+}
+
+Expected<bool> DispatchDelegateKernel::PreallocateOneHostBoundary(
+    TfLiteOpaqueContext* context, int tensor_id, bool is_input) {
+  const char* dir = is_input ? "in" : "out";
+  // Prepare can run more than once (the runtime re-runs AllocateTensors after
+  // attaching custom allocations). If we already pre-allocated a buffer for
+  // this tensor, keep it -- re-allocating would orphan the host pointer the
+  // runtime already attached as a CustomAllocation.
+  if (tensor_buffer_infos_.find(tensor_id) != tensor_buffer_infos_.end()) {
+    LITERT_LOG(LITERT_INFO,
+               "  %s boundary tensor %d: already pre-allocated; keeping", dir,
+               tensor_id);
+    return false;
+  }
+  auto* tfl_tensor = TfLiteOpaqueContextGetOpaqueTensor(context, tensor_id);
+  if (!tfl_tensor) {
+    LITERT_LOG(LITERT_INFO, "  %s boundary skip tensor %d: null tfl_tensor",
+               dir, tensor_id);
+    return false;
+  }
+
+  // Only pre-allocate when the backend can produce a host-addressable buffer
+  // for this tensor (its requirements were registered in ComputeRequirements
+  // during Init). If not, leave it to the normal Eval path (which will sync).
+  auto requirements = buffer_context_->GetBufferRequirements(tfl_tensor);
+  if (!requirements) {
+    LITERT_LOG(LITERT_INFO,
+               "  %s boundary skip tensor %d: no buffer requirements", dir,
+               tensor_id);
+    return false;
+  }
+  const auto& supported = (*requirements)->SupportedBufferTypes();
+  bool host_addressable = false;
+  for (auto t : supported) {
+    // OpenVINOTensorBuffer is backed by an OpenVINO host tensor
+    // (create_host_tensor); HostMemory is trivially host-addressable.
+    if (t == kLiteRtTensorBufferTypeOpenVINOTensorBuffer ||
+        t == kLiteRtTensorBufferTypeHostMemory) {
+      host_addressable = true;
+      break;
+    }
+  }
+  if (!host_addressable) {
+    LITERT_LOG(LITERT_INFO,
+               "  %s boundary skip tensor %d: not host-addressable (%zu "
+               "supported types, first=%d)",
+               dir, tensor_id, supported.size(),
+               supported.empty() ? -1 : static_cast<int>(supported[0]));
+    return false;
+  }
+
+  // CO-ALIAS: if this is the OUTPUT of an in-place DynamicUpdateSlice (i.e. THIS
+  // dispatch input is a DUS output whose operand is another partition's output
+  // feeding the same CPU DUS), reuse the OPERAND's already-allocated host buffer
+  // instead of a fresh one. Then island A writes buffer X (as the DUS operand),
+  // the CPU DUS updates X in place, and this island reads X (as the DUS output)
+  // -- and, because both the operand and output TFLite tensors are custom-
+  // allocated onto X by the drain, the reference DUS kernel takes its in-place
+  // fast path (skips the whole-tensor copy). Only on the input side; the operand
+  // buffer must already be registered (island A's Prepare ran first in exec
+  // order). If it is not yet there, fall through to a fresh allocation -- still
+  // correct (the DUS does a full copy), just not in-place.
+  if (is_input) {
+    auto out_tid = buffer_context_->GetTensorIdentifier(tfl_tensor);
+    if (const auto* operand_tid =
+            buffer_context_->DusInplaceOperandFor(out_tid)) {
+      auto* operand_tensor = TfLiteOpaqueContextGetOpaqueTensor(
+          context, operand_tid->tensor_idx);
+      if (operand_tensor) {
+        if (auto operand_buffer =
+                buffer_context_->GetTensorBuffer(operand_tensor)) {
+          void* operand_host_addr = nullptr;
+          if (LiteRtLockTensorBuffer(operand_buffer->get(), &operand_host_addr,
+                                     kLiteRtTensorBufferLockModeWrite) ==
+                  kLiteRtStatusOk &&
+              operand_host_addr != nullptr) {
+            (void)LiteRtUnlockTensorBuffer(operand_buffer->get());
+            size_t coalias_size = TfLiteOpaqueTensorByteSize(tfl_tensor);
+            tensor_buffer_infos_[tensor_id] = TensorInfo();
+            // Register the SAME buffer as this island's dispatch storage for the
+            // DUS output, so the NPU reads exactly the memory the CPU DUS wrote.
+            (*operand_buffer)->Duplicate();
+            LiteRtTensorBufferPtr context_buffer(operand_buffer->get());
+            LITERT_RETURN_IF_ERROR(buffer_context_->RegisterTensorBuffer(
+                tfl_tensor, std::move(context_buffer)));
+            LITERT_RETURN_IF_ERROR(RegisterBufferWithDispatchApi(
+                tensor_id, std::move(*operand_buffer)));
+            buffer_context_->AddHostCustomAllocationRequest(
+                out_tid.subgraph_idx, out_tid.tensor_idx, operand_host_addr,
+                coalias_size);
+            LITERT_LOG(LITERT_INFO,
+                       "  in boundary tensor %d (sg %d, idx %d): CO-ALIASED to "
+                       "DUS operand (sg %d, idx %d) host buffer %p size %zu "
+                       "(in-place DUS, zero-copy NPU<->CPU<->NPU)",
+                       tensor_id, out_tid.subgraph_idx, out_tid.tensor_idx,
+                       operand_tid->subgraph_idx, operand_tid->tensor_idx,
+                       operand_host_addr, coalias_size);
+            return true;
+          }
+          (void)LiteRtUnlockTensorBuffer(operand_buffer->get());
+        }
+      }
+      LITERT_LOG(LITERT_INFO,
+                 "  in boundary tensor %d: DUS output but operand buffer not "
+                 "available yet; allocating fresh (DUS will full-copy)",
+                 tensor_id);
+    }
+  }
+
+  // Allocate the backend buffer now (Prepare), register it in the buffer
+  // context so Eval's AllocateAndRegisterBuffer reuses it (and therefore does
+  // NOT mark it maybe_sync_with_cpu), and lock it to obtain the host pointer.
+  LITERT_ASSIGN_OR_RETURN(LiteRtTensorBufferPtr tensor_buffer,
+                          AllocateTensorBuffer(tfl_tensor));
+  void* host_addr = nullptr;
+  if (LiteRtLockTensorBuffer(tensor_buffer.get(), &host_addr,
+                             kLiteRtTensorBufferLockModeWrite) !=
+          kLiteRtStatusOk ||
+      host_addr == nullptr) {
+    // Not lockable to host after all; skip (fall back to sync path).
+    LITERT_LOG(LITERT_INFO, "  %s boundary skip tensor %d: not lockable",
+               dir, tensor_id);
+    return false;
+  }
+  // The OpenVINO host tensor's data pointer is STABLE regardless of lock state
+  // (create_host_tensor()), so unlock immediately: keeping the buffer locked
+  // would make the LiteRtTensorBufferT reject the Lock() the dispatch runtime /
+  // sync path issues later ("already locked"), aborting the first inference.
+  // The TFLite CPU tensor aliases host_addr via CustomAllocation.
+  (void)LiteRtUnlockTensorBuffer(tensor_buffer.get());
+  size_t used_size = TfLiteOpaqueTensorByteSize(tfl_tensor);
+
+  // Create the TensorInfo slot before registering
+  // (RegisterBufferWithDispatchApi requires it to exist). Do NOT set
+  // maybe_sync_with_cpu: this buffer is the TFLite tensor's own storage (via
+  // CustomAllocation), so Eval must not copy.
+  tensor_buffer_infos_[tensor_id] = TensorInfo();
+
+  tensor_buffer->Duplicate();
+  LiteRtTensorBufferPtr context_buffer(tensor_buffer.get());
+  LITERT_RETURN_IF_ERROR(buffer_context_->RegisterTensorBuffer(
+      tfl_tensor, std::move(context_buffer)));
+  LITERT_RETURN_IF_ERROR(
+      RegisterBufferWithDispatchApi(tensor_id, std::move(tensor_buffer)));
+
+  // Publish to the shared buffer context so CompiledModel can custom-allocate
+  // this host memory onto the TFLite CPU tensor before AllocateTensors. Record
+  // the OWNING subgraph: Interpreter::SetCustomAllocationForTensor only targets
+  // the primary subgraph, so a decode-subgraph boundary must be routed to
+  // interp_->subgraph(subgraph_idx) explicitly by the drain.
+  auto tid = buffer_context_->GetTensorIdentifier(tfl_tensor);
+  buffer_context_->AddHostCustomAllocationRequest(
+      tid.subgraph_idx, tid.tensor_idx, host_addr, used_size);
+  LITERT_LOG(LITERT_INFO,
+             "  %s boundary tensor %d (sg %d, idx %d): pre-allocated host "
+             "buffer %p size %zu (zero-copy candidate)",
+             dir, tensor_id, tid.subgraph_idx, tid.tensor_idx, host_addr,
+             used_size);
+  return true;
 }
 
 Expected<void> DispatchDelegateKernel::EvalHelper(TfLiteOpaqueContext* context,
                                                   TfLiteOpaqueNode* node) {
+  LITERT_LOG(LITERT_INFO,
+             "EvalHelper[zc]: ENTER graph '%s' (%zu in, %zu out)",
+             graph_name_.c_str(), input_tensor_ids_.size(),
+             output_tensor_ids_.size());
   LITERT_RETURN_IF_ERROR(AllocateTensorBuffersIfNeeded(context));
   LITERT_RETURN_IF_ERROR(AttachBuffersToInvocationContextsIfNeeded(context));
+
+  using Clock = std::chrono::steady_clock;
+  auto now_us = [](Clock::time_point a, Clock::time_point b) {
+    return std::chrono::duration<double, std::micro>(b - a).count();
+  };
+  auto t_in0 = Clock::now();
 
   // Copy input buffers from CPU, if needed.
   for (int tensor_id : input_tensor_ids_) {
@@ -459,9 +738,11 @@ Expected<void> DispatchDelegateKernel::EvalHelper(TfLiteOpaqueContext* context,
                                     kLiteRtTensorBufferLockModeRead));
         std::memcpy(host_buffer, tensor_data, buffer_size);
         LITERT_RETURN_IF_ERROR(tensor_buffer_info.tensor_buffer->Unlock());
+        if (profile_boundary_) input_sync_bytes_ += buffer_size;
       }
     }
   }
+  auto t_in1 = Clock::now();
 
   // Apply per-request scheduling info (if provided) to each invocation context.
   //
@@ -482,11 +763,16 @@ Expected<void> DispatchDelegateKernel::EvalHelper(TfLiteOpaqueContext* context,
     }
   }
 
+  LITERT_LOG(LITERT_INFO, "EvalHelper[zc]: dispatch invoke START (%zu nodes)",
+             node_invocation_contexts_.size());
+  auto t_disp0 = Clock::now();
   if (async_dispatch_ && buffer_context_->IsAsyncExecutionMode()) {
     LITERT_RETURN_IF_ERROR(ScheduleAsyncExecution(context));
   } else {
     LITERT_RETURN_IF_ERROR(ScheduleSyncExecution(context));
   }
+  auto t_disp1 = Clock::now();
+  LITERT_LOG(LITERT_INFO, "EvalHelper[zc]: dispatch invoke DONE");
 
   for (int tensor_id : output_tensor_ids_) {
     auto* tfl_tensor = TfLiteOpaqueContextGetOpaqueTensor(context, tensor_id);
@@ -507,8 +793,17 @@ Expected<void> DispatchDelegateKernel::EvalHelper(TfLiteOpaqueContext* context,
                                     kLiteRtTensorBufferLockModeWrite));
         std::memcpy(tensor_data, host_buffer, buffer_size);
         LITERT_RETURN_IF_ERROR(tensor_buffer_info.tensor_buffer->Unlock());
+        if (profile_boundary_) output_sync_bytes_ += buffer_size;
       }
     }
+  }
+  auto t_out1 = Clock::now();
+
+  if (profile_boundary_) {
+    ++eval_count_;
+    input_sync_us_ += now_us(t_in0, t_in1);
+    dispatch_invoke_us_ += now_us(t_disp0, t_disp1);
+    output_sync_us_ += now_us(t_disp1, t_out1);
   }
 
   return {};

--- a/litert/runtime/dispatch/dispatch_delegate_kernel.h
+++ b/litert/runtime/dispatch/dispatch_delegate_kernel.h
@@ -106,6 +106,24 @@ class DispatchDelegateKernel : public DispatchKernelInterface {
   Expected<void> ComputeRequirements(TfLiteOpaqueContext* context);
   Expected<void> ComputeTensorPortConnections(TfLiteOpaqueContext* context);
 
+  // Pre-allocates host-addressable OpenVINO buffers for internal NPU<->CPU
+  // partition-boundary tensors at Prepare time and records custom-allocation
+  // requests on buffer_context_ so the runtime can alias them onto the TFLite
+  // CPU tensors before AllocateTensors. Handles BOTH boundary directions of an
+  // un-offloaded CPU op (e.g. an in-graph DynamicUpdateSlice):
+  //   * dispatch OUTPUT feeding a CPU op (NPU -> CPU), and
+  //   * dispatch INPUT produced by a CPU op (CPU -> NPU).
+  // Only fires for tensors whose backend buffer requirements advertise a
+  // host-addressable type. Skips model I/O (handled by the normal binding path)
+  // and NPU<->NPU boundaries (already zero-copy via buffer_context_).
+  Expected<void> PreallocateHostBoundaryBuffers(TfLiteOpaqueContext* context);
+
+  // Shared implementation for one boundary tensor. `is_input` selects the
+  // direction (dispatch input vs output) purely for logging/semantics; the
+  // allocation + registration + custom-allocation-request are identical.
+  Expected<bool> PreallocateOneHostBoundary(TfLiteOpaqueContext* context,
+                                            int tensor_id, bool is_input);
+
   Expected<void> AllocateTensorBuffersIfNeeded(TfLiteOpaqueContext* context);
   Expected<LiteRtTensorBufferPtr> AllocateTensorBuffer(
       TfLiteOpaqueTensor* tfl_tensor);
@@ -199,6 +217,21 @@ class DispatchDelegateKernel : public DispatchKernelInterface {
 
   // Hold stale TensorInfo records for non-blocking out-fence unregistration.
   std::vector<std::pair<int, TensorInfo>> deferred_unregistrations_;
+
+  // Per-graph handover instrumentation (enabled by LITERT_PROFILE_BOUNDARY=1).
+  // Accumulated across all Eval calls and logged once at teardown, to separate
+  // the three costs in the DUS-rewritten NPU graph: input sync (CPU->OV
+  // memcpy), NPU dispatch invoke, and output sync (OV->CPU memcpy). With the
+  // in-place DUS co-alias working, the sync bytes for the KV boundaries should
+  // be ~0 (maybe_sync_with_cpu is false), so a nonzero sync total flags a
+  // fallback-to-copy.
+  bool profile_boundary_ = false;
+  uint64_t eval_count_ = 0;
+  double input_sync_us_ = 0.0;
+  double dispatch_invoke_us_ = 0.0;
+  double output_sync_us_ = 0.0;
+  uint64_t input_sync_bytes_ = 0;
+  uint64_t output_sync_bytes_ = 0;
 };
 
 }  // namespace litert::internal

--- a/litert/runtime/external_litert_buffer_context.h
+++ b/litert/runtime/external_litert_buffer_context.h
@@ -20,6 +20,8 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 #include <utility>
 
 #include "litert/c/internal/litert_scheduling_info.h"
@@ -156,6 +158,70 @@ class LiteRtExternalLiteRtBufferContextT : public TfLiteExternalContext {
         reinterpret_cast<const TfLiteOpaqueTensor*>(tensor));
   }
 
+  // Resolves the stable {subgraph_idx, tensor_idx} identifier for an opaque
+  // tensor (via the interpreter callback the CompiledModel installed). Used by
+  // delegate kernels to record WHICH subgraph a boundary tensor lives in, since
+  // the context-local tensor index alone is ambiguous across subgraphs.
+  inline litert::internal::TfLiteTensorIdentifier GetTensorIdentifier(
+      const TfLiteOpaqueTensor* tensor) const {
+    return get_tensor_identifier_fn_(tensor);
+  }
+
+  // A request from a delegate kernel (during Prepare) to back an internal
+  // partition-boundary TFLite tensor with a host buffer the backend already
+  // allocated, so an un-offloaded CPU consumer reads/writes it in place (no
+  // sync memcpy). CompiledModel drains these and calls
+  // SetCustomAllocationForTensor before AllocateTensors. `subgraph_index` and
+  // `tensor_index` are the subgraph-scoped identifier (Interpreter's
+  // SetCustomAllocationForTensor targets only the primary subgraph, so
+  // CompiledModel must route to the right subgraph explicitly).
+  struct HostCustomAllocationRequest {
+    int subgraph_index;
+    int tensor_index;
+    void* host_addr;
+    size_t size;
+  };
+  inline void AddHostCustomAllocationRequest(int subgraph_index,
+                                             int tensor_index, void* host_addr,
+                                             size_t size) {
+    host_custom_allocation_requests_.push_back(
+        {subgraph_index, tensor_index, host_addr, size});
+  }
+  inline const std::vector<HostCustomAllocationRequest>&
+  HostCustomAllocationRequests() const {
+    return host_custom_allocation_requests_;
+  }
+  inline void ClearHostCustomAllocationRequests() {
+    host_custom_allocation_requests_.clear();
+  }
+
+  // Records that a DYNAMIC_UPDATE_SLICE writes `output` in place from `operand`
+  // (operand has a single consumer, so the reference DUS kernel may share one
+  // buffer for both). CompiledModel populates this before delegation; the
+  // delegate kernel reads it during Prepare to co-alias the two partition
+  // boundaries onto ONE OpenVINO host buffer (island A writes it as the DUS
+  // operand, the CPU DUS updates it in place, island B reads it as the DUS
+  // output). Both keys are subgraph-scoped identifiers.
+  inline void AddDusInplacePair(
+      const litert::internal::TfLiteTensorIdentifier& output,
+      const litert::internal::TfLiteTensorIdentifier& operand) {
+    dus_inplace_operand_[output] = operand;
+    dus_inplace_operands_.insert(operand);
+  }
+  // If `output` is the output of an in-place DUS, returns its operand
+  // identifier; otherwise returns nullptr.
+  inline const litert::internal::TfLiteTensorIdentifier* DusInplaceOperandFor(
+      const litert::internal::TfLiteTensorIdentifier& output) const {
+    auto it = dus_inplace_operand_.find(output);
+    return it == dus_inplace_operand_.end() ? nullptr : &it->second;
+  }
+  // True if `operand` is the operand of some in-place DUS (i.e. it is consumed
+  // by a CPU DUS whose output is co-aliased back onto it).
+  inline bool IsDusInplaceOperand(
+      const litert::internal::TfLiteTensorIdentifier& operand) const {
+    return dus_inplace_operands_.find(operand) != dus_inplace_operands_.end();
+  }
+
   // Sets the async execution mode. It's set by CompiledModel and used by
   // DelegateKernel to decide whether to use async execution mode.
   inline void SetAsyncExecutionMode(bool async_execution_mode) {
@@ -282,6 +348,22 @@ class LiteRtExternalLiteRtBufferContextT : public TfLiteExternalContext {
       const LiteRtExternalLiteRtBufferContextT&) = delete;
   LiteRtExternalLiteRtBufferContextT& operator=(
       const LiteRtExternalLiteRtBufferContextT&) = delete;
+
+  std::vector<HostCustomAllocationRequest> host_custom_allocation_requests_;
+
+  // In-place DYNAMIC_UPDATE_SLICE pairing (see AddDusInplacePair). Maps a DUS
+  // output identifier to its operand identifier, plus the reverse set of
+  // operands, so the kernel and the drain can co-alias both boundaries onto one
+  // host buffer and trigger the reference DUS kernel's in-place fast path.
+  std::unordered_map<litert::internal::TfLiteTensorIdentifier,
+                     litert::internal::TfLiteTensorIdentifier,
+                     litert::internal::TensorIdentifierHash,
+                     litert::internal::TensorIdentifierEqual>
+      dus_inplace_operand_;
+  std::unordered_set<litert::internal::TfLiteTensorIdentifier,
+                     litert::internal::TensorIdentifierHash,
+                     litert::internal::TensorIdentifierEqual>
+      dus_inplace_operands_;
 
   bool async_execution_mode_ = false;
   LiteRtOptions run_options_ = nullptr;

--- a/litert/tools/BUILD
+++ b/litert/tools/BUILD
@@ -838,6 +838,7 @@ cc_library(
         ":benchmark_litert_model",
         "//tflite/c:c_api_types",
         "//tflite/tools:logging",
+        "@com_google_absl//absl/flags:parse",
         "@com_google_absl//absl/flags:reflection",
         "@com_google_absl//absl/strings",
     ],

--- a/litert/tools/benchmark_litert_model_main.cc
+++ b/litert/tools/benchmark_litert_model_main.cc
@@ -15,7 +15,9 @@ limitations under the License.
 
 #include <cstdlib>
 #include <iostream>
+#include <vector>
 
+#include "absl/flags/parse.h"  // from @com_google_absl
 #include "absl/flags/reflection.h"  // from @com_google_absl
 #include "absl/strings/match.h"  // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
@@ -34,6 +36,21 @@ int Main(int argc, char** argv) {
       break;
     }
   }
+
+  // Populate the LiteRT vendor (absl) flags -- e.g. --intel_openvino_configs_map
+  // -- from the command line. Without this they keep their defaults and the
+  // options parser registry (run during compile) never sees user-provided NPU
+  // options.
+  //
+  // ParseAbseilFlagsOnly (not ParseCommandLine) is used so the TFLite benchmark
+  // flags (--graph, --use_npu, ...) are NOT treated as errors: they come back as
+  // `unrecognized_flags` and are ignored here. The ORIGINAL argc/argv is then
+  // still forwarded to benchmark.Run() below, which runs TFLite's own parser
+  // over them. (TFLite only warns about the vendor flags it does not know, which
+  // is harmless.)
+  std::vector<char*> positional_args;
+  std::vector<absl::UnrecognizedFlag> unrecognized_flags;
+  absl::ParseAbseilFlagsOnly(argc, argv, positional_args, unrecognized_flags);
 
   if (has_help) {
     std::cout << "\n  NPU Vendor Flags from LiteRT:\n";

--- a/litert/vendors/intel_openvino/compiler/npu_optimizer.cc
+++ b/litert/vendors/intel_openvino/compiler/npu_optimizer.cc
@@ -91,6 +91,24 @@ ov::Output<ov::Node> PadEndOfAxis(const ov::Output<ov::Node>& input,
       ->output(0);
 }
 
+// If |transposed| is true, |input| is stored as [B,H,D,S] (K already
+// transposed, or V transposed); insert a Transpose(0,1,3,2) to restore the
+// [B,H,S,D] layout that v13::SDPA expects and append the created nodes to
+// |new_nodes|. Returns |input| unchanged when |transposed| is false.
+ov::Output<ov::Node> RestoreBhsdLayout(const ov::Output<ov::Node>& input,
+                                       bool transposed,
+                                       ov::NodeVector& new_nodes) {
+  if (!transposed) {
+    return input;
+  }
+  auto perm = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4},
+                                           {0, 1, 3, 2});
+  auto transpose = std::make_shared<ov::op::v1::Transpose>(input, perm);
+  new_nodes.push_back(perm);
+  new_nodes.push_back(transpose);
+  return transpose->output(0);
+}
+
 }  // namespace
 
 EliminateMatMulFakeQuantize::EliminateMatMulFakeQuantize() {
@@ -455,7 +473,224 @@ FuseSplitAttentionToSDPA::FuseSplitAttentionToSDPA(bool pad_kv_to_alignment) {
   register_matcher(m, callback);
 }
 
+FuseStandardAttentionToSDPA::FuseStandardAttentionToSDPA() {
+  namespace pattern = ov::pass::pattern;
+
+  // Anchor on the Softmax -- a rare, distinctive op, unlike MatMul which occurs
+  // all over the graph (FFN, projections, ...). From the Softmax we walk UP to
+  // the QK MatMul (through an optional mask Add) and DOWN to the PV MatMul. This
+  // matches the "standard" single-branch attention produced after an offline
+  // DynamicUpdateSlice merges the split KV cache into one tensor (see
+  // convert_inplace_kv.py); K/V reach the matmuls via CAST(DUS(...)), which is
+  // transparent here.
+  auto softmax_pattern = pattern::wrap_type<ov::op::v8::Softmax>();
+
+  ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
+    auto softmax_node =
+        std::dynamic_pointer_cast<ov::op::v8::Softmax>(m.get_match_root());
+    if (!softmax_node) {
+      return false;
+    }
+    const std::string root_name = softmax_node->get_friendly_name();
+    LITERT_LOG(LITERT_INFO,
+               "FuseStandardAttentionToSDPA[%s]: anchored on Softmax; "
+               "evaluating...",
+               root_name.c_str());
+
+    // Softmax must be on the last axis.
+    auto sm_rank = softmax_node->get_output_partial_shape(0).rank();
+    if (sm_rank.is_dynamic()) {
+      LITERT_LOG(LITERT_INFO,
+                 "FuseStandardAttentionToSDPA[%s]: reject: Softmax has dynamic "
+                 "rank",
+                 root_name.c_str());
+      return false;
+    }
+    int64_t sm_axis = static_cast<int64_t>(softmax_node->get_axis());
+    if (sm_axis < 0) sm_axis += sm_rank.get_length();
+    if (sm_axis != sm_rank.get_length() - 1) {
+      LITERT_LOG(LITERT_INFO,
+                 "FuseStandardAttentionToSDPA[%s]: reject: Softmax axis %lld is "
+                 "not the last axis (rank %lld)",
+                 root_name.c_str(), static_cast<long long>(sm_axis),
+                 static_cast<long long>(sm_rank.get_length()));
+      return false;
+    }
+
+    // Walk DOWN: the Softmax must feed exactly one consumer, the PV MatMul
+    // (probs is its input 0).
+    if (!HasSingleConsumer(softmax_node->output(0))) {
+      LITERT_LOG(LITERT_INFO,
+                 "FuseStandardAttentionToSDPA[%s]: reject: Softmax has %zu "
+                 "consumers (need 1 = the PV MatMul)",
+                 root_name.c_str(),
+                 softmax_node->output(0).get_target_inputs().size());
+      return false;
+    }
+    auto pv_consumer =
+        softmax_node->output(0).get_target_inputs().begin()->get_node();
+    auto pv = std::dynamic_pointer_cast<ov::op::v0::MatMul>(
+        pv_consumer->shared_from_this());
+    if (!pv) {
+      LITERT_LOG(LITERT_INFO,
+                 "FuseStandardAttentionToSDPA[%s]: reject: Softmax consumer is "
+                 "'%s', expected a PV MatMul",
+                 root_name.c_str(), pv_consumer->get_type_name());
+      return false;
+    }
+    if (pv->input_value(0).get_node_shared_ptr() != softmax_node) {
+      LITERT_LOG(LITERT_INFO,
+                 "FuseStandardAttentionToSDPA[%s]: reject: Softmax feeds PV "
+                 "MatMul input 1 (probs must be input 0)",
+                 root_name.c_str());
+      return false;
+    }
+
+    // Walk UP: Softmax input is either scores+mask (v1::Add) or the QK MatMul.
+    ov::Output<ov::Node> mask_value;
+    bool has_mask = false;
+    std::shared_ptr<ov::op::v0::MatMul> qk;
+    auto sm_src = softmax_node->input_value(0).get_node_shared_ptr();
+    if (auto mask_add = std::dynamic_pointer_cast<ov::op::v1::Add>(sm_src)) {
+      qk = std::dynamic_pointer_cast<ov::op::v0::MatMul>(
+          mask_add->input_value(0).get_node_shared_ptr());
+      if (!qk) {
+        LITERT_LOG(LITERT_INFO,
+                   "FuseStandardAttentionToSDPA[%s]: reject: Softmax<-Add but "
+                   "Add.input0 is '%s', not a MatMul",
+                   root_name.c_str(),
+                   mask_add->input_value(0).get_node()->get_type_name());
+        return false;
+      }
+      mask_value = mask_add->input_value(1);
+      has_mask = true;
+    } else {
+      qk = std::dynamic_pointer_cast<ov::op::v0::MatMul>(sm_src);
+      if (!qk) {
+        LITERT_LOG(LITERT_INFO,
+                   "FuseStandardAttentionToSDPA[%s]: reject: Softmax input is "
+                   "'%s', expected a mask Add or a QK MatMul",
+                   root_name.c_str(), sm_src->get_type_name());
+        return false;
+      }
+    }
+    LITERT_LOG(LITERT_INFO,
+               "FuseStandardAttentionToSDPA[%s]: QK MatMul '%s', PV MatMul '%s', "
+               "has_mask=%d",
+               root_name.c_str(), qk->get_friendly_name().c_str(),
+               pv->get_friendly_name().c_str(), static_cast<int>(has_mask));
+
+    if (!HasSingleConsumer(qk->output(0))) {
+      LITERT_LOG(LITERT_INFO,
+                 "FuseStandardAttentionToSDPA[%s]: reject: QK MatMul has %zu "
+                 "consumers (need 1)",
+                 root_name.c_str(),
+                 qk->output(0).get_target_inputs().size());
+      return false;
+    }
+    if (qk->get_transpose_a() || pv->get_transpose_a()) {
+      LITERT_LOG(LITERT_INFO,
+                 "FuseStandardAttentionToSDPA[%s]: reject: transpose_a set "
+                 "(qk.transpose_a=%d, pv.transpose_a=%d); expected false",
+                 root_name.c_str(), qk->get_transpose_a(),
+                 pv->get_transpose_a());
+      return false;
+    }
+
+    auto q = qk->input_value(0);
+    auto k = qk->input_value(1);
+    auto v = pv->input_value(1);
+
+    // Require static 4-D ranks for predictable layout reasoning.
+    const char* const in_names[] = {"Q", "K", "V"};
+    const ov::Output<ov::Node> ins[] = {q, k, v};
+    for (size_t i = 0; i < 3; ++i) {
+      const auto& ps = ins[i].get_partial_shape();
+      if (ps.rank().is_dynamic() || ps.rank().get_length() != 4) {
+        LITERT_LOG(LITERT_INFO,
+                   "FuseStandardAttentionToSDPA[%s]: reject: %s does not have "
+                   "static 4-D rank (rank=%s, from '%s')",
+                   root_name.c_str(), in_names[i],
+                   ps.rank().is_dynamic()
+                       ? "dynamic"
+                       : std::to_string(ps.rank().get_length()).c_str(),
+                   ins[i].get_node()->get_type_name());
+        return false;
+      }
+    }
+
+    // Interpret MatMul transpose flags as a physical-layout hint (identical to
+    // FuseSplitAttentionToSDPA):
+    //   qk transpose_b == true  -> K stored [B,H,S,D] (standard).
+    //   qk transpose_b == false -> K stored [B,H,D,S] (already K^T).
+    //   pv transpose_b == true  -> V stored [B,H,D,S].
+    //   pv transpose_b == false -> V stored [B,H,S,D] (standard).
+    const bool k_is_transposed = !qk->get_transpose_b();
+    const bool v_is_transposed = pv->get_transpose_b();
+    LITERT_LOG(LITERT_INFO,
+               "FuseStandardAttentionToSDPA[%s]: matched all gates "
+               "(k_pre_transposed=%d, v_pre_transposed=%d, has_mask=%d); "
+               "building SDPA",
+               root_name.c_str(), static_cast<int>(k_is_transposed),
+               static_cast<int>(v_is_transposed), static_cast<int>(has_mask));
+
+    ov::NodeVector new_nodes;
+    ov::Output<ov::Node> key_out =
+        RestoreBhsdLayout(k, k_is_transposed, new_nodes);
+    ov::Output<ov::Node> val_out =
+        RestoreBhsdLayout(v, v_is_transposed, new_nodes);
+
+    // Mask (if present) forwarded as the additive attn_mask; else a 0 scalar.
+    ov::Output<ov::Node> attn_mask;
+    if (has_mask) {
+      attn_mask = mask_value;
+    } else {
+      auto zero = ov::op::v0::Constant::create(q.get_element_type(),
+                                               ov::Shape{}, {0.0f});
+      new_nodes.push_back(zero);
+      attn_mask = zero;
+    }
+
+    // Scale = 1.0: any required scaling is assumed pre-applied to Q.
+    auto scale_const = ov::op::v0::Constant::create(
+        q.get_element_type(), ov::Shape{}, std::vector<float>{1.0f});
+    new_nodes.push_back(scale_const);
+
+    auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(
+        q, key_out, val_out, attn_mask, scale_const, /*is_causal=*/false);
+    new_nodes.push_back(sdpa);
+
+    sdpa->set_friendly_name(pv->get_friendly_name());
+    ov::copy_runtime_info(m.get_matched_nodes(), new_nodes);
+    ov::replace_node(pv, sdpa);
+    LITERT_LOG(LITERT_INFO,
+               "FuseStandardAttentionToSDPA: FUSED standard attention into "
+               "v13::ScaledDotProductAttention '%s' (k_pre_transposed=%d, "
+               "v_pre_transposed=%d, has_mask=%d)",
+               sdpa->get_friendly_name().c_str(),
+               static_cast<int>(k_is_transposed),
+               static_cast<int>(v_is_transposed), static_cast<int>(has_mask));
+    return true;
+  };
+
+  auto m = std::make_shared<pattern::Matcher>(softmax_pattern,
+                                              "FuseStandardAttentionToSDPA");
+  register_matcher(m, callback);
+}
+
 void NpuOptimizer::Run(const std::shared_ptr<ov::Model>& model) const {
+  // Log which optimizations are enabled so a "nothing happened" run can be
+  // told apart from a run where the pass fired but rejected every candidate.
+  LITERT_LOG(LITERT_INFO,
+             "NpuOptimizer::Run: cast_integer_sign_to_float=%d, "
+             "fuse_split_attention_to_sdpa=%d, "
+             "fuse_standard_attention_to_sdpa=%d, "
+             "eliminate_matmul_fq=%d, sdpa_pad_kv_to_alignment=%d",
+             static_cast<int>(cast_integer_sign_to_float_),
+             static_cast<int>(fuse_split_attention_to_sdpa_),
+             static_cast<int>(fuse_standard_attention_to_sdpa_),
+             static_cast<int>(eliminate_matmul_fq_),
+             static_cast<int>(sdpa_pad_kv_to_alignment_));
   ov::pass::Manager pass_manager;
   if (cast_integer_sign_to_float_) {
     pass_manager.register_pass<CastIntegerSignToFloat>();
@@ -463,6 +698,9 @@ void NpuOptimizer::Run(const std::shared_ptr<ov::Model>& model) const {
   if (fuse_split_attention_to_sdpa_) {
     pass_manager.register_pass<FuseSplitAttentionToSDPA>(
         sdpa_pad_kv_to_alignment_);
+  }
+  if (fuse_standard_attention_to_sdpa_) {
+    pass_manager.register_pass<FuseStandardAttentionToSDPA>();
   }
   if (eliminate_matmul_fq_) {
     pass_manager.register_pass<EliminateMatMulFakeQuantize>();

--- a/litert/vendors/intel_openvino/compiler/npu_optimizer.h
+++ b/litert/vendors/intel_openvino/compiler/npu_optimizer.h
@@ -83,6 +83,35 @@ class FuseSplitAttentionToSDPA : public ov::pass::MatcherPass {
   explicit FuseSplitAttentionToSDPA(bool pad_kv_to_alignment);
 };
 
+// Fuses the "standard" single-branch attention sub-graph into a single
+// `ov::op::v13::ScaledDotProductAttention`. This is the shape produced after an
+// offline transform merges a Gemma-style split KV cache into one tensor with a
+// DynamicUpdateSlice (see inplace_kv_conversion/convert_inplace_kv.py), so there
+// is no Concat/Slice pair and only one QK / one PV MatMul remain:
+//
+//   scores = MatMul(Q, K)                    // K may be [B,H,S,D] or [B,H,D,S]
+//   masked = Add(scores, mask)               // optional
+//   probs  = Softmax(masked, axis=-1)
+//   output = MatMul(probs, V)                // V may be [B,H,S,D] or [B,H,D,S]
+//                                            //   <-- match root
+//
+// The K/V operands typically arrive via CAST(DynamicUpdateSlice(...)); that is
+// transparent to this matcher, which anchors on the PV MatMul and reads the
+// MatMul transpose flags as a layout hint (inserting a Transpose(0,1,3,2) when
+// K or V is stored [B,H,D,S], as Gemma stores V). Restricted to static 4-D
+// ranks; scale is set to 1.0 (any scaling assumed pre-applied to Q). The merged
+// KV length is expected to already be a multiple of the NPU SDPA kernel's
+// alignment, so no KV/mask padding is performed here.
+//
+// The stock ov::pass::SDPAFusion does not cover this case because it requires
+// the PV MatMul to consume V in [S_kv, Ev] layout (transpose_b=false), whereas
+// Gemma stores V transposed as [B,H,D,S] and consumes it with transpose_b=true.
+class FuseStandardAttentionToSDPA : public ov::pass::MatcherPass {
+ public:
+  OPENVINO_MATCHER_PASS_RTTI("FuseStandardAttentionToSDPA");
+  FuseStandardAttentionToSDPA();
+};
+
 // Configurable runner for NPU-specific optimization passes.
 // Use the setter APIs to toggle individual optimizations, then call Run() to
 // apply the enabled passes to a model.
@@ -116,14 +145,23 @@ class NpuOptimizer {
     return *this;
   }
 
+  // Toggles the FuseStandardAttentionToSDPA pass. Disabled by default; enable
+  // via config key "fuse_standard_attention_to_sdpa" = "true" to collapse the
+  // single-branch (DUS-merged) attention pattern into a single SDPA op.
+  NpuOptimizer& SetFuseStandardAttentionToSDPA(bool enable) {
+    fuse_standard_attention_to_sdpa_ = enable;
+    return *this;
+  }
+
   // Runs all currently-enabled passes on |model|.
   void Run(const std::shared_ptr<ov::Model>& model) const;
 
  private:
   bool eliminate_matmul_fq_ = false;
   bool cast_integer_sign_to_float_ = true;
-  bool fuse_split_attention_to_sdpa_ = false;
+  bool fuse_split_attention_to_sdpa_ = true;
   bool sdpa_pad_kv_to_alignment_ = true;
+  bool fuse_standard_attention_to_sdpa_ = true;
 };
 
 }  // namespace openvino

--- a/litert/vendors/intel_openvino/compiler/npu_optimizer_test.cc
+++ b/litert/vendors/intel_openvino/compiler/npu_optimizer_test.cc
@@ -26,6 +26,7 @@
 #include "openvino/op/add.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/result.hpp"
@@ -119,6 +120,58 @@ std::shared_ptr<ov::Model> BuildSplitCacheAttention(int64_t s_past = 8,
       ov::ResultVector{result},
       ov::ParameterVector{q, k_cache, k_slice, v_cache, v_slice, mask},
       "split_cache_attention");
+}
+
+// Builds the "standard" single-branch attention that results after an offline
+// DynamicUpdateSlice merges the split KV cache into one tensor (see
+// inplace_kv_conversion/convert_inplace_kv.py). No Concat/Slice pair, one QK and
+// one PV MatMul:
+//   K: [B,H,S_kv,D]   V: [B,H,D,S_kv]  (V transposed, adj_y=true)
+//   scores = MatMul(Q, K, transpose_b=true)
+//   probs  = Softmax(scores + mask)
+//   out    = MatMul(probs, V, transpose_b=true)
+// When |with_mask| is false the mask Add is omitted (no-mask path).
+std::shared_ptr<ov::Model> BuildStandardAttention(int64_t s_kv = 16,
+                                                  int64_t lq = 1,
+                                                  bool with_mask = true) {
+  using ov::op::v0::Constant;
+  using ov::op::v0::MatMul;
+  using ov::op::v0::Parameter;
+  using ov::op::v1::Add;
+  using ov::op::v8::Softmax;
+
+  constexpr int64_t kBatch = 1;
+  constexpr int64_t kHeads = 8;
+  constexpr int64_t kDim = 256;
+  const auto f = ov::element::f32;
+
+  auto q = std::make_shared<Parameter>(
+      f, ov::Shape{static_cast<size_t>(kBatch), static_cast<size_t>(kHeads),
+                   static_cast<size_t>(lq), static_cast<size_t>(kDim)});
+  auto k = std::make_shared<Parameter>(
+      f, ov::Shape{static_cast<size_t>(kBatch), static_cast<size_t>(kHeads),
+                   static_cast<size_t>(s_kv), static_cast<size_t>(kDim)});
+  auto v = std::make_shared<Parameter>(
+      f, ov::Shape{static_cast<size_t>(kBatch), static_cast<size_t>(kHeads),
+                   static_cast<size_t>(kDim), static_cast<size_t>(s_kv)});
+
+  auto qk = std::make_shared<MatMul>(q, k, /*transpose_a=*/false,
+                                     /*transpose_b=*/true);
+  std::shared_ptr<ov::Node> scores = qk;
+  ov::ParameterVector params{q, k, v};
+  if (with_mask) {
+    auto mask = std::make_shared<Parameter>(
+        f, ov::Shape{static_cast<size_t>(kBatch), 1, static_cast<size_t>(lq),
+                     static_cast<size_t>(s_kv)});
+    scores = std::make_shared<Add>(qk, mask);
+    params.push_back(mask);
+  }
+  auto probs = std::make_shared<Softmax>(scores, /*axis=*/-1);
+  auto out = std::make_shared<MatMul>(probs, v, false, true);
+
+  auto result = std::make_shared<ov::op::v0::Result>(out);
+  return std::make_shared<ov::Model>(ov::ResultVector{result}, params,
+                                     "standard_attention");
 }
 
 template <typename T>
@@ -248,6 +301,125 @@ TEST(FuseSplitAttentionToSDPATest, NumericallyMatchesSplitCache) {
   }
   EXPECT_LT(max_abs_diff, 1e-4f)
       << "fused output diverges from split-cache reference";
+}
+
+TEST(FuseStandardAttentionToSDPATest, FusesStandardPattern) {
+  auto model = BuildStandardAttention(/*s_kv=*/16, /*lq=*/8);
+
+  EXPECT_EQ(CountOps<ov::op::v0::MatMul>(model), 2u);
+  EXPECT_EQ(CountOps<ov::op::v8::Softmax>(model), 1u);
+  EXPECT_EQ(CountOps<ov::op::v13::ScaledDotProductAttention>(model), 0u);
+
+  NpuOptimizer()
+      .SetCastIntegerSignToFloat(false)
+      .SetFuseStandardAttentionToSDPA(true)
+      .Run(model);
+
+  EXPECT_EQ(CountOps<ov::op::v13::ScaledDotProductAttention>(model), 1u);
+  EXPECT_EQ(CountOps<ov::op::v8::Softmax>(model), 0u);
+  EXPECT_EQ(CountOps<ov::op::v0::MatMul>(model), 0u);
+}
+
+// The fp16-DUS in-place model feeds K/V to the matmuls via a Convert (the OV
+// equivalent of the tflite CAST(fp16->f32) that follows the DynamicUpdateSlice).
+// The matcher takes whatever feeds the matmul as the SDPA K/V operand, so an
+// intervening Convert must not block the fusion.
+TEST(FuseStandardAttentionToSDPATest, FusesWithConvertedKv) {
+  using ov::op::v0::Constant;
+  using ov::op::v0::Convert;
+  using ov::op::v0::MatMul;
+  using ov::op::v0::Parameter;
+  using ov::op::v1::Add;
+  using ov::op::v8::Softmax;
+  const auto f16 = ov::element::f16;
+
+  // K/V provided as fp16 (like the persisted cache), Converted to f32 before the
+  // matmuls, exactly as in Section2_fp16kv_pruned_dusfp16.tflite.
+  auto q = std::make_shared<Parameter>(ov::element::f32, ov::Shape{1, 8, 1, 256});
+  auto k16 = std::make_shared<Parameter>(f16, ov::Shape{1, 8, 16, 256});
+  auto v16 = std::make_shared<Parameter>(f16, ov::Shape{1, 8, 256, 16});
+  auto mask =
+      std::make_shared<Parameter>(ov::element::f32, ov::Shape{1, 1, 1, 16});
+  auto k = std::make_shared<Convert>(k16, ov::element::f32);
+  auto v = std::make_shared<Convert>(v16, ov::element::f32);
+
+  auto qk = std::make_shared<MatMul>(q, k, false, true);
+  auto scores = std::make_shared<Add>(qk, mask);
+  auto probs = std::make_shared<Softmax>(scores, -1);
+  auto out = std::make_shared<MatMul>(probs, v, false, true);
+  auto model = std::make_shared<ov::Model>(
+      ov::ResultVector{std::make_shared<ov::op::v0::Result>(out)},
+      ov::ParameterVector{q, k16, v16, mask}, "converted_kv_attention");
+
+  NpuOptimizer()
+      .SetCastIntegerSignToFloat(false)
+      .SetFuseStandardAttentionToSDPA(true)
+      .Run(model);
+
+  EXPECT_EQ(CountOps<ov::op::v13::ScaledDotProductAttention>(model), 1u);
+  EXPECT_EQ(CountOps<ov::op::v8::Softmax>(model), 0u);
+  EXPECT_EQ(CountOps<ov::op::v0::MatMul>(model), 0u);
+  // The Convert nodes feeding K/V are preserved (SDPA consumes their f32 output).
+  EXPECT_EQ(CountOps<ov::op::v0::Convert>(model), 2u);
+}
+
+// The split-attention pass must not fire on the standard (single-branch)
+// pattern; the two matchers are mutually exclusive.
+TEST(FuseStandardAttentionToSDPATest, SplitPassDoesNotFireOnStandard) {
+  auto model = BuildStandardAttention(/*s_kv=*/16, /*lq=*/8);
+
+  NpuOptimizer()
+      .SetCastIntegerSignToFloat(false)
+      .SetFuseSplitAttentionToSDPA(true)
+      .Run(model);
+
+  EXPECT_EQ(CountOps<ov::op::v13::ScaledDotProductAttention>(model), 0u);
+  EXPECT_EQ(CountOps<ov::op::v0::MatMul>(model), 2u);
+}
+
+// End-to-end numerical check: the fused SDPA must match the original standard
+// attention. Decode shape (lq=1) exercises the transposed-V path.
+TEST(FuseStandardAttentionToSDPATest, NumericallyMatchesStandard) {
+  auto reference = BuildStandardAttention(/*s_kv=*/16, /*lq=*/1);
+  auto fused = reference->clone();
+
+  NpuOptimizer()
+      .SetCastIntegerSignToFloat(false)
+      .SetFuseStandardAttentionToSDPA(true)
+      .Run(fused);
+  ASSERT_NE(FindSdpa(fused), nullptr) << "fusion did not fire";
+
+  ov::Core core;
+  auto ref_compiled = core.compile_model(reference, "CPU");
+  auto fused_compiled = core.compile_model(fused, "CPU");
+  auto ref_req = ref_compiled.create_infer_request();
+  auto fused_req = fused_compiled.create_infer_request();
+
+  const size_t num_inputs = reference->inputs().size();
+  ASSERT_EQ(num_inputs, fused->inputs().size());
+  for (size_t i = 0; i < num_inputs; ++i) {
+    const auto& port = reference->input(i);
+    ov::Tensor t(port.get_element_type(), port.get_shape());
+    FillRandom(t, static_cast<uint32_t>(i + 1));
+    ref_req.set_input_tensor(i, t);
+    fused_req.set_input_tensor(i, t);
+  }
+
+  ref_req.infer();
+  fused_req.infer();
+
+  auto ref_out = ref_req.get_output_tensor(0);
+  auto fused_out = fused_req.get_output_tensor(0);
+  ASSERT_EQ(ref_out.get_size(), fused_out.get_size());
+  const auto* a = ref_out.data<float>();
+  const auto* b = fused_out.data<float>();
+  float max_abs_diff = 0.0f;
+  for (size_t i = 0; i < ref_out.get_size(); ++i) {
+    max_abs_diff = std::max(max_abs_diff, std::abs(a[i] - b[i]));
+    ASSERT_FALSE(std::isnan(b[i])) << "fused output has NaN at " << i;
+  }
+  EXPECT_LT(max_abs_diff, 1e-4f)
+      << "fused output diverges from standard-attention reference";
 }
 
 }  // namespace

--- a/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
+++ b/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
@@ -102,6 +102,13 @@ OpenVinoCompileContext::OpenVinoCompileContext() {
         context.sdpa_pad_kv_to_alignment_ = (value == "true");
         continue;
       }
+      if (key == "fuse_standard_attention_to_sdpa") {
+        LITERT_LOG(LITERT_INFO,
+                   "Custom config: fuse_standard_attention_to_sdpa = %s",
+                   value.c_str());
+        context.fuse_standard_attention_to_sdpa_ = (value == "true");
+        continue;
+      }
       context.configs_map_[key] = value;
       LITERT_LOG(LITERT_INFO, "Custom config: %s = %s", key.c_str(),
                  value.c_str());
@@ -170,6 +177,7 @@ void OpenVinoCompileContext::OptimizeModel(
         .SetEliminateMatMulFakeQuantize(eliminate_fq_after_matmul_)
         .SetFuseSplitAttentionToSDPA(fuse_split_attention_to_sdpa_)
         .SetSdpaPadKvToAlignment(sdpa_pad_kv_to_alignment_)
+        .SetFuseStandardAttentionToSDPA(fuse_standard_attention_to_sdpa_)
         .Run(model);
   }
 }

--- a/litert/vendors/intel_openvino/compiler/openvino_compile_context.h
+++ b/litert/vendors/intel_openvino/compiler/openvino_compile_context.h
@@ -63,12 +63,16 @@ class OpenVinoCompileContext {
   std::string device_ = "NPU";
   ov::AnyMap configs_map_;
   bool eliminate_fq_after_matmul_ = false;
-  bool fuse_split_attention_to_sdpa_ = false;
+  bool fuse_split_attention_to_sdpa_ = true;
   // `sdpa_pad_kv_to_alignment_` is only meaningful when
   // `fuse_split_attention_to_sdpa_` is true and enabled by default. It controls
   // whether the `FuseSplitAttentionToSDPA` pass pads KV sequences up to the NPU
   // SDPA kernel's required alignment when fusing.
   bool sdpa_pad_kv_to_alignment_ = true;
+  // Enables the `FuseStandardAttentionToSDPA` pass, which fuses the
+  // single-branch attention produced after an offline DynamicUpdateSlice cache
+  // merge (inplace_kv_conversion/convert_inplace_kv.py) into a single SDPA op.
+  bool fuse_standard_attention_to_sdpa_ = true;
 };
 
 }  // namespace openvino


### PR DESCRIPTION
Add host-addressable pre-allocation and in-place DynamicUpdateSlice co-aliasing at NPU<->CPU partition boundaries in the dispatch delegate kernel, so KV-cache and inter-partition tensors are shared with the OpenVINO host tensors instead of memcpy'd each Eval. Plumb the required custom-allocation requests through compiled_model and the external buffer context.

Extend the intel_openvino npu_optimizer with the corresponding compiler support and add LITERT_PROFILE_BOUNDARY instrumentation to the benchmark tool to separate input-sync, npu-dispatch, and output-sync costs.