### PR TITLE
BATCH_MATMUL: reject rank<2 operands in Prepare

### DIFF
--- a/tflite/kernels/batch_matmul.cc
+++ b/tflite/kernels/batch_matmul.cc
@@ -136,6 +136,9 @@ TfLiteStatus InitializeTemporaries(TfLiteContext* context, TfLiteNode* node,
 
   const int lhs_rank = NumDimensions(lhs);
   const int rhs_rank = NumDimensions(rhs);
+  // A rank < 2 operand would index dims->data[rank-2] out of bounds below.
+  TF_LITE_ENSURE(context, lhs_rank >= 2);
+  TF_LITE_ENSURE(context, rhs_rank >= 2);
   const int batch_size = op_context->params->adj_x
                              ? lhs->dims->data[lhs_rank - 1]
                              : lhs->dims->data[lhs_rank - 2];


### PR DESCRIPTION
`InitializeTemporaries` indexes `lhs`/`rhs` `dims->data[rank-2]` before checking that each operand has rank >= 2, so a rank-0 or rank-1 operand causes an out-of-bounds read during `AllocateTensors()`. This adds `TF_LITE_ENSURE(lhs_rank >= 2)` and `rhs_rank >= 2` right after the ranks are read.

Verified on an ASan build: the repro (a BATCH_MATMUL with a rank-1 operand) now returns `kTfLiteError` cleanly instead of reading out of bounds.

Fixes #8608
