### PR TITLE
Qualcomm AI Engine Direct - Fix Compiler plugin README table format.

### DIFF
--- a/litert/vendors/qualcomm/compiler/Qualcomm_QNN_Compiler.md
+++ b/litert/vendors/qualcomm/compiler/Qualcomm_QNN_Compiler.md
@@ -39,243 +39,96 @@ final QNN type depends on whether the tensor is quantized.
 The following `LiteRtOpCode` operations are supported. The "Note" column
 provides the corresponding QNN operation it is legalized to.
 
-| LiteRT Op Code                          | Note                               |
-| :-------------------------------------- | :--------------------------------- |
-| `kLiteRtOpCodeTflAbs`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY` (ABS). :
-| `kLiteRtOpCodeTflAdd`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (ADD). Supports fused activation.  :
-| `kLiteRtOpCodeTflArgMax`                | Legalized to `QNN_OP_ARGMAX`.      |
-| `kLiteRtOpCodeTflArgMin`                | Legalized to `QNN_OP_ARGMIN`.      |
-| `kLiteRtOpCodeTflAveragePool2d`         | Legalized to `QNN_OP_POOL_AVG_2D`. |
-:                                         : Supports fused activation.         :
-| `kLiteRtOpCodeTflBatchMatmul`           | Legalized to `QNN_OP_MAT_MUL`.     |
-| `kLiteRtOpCodeTflBroadcastTo`           | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY` (ADD) :
-:                                         : or `QNN_OP_ELEMENT_WISE_BINARY`    :
-:                                         : (OR) with a static tensor.         :
-| `kLiteRtOpCodeTflCast`                  | Legalized to `QNN_OP_CAST`.        |
-| `kLiteRtOpCodeTflCeil`                  | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY`        :
-:                                         : (CEIL).                            :
-| `kLiteRtOpCodeTflConcatenation`         | Legalized to `QNN_OP_CONCAT`.      |
-:                                         : Supports fused activation.         :
-| `kLiteRtOpCodeTflConv2d`                | Legalized to `QNN_OP_CONV_2D`.     |
-:                                         : Supports fused activation. For     :
-:                                         : data types other than              :
-:                                         : `QNN_DATATYPE_UFIXED_POINT_8` and  :
-:                                         : `QNN_DATATYPE_SFIXED_POINT_8`,     :
-:                                         : weights are transposed using       :
-:                                         : `QNN_OP_TRANSPOSE`.                :
-| `kLiteRtOpCodeTflConv3d`                | Legalized to `QNN_OP_CONV_3D`.     |
-:                                         : Supports fused activation.         :
-| `kLiteRtOpCodeTflCos`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY` (COS). :
-| `kLiteRtOpCodeTflCumsum`                | Legalized to                       |
-:                                         : `QNN_OP_CUMULATIVE_SUM`.           :
-| `kLiteRtOpCodeTflDepthToSpace`          | Legalized to                       |
-:                                         : `QNN_OP_DEPTH_TO_SPACE`.           :
-| `kLiteRtOpCodeTflDepthwiseConv2d`       | Legalized to                       |
-:                                         : `QNN_OP_DEPTH_WISE_CONV_2D`.       :
-:                                         : Supports fused activation. Weights :
-:                                         : are reshaped.                      :
-| `kLiteRtOpCodeTflDequantize`            | Legalized to `QNN_OP_DEQUANTIZE`   |
-:                                         : or `QNN_OP_CAST`.                  :
-| `kLiteRtOpCodeTflDiv`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_DIVIDE`.      :
-:                                         : Supports fused activation.         :
-| `kLiteRtOpCodeTflDynamicUpdateSlice`    | Legalized to a sequence of ops     |
-:                                         : including                          :
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (NOT_EQUAL), `QNN_OP_RESHAPE`,     :
-:                                         : `QNN_OP_REDUCE_SUM` and            :
-:                                         : `QNN_OP_ELEMENT_WISE_SELECT`.      :
-| `kLiteRtOpCodeTflElu`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_NEURON`       :
-:                                         : (ELU).                             :
-| `kLiteRtOpCodeTflEmbeddingLookup`       | Legalized to `QNN_OP_GATHER`.      |
-| `kLiteRtOpCodeTflEqual`                 | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (EQUAL).                           :
-| `kLiteRtOpCodeTflExp`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY` (EXP). :
-| `kLiteRtOpCodeTflFloor`                 | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY`        :
-:                                         : (FLOOR).                           :
-| `kLiteRtOpCodeTflFloorDiv`              | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (FLOOR_DIV).                       :
-| `kLiteRtOpCodeTflFullyConnected`        | Legalized to                       |
-:                                         : `QNN_OP_FULLY_CONNECTED` and       :
-:                                         : `QNN_OP_RESHAPE` if                :
-:                                         : keep_num_dims = true. Supports     :
-:                                         : fused activation.                  :
-| `kLiteRtOpCodeTflGather`                | Legalized to `QNN_OP_GATHER`.      |
-| `kLiteRtOpCodeTflGatherNd`              | Legalized to `QNN_OP_GATHER_ND`.   |
-| `kLiteRtOpCodeTflGelu`                  | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_NEURON`       :
-:                                         : (GELU).                            :
-| `kLiteRtOpCodeTflGreater`               | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (GREATER).                         :
-| `kLiteRtOpCodeTflGreaterEqual`          | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (GREATER_EQUAL).                   :
-| `kLiteRtOpCodeTflHardSwish`             | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_NEURON`       :
-:                                         : (HARD_SWISH).                      :
-| `kLiteRtOpCodeTflL2Normalization`       | Legalized to `QNN_OP_L2_NORM`.     |
-| `kLiteRtOpCodeTflL2Pool2d`              | Legalized to `QNN_OP_L2_POOL_2D`.  |
-:                                         : Supports fused activation.         :
-| `kLiteRtOpCodeTflLeakyRelu`             | Legalized to `QNN_OP_PRELU`.       |
-| `kLiteRtOpCodeTflLess`                  | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (LESS).                            :
-| `kLiteRtOpCodeTflLessEqual`             | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (LESS_EQUAL).                      :
-| `kLiteRtOpCodeTflLog`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY` (LOG). :
-| `kLiteRtOpCodeTflLogicalAnd`            | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (AND).                             :
-| `kLiteRtOpCodeTflLogicalNot`            | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY` (NOT). :
-| `kLiteRtOpCodeTflLogicalOr`             | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY` (OR). :
-| `kLiteRtOpCodeTflLogistic`              | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_NEURON`       :
-:                                         : (SIGMOID).                         :
-| `kLiteRtOpCodeTflMaximum`               | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (MAXIMUM).                         :
-| `kLiteRtOpCodeTflMaxPool2d`             | Legalized to `QNN_OP_POOL_MAX_2D`. |
-:                                         : Supports fused activation.         :
-| `kLiteRtOpCodeTflMean`                  | Legalized to `QNN_OP_REDUCE_MEAN`. |
-| `kLiteRtOpCodeTflMinimum`               | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (MINIMUM).                         :
-| `kLiteRtOpCodeTflMirrorPad`             | Legalized to `QNN_OP_PAD` with     |
-:                                         : `REFLECT` or `SYMMETRIC` scheme.   :
-| `kLiteRtOpCodeTflMul`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_MULTIPLY`.    :
-:                                         : Supports fused activation.         :
-| `kLiteRtOpCodeTflNeg`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY` (NEG). :
-| `kLiteRtOpCodeTflNotEqual`              | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (NOT_EQUAL).                       :
-| `kLiteRtOpCodeTflOneHot`                | Legalized to `QNN_OP_ONE_HOT`.     |
-:                                         : Depth must be a static scalar      :
-:                                         : `QNN_DATATYPE_INT_32` or           :
-:                                         : `QNN_DATATYPE_UINT_32`. On/off     :
-:                                         : values must be static scalars with :
-:                                         : the same data type as the output.  :
-:                                         : Supported output/on/off types\:    :
-:                                         : `QNN_DATATYPE_SFIXED_POINT_8`,     :
-:                                         : `QNN_DATATYPE_UFIXED_POINT_8`,     :
-:                                         : `QNN_DATATYPE_SFIXED_POINT_16`,    :
-:                                         : `QNN_DATATYPE_UFIXED_POINT_16`,    :
-:                                         : `QNN_DATATYPE_FLOAT_32` (quantized :
-:                                         : types require per-tensor           :
-:                                         : quantization). Axis is normalized  :
-:                                         : to `[0, rank]`.                    :
-| `kLiteRtOpCodeTflPack`                  | Legalized to `QNN_OP_PACK`,        |
-:                                         : `QNN_OP_RESHAPE`, or               :
-:                                         : `QNN_OP_CONCAT` depending on input :
-:                                         : count.                             :
-| `kLiteRtOpCodeTflPad`,                  | Legalized to `QNN_OP_PAD` with     |
-: `kLiteRtOpCodeTflPadv2`                 : `CONSTANT` scheme.                 :
-| `kLiteRtOpCodeTflPow`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (POWER).                           :
-| `kLiteRtOpCodeTflPrelu`                 | Legalized to `QNN_OP_PRELU`.       |
-| `kLiteRtOpCodeTflQuantize`              | Legalized to `QNN_OP_QUANTIZE`,    |
-:                                         : `QNN_OP_CONVERT`, or               :
-:                                         : `QNN_OP_CAST`.                     :
-| `kLiteRtOpCodeTflReduceAll`             | Legalized to a sequence of         |
-:                                         : `QNN_OP_CAST` and                  :
-:                                         : `QNN_OP_REDUCE_MIN`.               :
-| `kLiteRtOpCodeTflReduceAny`             | Legalized to a sequence of         |
-:                                         : `QNN_OP_CAST` and                  :
-:                                         : `QNN_OP_REDUCE_MAX`.               :
-| `kLiteRtOpCodeTflReduceMax`             | Legalized to `QNN_OP_REDUCE_MAX`.  |
-| `kLiteRtOpCodeTflReduceMin`             | Legalized to `QNN_OP_REDUCE_MIN`.  |
-| `kLiteRtOpCodeTflRelu`                  | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_NEURON`       :
-:                                         : (RELU).                            :
-| `kLiteRtOpCodeTflRelu0To1`              | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_NEURON`       :
-:                                         : (RELU_MIN_MAX).                    :
-| `kLiteRtOpCodeTflRelu6`                 | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_NEURON`       :
-:                                         : (RELU_MIN_MAX).                    :
-| `kLiteRtOpCodeTflReluN1To1`             | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_NEURON`       :
-:                                         : (RELU_MIN_MAX).                    :
-| `kLiteRtOpCodeTflReshape`               | Legalized to `QNN_OP_RESHAPE`.     |
-| `kLiteRtOpCodeTflResizeBilinear`        | Legalized to                       |
-:                                         : `QNN_OP_RESIZE_BILINEAR`.          :
-| `kLiteRtOpCodeTflResizeNearestNeighbor` | Legalized to                       |
-:                                         : `QNN_OP_RESIZE_NEAREST_NEIGHBOR`.  :
-| `kLiteRtOpCodeTflReverseV2`             | Legalized to                       |
-:                                         : `QNN_OP_STRIDED_SLICE`.            :
-| `kLiteRtOpCodeTflRound`                 | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY`        :
-:                                         : (ROUND).                           :
-| `kLiteRtOpCodeTflRsqrt`                 | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_RSQRT`.       :
-| `kLiteRtOpCodeTflSelect`,               | Legalized to                       |
-: `kLiteRtOpCodeTflSelectV2`              : `QNN_OP_ELEMENT_WISE_SELECT`.      :
-| `kLiteRtOpCodeTflSign`                  | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY`        :
-:                                         : (SIGN).                            :
-| `kLiteRtOpCodeTflSin`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY` (SIN). :
-| `kLiteRtOpCodeTflSlice`                 | Legalized to                       |
-:                                         : `QNN_OP_STRIDED_SLICE`.            :
-| `kLiteRtOpCodeTflSoftmax`               | Legalized to `QNN_OP_SOFTMAX`.     |
-| `kLiteRtOpCodeTflSpaceToDepth`          | Legalized to                       |
-:                                         : `QNN_OP_SPACE_TO_DEPTH`.           :
-| `kLiteRtOpCodeTflSplit`                 | Legalized to `QNN_OP_SPLIT`.       |
-| `kLiteRtOpCodeTflSplitV`                | Legalized to `QNN_OP_SPLIT` with a |
-:                                         : cumulative `split_index` derived   :
-:                                         : from the static `size_splits`      :
-:                                         : input.                             :
-| `kLiteRtOpCodeTflSquare`                | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (MULTIPLY).                        :
-| `kLiteRtOpCodeTflSquaredDifference`     | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (SQUARED_DIFFERENCE).              :
-| `kLiteRtOpCodeTflSqrt`                  | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_UNARY`        :
-:                                         : (SQRT).                            :
-| `kLiteRtOpCodeTflStridedSlice`          | Legalized to                       |
-:                                         : `QNN_OP_STRIDED_SLICE`.            :
-| `kLiteRtOpCodeTflSub`                   | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_BINARY`       :
-:                                         : (SUBTRACT). Supports fused         :
-:                                         : activation.                        :
-| `kLiteRtOpCodeTflSum`                   | Legalized to `QNN_OP_REDUCE_SUM`.  |
-| `kLiteRtOpCodeTflTanh`                  | Legalized to                       |
-:                                         : `QNN_OP_ELEMENT_WISE_NEURON`       :
-:                                         : (TANH).                            :
-| `kLiteRtOpCodeTflTile`                  | Legalized to `QNN_OP_TILE`.        |
-| `kLiteRtOpCodeTflTopkV2`                | Legalized to `QNN_OP_TOP_K`.       |
-| `kLiteRtOpCodeTflTranspose`             | Legalized to `QNN_OP_TRANSPOSE`.   |
-| `kLiteRtOpCodeTflTransposeConv`         | Legalized to                       |
-:                                         : `QNN_OP_TRANSPOSE_CONV_2D`.        :
-:                                         : Supports fused activation. For     :
-:                                         : data types other than              :
-:                                         : `QNN_DATATYPE_UFIXED_POINT_8` and  :
-:                                         : `QNN_DATATYPE_SFIXED_POINT_8`,     :
-:                                         : weights are transposed using       :
-:                                         : `QNN_OP_TRANSPOSE`.                :
-| `kLiteRtOpCodeTflUnpack`                | Legalized to `QNN_OP_UN_PACK`.     |
-| `kLiteRtOpCodeShloComposite`            | Supports `RmsNorm` (legalized to   |
-:                                         : `QNN_OP_RMS_NORM`), `GroupNorm`    :
-:                                         : (legalized to `QNN_OP_GROUP_NORM`, :
-:                                         : `QNN_OP_LAYER_NORM`), and `L2Norm` :
-:                                         : (legalized to `QNN_OP_L2_NORM`).   :
+| LiteRT Op Code                          | Note                                                                                                                                                                                                                                                                                         |
+| :-------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kLiteRtOpCodeTflAbs`                   | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (ABS).                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflAdd`                   | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (ADD). Supports fused activation.                                                                                                                                                                                                                |
+| `kLiteRtOpCodeTflArgMax`                | Legalized to `QNN_OP_ARGMAX`.                                                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflArgMin`                | Legalized to `QNN_OP_ARGMIN`.                                                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflAveragePool2d`         | Legalized to `QNN_OP_POOL_AVG_2D`. Supports fused activation.                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflBatchMatmul`           | Legalized to `QNN_OP_MAT_MUL`.                                                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflBroadcastTo`           | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (ADD) or `QNN_OP_ELEMENT_WISE_BINARY` (OR) with a static tensor.                                                                                                                                                                                  |
+| `kLiteRtOpCodeTflCast`                  | Legalized to `QNN_OP_CAST`.                                                                                                                                                                                                                                                                 |
+| `kLiteRtOpCodeTflCeil`                  | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (CEIL).                                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflConcatenation`         | Legalized to `QNN_OP_CONCAT`. Supports fused activation.                                                                                                                                                                                                                                    |
+| `kLiteRtOpCodeTflConv2d`                | Legalized to `QNN_OP_CONV_2D`. Supports fused activation. For data types other than `QNN_DATATYPE_UFIXED_POINT_8` and `QNN_DATATYPE_SFIXED_POINT_8`, weights are transposed using `QNN_OP_TRANSPOSE`.                                                        |
+| `kLiteRtOpCodeTflConv3d`                | Legalized to `QNN_OP_CONV_3D`. Supports fused activation.                                                                                                                                                                                                                                   |
+| `kLiteRtOpCodeTflCos`                   | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (COS).                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflCumsum`                | Legalized to `QNN_OP_CUMULATIVE_SUM`.                                                                                                                                                                                                                                                       |
+| `kLiteRtOpCodeTflDepthToSpace`          | Legalized to `QNN_OP_DEPTH_TO_SPACE`.                                                                                                                                                                                                                                                      |
+| `kLiteRtOpCodeTflDepthwiseConv2d`       | Legalized to `QNN_OP_DEPTH_WISE_CONV_2D`. Supports fused activation. Weights are reshaped.                                                                                                                                                                                                  |
+| `kLiteRtOpCodeTflDequantize`            | Legalized to `QNN_OP_DEQUANTIZE` or `QNN_OP_CAST`.                                                                                                                                                                                                                                          |
+| `kLiteRtOpCodeTflDiv`                   | Legalized to `QNN_OP_ELEMENT_WISE_DIVIDE`. Supports fused activation.                                                                                                                                                                                                                       |
+| `kLiteRtOpCodeTflDynamicUpdateSlice`    | Legalized to a sequence of ops including `QNN_OP_ELEMENT_WISE_BINARY` (NOT_EQUAL), `QNN_OP_RESHAPE`, `QNN_OP_REDUCE_SUM` and `QNN_OP_ELEMENT_WISE_SELECT`.                                                                                                                                  |
+| `kLiteRtOpCodeTflElu`                   | Legalized to `QNN_OP_ELEMENT_WISE_NEURON` (ELU).                                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflEmbeddingLookup`       | Legalized to `QNN_OP_GATHER`.                                                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflEqual`                 | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (EQUAL).                                                                                                                                                                                                                                         |
+| `kLiteRtOpCodeTflExp`                   | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (EXP).                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflFloor`                 | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (FLOOR).                                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflFloorDiv`              | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (FLOOR_DIV).                                                                                                                                                                                                                                     |
+| `kLiteRtOpCodeTflFullyConnected`        | Legalized to `QNN_OP_FULLY_CONNECTED` and `QNN_OP_RESHAPE` if keep_num_dims = true. Supports fused activation.                                                                                                                                                                              |
+| `kLiteRtOpCodeTflGather`                | Legalized to `QNN_OP_GATHER`.                                                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflGatherNd`              | Legalized to `QNN_OP_GATHER_ND`.                                                                                                                                                                                                                                                            |
+| `kLiteRtOpCodeTflGelu`                  | Legalized to `QNN_OP_ELEMENT_WISE_NEURON` (GELU).                                                                                                                                                                                                                                          |
+| `kLiteRtOpCodeTflGreater`               | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (GREATER).                                                                                                                                                                                                                                       |
+| `kLiteRtOpCodeTflGreaterEqual`          | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (GREATER_EQUAL).                                                                                                                                                                                                                                 |
+| `kLiteRtOpCodeTflHardSwish`             | Legalized to `QNN_OP_ELEMENT_WISE_NEURON` (HARD_SWISH).                                                                                                                                                                                                                                     |
+| `kLiteRtOpCodeTflL2Normalization`       | Legalized to `QNN_OP_L2_NORM`.                                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflL2Pool2d`              | Legalized to `QNN_OP_L2_POOL_2D`. Supports fused activation.                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflLeakyRelu`             | Legalized to `QNN_OP_PRELU`.                                                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflLess`                  | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (LESS).                                                                                                                                                                                                                                          |
+| `kLiteRtOpCodeTflLessEqual`             | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (LESS_EQUAL).                                                                                                                                                                                                                                     |
+| `kLiteRtOpCodeTflLog`                   | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (LOG).                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflLogicalAnd`            | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (AND).                                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflLogicalNot`            | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (NOT).                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflLogicalOr`             | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (OR).                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflLogistic`              | Legalized to `QNN_OP_ELEMENT_WISE_NEURON` (SIGMOID).                                                                                                                                                                                                                                       |
+| `kLiteRtOpCodeTflMaximum`               | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (MAXIMUM).                                                                                                                                                                                                                                       |
+| `kLiteRtOpCodeTflMaxPool2d`             | Legalized to `QNN_OP_POOL_MAX_2D`. Supports fused activation.                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflMean`                  | Legalized to `QNN_OP_REDUCE_MEAN`.                                                                                                                                                                                                                                                         |
+| `kLiteRtOpCodeTflMinimum`               | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (MINIMUM).                                                                                                                                                                                                                                       |
+| `kLiteRtOpCodeTflMirrorPad`             | Legalized to `QNN_OP_PAD` with `REFLECT` or `SYMMETRIC` scheme.                                                                                                                                                                                                                            |
+| `kLiteRtOpCodeTflMul`                   | Legalized to `QNN_OP_ELEMENT_WISE_MULTIPLY`. Supports fused activation.                                                                                                                                                                                                                    |
+| `kLiteRtOpCodeTflNeg`                   | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (NEG).                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflNotEqual`              | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (NOT_EQUAL).                                                                                                                                                                                                                                     |
+| `kLiteRtOpCodeTflOneHot`                | Legalized to `QNN_OP_ONE_HOT`. Depth must be a static scalar `QNN_DATATYPE_INT_32` or `QNN_DATATYPE_UINT_32`. On/off values must be static scalars with the same data type as the output. Supported output/on/off types: `QNN_DATATYPE_SFIXED_POINT_8`, `QNN_DATATYPE_UFIXED_POINT_8`, `QNN_DATATYPE_SFIXED_POINT_16`, `QNN_DATATYPE_UFIXED_POINT_16`, `QNN_DATATYPE_FLOAT_32` (quantized types require per-tensor quantization). Axis is normalized to `[0, rank]`. |
+| `kLiteRtOpCodeTflPack`                  | Legalized to `QNN_OP_PACK`, `QNN_OP_RESHAPE`, or `QNN_OP_CONCAT` depending on input count.                                                                                                                                                                                                  |
+| `kLiteRtOpCodeTflPad`, `kLiteRtOpCodeTflPadv2` | Legalized to `QNN_OP_PAD` with `CONSTANT` scheme.                                                                                                                                                                                                                                  |
+| `kLiteRtOpCodeTflPow`                   | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (POWER).                                                                                                                                                                                                                                         |
+| `kLiteRtOpCodeTflPrelu`                 | Legalized to `QNN_OP_PRELU`.                                                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflQuantize`              | Legalized to `QNN_OP_QUANTIZE`, `QNN_OP_CONVERT`, or `QNN_OP_CAST`.                                                                                                                                                                                                                        |
+| `kLiteRtOpCodeTflReduceAll`             | Legalized to a sequence of `QNN_OP_CAST` and `QNN_OP_REDUCE_MIN`.                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflReduceAny`             | Legalized to a sequence of `QNN_OP_CAST` and `QNN_OP_REDUCE_MAX`.                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflReduceMax`             | Legalized to `QNN_OP_REDUCE_MAX`.                                                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflReduceMin`             | Legalized to `QNN_OP_REDUCE_MIN`.                                                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflRelu`                  | Legalized to `QNN_OP_ELEMENT_WISE_NEURON` (RELU).                                                                                                                                                                                                                                          |
+| `kLiteRtOpCodeTflRelu0To1`              | Legalized to `QNN_OP_ELEMENT_WISE_NEURON` (RELU_MIN_MAX).                                                                                                                                                                                                                                   |
+| `kLiteRtOpCodeTflRelu6`                 | Legalized to `QNN_OP_ELEMENT_WISE_NEURON` (RELU_MIN_MAX).                                                                                                                                                                                                                                   |
+| `kLiteRtOpCodeTflReluN1To1`             | Legalized to `QNN_OP_ELEMENT_WISE_NEURON` (RELU_MIN_MAX).                                                                                                                                                                                                                                   |
+| `kLiteRtOpCodeTflReshape`               | Legalized to `QNN_OP_RESHAPE`.                                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflResizeBilinear`        | Legalized to `QNN_OP_RESIZE_BILINEAR`.                                                                                                                                                                                                                                                     |
+| `kLiteRtOpCodeTflResizeNearestNeighbor` | Legalized to `QNN_OP_RESIZE_NEAREST_NEIGHBOR`.                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflReverseV2`             | Legalized to `QNN_OP_STRIDED_SLICE`.                                                                                                                                                                                                                                                       |
+| `kLiteRtOpCodeTflRound`                 | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (ROUND).                                                                                                                                                                                                                                          |
+| `kLiteRtOpCodeTflRsqrt`                 | Legalized to `QNN_OP_ELEMENT_WISE_RSQRT`.                                                                                                                                                                                                                                                   |
+| `kLiteRtOpCodeTflSelect`, `kLiteRtOpCodeTflSelectV2` | Legalized to `QNN_OP_ELEMENT_WISE_SELECT`.                                                                                                                                                                                                                                  |
+| `kLiteRtOpCodeTflSign`                  | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (SIGN).                                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflSin`                   | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (SIN).                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflSlice`                 | Legalized to `QNN_OP_STRIDED_SLICE`.                                                                                                                                                                                                                                                       |
+| `kLiteRtOpCodeTflSoftmax`               | Legalized to `QNN_OP_SOFTMAX`.                                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeTflSpaceToDepth`          | Legalized to `QNN_OP_SPACE_TO_DEPTH`.                                                                                                                                                                                                                                                      |
+| `kLiteRtOpCodeTflSplit`                 | Legalized to `QNN_OP_SPLIT`.                                                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflSplitV`                | Legalized to `QNN_OP_SPLIT` with a cumulative `split_index` derived from the static `size_splits` input.                                                                                                                                                                                   |
+| `kLiteRtOpCodeTflSquare`                | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (MULTIPLY).                                                                                                                                                                                                                                      |
+| `kLiteRtOpCodeTflSquaredDifference`     | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (SQUARED_DIFFERENCE).                                                                                                                                                                                                                            |
+| `kLiteRtOpCodeTflSqrt`                  | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (SQRT).                                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflStridedSlice`          | Legalized to `QNN_OP_STRIDED_SLICE`.                                                                                                                                                                                                                                                       |
+| `kLiteRtOpCodeTflSub`                   | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (SUBTRACT). Supports fused activation.                                                                                                                                                                                                            |
+| `kLiteRtOpCodeTflSum`                   | Legalized to `QNN_OP_REDUCE_SUM`.                                                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflTanh`                  | Legalized to `QNN_OP_ELEMENT_WISE_NEURON` (TANH).                                                                                                                                                                                                                                          |
+| `kLiteRtOpCodeTflTile`                  | Legalized to `QNN_OP_TILE`.                                                                                                                                                                                                                                                                 |
+| `kLiteRtOpCodeTflTopkV2`                | Legalized to `QNN_OP_TOP_K`.                                                                                                                                                                                                                                                               |
+| `kLiteRtOpCodeTflTranspose`             | Legalized to `QNN_OP_TRANSPOSE`.                                                                                                                                                                                                                                                           |
+| `kLiteRtOpCodeTflTransposeConv`         | Legalized to `QNN_OP_TRANSPOSE_CONV_2D`. Supports fused activation. For data types other than `QNN_DATATYPE_UFIXED_POINT_8` and `QNN_DATATYPE_SFIXED_POINT_8`, weights are transposed using `QNN_OP_TRANSPOSE`.                                            |
+| `kLiteRtOpCodeTflUnpack`                | Legalized to `QNN_OP_UN_PACK`.                                                                                                                                                                                                                                                             |
+| `kLiteRtOpCodeShloComposite`            | Supports `RmsNorm` (legalized to `QNN_OP_RMS_NORM`), `GroupNorm` (legalized to `QNN_OP_GROUP_NORM`, `QNN_OP_LAYER_NORM`), and `L2Norm` (legalized to `QNN_OP_L2_NORM`).                                                                                                                    |


### PR DESCRIPTION
Summary:
- The "Supported Operations" table in Qualcomm_QNN_Compiler.md rendered broken on GitHub. The Copybara merge of the SplitV PR (74a4257) reflowed the whole table into pandoc/kramdown `: ... :` continuation lines, which are not valid GitHub-Flavored Markdown.
- Restore the table to the single-line row format. Content is unchanged (same ops and notes, including the SplitV row); only the layout is fixed.