### PR TITLE
LSTM: check input-to-output weights rank before reading dims->data[0]

### DIFF
--- a/tflite/kernels/lstm.cc
+++ b/tflite/kernels/lstm.cc
@@ -1326,8 +1326,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_ENSURE_OK(context,
                     GetInputSafe(context, node, kInputToOutputWeightsTensor,
                                  &input_to_output_weights));
-  const int n_cell = input_to_output_weights->dims->data[0];
   TF_LITE_ENSURE_EQ(context, input_to_output_weights->dims->size, 2);
+  const int n_cell = input_to_output_weights->dims->data[0];
   TF_LITE_ENSURE_EQ(context, input_to_output_weights->dims->data[1], n_input);
 
   const TfLiteTensor* recurrent_to_output_weights;

--- a/tflite/kernels/unidirectional_sequence_lstm.cc
+++ b/tflite/kernels/unidirectional_sequence_lstm.cc
@@ -932,8 +932,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
       context,
       GetInputSafe(context, node, lstm::full::kInputToOutputWeightsTensor,
                    &input_to_output_weights));
-  const int n_cell = input_to_output_weights->dims->data[0];
   TF_LITE_ENSURE_EQ(context, input_to_output_weights->dims->size, 2);
+  const int n_cell = input_to_output_weights->dims->data[0];
   TF_LITE_ENSURE_EQ(context, input_to_output_weights->dims->data[1], n_input);
 
   const TfLiteTensor* recurrent_to_output_weights;


### PR DESCRIPTION
`lstm.cc` and `unidirectional_sequence_lstm.cc` read `input_to_output_weights->dims->data[0]` before the `dims->size == 2` check on the next line, so a rank-0 weights tensor reads past the `dims` array. This moves the size check above the read in both files.

Verified on an ASan build: both repros (a rank-0 input-to-output weights tensor) now return `kTfLiteError` cleanly.

Fixes #8610
