### PR TITLE
Subgraph: bounds-check tensor indices before indexing tensors_

### DIFF
--- a/tflite/core/subgraph.cc
+++ b/tflite/core/subgraph.cc
@@ -872,6 +872,9 @@ void Subgraph::SetCancellationFunction(void* data,
 }
 
 TfLiteStatus Subgraph::EnsureTensorDataIsReadable(int tensor_index) {
+  // Guard the tensors_ index for every caller (e.g. Interpreter::Invoke).
+  TF_LITE_ENSURE(&context_, tensor_index >= 0 &&
+                                tensor_index < static_cast<int>(tensors_.size()));
   TfLiteTensor* t = &tensors_[tensor_index];
   TF_LITE_ENSURE(&context_, t != nullptr);
   TfLiteStatus status = kTfLiteOk;
@@ -1722,6 +1725,8 @@ TfLiteStatus Subgraph::InvokeImpl() {
       if (tensor_index == kTfLiteOptionalTensor) {
         continue;
       }
+      TF_LITE_ENSURE(&context_, tensor_index >= 0 &&
+                                    tensor_index < static_cast<int>(tensors_.size()));
       TfLiteTensor* tensor = &tensors_[tensor_index];
       if (tensor->delegate && tensor->delegate != node.delegate &&
           tensor->data_is_stale) {


### PR DESCRIPTION
`EnsureTensorDataIsReadable` (reached from `Interpreter::Invoke`) and the `InvokeImpl` input loop index `tensors_[tensor_index]` with no bounds check, so a node input index past the subgraph tensor count reads out of bounds. This adds range checks so a malformed graph returns `kTfLiteError`.

Verified on an ASan build: the repro (a node input index past the tensor count) now returns cleanly instead of reading out of bounds.

Fixes #8609
