### PR TITLE
litert/qualcomm: add soversion, install rules and pkg-config for disp…

### DIFF
--- a/litert/vendors/qualcomm/compiler/CMakeLists.txt
+++ b/litert/vendors/qualcomm/compiler/CMakeLists.txt
@@ -72,3 +72,27 @@ elseif(UNIX)
     )
 endif()
 
+
+if(LITERT_MAJOR_VERSION)
+    set_target_properties(qnn_compiler_plugin PROPERTIES
+        VERSION   "${LITERT_MAJOR_VERSION}.${LITERT_MINOR_VERSION}.${LITERT_PATCH_VERSION}"
+        SOVERSION "${LITERT_MAJOR_VERSION}"
+    )
+endif()
+
+install(TARGETS qnn_compiler_plugin
+    LIBRARY
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT   Runtime
+    NAMELINK_COMPONENT Development
+)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/litert_qcom_compiler_plugin.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/litert_qcom_compiler_plugin.pc
+    @ONLY
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/litert_qcom_compiler_plugin.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    COMPONENT   Development
+)

--- a/litert/vendors/qualcomm/compiler/litert_qcom_compiler_plugin.pc.in
+++ b/litert/vendors/qualcomm/compiler/litert_qcom_compiler_plugin.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: litert-qcom-compiler-plugin
+Description: LiteRT Qualcomm AOT compiler plugin
+Version: @LITERT_MAJOR_VERSION@.@LITERT_MINOR_VERSION@.@LITERT_PATCH_VERSION@
+Libs: -L${libdir} -lLiteRtCompilerPlugin_Qualcomm
+Cflags: -I${includedir}

--- a/litert/vendors/qualcomm/dispatch/CMakeLists.txt
+++ b/litert/vendors/qualcomm/dispatch/CMakeLists.txt
@@ -53,3 +53,27 @@ if(UNIX AND NOT APPLE)
         "-Wl,--end-group"
     )
 endif()
+
+if(LITERT_MAJOR_VERSION)
+    set_target_properties(dispatch_api_qualcomm_so PROPERTIES
+        VERSION   "${LITERT_MAJOR_VERSION}.${LITERT_MINOR_VERSION}.${LITERT_PATCH_VERSION}"
+        SOVERSION "${LITERT_MAJOR_VERSION}"
+    )
+endif()
+
+install(TARGETS dispatch_api_qualcomm_so
+    LIBRARY
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT   Runtime
+    NAMELINK_COMPONENT Development
+)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/litert_qcom_dispatch.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/litert_qcom_dispatch.pc
+    @ONLY
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/litert_qcom_dispatch.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    COMPONENT   Development
+)

--- a/litert/vendors/qualcomm/dispatch/litert_qcom_dispatch.pc.in
+++ b/litert/vendors/qualcomm/dispatch/litert_qcom_dispatch.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: litert-qcom-dispatch
+Description: LiteRT Qualcomm dispatch plugin
+Version: @LITERT_MAJOR_VERSION@.@LITERT_MINOR_VERSION@.@LITERT_PATCH_VERSION@
+Libs: -L${libdir} -lLiteRtDispatch_Qualcomm
+Cflags: -I${includedir}


### PR DESCRIPTION
…atch and compiler plugins

The two Qualcomm vendor plugin shared libraries
(libLiteRtDispatch_Qualcomm.so / libLiteRtCompilerPlugin_Qualcomm.so) are built with no version information and have no CMake install() rules, so they are never installed by "cmake --install" and carry plain unversioned SONAMEs.

Add VERSION / SOVERSION target properties (guarded by if(LITERT_MAJOR_VERSION) so the change is opt-in and backwards compatible), CMake install() rules for the Runtime and Development components, and a pkg-config .pc.in template for each plugin, mirroring the convention already introduced for the LiteRT C API library in litert/c/CMakeLists.txt by the companion patch.

The LITERT_{MAJOR,MINOR,PATCH}_VERSION cache variables are expected to be set by the parent build (e.g. -DLITERT_MAJOR_VERSION=2) at configure time; when they are absent the VERSION/SOVERSION block is skipped and the libraries install without version suffixes, preserving the existing behaviour for in-tree builds.

Install layout (when version is supplied):
  * libLiteRtDispatch_Qualcomm.so.MAJOR.MINOR.PATCH  -> ${CMAKE_INSTALL_LIBDIR}
  * libLiteRtDispatch_Qualcomm.so.MAJOR              -> SONAME symlink
  * libLiteRtDispatch_Qualcomm.so                    -> development namelink
  * litert_qcom_dispatch.pc                          -> ${CMAKE_INSTALL_LIBDIR}/pkgconfig
  * libLiteRtCompilerPlugin_Qualcomm.so.*            -> same pattern
  * litert_qcom_compiler_plugin.pc                   -> same pattern