### PR TITLE
[OpenVino] Convert i2 weights to i4 for OpenVINO GPU

### DIFF
--- a/litert/vendors/intel_openvino/compiler/BUILD
+++ b/litert/vendors/intel_openvino/compiler/BUILD
@@ -277,6 +277,32 @@ litert_test(
 )
 
 litert_test(
+    name = "graph_iterator_test",
+    srcs = ["graph_iterator_test.cc"],
+    copts = select({
+        "//litert:windows": [],
+        "//conditions:default": ["-fexceptions"],
+    }),
+    data = ["//litert/test:tflite_test_data"],
+    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
+    tags = [
+        "manual",
+        "nobuilder",
+        "notap",
+    ],
+    deps = [
+        ":graph_iterator",
+        "//litert/c:litert_runtime_c_api_shared_lib",
+        "//litert/c/internal:litert_compiler_context",
+        "//litert/cc:litert_element_type",
+        "//litert/cc/dynamic_runtime:litert_extended_model",
+        "//litert/compiler/cc:litert_model",
+        "//litert/test:load_test_model",
+        "@intel_openvino//:openvino",
+    ],
+)
+
+litert_test(
     name = "openvino_compiler_plugin_test",
     srcs = [
         "openvino_compiler_plugin_test.cc",

--- a/litert/vendors/intel_openvino/compiler/graph_iterator.cc
+++ b/litert/vendors/intel_openvino/compiler/graph_iterator.cc
@@ -114,6 +114,70 @@ bool fill_tensor_meta(
   return true;
 }
 
+void GraphIteratorDelegate::ConvertI2WeightsToU2(
+    const litert::compiler::Tensor& tensor,
+    ov::frontend::tensorflow_lite::TensorMetaInfo& tensor_meta_info) const {
+  // XOR flips each sub-byte element's MSB, which is equivalent to adding
+  // 2^(bits-1) mod 2^bits. The zero points are adjusted by the same offset
+  // to keep dequantized values unchanged. u2 packs 4 elements per byte, so
+  // the byte layout is preserved and only the bit pattern changes.
+  constexpr uint8_t xor_mask = 0xAA;  // flip MSB of each 2-bit pair
+  constexpr int64_t zp_offset = 2;    // [-2..1] -> [0..3]
+
+  auto weight_bytes = tensor.Weights().Bytes();
+  auto& buf = converted_weight_buffers_.emplace_back(
+      weight_bytes.data(), weight_bytes.data() + weight_bytes.size());
+  for (auto& byte : buf) {
+    byte ^= xor_mask;
+  }
+  tensor_meta_info.m_tensor_data = buf.data();
+  tensor_meta_info.m_element_type = ov::element::u2;
+
+  auto adjusted_qi =
+      std::make_shared<ov::frontend::tensorflow_lite::QuantizationInfo>(
+          *tensor_meta_info.m_quantization_info);
+  auto zps = adjusted_qi->get_zero_point();
+  for (auto& zp : zps) {
+    zp += zp_offset;
+  }
+  adjusted_qi->set_zero_point(zps);
+  tensor_meta_info.m_quantization_info = adjusted_qi;
+  LITERT_LOG(LITERT_INFO, "Converted i2 weights to u2 for tensor: %s",
+             tensor_meta_info.m_tensor_name.c_str());
+}
+
+void GraphIteratorDelegate::ConvertI2WeightsToI4(
+    const litert::compiler::Tensor& tensor,
+    ov::frontend::tensorflow_lite::TensorMetaInfo& tensor_meta_info) const {
+  // i2 packs 4 signed 2-bit elements per byte (least-significant element
+  // first); i4 packs 2 signed 4-bit elements per byte (low nibble first).
+  // Each 2-bit two's-complement value in [-2, 1] is sign-extended to a 4-bit
+  // two's-complement nibble, so the converted buffer is twice as large. The
+  // zero points are unchanged because i4 represents the same signed values.
+  auto weight_bytes = tensor.Weights().Bytes();
+  auto& buf = converted_weight_buffers_.emplace_back();
+  buf.reserve(weight_bytes.size() * 2);
+
+  // Sign-extends a 2-bit two's-complement value to a 4-bit nibble.
+  auto i2_to_i4_nibble = [](uint8_t v2) -> uint8_t {
+    return (v2 & 0x2) ? static_cast<uint8_t>(0xC | v2) : v2;
+  };
+
+  for (uint8_t packed : weight_bytes) {
+    // Elements 0..3 occupy bit pairs [1:0], [3:2], [5:4], [7:6].
+    for (int e = 0; e < 4; e += 2) {
+      const uint8_t lo2 = (packed >> (2 * e)) & 0x3;
+      const uint8_t hi2 = (packed >> (2 * (e + 1))) & 0x3;
+      buf.push_back(static_cast<uint8_t>(i2_to_i4_nibble(lo2) |
+                                         (i2_to_i4_nibble(hi2) << 4)));
+    }
+  }
+  tensor_meta_info.m_tensor_data = buf.data();
+  tensor_meta_info.m_element_type = ov::element::i4;
+  LITERT_LOG(LITERT_INFO, "Converted i2 weights to i4 for tensor: %s",
+             tensor_meta_info.m_tensor_name.c_str());
+}
+
 std::shared_ptr<ov::frontend::tensorflow_lite::DecoderBase>
 GraphIteratorDelegate::get_decoder() const {
   converted_weight_buffers_.clear();
@@ -158,39 +222,18 @@ GraphIteratorDelegate::get_decoder() const {
                    op.Code());
         tensor_meta_info.m_tensor_data = input.Weights().Bytes().data();
 
-        // Convert signed i2 weights to unsigned u2 for NPU friendliness.
-        // XOR flips each sub-byte element's MSB, which is equivalent to
-        // adding 2^(bits-1) mod 2^bits. The zero points are adjusted by the
-        // same offset to keep dequantized values unchanged.
-        // i2 → u2: for all ops, since MapLiteTypeToOV maps i2 to u2
-        //   globally and OpenVINO never sees ov::element::i2.
+        // Signed i2 weights are rewritten before reaching OpenVINO, which
+        // never sees ov::element::i2. The target device selects the
+        // encoding: NPU/CPU use unsigned u2, GPU uses signed i4.
         if (tensor_meta_info.m_quantization_info) {
           const auto litert_type =
               static_cast<LiteRtElementType>(input.ElementType());
           if (litert_type == kLiteRtElementTypeInt2) {
-            constexpr uint8_t xor_mask = 0xAA;  // flip MSB of each 2-bit pair
-            constexpr int64_t zp_offset = 2;    // [-2..1] -> [0..3]
-
-            auto weight_bytes = input.Weights().Bytes();
-            auto& buf = converted_weight_buffers_.emplace_back(
-                weight_bytes.data(), weight_bytes.data() + weight_bytes.size());
-            for (auto& byte : buf) {
-              byte ^= xor_mask;
+            if (device_ == "GPU") {
+              ConvertI2WeightsToI4(input, tensor_meta_info);
+            } else {
+              ConvertI2WeightsToU2(input, tensor_meta_info);
             }
-            tensor_meta_info.m_tensor_data = buf.data();
-            tensor_meta_info.m_element_type = ov::element::u2;
-
-            auto adjusted_qi = std::make_shared<
-                ov::frontend::tensorflow_lite::QuantizationInfo>(
-                *tensor_meta_info.m_quantization_info);
-            auto zps = adjusted_qi->get_zero_point();
-            for (auto& zp : zps) {
-              zp += zp_offset;
-            }
-            adjusted_qi->set_zero_point(zps);
-            tensor_meta_info.m_quantization_info = adjusted_qi;
-            LITERT_LOG(LITERT_INFO, "Converted i2 weights to u2 for tensor: %s",
-                       tensor_meta_info.m_tensor_name.c_str());
           }
         }
       }

--- a/litert/vendors/intel_openvino/compiler/graph_iterator.h
+++ b/litert/vendors/intel_openvino/compiler/graph_iterator.h
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "openvino/frontend/tensorflow_lite/decoder.hpp"
@@ -47,8 +48,9 @@ class GraphIteratorDelegate
     : public ov::frontend::tensorflow_lite::GraphIterator {
  public:
   GraphIteratorDelegate(const LiteRtCompilerContext* ctx,
-                        const litert::compiler::Subgraph* graph)
-      : ctx_(ctx), subgraph_ptr_(graph) {
+                        const litert::compiler::Subgraph* graph,
+                        std::string device = "NPU")
+      : ctx_(ctx), subgraph_ptr_(graph), device_(std::move(device)) {
     for (const auto& input : subgraph_ptr_->Inputs()) {
       if (input.IsSubgraphInput()) {
         iterator_indices_.input_index_++;
@@ -96,13 +98,32 @@ class GraphIteratorDelegate
   };
 
  private:
+  // Rewrites signed i2 weights to unsigned u2 (NPU/CPU path): flips the MSB
+  // of every 2-bit element (XOR 0xAA) and shifts the zero points by +2 so
+  // the dequantized values are unchanged.  Updates |tensor_meta_info| in
+  // place to point at the converted buffer with element type u2.
+  void ConvertI2WeightsToU2(
+      const litert::compiler::Tensor& tensor,
+      ov::frontend::tensorflow_lite::TensorMetaInfo& tensor_meta_info) const;
+
+  // Rewrites signed i2 weights to signed i4 (GPU path): sign-extends each
+  // 2-bit element to 4 bits and repacks two elements per byte.  The zero
+  // points are left unchanged because i4 represents the same signed values.
+  // Updates |tensor_meta_info| in place to point at the converted buffer
+  // with element type i4.
+  void ConvertI2WeightsToI4(
+      const litert::compiler::Tensor& tensor,
+      ov::frontend::tensorflow_lite::TensorMetaInfo& tensor_meta_info) const;
+
   const LiteRtCompilerContext* ctx_;
   size_t node_index_ = 0;
   const litert::compiler::Subgraph* subgraph_ptr_;
   struct OVGraphIndices iterator_indices_;
-  // Owns converted weight buffers for i2-to-u2 transformations. Each entry
-  // holds a copy of the original packed bytes with the MSB of every 2-bit
-  // pair flipped (XOR 0xAA), which shifts signed [-2,1] to unsigned [0,3].
+  // OpenVINO target device string for this partition ("NPU", "GPU", "CPU").
+  std::string device_;
+  // Owns converted weight buffers for i2 weight transformations. Each entry
+  // holds a copy of the repacked bytes (u2 for NPU/CPU, i4 for GPU) that
+  // outlives the decoder returned by get_decoder().
   mutable std::vector<std::vector<uint8_t>> converted_weight_buffers_;
 };
 

--- a/litert/vendors/intel_openvino/compiler/graph_iterator_test.cc
+++ b/litert/vendors/intel_openvino/compiler/graph_iterator_test.cc
@@ -1,0 +1,111 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/intel_openvino/compiler/graph_iterator.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "openvino/core/type/element_type.hpp"
+#include <gtest/gtest.h>
+#include "litert/c/internal/litert_compiler_context.h"
+#include "litert/cc/litert_element_type.h"
+#include "litert/compiler/cc/litert_model.h"
+#include "litert/test/load_test_model.h"
+
+namespace litert::openvino {
+namespace {
+
+struct ConversionTestParam {
+  std::string device;
+  ov::element::Type expected_type;
+  bool adjusts_zero_points;
+};
+
+class GraphIteratorI2ConversionTest
+    : public ::testing::TestWithParam<ConversionTestParam> {};
+
+TEST_P(GraphIteratorI2ConversionTest, ConvertsConstantWeights) {
+  auto cc_model = testing::LoadTestFileModel("FFW-2-bit.tflite");
+  const LiteRtCompilerContext* context = LrtGetCompilerContext();
+  litert::compiler::Model model(context, cc_model.Get());
+  auto graph_or = model.Subgraph(0);
+  ASSERT_TRUE(graph_or.HasValue());
+  auto graph = graph_or.Value();
+
+  GraphIteratorDelegate iterator(context, &graph, GetParam().device);
+  const auto operations = graph.Ops();
+  size_t operation_index = 0;
+  for (; !iterator.is_end(); iterator.next()) {
+    auto decoder = iterator.get_decoder();
+    auto operation =
+        std::dynamic_pointer_cast<DecoderOperation>(std::move(decoder));
+    if (!operation) {
+      continue;
+    }
+
+    ASSERT_LT(operation_index, operations.size());
+    const auto& op = operations[operation_index++];
+    const auto inputs = op.Inputs();
+    ASSERT_EQ(operation->get_input_size(), inputs.size());
+    for (size_t input_index = 0; input_index < operation->get_input_size();
+         ++input_index) {
+      const auto& input = inputs[input_index];
+      if (!input.HasWeights() ||
+          input.ElementType() != litert::ElementType::Int2) {
+        continue;
+      }
+
+      const auto tensor_info = operation->get_input_tensor_info(input_index);
+      ASSERT_EQ(tensor_info.m_element_type, GetParam().expected_type);
+      ASSERT_NE(tensor_info.m_tensor_data, nullptr);
+      ASSERT_NE(tensor_info.m_quantization_info, nullptr);
+
+      const auto original_bytes = input.Weights().Bytes();
+      const auto* converted_bytes =
+          static_cast<const uint8_t*>(tensor_info.m_tensor_data);
+      if (GetParam().device == "GPU") {
+        const auto sign_extend = [](uint8_t value) {
+          return static_cast<uint8_t>((value & 0x2) ? 0xC | value : value);
+        };
+        for (size_t byte_index = 0; byte_index < original_bytes.size();
+             ++byte_index) {
+          const uint8_t packed = original_bytes[byte_index];
+          for (int element = 0; element < 4; element += 2) {
+            const uint8_t low = (packed >> (2 * element)) & 0x3;
+            const uint8_t high = (packed >> (2 * (element + 1))) & 0x3;
+            EXPECT_EQ(converted_bytes[2 * byte_index + element / 2],
+                      sign_extend(low) | (sign_extend(high) << 4));
+          }
+        }
+      } else {
+        for (size_t byte_index = 0; byte_index < original_bytes.size();
+             ++byte_index) {
+          EXPECT_EQ(converted_bytes[byte_index],
+                    static_cast<uint8_t>(original_bytes[byte_index] ^ 0xAA));
+        }
+      }
+
+      const auto zero_points =
+          tensor_info.m_quantization_info->get_zero_point();
+      for (int64_t zero_point : zero_points) {
+        EXPECT_EQ(zero_point, GetParam().adjusts_zero_points ? 2 : 0);
+      }
+      return;
+    }
+  }
+  FAIL() << "No constant int2 weights found";
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Devices, GraphIteratorI2ConversionTest,
+    ::testing::Values(
+        ConversionTestParam{"GPU", ov::element::i4,
+                            /*adjusts_zero_points=*/false},
+        ConversionTestParam{"NPU", ov::element::u2,
+                            /*adjusts_zero_points=*/true}));
+
+}  // namespace
+}  // namespace litert::openvino

--- a/litert/vendors/intel_openvino/compiler/openvino_compiler_plugin.cc
+++ b/litert/vendors/intel_openvino/compiler/openvino_compiler_plugin.cc
@@ -521,7 +521,8 @@ LiteRtStatus LiteRtCompilerPluginCompile(
         std::shared_ptr<ov::frontend::tensorflow_lite::GraphIterator>
             graph_delegate =
                 std::make_shared<litert::openvino::GraphIteratorDelegate>(
-                    compiler_plugin->ctx(), &expected_subgraph.Value());
+                    compiler_plugin->ctx(), &expected_subgraph.Value(),
+                    context.Device());
         auto input_model = tflite_fe->load(graph_delegate);
         LITERT_LOG(LITERT_INFO, "Model loaded");
         auto ov_model = tflite_fe->convert(input_model);


### PR DESCRIPTION
OpenVINO GPU does not support i2 or u2 weights directly, so convert them to i4 to make the generated model more compatible with the OV GPU backend.

Test commands: 
.\apply_plugin_main.exe --cmd apply --model=.\models\model.tflite       -o .\intel_gemma4_gpu_aot.tflite --libs .\ --intel_openvino_graph_backends="gpu" --soc_manufacturer "IntelOpenVINO"
.\litertlm_builder_cli.exe ... output --path .\intel_gemma4_gpu_aot.litertlm
.\litert_lm_advanced_main.exe --backend=npu --model_path=.\intel_gemma4_gpu_aot.litertlm --use_hw_masking_for_npu=false --benchmark --benchmark_prefill_tokens=3840 --benchmark_decode_tokens=256 
