### PR TITLE
Qualcomm AI Engine Direct - Optimize gemma4-E4B with GQA2SHA.

### DIFF
--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
@@ -242,6 +242,58 @@ void GraphToGraphTransform(G2GConfig g2g_option, std::vector<OpWrapper>& ops,
   Transform(validate_op_config, ops, tensor_pool, embedding_gemma,
             TransformEmbeddingGemma);
 
+  // Gemma 4 Optimization
+  // Base: perm=[0,2,1,3] transpose bookends, one far-away Convert before QK,
+  // two QK matmuls, concat, mask-add, softmax, two strided-slices, two V
+  // matmuls, add, output-quantize Convert, reshape+transpose.
+  // Optional inserts:
+  //   has_k_slice_attn_update_convert : kConvert between the two QK matmuls
+  //   has_v_slice_attn_update_convert  : kConvert between the two V  matmuls
+  //   has_global_mask : kConcat + kReshape after the first kConcat
+  auto build_gqa_gemma4b_prefill_pattern = [](bool has_k_slice_attn_update_convert,
+                                         bool has_v_slice_attn_update_convert,
+                                         bool has_global_mask) {
+    std::vector<QnnOpCode> p = {
+        QnnOpCode::kTranspose,
+        QnnOpCode::kReshape,
+        QnnOpCode::kConvert,  // far-away input quantize
+        QnnOpCode::kMatMul,   // Q x K cache
+    };
+    if (has_k_slice_attn_update_convert) p.push_back(QnnOpCode::kConvert);
+    p.push_back(QnnOpCode::kMatMul);  // Q x K slice
+    p.push_back(QnnOpCode::kConcat);
+    if (has_global_mask) {
+      p.push_back(QnnOpCode::kConcat);   // concat local/global mask
+      p.push_back(QnnOpCode::kReshape);  // reshape mask
+    }
+    p.insert(p.end(), {
+        QnnOpCode::kElementWiseBinary,  // mask add
+        QnnOpCode::kSoftmax,
+        QnnOpCode::kStridedSlice,
+        QnnOpCode::kStridedSlice,
+        QnnOpCode::kMatMul,  // QK x V cache
+    });
+    if (has_v_slice_attn_update_convert) p.push_back(QnnOpCode::kConvert);
+    p.insert(p.end(), {
+        QnnOpCode::kMatMul,             // QK x V slice
+        QnnOpCode::kElementWiseBinary,  // qkv add
+        QnnOpCode::kConvert,            // output quantize
+        QnnOpCode::kReshape,
+        QnnOpCode::kTranspose,
+    });
+    return p;
+  };
+  for (auto has_k_slice_convert : {false, true}) {
+    for (auto has_v_slice_convert : {false, true}) {
+      Transform(validate_op_config, ops, tensor_pool,
+                build_gqa_gemma4b_prefill_pattern(has_k_slice_convert, has_v_slice_convert, false),
+                OptimizeGQAGemma4BPrefill);
+    }
+  }
+  Transform(validate_op_config, ops, tensor_pool,
+            build_gqa_gemma4b_prefill_pattern(false, false, true),
+            OptimizeGQAGemma4BPrefill);
+
   // Fast Vlm Optimization
   const std::vector<QnnOpCode> fast_vlm_mha_prefill = {
       QnnOpCode::kElementWiseBinary,

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
@@ -242,6 +242,60 @@ void GraphToGraphTransform(G2GConfig g2g_option, std::vector<OpWrapper>& ops,
   Transform(validate_op_config, ops, tensor_pool, embedding_gemma,
             TransformEmbeddingGemma);
 
+  // Gemma 4 Optimization
+  // Base: perm=[0,2,1,3] transpose bookends, one far-away Convert before QK,
+  // two QK matmuls, concat, mask-add, softmax, two strided-slices, two V
+  // matmuls, add, output-quantize Convert, reshape+transpose.
+  // Optional inserts:
+  //   has_k_slice_attn_update_convert : kConvert between the two QK matmuls
+  //   has_v_slice_attn_update_convert  : kConvert between the two V  matmuls
+  //   has_global_mask : kConcat + kReshape after the first kConcat
+  auto build_gqa_gemma4b_prefill_pattern = [](bool has_k_slice_attn_update_convert,
+                                         bool has_v_slice_attn_update_convert,
+                                         bool has_global_mask) {
+    std::vector<QnnOpCode> p = {
+        QnnOpCode::kTranspose,
+        QnnOpCode::kReshape,
+        QnnOpCode::kConvert,  // far-away input quantize
+        QnnOpCode::kMatMul,   // Q x K cache
+    };
+    if (has_k_slice_attn_update_convert) {
+      p.push_back(QnnOpCode::kConvert);
+    }
+    p.push_back(QnnOpCode::kMatMul);  // Q x K slice
+    p.push_back(QnnOpCode::kConcat);
+    if (has_global_mask) {
+      p.push_back(QnnOpCode::kConcat);   // concat local/global mask
+      p.push_back(QnnOpCode::kReshape);  // reshape mask
+    }
+    p.insert(p.end(), {
+        QnnOpCode::kElementWiseBinary,  // mask add
+        QnnOpCode::kSoftmax,
+        QnnOpCode::kStridedSlice,
+        QnnOpCode::kStridedSlice,
+        QnnOpCode::kMatMul,  // QK x V cache
+    });
+    if (has_v_slice_attn_update_convert) p.push_back(QnnOpCode::kConvert);
+    p.insert(p.end(), {
+        QnnOpCode::kMatMul,             // QK x V slice
+        QnnOpCode::kElementWiseBinary,  // qkv add
+        QnnOpCode::kConvert,            // output quantize
+        QnnOpCode::kReshape,
+        QnnOpCode::kTranspose,
+    });
+    return p;
+  };
+  for (auto has_k_slice_convert : {false, true}) {
+    for (auto has_v_slice_convert : {false, true}) {
+      Transform(validate_op_config, ops, tensor_pool,
+                build_gqa_gemma4b_prefill_pattern(has_k_slice_convert, has_v_slice_convert, false),
+                OptimizeGQAGemma4BPrefill);
+    }
+  }
+  Transform(validate_op_config, ops, tensor_pool,
+            build_gqa_gemma4b_prefill_pattern(false, false, true),
+            OptimizeGQAGemma4BPrefill);
+
   // Fast Vlm Optimization
   const std::vector<QnnOpCode> fast_vlm_mha_prefill = {
       QnnOpCode::kElementWiseBinary,

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
@@ -762,6 +762,703 @@ TEST(MaskTransformTest, Gemma4Mask) {
             op_wrappers[0].GetInputTensor(2).GetQuantParams());
 }
 
+TEST(MHASHATest, GQAGemma4BPrefill) {
+  // ------------------- Before ---------------------
+  //                       In0
+  //                        |
+  //                    Transpose0
+  //                        |
+  //                     Reshape0
+  //                      /   \
+  //             KIn     /     \     In1
+  //               \    /       \     /
+  //                Matmul0     Matmul1
+  //                    \       /
+  //                     Concat
+  //                        |
+  //                   Mask |
+  //                      \ |
+  //                       Add1
+  //                        |
+  //                     Softmax
+  //                    /       \
+  //                  Slice0  Slice1
+  //                    |       |
+  //              VIn   |       |    In2
+  //                \   |       |    /
+  //                 Matmul2  Matmul3
+  //                     \     /
+  //                       Add2
+  //                        |
+  //                     Convert
+  //                        |
+  //                     Reshape1
+  //                        |
+  //                    Transpose1
+  //                        |
+  //                       Out
+  //
+  // -------------------- After ---------------------
+  //
+  //                       In0
+  //                        |
+  //        KIn          Unpack          In1
+  //         |            /  \            |
+  //       Unpack        /    \         Unpack
+  //       //|          /      \          |\\
+  //      // └------Matmul0    Matmul1---┘ \\
+  //     ..             \        /         ..
+  //                     \      /
+  //                     Concat
+  //                        |
+  //                   Mask |
+  //                      \ |
+  //                       Add1
+  //                        |
+  //                     Softmax
+  //                    /       \     In2
+  //        VIn       Slice0  Slice1   |
+  //         |          |       |    Unpack
+  //       Unpack       |       |     /\\
+  //       //|          |       |    /  \\
+  //      // └------Matmul2  Matmul3     ..
+  //     ..              \     /
+  //                       Add2
+  //                        |
+  //                     Convert  ..
+  //                        |   //
+  //                        |  //
+  //                      Concat
+  //                        |
+  //                       Out
+  TensorPool tensor_pool;
+  QuantizeParamsWrapperVariant quant_param;
+  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  std::vector<OpWrapper> op_wrappers;
+
+  // In0: [B,S,H,D] input to Transpose0
+  auto& in0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                        quant_param, {1, 128, 8, 256});
+
+  // Transpose0: [B,S,H,D] -> [B,H,S,D]
+  static const std::uint32_t kPerm0213[] = {0, 2, 1, 3};
+  auto& perm0213 = tensor_pool.CreateStaticTensor(
+    QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+  auto& transpose0_output =
+    tensor_pool.CloneNativeTensorFrom(in0, {1, 8, 128, 256});
+  op_wrappers.emplace_back(
+    CreateTransposeOp(in0, transpose0_output, perm0213));
+
+  // Reshape0
+  auto& reshape0_output =
+    tensor_pool.CloneNativeTensorFrom(transpose0_output, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateReshapeOp(transpose0_output, reshape0_output));
+
+  // Far-away Convert (K_slice quantize, not connected to main chain)
+  auto& k_slice_raw = tensor_pool.CreateNativeTensor(QNN_DATATYPE_FLOAT_16,
+                            quant_param, {1, 2, 128, 256});
+  auto& k_slice_converted = tensor_pool.CreateNativeTensor(
+    QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 128, 256});
+  op_wrappers.emplace_back(CreateConvertOp(k_slice_raw, k_slice_converted));
+
+  // MatMul0 (Q x K_cache)
+  auto& q_in = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                        quant_param, {1, 2, 2560, 256});
+  auto& matmul0_output = tensor_pool.CreateNativeTensor(
+    QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 2560});
+  op_wrappers.emplace_back(
+    CreateMatmulOp(reshape0_output, q_in, matmul0_output, false, true));
+
+  // MatMul1 (Q x K_slice), using the far-away Convert output
+  auto& matmul1_output = tensor_pool.CreateNativeTensor(
+    QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 128});
+  op_wrappers.emplace_back(CreateMatmulOp(reshape0_output, k_slice_converted,
+                      matmul1_output, false, true));
+
+  // Concat
+  auto& concat_output =
+    tensor_pool.CloneNativeTensorFrom(matmul0_output, {1, 2, 512, 2688});
+  op_wrappers.emplace_back(CreateConcatenationOp(
+    {matmul0_output, matmul1_output}, concat_output, 3));
+
+  // Add1: concat_output must be input[0] for connectivity check
+  auto& mask = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                        quant_param, {1, 1, 512, 2688});
+  auto& add1_output = tensor_pool.CloneNativeTensorFrom(concat_output);
+  op_wrappers.emplace_back(
+    CreateElementWiseAddOp(concat_output, mask, add1_output));
+
+  // Softmax
+  auto& softmax_output = tensor_pool.CloneNativeTensorFrom(add1_output);
+  op_wrappers.emplace_back(
+    CreateSoftmaxOp(add1_output, softmax_output, 1.0f));
+
+  // Slice0
+  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
+                          0, 512, 1, 0, 2560, 1};
+  auto& slice0_ranges = tensor_pool.CreateStaticTensor(
+    QNN_DATATYPE_INT_32, {}, {4, 3},
+    sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+  auto& slice0_output =
+    tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 2560});
+  op_wrappers.emplace_back(
+    CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
+
+  // Slice1
+  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
+                          0, 512, 1, 2560, 2688, 1};
+  auto& slice1_ranges = tensor_pool.CreateStaticTensor(
+    QNN_DATATYPE_INT_32, {}, {4, 3},
+    sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+  auto& slice1_output =
+    tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 128});
+  op_wrappers.emplace_back(
+    CreateSliceOp(softmax_output, slice1_output, slice1_ranges));
+
+  // MatMul2
+  auto& v_in = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                        quant_param, {1, 2, 256, 2560});
+  auto& matmul2_output = tensor_pool.CreateNativeTensor(
+    QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 256});
+  op_wrappers.emplace_back(
+    CreateMatmulOp(slice0_output, v_in, matmul2_output, false, true));
+
+  // MatMul3
+  auto& in2 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                        quant_param, {1, 2, 256, 128});
+  auto& matmul3_output = tensor_pool.CreateNativeTensor(
+    QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 256});
+  op_wrappers.emplace_back(CreateMatmulOp(slice1_output, in2,
+                      matmul3_output, false, true));
+
+  // Add2
+  auto& add2_output = tensor_pool.CloneNativeTensorFrom(matmul3_output);
+  op_wrappers.emplace_back(
+    CreateElementWiseAddOp(matmul2_output, matmul3_output, add2_output));
+
+  QuantizeParamsWrapperVariant quant_param_out;
+  quant_param_out.emplace<ScaleOffsetQuantizeParamsWrapper>(3.66805e-02f, 0);
+  auto& quant_output = tensor_pool.CreateNativeTensor(
+    QNN_DATATYPE_SFIXED_POINT_8, quant_param_out, {1, 2, 512, 256});
+  op_wrappers.emplace_back(CreateConvertOp(add2_output, quant_output));
+
+  // Reshape1
+  auto& reshape1_output =
+    tensor_pool.CloneNativeTensorFrom(quant_output, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateReshapeOp(quant_output, reshape1_output));
+
+  // Transpose1: [B,H,S,D] -> [B,S,H,D]
+  auto& perm0213_t1 = tensor_pool.CreateStaticTensor(
+    QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+  auto& transpose1_output =
+    tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 128, 8, 256});
+  op_wrappers.emplace_back(
+    CreateTransposeOp(reshape1_output, transpose1_output, perm0213_t1));
+
+  ASSERT_EQ(op_wrappers.size(), 16);
+
+  const ::qnn::G2GConfig g2g_option = ::qnn::G2GConfig::kMHAOptPrefill;
+  GraphToGraphTransform(g2g_option, op_wrappers, tensor_pool,
+              [](OpWrapper& op) { return true; });
+
+  // Check OpCode after G2G
+  const size_t num_head = 8; // 2 groups in KV Cache serving 8 queries
+  // Q·KC, Q·KS, Concat, MaskAdd, Softmax, Slice(VC), Slice(VS), QK·VC, QK·VS, Add, Convert
+  const size_t num_op_in_sha = 11;
+
+  // new_ops layout before per-head SHA:
+  //   op_wrappers[0]: far-away Convert (kept from original pattern)
+  //   op_wrappers[1]  Unpack Q (axis=2) -> 8 heads
+  //   op_wrappers[2]  Unpack K_cache (axis=1) -> 2 kv heads
+  //   op_wrappers[3]  Unpack K_slice (axis=1)
+  //   op_wrappers[4]  Unpack V_cache (axis=1)
+  //   op_wrappers[5]  Unpack V_slice (axis=1)
+  //   op_wrappers[6]  Reshape(mask -> mask_reshaped)
+  //   op_wrappers[7]  Unpack(mask_reshaped, axis=1)
+  //   op_wrappers[8 .. 8+11*8-1] per-head SHA ops
+  //   op_wrappers[8+88] Concat, op_wrappers[8+89] Reshape
+  const size_t sha_init_idx = 8;
+
+  for (size_t i = 0; i < num_head; ++i) {
+    ASSERT_TRUE(op_wrappers[sha_init_idx + num_op_in_sha * i].IsOpCode(QnnOpCode::kMatMul));
+    ASSERT_TRUE(op_wrappers[(sha_init_idx+1) + num_op_in_sha * i].IsOpCode(QnnOpCode::kMatMul));
+    ASSERT_TRUE(op_wrappers[(sha_init_idx+2) + num_op_in_sha * i].IsOpCode(QnnOpCode::kConcat));
+    ASSERT_TRUE(
+      op_wrappers[(sha_init_idx+3) + num_op_in_sha * i].IsOpCode(QnnOpCode::kElementWiseBinary));
+    ASSERT_TRUE(IsElementWiseAdd(op_wrappers[(sha_init_idx+3) + num_op_in_sha * i]));
+    ASSERT_TRUE(op_wrappers[(sha_init_idx+4) + num_op_in_sha * i].IsOpCode(QnnOpCode::kSoftmax));
+    ASSERT_TRUE(
+      op_wrappers[(sha_init_idx+5) + num_op_in_sha * i].IsOpCode(QnnOpCode::kStridedSlice));
+    ASSERT_TRUE(
+      op_wrappers[(sha_init_idx+6) + num_op_in_sha * i].IsOpCode(QnnOpCode::kStridedSlice));
+    ASSERT_TRUE(op_wrappers[(sha_init_idx+7) + num_op_in_sha * i].IsOpCode(QnnOpCode::kMatMul));
+    ASSERT_TRUE(op_wrappers[(sha_init_idx+8) + num_op_in_sha * i].IsOpCode(QnnOpCode::kMatMul));
+    ASSERT_TRUE(
+      op_wrappers[(sha_init_idx+9) + num_op_in_sha * i].IsOpCode(QnnOpCode::kElementWiseBinary));
+    ASSERT_TRUE(IsElementWiseAdd(op_wrappers[(sha_init_idx+9) + num_op_in_sha * i]));
+    // The output Convert (kConvert) is emitted per-head from convert_out.
+    ASSERT_TRUE(
+      op_wrappers[(sha_init_idx+10) + num_op_in_sha * i].IsOpCode(QnnOpCode::kConvert));
+  }
+}
+
+// Variant: has_k_slice_attn_update_convert=true — a Convert between K_slice and Q·KS matmul.
+// Verifies that BuildSingleSHAGemma4B emits a per-head KSliceAttnUpdateConvert (17-op pattern).
+TEST(MHASHATest, GQAGemma4BPrefill_KSliceAttnUpdateConvert) {
+  TensorPool tensor_pool;
+  QuantizeParamsWrapperVariant quant_param;
+  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  std::vector<OpWrapper> op_wrappers;
+
+  // In0: [B,S,H,D]
+  auto& in0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 128, 8, 256});
+  static const std::uint32_t kPerm0213[] = {0, 2, 1, 3};
+  auto& perm0213 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+  auto& transpose0_output =
+      tensor_pool.CloneNativeTensorFrom(in0, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateTransposeOp(in0, transpose0_output, perm0213));
+
+  auto& reshape0_output =
+      tensor_pool.CloneNativeTensorFrom(transpose0_output, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateReshapeOp(transpose0_output, reshape0_output));
+
+  // Far-away Convert (index 2, not locally connected)
+  auto& k_slice_raw = tensor_pool.CreateNativeTensor(QNN_DATATYPE_FLOAT_16,
+                                                      quant_param, {1, 2, 128, 256});
+  auto& k_slice_fp8 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                                      quant_param, {1, 2, 128, 256});
+  op_wrappers.emplace_back(CreateConvertOp(k_slice_raw, k_slice_fp8));
+
+  // MatMul0 (Q x K_cache)
+  auto& q_in = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 2, 2560, 256});
+  auto& matmul0_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 2560});
+  op_wrappers.emplace_back(
+      CreateMatmulOp(reshape0_output, q_in, matmul0_output, false, true));
+
+  // KSliceAttnUpdateConvert (index 4): k_slice_fp8 -> k_slice_int8
+  auto& k_slice_int8 = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 128, 256});
+  op_wrappers.emplace_back(CreateConvertOp(k_slice_fp8, k_slice_int8));
+
+  // MatMul1 (Q x K_slice converted)
+  auto& matmul1_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 128});
+  op_wrappers.emplace_back(CreateMatmulOp(reshape0_output, k_slice_int8,
+                                          matmul1_output, false, true));
+
+  // Concat
+  auto& concat_output =
+      tensor_pool.CloneNativeTensorFrom(matmul0_output, {1, 2, 512, 2688});
+  op_wrappers.emplace_back(CreateConcatenationOp(
+      {matmul0_output, matmul1_output}, concat_output, 3));
+
+  // MaskAdd
+  auto& mask = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 1, 512, 2688});
+  auto& add1_output = tensor_pool.CloneNativeTensorFrom(concat_output);
+  op_wrappers.emplace_back(
+      CreateElementWiseAddOp(concat_output, mask, add1_output));
+
+  // Softmax
+  auto& softmax_output = tensor_pool.CloneNativeTensorFrom(add1_output);
+  op_wrappers.emplace_back(CreateSoftmaxOp(add1_output, softmax_output, 1.0f));
+
+  // Slice0
+  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
+                                                   0, 512, 1, 0, 2560, 1};
+  auto& slice0_ranges = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {4, 3},
+      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+  auto& slice0_output =
+      tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 2560});
+  op_wrappers.emplace_back(
+      CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
+
+  // Slice1
+  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
+                                                   0, 512, 1, 2560, 2688, 1};
+  auto& slice1_ranges = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {4, 3},
+      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+  auto& slice1_output =
+      tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 128});
+  op_wrappers.emplace_back(
+      CreateSliceOp(softmax_output, slice1_output, slice1_ranges));
+
+  // MatMul2 (QK x V_cache)
+  auto& v_in = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 2, 256, 2560});
+  auto& matmul2_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 256});
+  op_wrappers.emplace_back(
+      CreateMatmulOp(slice0_output, v_in, matmul2_output, false, true));
+
+  // MatMul3 (QK x V_slice)
+  auto& in2 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 2, 256, 128});
+  auto& matmul3_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 256});
+  op_wrappers.emplace_back(CreateMatmulOp(slice1_output, in2,
+                                          matmul3_output, false, true));
+
+  // Add2
+  auto& add2_output = tensor_pool.CloneNativeTensorFrom(matmul3_output);
+  op_wrappers.emplace_back(
+      CreateElementWiseAddOp(matmul2_output, matmul3_output, add2_output));
+
+  // Output Convert
+  QuantizeParamsWrapperVariant quant_param_out;
+  quant_param_out.emplace<ScaleOffsetQuantizeParamsWrapper>(3.66805e-02f, 0);
+  auto& quant_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param_out, {1, 2, 512, 256});
+  op_wrappers.emplace_back(CreateConvertOp(add2_output, quant_output));
+
+  // Reshape1
+  auto& reshape1_output =
+      tensor_pool.CloneNativeTensorFrom(quant_output, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateReshapeOp(quant_output, reshape1_output));
+
+  // Transpose1
+  auto& perm0213_t1 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+  auto& transpose1_output =
+      tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 128, 8, 256});
+  op_wrappers.emplace_back(
+      CreateTransposeOp(reshape1_output, transpose1_output, perm0213_t1));
+
+  ASSERT_EQ(op_wrappers.size(), 17);
+
+  GraphToGraphTransform(::qnn::G2GConfig::kMHAOptPrefill, op_wrappers,
+                        tensor_pool, [](OpWrapper& op) { return true; });
+
+  // Each SHA head has 12 ops: the base 11 + 1 KSliceAttnUpdateConvert.
+  const size_t num_head = 8;
+  const size_t num_op_in_sha = 12;  // Q·KC, KSliceAttnUpdateConvert, Q·KS, Concat, MaskAdd, Softmax,
+                                    // Slice(VC), Slice(VS), QK·VC, QK·VS, Add, Convert
+  const size_t sha_init_idx = 8;
+  for (size_t i = 0; i < num_head; ++i) {
+    ASSERT_TRUE(op_wrappers[sha_init_idx + num_op_in_sha * i].IsOpCode(
+        QnnOpCode::kMatMul));
+    ASSERT_TRUE(op_wrappers[(sha_init_idx + 1) + num_op_in_sha * i].IsOpCode(
+        QnnOpCode::kConvert));  // KSliceAttnUpdateConvert per head
+    ASSERT_TRUE(op_wrappers[(sha_init_idx + 2) + num_op_in_sha * i].IsOpCode(
+        QnnOpCode::kMatMul));
+    ASSERT_TRUE(op_wrappers[(sha_init_idx + 11) + num_op_in_sha * i].IsOpCode(
+        QnnOpCode::kConvert));  // output Convert per head
+  }
+}
+
+// Variant: has_v_slice_attn_update_convert=true — a Convert between V_slice and QK·VS matmul.
+// Verifies that BuildSingleSHAGemma4B emits a per-head VSliceAttnUpdateConvert (17-op pattern).
+TEST(MHASHATest, GQAGemma4BPrefill_VSliceAttnUpdateConvert) {
+  TensorPool tensor_pool;
+  QuantizeParamsWrapperVariant quant_param;
+  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  std::vector<OpWrapper> op_wrappers;
+
+  auto& in0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 128, 8, 256});
+  static const std::uint32_t kPerm0213[] = {0, 2, 1, 3};
+  auto& perm0213 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+  auto& transpose0_output =
+      tensor_pool.CloneNativeTensorFrom(in0, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateTransposeOp(in0, transpose0_output, perm0213));
+
+  auto& reshape0_output =
+      tensor_pool.CloneNativeTensorFrom(transpose0_output, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateReshapeOp(transpose0_output, reshape0_output));
+
+  // Far-away Convert (index 2)
+  auto& k_slice_raw = tensor_pool.CreateNativeTensor(QNN_DATATYPE_FLOAT_16,
+                                                      quant_param, {1, 2, 128, 256});
+  auto& k_slice_converted = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 128, 256});
+  op_wrappers.emplace_back(CreateConvertOp(k_slice_raw, k_slice_converted));
+
+  // MatMul0 (Q x K_cache)
+  auto& q_in = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 2, 2560, 256});
+  auto& matmul0_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 2560});
+  op_wrappers.emplace_back(
+      CreateMatmulOp(reshape0_output, q_in, matmul0_output, false, true));
+
+  // MatMul1 (Q x K_slice, no KSliceAttnUpdateConvert)
+  auto& matmul1_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 128});
+  op_wrappers.emplace_back(CreateMatmulOp(reshape0_output, k_slice_converted,
+                                          matmul1_output, false, true));
+
+  // Concat
+  auto& concat_output =
+      tensor_pool.CloneNativeTensorFrom(matmul0_output, {1, 2, 512, 2688});
+  op_wrappers.emplace_back(CreateConcatenationOp(
+      {matmul0_output, matmul1_output}, concat_output, 3));
+
+  // MaskAdd
+  auto& mask = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 1, 512, 2688});
+  auto& add1_output = tensor_pool.CloneNativeTensorFrom(concat_output);
+  op_wrappers.emplace_back(
+      CreateElementWiseAddOp(concat_output, mask, add1_output));
+
+  // Softmax
+  auto& softmax_output = tensor_pool.CloneNativeTensorFrom(add1_output);
+  op_wrappers.emplace_back(CreateSoftmaxOp(add1_output, softmax_output, 1.0f));
+
+  // Slice0
+  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
+                                                   0, 512, 1, 0, 2560, 1};
+  auto& slice0_ranges = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {4, 3},
+      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+  auto& slice0_output =
+      tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 2560});
+  op_wrappers.emplace_back(
+      CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
+
+  // Slice1
+  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
+                                                   0, 512, 1, 2560, 2688, 1};
+  auto& slice1_ranges = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {4, 3},
+      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+  auto& slice1_output =
+      tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 128});
+  op_wrappers.emplace_back(
+      CreateSliceOp(softmax_output, slice1_output, slice1_ranges));
+
+  // MatMul2 (QK x V_cache)
+  auto& v_in = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 2, 256, 2560});
+  auto& matmul2_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 256});
+  op_wrappers.emplace_back(
+      CreateMatmulOp(slice0_output, v_in, matmul2_output, false, true));
+
+  // VSliceAttnUpdateConvert (between V_slice and QK·VS)
+  auto& v_slice_raw = tensor_pool.CreateNativeTensor(QNN_DATATYPE_FLOAT_16,
+                                                      quant_param, {1, 2, 256, 128});
+  auto& v_slice_int8 = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 256, 128});
+  op_wrappers.emplace_back(CreateConvertOp(v_slice_raw, v_slice_int8));
+
+  // MatMul3 (QK x V_slice converted)
+  auto& matmul3_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 256});
+  op_wrappers.emplace_back(CreateMatmulOp(slice1_output, v_slice_int8,
+                                          matmul3_output, false, true));
+
+  // Add2
+  auto& add2_output = tensor_pool.CloneNativeTensorFrom(matmul3_output);
+  op_wrappers.emplace_back(
+      CreateElementWiseAddOp(matmul2_output, matmul3_output, add2_output));
+
+  // Output Convert
+  QuantizeParamsWrapperVariant quant_param_out;
+  quant_param_out.emplace<ScaleOffsetQuantizeParamsWrapper>(3.66805e-02f, 0);
+  auto& quant_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param_out, {1, 2, 512, 256});
+  op_wrappers.emplace_back(CreateConvertOp(add2_output, quant_output));
+
+  // Reshape1
+  auto& reshape1_output =
+      tensor_pool.CloneNativeTensorFrom(quant_output, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateReshapeOp(quant_output, reshape1_output));
+
+  // Transpose1
+  auto& perm0213_t1 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+  auto& transpose1_output =
+      tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 128, 8, 256});
+  op_wrappers.emplace_back(
+      CreateTransposeOp(reshape1_output, transpose1_output, perm0213_t1));
+
+  ASSERT_EQ(op_wrappers.size(), 17);
+
+  GraphToGraphTransform(::qnn::G2GConfig::kMHAOptPrefill, op_wrappers,
+                        tensor_pool, [](OpWrapper& op) { return true; });
+
+  // Each SHA head has 12 ops: the base 11 + 1 VSliceAttnUpdateConvert.
+  const size_t num_head = 8;
+  const size_t num_op_in_sha = 12;  // Q·KC, Q·KS, Concat, MaskAdd, Softmax,
+                                    // Slice(VC), Slice(VS), QK·VC, VSliceAttnUpdateConvert, QK·VS, Add, Convert
+  const size_t sha_init_idx = 8;
+  for (size_t i = 0; i < num_head; ++i) {
+    ASSERT_TRUE(op_wrappers[sha_init_idx + num_op_in_sha * i].IsOpCode(
+        QnnOpCode::kMatMul));
+    // VSliceAttnUpdateConvert is at position 8 within each SHA (between QK·VC and QK·VS)
+    ASSERT_TRUE(op_wrappers[(sha_init_idx + 8) + num_op_in_sha * i].IsOpCode(
+        QnnOpCode::kConvert));
+    ASSERT_TRUE(op_wrappers[(sha_init_idx + 11) + num_op_in_sha * i].IsOpCode(
+        QnnOpCode::kConvert));  // output Convert per head
+  }
+}
+
+// Variant: has_global_mask=true — Concat+Reshape inserted after QK Concat (18-op pattern).
+// Verifies that the shifted index calculation still produces the correct SHA layout.
+TEST(MHASHATest, GQAGemma4BPrefill_GlobalMask) {
+  TensorPool tensor_pool;
+  QuantizeParamsWrapperVariant quant_param;
+  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  std::vector<OpWrapper> op_wrappers;
+
+  auto& in0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 128, 8, 256});
+  static const std::uint32_t kPerm0213[] = {0, 2, 1, 3};
+  auto& perm0213 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+  auto& transpose0_output =
+      tensor_pool.CloneNativeTensorFrom(in0, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateTransposeOp(in0, transpose0_output, perm0213));
+
+  auto& reshape0_output =
+      tensor_pool.CloneNativeTensorFrom(transpose0_output, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateReshapeOp(transpose0_output, reshape0_output));
+
+  // Far-away Convert (index 2)
+  auto& k_slice_raw = tensor_pool.CreateNativeTensor(QNN_DATATYPE_FLOAT_16,
+                                                      quant_param, {1, 2, 128, 256});
+  auto& k_slice_converted = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 128, 256});
+  op_wrappers.emplace_back(CreateConvertOp(k_slice_raw, k_slice_converted));
+
+  // MatMul0 (Q x K_cache)
+  auto& q_in = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 2, 2560, 256});
+  auto& matmul0_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 2560});
+  op_wrappers.emplace_back(
+      CreateMatmulOp(reshape0_output, q_in, matmul0_output, false, true));
+
+  // MatMul1 (Q x K_slice)
+  auto& matmul1_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 128});
+  op_wrappers.emplace_back(CreateMatmulOp(reshape0_output, k_slice_converted,
+                                          matmul1_output, false, true));
+
+  // QK Concat
+  auto& qk_concat_output =
+      tensor_pool.CloneNativeTensorFrom(matmul0_output, {1, 2, 512, 2688});
+  op_wrappers.emplace_back(CreateConcatenationOp(
+      {matmul0_output, matmul1_output}, qk_concat_output, 3));
+
+  // Global mask: Concat local+global masks, then Reshape — these two ops
+  // signal has_global_mask=true to OptimizeGQAGemma4BPrefill.
+  auto& local_mask = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                                    quant_param, {1, 1, 512, 2688});
+  auto& global_mask = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                                     quant_param, {1, 1, 512, 2688});
+  auto& mask_concat_output =
+      tensor_pool.CloneNativeTensorFrom(local_mask, {1, 2, 512, 2688});
+  op_wrappers.emplace_back(CreateConcatenationOp(
+      {local_mask, global_mask}, mask_concat_output, 1));
+  auto& mask_reshape_output =
+      tensor_pool.CloneNativeTensorFrom(mask_concat_output, {1, 2, 512, 2688});
+  op_wrappers.emplace_back(
+      CreateReshapeOp(mask_concat_output, mask_reshape_output));
+
+  // MaskAdd: qk_concat_output + mask_reshape_output
+  auto& add1_output = tensor_pool.CloneNativeTensorFrom(qk_concat_output);
+  op_wrappers.emplace_back(
+      CreateElementWiseAddOp(qk_concat_output, mask_reshape_output, add1_output));
+
+  // Softmax
+  auto& softmax_output = tensor_pool.CloneNativeTensorFrom(add1_output);
+  op_wrappers.emplace_back(CreateSoftmaxOp(add1_output, softmax_output, 1.0f));
+
+  // Slice0
+  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
+                                                   0, 512, 1, 0, 2560, 1};
+  auto& slice0_ranges = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {4, 3},
+      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+  auto& slice0_output =
+      tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 2560});
+  op_wrappers.emplace_back(
+      CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
+
+  // Slice1
+  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
+                                                   0, 512, 1, 2560, 2688, 1};
+  auto& slice1_ranges = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {4, 3},
+      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+  auto& slice1_output =
+      tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 128});
+  op_wrappers.emplace_back(
+      CreateSliceOp(softmax_output, slice1_output, slice1_ranges));
+
+  // MatMul2
+  auto& v_in = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 2, 256, 2560});
+  auto& matmul2_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 256});
+  op_wrappers.emplace_back(
+      CreateMatmulOp(slice0_output, v_in, matmul2_output, false, true));
+
+  // MatMul3
+  auto& in2 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 2, 256, 128});
+  auto& matmul3_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 256});
+  op_wrappers.emplace_back(CreateMatmulOp(slice1_output, in2,
+                                          matmul3_output, false, true));
+
+  // Add2
+  auto& add2_output = tensor_pool.CloneNativeTensorFrom(matmul3_output);
+  op_wrappers.emplace_back(
+      CreateElementWiseAddOp(matmul2_output, matmul3_output, add2_output));
+
+  // Output Convert
+  QuantizeParamsWrapperVariant quant_param_out;
+  quant_param_out.emplace<ScaleOffsetQuantizeParamsWrapper>(3.66805e-02f, 0);
+  auto& quant_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param_out, {1, 2, 512, 256});
+  op_wrappers.emplace_back(CreateConvertOp(add2_output, quant_output));
+
+  // Reshape1
+  auto& reshape1_output =
+      tensor_pool.CloneNativeTensorFrom(quant_output, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateReshapeOp(quant_output, reshape1_output));
+
+  // Transpose1
+  auto& perm0213_t1 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+  auto& transpose1_output =
+      tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 128, 8, 256});
+  op_wrappers.emplace_back(
+      CreateTransposeOp(reshape1_output, transpose1_output, perm0213_t1));
+
+  ASSERT_EQ(op_wrappers.size(), 18);
+
+  GraphToGraphTransform(::qnn::G2GConfig::kMHAOptPrefill, op_wrappers,
+                        tensor_pool, [](OpWrapper& op) { return true; });
+
+  // Same SHA layout as the base case — has_global_mask only shifts internal
+  // index arithmetic, the output structure is identical.
+  const size_t num_head = 8;
+  // Q·KC, Q·KS, Concat, MaskAdd, Softmax, Slice(VC), Slice(VS), QK·VC, QK·VS, Add, Convert
+  const size_t num_op_in_sha = 11;
+  // With has_global_mask the kept mask Concat+Reshape sit at indices 0 and 1,
+  // pushing new_ops (far-away Convert, unpacks, SHAs, final Concat+Reshape) up
+  // by 2, so the per-head SHA block starts at index 10 instead of 8.
+  const size_t sha_init_idx = 10;
+  for (size_t i = 0; i < num_head; ++i) {
+    ASSERT_TRUE(op_wrappers[sha_init_idx + num_op_in_sha * i].IsOpCode(
+        QnnOpCode::kMatMul));
+    ASSERT_TRUE(op_wrappers[(sha_init_idx + 4) + num_op_in_sha * i].IsOpCode(
+        QnnOpCode::kSoftmax));
+    ASSERT_TRUE(op_wrappers[(sha_init_idx + 10) + num_op_in_sha * i].IsOpCode(
+        QnnOpCode::kConvert));
+  }
+}
+
 TEST(MHASHATest, FastVlm) {
   // G2G Test case: MHA -> SHA
   // ------------------- Before ---------------------

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
@@ -323,21 +323,21 @@ TEST(MHAOptimization, Gemma3Prefill) {
   op_wrappers.emplace_back(
       CreateSoftmaxOp(reshape2_output, softmax_output, 1.0f));
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 1,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 1,    1,
                                                    0, 512, 1, 0, 1280, 1};
   auto& slice0_rangs = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
       tensor_pool.CloneNativeTensorFrom(reshape2_output, {1, 1, 512, 1280});
   op_wrappers.emplace_back(
       CreateSliceOp(softmax_output, slice0_output, slice0_rangs));
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    1,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    1,    1,
                                                    0, 512, 1, 1280, 1408, 1};
   auto& slice1_rangs = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
       tensor_pool.CloneNativeTensorFrom(reshape2_output, {1, 1, 512, 128});
   op_wrappers.emplace_back(
@@ -539,21 +539,21 @@ TEST(MHAOptimization, Gemma3Decode) {
   op_wrappers.emplace_back(
       CreateSoftmaxOp(reshape1_output, softmax_output, 1.0f));
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1, 1, 0, 1,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1, 1, 0, 1,    1,
                                                    0, 4, 1, 0, 1280, 1};
   auto& slice0_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
       tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 1, 4, 1280});
   op_wrappers.emplace_back(
       CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1, 1, 0,    1,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1, 1, 0,    1,    1,
                                                    0, 4, 1, 1280, 1281, 1};
   auto& slice1_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
       tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 1, 4, 256});
   op_wrappers.emplace_back(
@@ -762,6 +762,285 @@ TEST(MaskTransformTest, Gemma4Mask) {
             op_wrappers[0].GetInputTensor(2).GetQuantParams());
 }
 
+struct GQAGemma4BPrefillParams {
+  bool has_k_slice_attn_update_convert;
+  bool has_v_slice_attn_update_convert;
+  bool has_global_mask;
+};
+
+class GQAGemma4BPrefillTest
+    : public ::testing::TestWithParam<GQAGemma4BPrefillParams> {};
+
+TEST_P(GQAGemma4BPrefillTest, GQAGemma4BPrefill) {
+  const auto& params = GetParam();
+  TensorPool tensor_pool;
+  QuantizeParamsWrapperVariant quant_param(
+      std::in_place_type<ScaleOffsetQuantizeParamsWrapper>, 1e-4f, 0);
+  std::vector<OpWrapper> op_wrappers;
+
+  // In0: [B,S,H,D] input to Transpose0
+  auto& in0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                             quant_param, {1, 128, 8, 256});
+
+  // Transpose0: [B,S,H,D] -> [B,H,S,D]
+  static constexpr std::array<std::uint32_t, 4> kPerm0213{0, 2, 1, 3};
+  auto& perm0213 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, {}, {kPerm0213.size()},
+      sizeof(std::uint32_t) * kPerm0213.size(), kPerm0213.data());
+  auto& transpose0_output =
+      tensor_pool.CloneNativeTensorFrom(in0, {1, 8, 128, 256});
+  op_wrappers.emplace_back(
+      CreateTransposeOp(in0, transpose0_output, perm0213));
+
+  // Reshape0
+  auto& reshape0_output =
+      tensor_pool.CloneNativeTensorFrom(transpose0_output, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateReshapeOp(transpose0_output, reshape0_output));
+
+  // Far-away Convert (K_slice quantize, not connected to main chain)
+  auto& k_slice_raw = tensor_pool.CreateNativeTensor(QNN_DATATYPE_FLOAT_16,
+                                                     quant_param, {1, 2, 128, 256});
+  auto& k_slice_fp8 = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 128, 256});
+  op_wrappers.emplace_back(CreateConvertOp(k_slice_raw, k_slice_fp8));
+
+  // MatMul0 (Q x K_cache)
+  auto& q_in = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 2, 2560, 256});
+  auto& matmul0_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 2560});
+  op_wrappers.emplace_back(
+      CreateMatmulOp(reshape0_output, q_in, matmul0_output, false, true));
+
+  // Optional KSliceAttnUpdateConvert between far-away Convert output and MatMul1
+  TensorWrapper* k_slice_for_matmul1 = &k_slice_fp8;
+  if (params.has_k_slice_attn_update_convert) {
+    auto& k_slice_int8 = tensor_pool.CreateNativeTensor(
+        QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 128, 256});
+    op_wrappers.emplace_back(CreateConvertOp(k_slice_fp8, k_slice_int8));
+    k_slice_for_matmul1 = &k_slice_int8;
+  }
+
+  // MatMul1 (Q x K_slice)
+  auto& matmul1_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 128});
+  op_wrappers.emplace_back(CreateMatmulOp(reshape0_output, *k_slice_for_matmul1,
+                                          matmul1_output, false, true));
+
+  // Concat
+  auto& concat_output =
+      tensor_pool.CloneNativeTensorFrom(matmul0_output, {1, 2, 512, 2688});
+  op_wrappers.emplace_back(CreateConcatenationOp(
+      {matmul0_output, matmul1_output}, concat_output, 3));
+
+  // Optional global mask: Concat local+global masks then Reshape before MaskAdd.
+  // When absent, a single mask tensor is used directly.
+  TensorWrapper* mask_for_add = nullptr;
+  if (params.has_global_mask) {
+    auto& local_mask = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                                      quant_param, {1, 1, 512, 2688});
+    auto& global_mask = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                                       quant_param, {1, 1, 512, 2688});
+    auto& mask_concat_output =
+        tensor_pool.CloneNativeTensorFrom(local_mask, {1, 2, 512, 2688});
+    op_wrappers.emplace_back(CreateConcatenationOp(
+        {local_mask, global_mask}, mask_concat_output, 1));
+    auto& mask_reshape_output =
+        tensor_pool.CloneNativeTensorFrom(mask_concat_output, {1, 2, 512, 2688});
+    op_wrappers.emplace_back(
+        CreateReshapeOp(mask_concat_output, mask_reshape_output));
+    mask_for_add = &mask_reshape_output;
+  } else {
+    auto& mask = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                                quant_param, {1, 1, 512, 2688});
+    mask_for_add = &mask;
+  }
+
+  // Add1
+  auto& add1_output = tensor_pool.CloneNativeTensorFrom(concat_output);
+  op_wrappers.emplace_back(
+      CreateElementWiseAddOp(concat_output, *mask_for_add, add1_output));
+
+  // Softmax
+  auto& softmax_output = tensor_pool.CloneNativeTensorFrom(add1_output);
+  op_wrappers.emplace_back(
+      CreateSoftmaxOp(add1_output, softmax_output, 1.0f));
+
+  // Slice0
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
+                                                               0, 512, 1, 0, 2560, 1};
+  auto& slice0_ranges = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {4, 3},
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
+  auto& slice0_output =
+      tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 2560});
+  op_wrappers.emplace_back(
+      CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
+
+  // Slice1
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
+                                                               0, 512, 1, 2560, 2688, 1};
+  auto& slice1_ranges = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, {4, 3},
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
+  auto& slice1_output =
+      tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 128});
+  op_wrappers.emplace_back(
+      CreateSliceOp(softmax_output, slice1_output, slice1_ranges));
+
+  // MatMul2 (QK x V_cache)
+  auto& v_in = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                              quant_param, {1, 2, 256, 2560});
+  auto& matmul2_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 256});
+  op_wrappers.emplace_back(
+      CreateMatmulOp(slice0_output, v_in, matmul2_output, false, true));
+
+  // Optional VSliceAttnUpdateConvert between V_slice and MatMul3
+  auto& in2_base = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
+                                                  quant_param, {1, 2, 256, 128});
+  TensorWrapper* v_slice_for_matmul3 = &in2_base;
+  if (params.has_v_slice_attn_update_convert) {
+    auto& v_slice_raw_tensor = tensor_pool.CreateNativeTensor(
+        QNN_DATATYPE_FLOAT_16, quant_param, {1, 2, 256, 128});
+    auto& v_slice_int8 = tensor_pool.CreateNativeTensor(
+        QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 256, 128});
+    op_wrappers.emplace_back(CreateConvertOp(v_slice_raw_tensor, v_slice_int8));
+    v_slice_for_matmul3 = &v_slice_int8;
+  }
+
+  // MatMul3 (QK x V_slice)
+  auto& matmul3_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param, {1, 2, 512, 256});
+  op_wrappers.emplace_back(CreateMatmulOp(slice1_output, *v_slice_for_matmul3,
+                                          matmul3_output, false, true));
+
+  // Add2
+  auto& add2_output = tensor_pool.CloneNativeTensorFrom(matmul3_output);
+  op_wrappers.emplace_back(
+      CreateElementWiseAddOp(matmul2_output, matmul3_output, add2_output));
+
+  // Output Convert
+  QuantizeParamsWrapperVariant quant_param_out(
+      std::in_place_type<ScaleOffsetQuantizeParamsWrapper>, 3.66805e-02f, 0);
+  auto& quant_output = tensor_pool.CreateNativeTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, quant_param_out, {1, 2, 512, 256});
+  op_wrappers.emplace_back(CreateConvertOp(add2_output, quant_output));
+
+  // Reshape1
+  auto& reshape1_output =
+      tensor_pool.CloneNativeTensorFrom(quant_output, {1, 8, 128, 256});
+  op_wrappers.emplace_back(CreateReshapeOp(quant_output, reshape1_output));
+
+  // Transpose1: [B,H,S,D] -> [B,S,H,D]
+  auto& perm0213_t1 = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, {}, {kPerm0213.size()},
+      sizeof(std::uint32_t) * kPerm0213.size(), kPerm0213.data());
+  auto& transpose1_output =
+      tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 128, 8, 256});
+  op_wrappers.emplace_back(
+      CreateTransposeOp(reshape1_output, transpose1_output, perm0213_t1));
+
+  const size_t expected_input_ops =
+      16 + (params.has_k_slice_attn_update_convert ? 1 : 0) +
+      (params.has_v_slice_attn_update_convert ? 1 : 0) +
+      (params.has_global_mask ? 2 : 0);
+  ASSERT_EQ(op_wrappers.size(), expected_input_ops);
+
+  GraphToGraphTransform(::qnn::G2GConfig::kMHAOptPrefill, op_wrappers,
+                        tensor_pool, [](OpWrapper& op) { return true; });
+
+  static constexpr size_t kNumHead = 8;
+  // Base: 11 ops per head. Each optional attn-update-convert adds 1.
+  const size_t kNumOpInSha =
+      11 + (params.has_k_slice_attn_update_convert ? 1 : 0) +
+      (params.has_v_slice_attn_update_convert ? 1 : 0);
+  // With has_global_mask the kept mask Concat+Reshape sit at indices 0 and 1,
+  // pushing new_ops up by 2, so per-head SHA block starts at 10 instead of 8.
+  const size_t kShaInitIdx = params.has_global_mask ? 10 : 8;
+
+  // --- Ops before SHA ---
+  // The far-away Convert is always at index 0.
+  // When has_global_mask, the preserved mask Concat+Reshape sit at [1] and [2],
+  // followed by new_ops starting at [3]. Otherwise new_ops start at [1].
+  // new_ops layout (at kPreShaBase = kShaInitIdx - 7):
+  //   [kPreShaBase+0] UnpackQ       (axis=2, 8 heads)
+  //   [kPreShaBase+1] UnpackK_cache (axis=1, 2 kv-heads)
+  //   [kPreShaBase+2] UnpackK_slice (axis=1, 2 kv-heads)
+  //   [kPreShaBase+3] UnpackV_cache (axis=1, 2 kv-heads)
+  //   [kPreShaBase+4] UnpackV_slice (axis=1, 2 kv-heads)
+  //   [kPreShaBase+5] Reshape(mask)
+  //   [kPreShaBase+6] UnpackMask    (axis=1, 4 per-kv heads)
+  ASSERT_TRUE(op_wrappers[0].IsOpCode(QnnOpCode::kConvert));  // far-away Convert
+  if (params.has_global_mask) {
+    ASSERT_TRUE(op_wrappers[1].IsOpCode(QnnOpCode::kConcat));
+    ASSERT_TRUE(op_wrappers[2].IsOpCode(QnnOpCode::kReshape));
+  }
+  const size_t kPreShaBase = kShaInitIdx - 7;
+  ASSERT_TRUE(op_wrappers[kPreShaBase + 0].IsOpCode(QnnOpCode::kUnPack));   // UnpackQ
+  ASSERT_TRUE(op_wrappers[kPreShaBase + 1].IsOpCode(QnnOpCode::kUnPack));   // UnpackK_cache
+  ASSERT_TRUE(op_wrappers[kPreShaBase + 2].IsOpCode(QnnOpCode::kUnPack));   // UnpackK_slice
+  ASSERT_TRUE(op_wrappers[kPreShaBase + 3].IsOpCode(QnnOpCode::kUnPack));   // UnpackV_cache
+  ASSERT_TRUE(op_wrappers[kPreShaBase + 4].IsOpCode(QnnOpCode::kUnPack));   // UnpackV_slice
+  ASSERT_TRUE(op_wrappers[kPreShaBase + 5].IsOpCode(QnnOpCode::kReshape));  // Reshape(mask)
+  ASSERT_TRUE(op_wrappers[kPreShaBase + 6].IsOpCode(QnnOpCode::kUnPack));   // UnpackMask
+
+  // --- Per-head SHA ops ---
+  for (size_t i = 0; i < kNumHead; ++i) {
+    // Q·KC is always first
+    ASSERT_TRUE(op_wrappers[kShaInitIdx + kNumOpInSha * i].IsOpCode(
+        QnnOpCode::kMatMul));
+
+    if (params.has_k_slice_attn_update_convert) {
+      // KSliceAttnUpdateConvert immediately after Q·KC
+      ASSERT_TRUE(op_wrappers[(kShaInitIdx + 1) + kNumOpInSha * i].IsOpCode(
+          QnnOpCode::kConvert));
+      // Q·KS follows
+      ASSERT_TRUE(op_wrappers[(kShaInitIdx + 2) + kNumOpInSha * i].IsOpCode(
+          QnnOpCode::kMatMul));
+    }
+
+    // KSlice Convert at position 1 shifts all subsequent ops by 1.
+    const size_t kShift = params.has_k_slice_attn_update_convert ? 1 : 0;
+
+    if (params.has_v_slice_attn_update_convert) {
+      // VSliceAttnUpdateConvert is between QK·VC and QK·VS (position 8 + shift)
+      ASSERT_TRUE(op_wrappers[(kShaInitIdx + 8 + kShift) + kNumOpInSha * i].IsOpCode(
+          QnnOpCode::kConvert));
+    }
+
+    // Softmax is at position 4 + shift within each SHA head
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx + 4 + kShift) + kNumOpInSha * i].IsOpCode(
+        QnnOpCode::kSoftmax));
+
+    // Output Convert is always last in each SHA head
+    ASSERT_TRUE(
+        op_wrappers[(kShaInitIdx + kNumOpInSha - 1) + kNumOpInSha * i].IsOpCode(
+            QnnOpCode::kConvert));
+  }
+
+  // --- Ops after all SHA heads ---
+  // Final Concat (all head outputs along axis=2) and Reshape into output shape.
+  const size_t kPostShaBase = kShaInitIdx + kNumOpInSha * kNumHead;
+  ASSERT_TRUE(op_wrappers[kPostShaBase + 0].IsOpCode(QnnOpCode::kConcat));
+  ASSERT_TRUE(op_wrappers[kPostShaBase + 1].IsOpCode(QnnOpCode::kReshape));
+  ASSERT_EQ(op_wrappers.size(), kPostShaBase + 2);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MHASHATest, GQAGemma4BPrefillTest,
+    ::testing::Values(
+        GQAGemma4BPrefillParams{false, false, false},
+        GQAGemma4BPrefillParams{true, false, false},
+        GQAGemma4BPrefillParams{false, true, false},
+        GQAGemma4BPrefillParams{false, false, true}),
+    [](const ::testing::TestParamInfo<GQAGemma4BPrefillParams>& info) {
+      if (info.param.has_k_slice_attn_update_convert) return "KSliceAttnUpdateConvert";
+      if (info.param.has_v_slice_attn_update_convert) return "VSliceAttnUpdateConvert";
+      if (info.param.has_global_mask) return "GlobalMask";
+      return "Base";
+    });
+
 TEST(MHASHATest, FastVlm) {
   // G2G Test case: MHA -> SHA
   // ------------------- Before ---------------------
@@ -924,22 +1203,22 @@ TEST(MHASHATest, FastVlm) {
       CreateSoftmaxOp(reshape2_output, softmax_output, 1.0f));
 
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
                                                    0, 896, 1, 0, 1280, 1};
   auto& slice0_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 896, 1280});
   op_wrappers.emplace_back(
       CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
 
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
                                                    0, 896, 1, 1280, 1408, 1};
   auto& slice1_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 896, 128});
   op_wrappers.emplace_back(
@@ -1168,21 +1447,21 @@ TEST(MHAOptimization, TinyGemma3Prefill) {
   auto& softmax_output = tensor_pool.CloneNativeTensorFrom(add0_output);
   op_wrappers.emplace_back(CreateSoftmaxOp(add0_output, softmax_output, 1.0f));
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 1,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 1,    1,
                                                    0, 512, 1, 0, 1280, 1};
   auto& slice0_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 1, 512, 1280});
   op_wrappers.emplace_back(
       CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    1,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    1,    1,
                                                    0, 512, 1, 1280, 1408, 1};
   auto& slice1_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 1, 512, 128});
   op_wrappers.emplace_back(

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph_test.cc
@@ -323,21 +323,21 @@ TEST(MHAOptimization, Gemma3Prefill) {
   op_wrappers.emplace_back(
       CreateSoftmaxOp(reshape2_output, softmax_output, 1.0f));
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 1,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 1,    1,
                                                    0, 512, 1, 0, 1280, 1};
   auto& slice0_rangs = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
       tensor_pool.CloneNativeTensorFrom(reshape2_output, {1, 1, 512, 1280});
   op_wrappers.emplace_back(
       CreateSliceOp(softmax_output, slice0_output, slice0_rangs));
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    1,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    1,    1,
                                                    0, 512, 1, 1280, 1408, 1};
   auto& slice1_rangs = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
       tensor_pool.CloneNativeTensorFrom(reshape2_output, {1, 1, 512, 128});
   op_wrappers.emplace_back(
@@ -539,21 +539,21 @@ TEST(MHAOptimization, Gemma3Decode) {
   op_wrappers.emplace_back(
       CreateSoftmaxOp(reshape1_output, softmax_output, 1.0f));
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1, 1, 0, 1,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1, 1, 0, 1,    1,
                                                    0, 4, 1, 0, 1280, 1};
   auto& slice0_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
       tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 1, 4, 1280});
   op_wrappers.emplace_back(
       CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1, 1, 0,    1,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1, 1, 0,    1,    1,
                                                    0, 4, 1, 1280, 1281, 1};
   auto& slice1_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
       tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 1, 4, 256});
   op_wrappers.emplace_back(
@@ -832,8 +832,8 @@ TEST(MHASHATest, GQAGemma4BPrefill) {
   //                        |
   //                       Out
   TensorPool tensor_pool;
-  QuantizeParamsWrapperVariant quant_param;
-  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  QuantizeParamsWrapperVariant quant_param(
+      std::in_place_type<ScaleOffsetQuantizeParamsWrapper>, 1e-4f, 0);
   std::vector<OpWrapper> op_wrappers;
 
   // In0: [B,S,H,D] input to Transpose0
@@ -841,9 +841,10 @@ TEST(MHASHATest, GQAGemma4BPrefill) {
                         quant_param, {1, 128, 8, 256});
 
   // Transpose0: [B,S,H,D] -> [B,H,S,D]
-  static const std::uint32_t kPerm0213[] = {0, 2, 1, 3};
+  static constexpr std::array<std::uint32_t, 4> kPerm0213{0, 2, 1, 3};
   auto& perm0213 = tensor_pool.CreateStaticTensor(
-    QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+    QNN_DATATYPE_UINT_32, {}, {kPerm0213.size()},
+    sizeof(std::uint32_t) * kPerm0213.size(), kPerm0213.data());
   auto& transpose0_output =
     tensor_pool.CloneNativeTensorFrom(in0, {1, 8, 128, 256});
   op_wrappers.emplace_back(
@@ -894,22 +895,22 @@ TEST(MHASHATest, GQAGemma4BPrefill) {
     CreateSoftmaxOp(add1_output, softmax_output, 1.0f));
 
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
                           0, 512, 1, 0, 2560, 1};
   auto& slice0_ranges = tensor_pool.CreateStaticTensor(
     QNN_DATATYPE_INT_32, {}, {4, 3},
-    sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+    sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
     tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 2560});
   op_wrappers.emplace_back(
     CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
 
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
                           0, 512, 1, 2560, 2688, 1};
   auto& slice1_ranges = tensor_pool.CreateStaticTensor(
     QNN_DATATYPE_INT_32, {}, {4, 3},
-    sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+    sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
     tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 128});
   op_wrappers.emplace_back(
@@ -936,8 +937,8 @@ TEST(MHASHATest, GQAGemma4BPrefill) {
   op_wrappers.emplace_back(
     CreateElementWiseAddOp(matmul2_output, matmul3_output, add2_output));
 
-  QuantizeParamsWrapperVariant quant_param_out;
-  quant_param_out.emplace<ScaleOffsetQuantizeParamsWrapper>(3.66805e-02f, 0);
+  QuantizeParamsWrapperVariant quant_param_out(
+      std::in_place_type<ScaleOffsetQuantizeParamsWrapper>, 3.66805e-02f, 0);
   auto& quant_output = tensor_pool.CreateNativeTensor(
     QNN_DATATYPE_SFIXED_POINT_8, quant_param_out, {1, 2, 512, 256});
   op_wrappers.emplace_back(CreateConvertOp(add2_output, quant_output));
@@ -949,7 +950,8 @@ TEST(MHASHATest, GQAGemma4BPrefill) {
 
   // Transpose1: [B,H,S,D] -> [B,S,H,D]
   auto& perm0213_t1 = tensor_pool.CreateStaticTensor(
-    QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+    QNN_DATATYPE_UINT_32, {}, {kPerm0213.size()},
+    sizeof(std::uint32_t) * kPerm0213.size(), kPerm0213.data());
   auto& transpose1_output =
     tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 128, 8, 256});
   op_wrappers.emplace_back(
@@ -962,9 +964,9 @@ TEST(MHASHATest, GQAGemma4BPrefill) {
               [](OpWrapper& op) { return true; });
 
   // Check OpCode after G2G
-  const size_t num_head = 8; // 2 groups in KV Cache serving 8 queries
+  static constexpr size_t kNumHead = 8; // 2 groups in KV Cache serving 8 queries
   // Q·KC, Q·KS, Concat, MaskAdd, Softmax, Slice(VC), Slice(VS), QK·VC, QK·VS, Add, Convert
-  const size_t num_op_in_sha = 11;
+  static constexpr size_t kNumOpInSha = 11;
 
   // new_ops layout before per-head SHA:
   //   op_wrappers[0]: far-away Convert (kept from original pattern)
@@ -977,28 +979,28 @@ TEST(MHASHATest, GQAGemma4BPrefill) {
   //   op_wrappers[7]  Unpack(mask_reshaped, axis=1)
   //   op_wrappers[8 .. 8+11*8-1] per-head SHA ops
   //   op_wrappers[8+88] Concat, op_wrappers[8+89] Reshape
-  const size_t sha_init_idx = 8;
+  static constexpr size_t kShaInitIdx = 8;
 
-  for (size_t i = 0; i < num_head; ++i) {
-    ASSERT_TRUE(op_wrappers[sha_init_idx + num_op_in_sha * i].IsOpCode(QnnOpCode::kMatMul));
-    ASSERT_TRUE(op_wrappers[(sha_init_idx+1) + num_op_in_sha * i].IsOpCode(QnnOpCode::kMatMul));
-    ASSERT_TRUE(op_wrappers[(sha_init_idx+2) + num_op_in_sha * i].IsOpCode(QnnOpCode::kConcat));
+  for (size_t i = 0; i < kNumHead; ++i) {
+    ASSERT_TRUE(op_wrappers[kShaInitIdx + kNumOpInSha * i].IsOpCode(QnnOpCode::kMatMul));
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx+1) + kNumOpInSha * i].IsOpCode(QnnOpCode::kMatMul));
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx+2) + kNumOpInSha * i].IsOpCode(QnnOpCode::kConcat));
     ASSERT_TRUE(
-      op_wrappers[(sha_init_idx+3) + num_op_in_sha * i].IsOpCode(QnnOpCode::kElementWiseBinary));
-    ASSERT_TRUE(IsElementWiseAdd(op_wrappers[(sha_init_idx+3) + num_op_in_sha * i]));
-    ASSERT_TRUE(op_wrappers[(sha_init_idx+4) + num_op_in_sha * i].IsOpCode(QnnOpCode::kSoftmax));
+      op_wrappers[(kShaInitIdx+3) + kNumOpInSha * i].IsOpCode(QnnOpCode::kElementWiseBinary));
+    ASSERT_TRUE(IsElementWiseAdd(op_wrappers[(kShaInitIdx+3) + kNumOpInSha * i]));
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx+4) + kNumOpInSha * i].IsOpCode(QnnOpCode::kSoftmax));
     ASSERT_TRUE(
-      op_wrappers[(sha_init_idx+5) + num_op_in_sha * i].IsOpCode(QnnOpCode::kStridedSlice));
+      op_wrappers[(kShaInitIdx+5) + kNumOpInSha * i].IsOpCode(QnnOpCode::kStridedSlice));
     ASSERT_TRUE(
-      op_wrappers[(sha_init_idx+6) + num_op_in_sha * i].IsOpCode(QnnOpCode::kStridedSlice));
-    ASSERT_TRUE(op_wrappers[(sha_init_idx+7) + num_op_in_sha * i].IsOpCode(QnnOpCode::kMatMul));
-    ASSERT_TRUE(op_wrappers[(sha_init_idx+8) + num_op_in_sha * i].IsOpCode(QnnOpCode::kMatMul));
+      op_wrappers[(kShaInitIdx+6) + kNumOpInSha * i].IsOpCode(QnnOpCode::kStridedSlice));
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx+7) + kNumOpInSha * i].IsOpCode(QnnOpCode::kMatMul));
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx+8) + kNumOpInSha * i].IsOpCode(QnnOpCode::kMatMul));
     ASSERT_TRUE(
-      op_wrappers[(sha_init_idx+9) + num_op_in_sha * i].IsOpCode(QnnOpCode::kElementWiseBinary));
-    ASSERT_TRUE(IsElementWiseAdd(op_wrappers[(sha_init_idx+9) + num_op_in_sha * i]));
+      op_wrappers[(kShaInitIdx+9) + kNumOpInSha * i].IsOpCode(QnnOpCode::kElementWiseBinary));
+    ASSERT_TRUE(IsElementWiseAdd(op_wrappers[(kShaInitIdx+9) + kNumOpInSha * i]));
     // The output Convert (kConvert) is emitted per-head from convert_out.
     ASSERT_TRUE(
-      op_wrappers[(sha_init_idx+10) + num_op_in_sha * i].IsOpCode(QnnOpCode::kConvert));
+      op_wrappers[(kShaInitIdx+10) + kNumOpInSha * i].IsOpCode(QnnOpCode::kConvert));
   }
 }
 
@@ -1006,16 +1008,17 @@ TEST(MHASHATest, GQAGemma4BPrefill) {
 // Verifies that BuildSingleSHAGemma4B emits a per-head KSliceAttnUpdateConvert (17-op pattern).
 TEST(MHASHATest, GQAGemma4BPrefill_KSliceAttnUpdateConvert) {
   TensorPool tensor_pool;
-  QuantizeParamsWrapperVariant quant_param;
-  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  QuantizeParamsWrapperVariant quant_param(
+      std::in_place_type<ScaleOffsetQuantizeParamsWrapper>, 1e-4f, 0);
   std::vector<OpWrapper> op_wrappers;
 
   // In0: [B,S,H,D]
   auto& in0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
                                               quant_param, {1, 128, 8, 256});
-  static const std::uint32_t kPerm0213[] = {0, 2, 1, 3};
+  static constexpr std::array<std::uint32_t, 4> kPerm0213{0, 2, 1, 3};
   auto& perm0213 = tensor_pool.CreateStaticTensor(
-      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+      QNN_DATATYPE_UINT_32, {}, {kPerm0213.size()},
+      sizeof(std::uint32_t) * kPerm0213.size(), kPerm0213.data());
   auto& transpose0_output =
       tensor_pool.CloneNativeTensorFrom(in0, {1, 8, 128, 256});
   op_wrappers.emplace_back(CreateTransposeOp(in0, transpose0_output, perm0213));
@@ -1068,22 +1071,22 @@ TEST(MHASHATest, GQAGemma4BPrefill_KSliceAttnUpdateConvert) {
   op_wrappers.emplace_back(CreateSoftmaxOp(add1_output, softmax_output, 1.0f));
 
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
                                                    0, 512, 1, 0, 2560, 1};
   auto& slice0_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 2560});
   op_wrappers.emplace_back(
       CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
 
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
                                                    0, 512, 1, 2560, 2688, 1};
   auto& slice1_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 128});
   op_wrappers.emplace_back(
@@ -1111,8 +1114,8 @@ TEST(MHASHATest, GQAGemma4BPrefill_KSliceAttnUpdateConvert) {
       CreateElementWiseAddOp(matmul2_output, matmul3_output, add2_output));
 
   // Output Convert
-  QuantizeParamsWrapperVariant quant_param_out;
-  quant_param_out.emplace<ScaleOffsetQuantizeParamsWrapper>(3.66805e-02f, 0);
+  QuantizeParamsWrapperVariant quant_param_out(
+      std::in_place_type<ScaleOffsetQuantizeParamsWrapper>, 3.66805e-02f, 0);
   auto& quant_output = tensor_pool.CreateNativeTensor(
       QNN_DATATYPE_SFIXED_POINT_8, quant_param_out, {1, 2, 512, 256});
   op_wrappers.emplace_back(CreateConvertOp(add2_output, quant_output));
@@ -1124,7 +1127,8 @@ TEST(MHASHATest, GQAGemma4BPrefill_KSliceAttnUpdateConvert) {
 
   // Transpose1
   auto& perm0213_t1 = tensor_pool.CreateStaticTensor(
-      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+      QNN_DATATYPE_UINT_32, {}, {kPerm0213.size()},
+      sizeof(std::uint32_t) * kPerm0213.size(), kPerm0213.data());
   auto& transpose1_output =
       tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 128, 8, 256});
   op_wrappers.emplace_back(
@@ -1136,18 +1140,18 @@ TEST(MHASHATest, GQAGemma4BPrefill_KSliceAttnUpdateConvert) {
                         tensor_pool, [](OpWrapper& op) { return true; });
 
   // Each SHA head has 12 ops: the base 11 + 1 KSliceAttnUpdateConvert.
-  const size_t num_head = 8;
-  const size_t num_op_in_sha = 12;  // Q·KC, KSliceAttnUpdateConvert, Q·KS, Concat, MaskAdd, Softmax,
+  static constexpr size_t kNumHead = 8;
+  static constexpr size_t kNumOpInSha = 12;  // Q·KC, KSliceAttnUpdateConvert, Q·KS, Concat, MaskAdd, Softmax,
                                     // Slice(VC), Slice(VS), QK·VC, QK·VS, Add, Convert
-  const size_t sha_init_idx = 8;
-  for (size_t i = 0; i < num_head; ++i) {
-    ASSERT_TRUE(op_wrappers[sha_init_idx + num_op_in_sha * i].IsOpCode(
+  static constexpr size_t kShaInitIdx = 8;
+  for (size_t i = 0; i < kNumHead; ++i) {
+    ASSERT_TRUE(op_wrappers[kShaInitIdx + kNumOpInSha * i].IsOpCode(
         QnnOpCode::kMatMul));
-    ASSERT_TRUE(op_wrappers[(sha_init_idx + 1) + num_op_in_sha * i].IsOpCode(
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx + 1) + kNumOpInSha * i].IsOpCode(
         QnnOpCode::kConvert));  // KSliceAttnUpdateConvert per head
-    ASSERT_TRUE(op_wrappers[(sha_init_idx + 2) + num_op_in_sha * i].IsOpCode(
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx + 2) + kNumOpInSha * i].IsOpCode(
         QnnOpCode::kMatMul));
-    ASSERT_TRUE(op_wrappers[(sha_init_idx + 11) + num_op_in_sha * i].IsOpCode(
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx + 11) + kNumOpInSha * i].IsOpCode(
         QnnOpCode::kConvert));  // output Convert per head
   }
 }
@@ -1156,15 +1160,16 @@ TEST(MHASHATest, GQAGemma4BPrefill_KSliceAttnUpdateConvert) {
 // Verifies that BuildSingleSHAGemma4B emits a per-head VSliceAttnUpdateConvert (17-op pattern).
 TEST(MHASHATest, GQAGemma4BPrefill_VSliceAttnUpdateConvert) {
   TensorPool tensor_pool;
-  QuantizeParamsWrapperVariant quant_param;
-  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  QuantizeParamsWrapperVariant quant_param(
+      std::in_place_type<ScaleOffsetQuantizeParamsWrapper>, 1e-4f, 0);
   std::vector<OpWrapper> op_wrappers;
 
   auto& in0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
                                               quant_param, {1, 128, 8, 256});
-  static const std::uint32_t kPerm0213[] = {0, 2, 1, 3};
+  static constexpr std::array<std::uint32_t, 4> kPerm0213{0, 2, 1, 3};
   auto& perm0213 = tensor_pool.CreateStaticTensor(
-      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+      QNN_DATATYPE_UINT_32, {}, {kPerm0213.size()},
+      sizeof(std::uint32_t) * kPerm0213.size(), kPerm0213.data());
   auto& transpose0_output =
       tensor_pool.CloneNativeTensorFrom(in0, {1, 8, 128, 256});
   op_wrappers.emplace_back(CreateTransposeOp(in0, transpose0_output, perm0213));
@@ -1212,22 +1217,22 @@ TEST(MHASHATest, GQAGemma4BPrefill_VSliceAttnUpdateConvert) {
   op_wrappers.emplace_back(CreateSoftmaxOp(add1_output, softmax_output, 1.0f));
 
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
                                                    0, 512, 1, 0, 2560, 1};
   auto& slice0_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 2560});
   op_wrappers.emplace_back(
       CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
 
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
                                                    0, 512, 1, 2560, 2688, 1};
   auto& slice1_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 128});
   op_wrappers.emplace_back(
@@ -1260,8 +1265,8 @@ TEST(MHASHATest, GQAGemma4BPrefill_VSliceAttnUpdateConvert) {
       CreateElementWiseAddOp(matmul2_output, matmul3_output, add2_output));
 
   // Output Convert
-  QuantizeParamsWrapperVariant quant_param_out;
-  quant_param_out.emplace<ScaleOffsetQuantizeParamsWrapper>(3.66805e-02f, 0);
+  QuantizeParamsWrapperVariant quant_param_out(
+      std::in_place_type<ScaleOffsetQuantizeParamsWrapper>, 3.66805e-02f, 0);
   auto& quant_output = tensor_pool.CreateNativeTensor(
       QNN_DATATYPE_SFIXED_POINT_8, quant_param_out, {1, 2, 512, 256});
   op_wrappers.emplace_back(CreateConvertOp(add2_output, quant_output));
@@ -1273,7 +1278,8 @@ TEST(MHASHATest, GQAGemma4BPrefill_VSliceAttnUpdateConvert) {
 
   // Transpose1
   auto& perm0213_t1 = tensor_pool.CreateStaticTensor(
-      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+      QNN_DATATYPE_UINT_32, {}, {kPerm0213.size()},
+      sizeof(std::uint32_t) * kPerm0213.size(), kPerm0213.data());
   auto& transpose1_output =
       tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 128, 8, 256});
   op_wrappers.emplace_back(
@@ -1285,17 +1291,17 @@ TEST(MHASHATest, GQAGemma4BPrefill_VSliceAttnUpdateConvert) {
                         tensor_pool, [](OpWrapper& op) { return true; });
 
   // Each SHA head has 12 ops: the base 11 + 1 VSliceAttnUpdateConvert.
-  const size_t num_head = 8;
-  const size_t num_op_in_sha = 12;  // Q·KC, Q·KS, Concat, MaskAdd, Softmax,
+  static constexpr size_t kNumHead = 8;
+  static constexpr size_t kNumOpInSha = 12;  // Q·KC, Q·KS, Concat, MaskAdd, Softmax,
                                     // Slice(VC), Slice(VS), QK·VC, VSliceAttnUpdateConvert, QK·VS, Add, Convert
-  const size_t sha_init_idx = 8;
-  for (size_t i = 0; i < num_head; ++i) {
-    ASSERT_TRUE(op_wrappers[sha_init_idx + num_op_in_sha * i].IsOpCode(
+  static constexpr size_t kShaInitIdx = 8;
+  for (size_t i = 0; i < kNumHead; ++i) {
+    ASSERT_TRUE(op_wrappers[kShaInitIdx + kNumOpInSha * i].IsOpCode(
         QnnOpCode::kMatMul));
     // VSliceAttnUpdateConvert is at position 8 within each SHA (between QK·VC and QK·VS)
-    ASSERT_TRUE(op_wrappers[(sha_init_idx + 8) + num_op_in_sha * i].IsOpCode(
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx + 8) + kNumOpInSha * i].IsOpCode(
         QnnOpCode::kConvert));
-    ASSERT_TRUE(op_wrappers[(sha_init_idx + 11) + num_op_in_sha * i].IsOpCode(
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx + 11) + kNumOpInSha * i].IsOpCode(
         QnnOpCode::kConvert));  // output Convert per head
   }
 }
@@ -1304,15 +1310,16 @@ TEST(MHASHATest, GQAGemma4BPrefill_VSliceAttnUpdateConvert) {
 // Verifies that the shifted index calculation still produces the correct SHA layout.
 TEST(MHASHATest, GQAGemma4BPrefill_GlobalMask) {
   TensorPool tensor_pool;
-  QuantizeParamsWrapperVariant quant_param;
-  quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(1e-4f, 0);
+  QuantizeParamsWrapperVariant quant_param(
+      std::in_place_type<ScaleOffsetQuantizeParamsWrapper>, 1e-4f, 0);
   std::vector<OpWrapper> op_wrappers;
 
   auto& in0 = tensor_pool.CreateNativeTensor(QNN_DATATYPE_SFIXED_POINT_8,
                                               quant_param, {1, 128, 8, 256});
-  static const std::uint32_t kPerm0213[] = {0, 2, 1, 3};
+  static constexpr std::array<std::uint32_t, 4> kPerm0213{0, 2, 1, 3};
   auto& perm0213 = tensor_pool.CreateStaticTensor(
-      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+      QNN_DATATYPE_UINT_32, {}, {kPerm0213.size()},
+      sizeof(std::uint32_t) * kPerm0213.size(), kPerm0213.data());
   auto& transpose0_output =
       tensor_pool.CloneNativeTensorFrom(in0, {1, 8, 128, 256});
   op_wrappers.emplace_back(CreateTransposeOp(in0, transpose0_output, perm0213));
@@ -1373,22 +1380,22 @@ TEST(MHASHATest, GQAGemma4BPrefill_GlobalMask) {
   op_wrappers.emplace_back(CreateSoftmaxOp(add1_output, softmax_output, 1.0f));
 
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
                                                    0, 512, 1, 0, 2560, 1};
   auto& slice0_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 2560});
   op_wrappers.emplace_back(
       CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
 
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
                                                    0, 512, 1, 2560, 2688, 1};
   auto& slice1_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 512, 128});
   op_wrappers.emplace_back(
@@ -1416,8 +1423,8 @@ TEST(MHASHATest, GQAGemma4BPrefill_GlobalMask) {
       CreateElementWiseAddOp(matmul2_output, matmul3_output, add2_output));
 
   // Output Convert
-  QuantizeParamsWrapperVariant quant_param_out;
-  quant_param_out.emplace<ScaleOffsetQuantizeParamsWrapper>(3.66805e-02f, 0);
+  QuantizeParamsWrapperVariant quant_param_out(
+      std::in_place_type<ScaleOffsetQuantizeParamsWrapper>, 3.66805e-02f, 0);
   auto& quant_output = tensor_pool.CreateNativeTensor(
       QNN_DATATYPE_SFIXED_POINT_8, quant_param_out, {1, 2, 512, 256});
   op_wrappers.emplace_back(CreateConvertOp(add2_output, quant_output));
@@ -1429,7 +1436,8 @@ TEST(MHASHATest, GQAGemma4BPrefill_GlobalMask) {
 
   // Transpose1
   auto& perm0213_t1 = tensor_pool.CreateStaticTensor(
-      QNN_DATATYPE_UINT_32, {}, {4}, sizeof(kPerm0213), kPerm0213);
+      QNN_DATATYPE_UINT_32, {}, {kPerm0213.size()},
+      sizeof(std::uint32_t) * kPerm0213.size(), kPerm0213.data());
   auto& transpose1_output =
       tensor_pool.CloneNativeTensorFrom(reshape1_output, {1, 128, 8, 256});
   op_wrappers.emplace_back(
@@ -1442,19 +1450,19 @@ TEST(MHASHATest, GQAGemma4BPrefill_GlobalMask) {
 
   // Same SHA layout as the base case — has_global_mask only shifts internal
   // index arithmetic, the output structure is identical.
-  const size_t num_head = 8;
+  static constexpr size_t kNumHead = 8;
   // Q·KC, Q·KS, Concat, MaskAdd, Softmax, Slice(VC), Slice(VS), QK·VC, QK·VS, Add, Convert
-  const size_t num_op_in_sha = 11;
+  static constexpr size_t kNumOpInSha = 11;
   // With has_global_mask the kept mask Concat+Reshape sit at indices 0 and 1,
   // pushing new_ops (far-away Convert, unpacks, SHAs, final Concat+Reshape) up
   // by 2, so the per-head SHA block starts at index 10 instead of 8.
-  const size_t sha_init_idx = 10;
-  for (size_t i = 0; i < num_head; ++i) {
-    ASSERT_TRUE(op_wrappers[sha_init_idx + num_op_in_sha * i].IsOpCode(
+  static constexpr size_t kShaInitIdx = 10;
+  for (size_t i = 0; i < kNumHead; ++i) {
+    ASSERT_TRUE(op_wrappers[kShaInitIdx + kNumOpInSha * i].IsOpCode(
         QnnOpCode::kMatMul));
-    ASSERT_TRUE(op_wrappers[(sha_init_idx + 4) + num_op_in_sha * i].IsOpCode(
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx + 4) + kNumOpInSha * i].IsOpCode(
         QnnOpCode::kSoftmax));
-    ASSERT_TRUE(op_wrappers[(sha_init_idx + 10) + num_op_in_sha * i].IsOpCode(
+    ASSERT_TRUE(op_wrappers[(kShaInitIdx + 10) + kNumOpInSha * i].IsOpCode(
         QnnOpCode::kConvert));
   }
 }
@@ -1621,22 +1629,22 @@ TEST(MHASHATest, FastVlm) {
       CreateSoftmaxOp(reshape2_output, softmax_output, 1.0f));
 
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 2,    1,
                                                    0, 896, 1, 0, 1280, 1};
   auto& slice0_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 896, 1280});
   op_wrappers.emplace_back(
       CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
 
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    2,    1,
                                                    0, 896, 1, 1280, 1408, 1};
   auto& slice1_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 2, 896, 128});
   op_wrappers.emplace_back(
@@ -1865,21 +1873,21 @@ TEST(MHAOptimization, TinyGemma3Prefill) {
   auto& softmax_output = tensor_pool.CloneNativeTensorFrom(add0_output);
   op_wrappers.emplace_back(CreateSoftmaxOp(add0_output, softmax_output, 1.0f));
   // Slice0
-  const std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 1,    1,
+  static constexpr std::array<int32_t, 12> slice0_ranges_data{0, 1,   1, 0, 1,    1,
                                                    0, 512, 1, 0, 1280, 1};
   auto& slice0_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice0_ranges_data.size(), slice0_ranges_data.data());
+      sizeof(slice0_ranges_data[0]) * slice0_ranges_data.size(), slice0_ranges_data.data());
   auto& slice0_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 1, 512, 1280});
   op_wrappers.emplace_back(
       CreateSliceOp(softmax_output, slice0_output, slice0_ranges));
   // Slice1
-  const std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    1,    1,
+  static constexpr std::array<int32_t, 12> slice1_ranges_data{0, 1,   1, 0,    1,    1,
                                                    0, 512, 1, 1280, 1408, 1};
   auto& slice1_ranges = tensor_pool.CreateStaticTensor(
       QNN_DATATYPE_INT_32, {}, {4, 3},
-      sizeof(int32_t) * slice1_ranges_data.size(), slice1_ranges_data.data());
+      sizeof(slice1_ranges_data[0]) * slice1_ranges_data.size(), slice1_ranges_data.data());
   auto& slice1_output =
       tensor_pool.CloneNativeTensorFrom(softmax_output, {1, 1, 512, 128});
   op_wrappers.emplace_back(

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
@@ -582,6 +582,396 @@ size_t OptimizeMHADecode(std::function<bool(OpWrapper&)> validate_op_config,
   return 1;
 }
 
+namespace {
+
+// Builds a single SHA for Gemma4B prefill. Returns the output Convert tensor.
+// Pass k_slice_attn_update_convert_op=nullptr to skip the KSliceAttnUpdateConvert
+// Pass v_slice_attn_update_convert_op=nullptr to skip the VSliceAttnUpdateConvert.
+TensorWrapper& BuildSingleSHAGemma4B(
+    std::vector<OpWrapper>& new_ops, TensorPool& tensor_pool,
+    uint32_t num_attn_per_kv_heads, const TensorWrapper& query,
+    const TensorWrapper& k_cache, const TensorWrapper& k_slice,
+    const TensorWrapper& v_cache, const TensorWrapper& v_slice,
+    const TensorWrapper& mask, const OpWrapper& q_kcache_matmul,
+    const OpWrapper* k_slice_attn_update_convert_op, const OpWrapper& q_kslice_matmul,
+    const OpWrapper& qk_concat, const OpWrapper& mask_add,
+    const OpWrapper& softmax, const OpWrapper& qk_vcache_slice,
+    const OpWrapper& qk_vslice_slice, const OpWrapper& qk_vcache_matmul,
+    const OpWrapper* v_slice_attn_update_convert_op, const OpWrapper& qk_vslice_matmul,
+    const OpWrapper& qkv_add, const OpWrapper& convert_out) {
+  const auto head_dims = [&](const OpWrapper& op) {
+    auto dims = op.GetOutputTensor(0).GetDimensions();
+    dims.erase(dims.begin() + 1);
+    dims[1] /= num_attn_per_kv_heads;
+    return dims;
+  };
+
+  const auto build_slice_ranges = [&](const OpWrapper& slice) -> TensorWrapper& {
+    auto param = slice.GetTensorParam(0).GetTensor();
+    auto param_data = param.GetTensorData<std::int32_t>();
+    std::vector<std::int32_t> ranges(param_data.value().begin(),
+                                     param_data.value().end());
+    ranges.erase(ranges.begin() + 3, ranges.begin() + 6);
+    ranges[4] /= static_cast<std::int32_t>(num_attn_per_kv_heads);
+    const std::vector<std::uint32_t> ranges_dims = {
+        static_cast<std::uint32_t>(ranges.size() / 3), 3};
+    return tensor_pool.CreateStaticTensor(
+        param.GetDataType(), param.GetQuantParams(), ranges_dims,
+        sizeof(std::int32_t) * ranges.size(), ranges.data());
+  };
+  auto& vcache_slice_ranges = build_slice_ranges(qk_vcache_slice);
+  auto& vslice_slice_ranges = build_slice_ranges(qk_vslice_slice);
+
+  // Q x K cache.
+  auto& qk_cache_output = tensor_pool.CloneNativeTensorFrom(
+      q_kcache_matmul.GetOutputTensor(0), head_dims(q_kcache_matmul));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      q_kcache_matmul, {query, k_cache}, {qk_cache_output}));
+
+  // Optional KSliceAttnUpdateConvert: convert k_slice before q_kslice_matmul.
+  const TensorWrapper* k_slice_input = &k_slice;
+  if (k_slice_attn_update_convert_op != nullptr) {
+    auto& k_slice_cv_output = tensor_pool.CloneNativeTensorFrom(
+        k_slice_attn_update_convert_op->GetOutputTensor(0), k_slice.GetDimensions());
+    new_ops.emplace_back(
+        CreateOpWithSameParams(*k_slice_attn_update_convert_op, {k_slice}, {k_slice_cv_output}));
+    k_slice_input = &k_slice_cv_output;
+  }
+
+  // Q x K slice.
+  auto& qk_slice_output = tensor_pool.CloneNativeTensorFrom(
+      q_kslice_matmul.GetOutputTensor(0), head_dims(q_kslice_matmul));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      q_kslice_matmul, {query, *k_slice_input}, {qk_slice_output}));
+
+  // QK Concat.
+  auto& concat_output = tensor_pool.CloneNativeTensorFrom(
+      qk_concat.GetOutputTensor(0), head_dims(qk_concat));
+  new_ops.emplace_back(CreateConcatenationOp(
+      {qk_cache_output, qk_slice_output}, concat_output, 2));
+
+  // Mask add.
+  auto& mask_add_output = tensor_pool.CloneNativeTensorFrom(
+      mask_add.GetOutputTensor(0), head_dims(mask_add));
+  new_ops.emplace_back(
+      CreateElementWiseAddOp(concat_output, mask, mask_add_output));
+
+  // Softmax.
+  auto& softmax_output = tensor_pool.CloneNativeTensorFrom(
+      softmax.GetOutputTensor(0), head_dims(softmax));
+  new_ops.emplace_back(
+      CreateOpWithSameParams(softmax, {mask_add_output}, {softmax_output}));
+
+  // Slice V cache.
+  auto& vcache_slice_output = tensor_pool.CloneNativeTensorFrom(
+      qk_vcache_slice.GetOutputTensor(0), head_dims(qk_vcache_slice));
+  new_ops.emplace_back(
+      CreateSliceOp(softmax_output, vcache_slice_output, vcache_slice_ranges));
+
+  // Slice V slice.
+  auto& vslice_slice_output = tensor_pool.CloneNativeTensorFrom(
+      qk_vslice_slice.GetOutputTensor(0), head_dims(qk_vslice_slice));
+  new_ops.emplace_back(
+      CreateSliceOp(softmax_output, vslice_slice_output, vslice_slice_ranges));
+
+  // QK x V cache.
+  auto& qkv_cache_output = tensor_pool.CloneNativeTensorFrom(
+      qk_vcache_matmul.GetOutputTensor(0), head_dims(qk_vcache_matmul));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      qk_vcache_matmul, {vcache_slice_output, v_cache}, {qkv_cache_output}));
+
+  // Optional VSliceAttnUpdateConvert: convert v_slice before qk_vslice_matmul.
+  const TensorWrapper* v_slice_input = &v_slice;
+  if (v_slice_attn_update_convert_op != nullptr) {
+    auto& v_slice_cv_output = tensor_pool.CloneNativeTensorFrom(
+        v_slice_attn_update_convert_op->GetOutputTensor(0), v_slice.GetDimensions());
+    new_ops.emplace_back(
+        CreateOpWithSameParams(*v_slice_attn_update_convert_op, {v_slice}, {v_slice_cv_output}));
+    v_slice_input = &v_slice_cv_output;
+  }
+
+  // QK x V slice.
+  auto& qkv_slice_output = tensor_pool.CloneNativeTensorFrom(
+      qk_vslice_matmul.GetOutputTensor(0), head_dims(qk_vslice_matmul));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      qk_vslice_matmul, {vslice_slice_output, *v_slice_input},
+      {qkv_slice_output}));
+
+  // QKV add.
+  auto& qkv_add_output = tensor_pool.CloneNativeTensorFrom(
+      qkv_add.GetOutputTensor(0), head_dims(qkv_add));
+  new_ops.emplace_back(CreateElementWiseAddOp(
+      qkv_cache_output, qkv_slice_output, qkv_add_output));
+
+  // Output Convert.
+  auto& convert_out_output = tensor_pool.CloneNativeTensorFrom(
+      convert_out.GetOutputTensor(0), head_dims(convert_out));
+  new_ops.emplace_back(
+      CreateOpWithSameParams(convert_out, {qkv_add_output}, {convert_out_output}));
+
+  return convert_out_output;
+}
+
+}  // namespace
+
+size_t OptimizeGQAGemma4BPrefill(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size) {
+  // Four pattern variants based on optional Convert nodes between matmuls:
+  //   Case 1 (base):       T R Cv M  M  Cc Add Sm Sl Sl M  M  Add Cv R T   (16)
+  //   Case 2 (k_slice_cv): T R Cv M  Cv M  Cc Add Sm Sl Sl M  M  Add Cv R T (17)
+  //   Case 3 (v_slice_cv): T R Cv M  M  Cc Add Sm Sl Sl M  Cv M  Add Cv R T (17)
+  //   Case 4 (both):       T R Cv M  Cv M  Cc Add Sm Sl Sl M  Cv M  Add Cv R T (18)
+  // Each variant also exists with a local/global mask (Concat+Reshape after
+  // the QK Concat, +2 ops).
+  //
+  // Detect KSliceAttnUpdateConvert: ops[4] == kConvert.
+  // Detect local/global mask: ops[kQKConcatIdx+1] == kConcat &&
+  //                           ops[kQKConcatIdx+2] == kReshape.
+  // Detect VSliceAttnUpdateConvert: ops[kQKVCacheMatmulIdx+1] == kConvert.
+
+  constexpr size_t kTranspose0Idx = 0;
+  constexpr size_t kReshape0Idx = 1;
+  // Index 2 is the far-away Convert (always present, not locally connected).
+  constexpr size_t kQKCacheMatmulIdx = 3;
+
+  // Step 1: detect optional KSliceAttnUpdateConvert (between the two QK matmuls).
+  const bool has_k_slice_attn_update_convert =
+    ops[start_index + 4].IsOpCode(QnnOpCode::kConvert);
+  const size_t kKSliceAttnUpdateConvertIdx = 4;  // valid only if has_k_slice_attn_update_convert
+  const size_t kQKSliceMatmulIdx = has_k_slice_attn_update_convert ? 5 : 4;
+  const size_t kQKConcatIdx = has_k_slice_attn_update_convert ? 6 : 5;
+
+  // Step 2: detect local/global mask (Concat+Reshape immediately after QK Concat).
+  const size_t kAfterQKConcat = kQKConcatIdx + 1;
+  const bool has_mask =
+    ops[start_index + kAfterQKConcat].IsOpCode(QnnOpCode::kConcat) &&
+    ops[start_index + kAfterQKConcat + 1].IsOpCode(QnnOpCode::kReshape);
+  const size_t offset_mask = has_mask ? 2 : 0;
+
+  // Step 3: remaining indices after the optional mask.
+  const size_t kMaskAddIdx = kAfterQKConcat + offset_mask;
+  const size_t kSoftmaxIdx = kMaskAddIdx + 1;
+  const size_t kQKVCacheSliceIdx = kSoftmaxIdx + 1;
+  const size_t kQKVSliceSliceIdx = kQKVCacheSliceIdx + 1;
+  const size_t kQKVCacheMatmulIdx = kQKVSliceSliceIdx + 1;
+
+  // Step 4: detect optional VSliceAttnUpdateConvert (between the two QKV matmuls).
+  const bool has_v_slice_attn_update_convert =
+    ops[start_index + kQKVCacheMatmulIdx + 1].IsOpCode(QnnOpCode::kConvert);
+  const size_t kVSliceAttnUpdateConvertIdx = kQKVCacheMatmulIdx + 1;  // valid only if has_v_slice_attn_update_convert
+  const size_t kQKVSliceMatmulIdx = kQKVCacheMatmulIdx + (has_v_slice_attn_update_convert ? 2 : 1);
+
+  // Step 5: final indices.
+  const size_t kQKVAddIdx = kQKVSliceMatmulIdx + 1;
+  const size_t kConvertOutIdx = kQKVAddIdx + 1;  // output Convert (always present)
+  const size_t kReshape1Idx = kConvertOutIdx + 1;
+  const size_t kTranspose1Idx = kReshape1Idx + 1;
+
+  QNN_LOG_INFO("[G2G] GQA optimization on Gemma4B Prefill");
+
+  const OpWrapper* k_slice_attn_update_convert_op =
+    has_k_slice_attn_update_convert ? &ops[start_index + kKSliceAttnUpdateConvertIdx] : nullptr;
+  const OpWrapper* v_slice_attn_update_convert_op =
+    has_v_slice_attn_update_convert ? &ops[start_index + kVSliceAttnUpdateConvertIdx] : nullptr;
+
+  // Validate both Transpose permutations are [0,2,1,3].
+  const auto validate_perm_0213 = [](const OpWrapper& transpose) -> bool {
+    const auto perm_param = transpose.GetTensorParam(0).GetTensor();
+    const auto perm_data = perm_param.GetTensorData<uint32_t>();
+    return perm_data.has_value() && perm_data->size() == 4 &&
+      (*perm_data)[0] == 0 && (*perm_data)[1] == 2 &&
+      (*perm_data)[2] == 1 && (*perm_data)[3] == 3;
+  };
+  if (!validate_perm_0213(ops[start_index + kTranspose0Idx]) ||
+    !validate_perm_0213(ops[start_index + kTranspose1Idx])) {
+    return 1;
+  }
+
+  // Connection check.
+  const auto is_connected =
+    [](const OpWrapper& output, size_t output_tensor_index,
+           const OpWrapper& input, size_t input_tensor_index) -> bool {
+    return output.GetOutputTensor(output_tensor_index) ==
+      input.GetInputTensor(input_tensor_index);
+  };
+
+  // q_kcache_matmul -> (optional k_slice_attn_update_convert ->) qk_concat(0)
+  const bool convert_to_kslice_matmul = !has_k_slice_attn_update_convert ||
+    is_connected(*k_slice_attn_update_convert_op, 0,
+           ops[start_index + kQKSliceMatmulIdx], 1);
+
+  // qkv_cache_matmul -> (optional v_slice_attn_update_convert ->) qkv_add(0)
+  const bool convert_to_vslice_matmul = !has_v_slice_attn_update_convert ||
+    is_connected(*v_slice_attn_update_convert_op, 0,
+          ops[start_index + kQKVSliceMatmulIdx], 1);
+
+  if (!(is_connected(ops[start_index + kTranspose0Idx], 0,
+                     ops[start_index + kReshape0Idx], 0) &&
+    is_connected(ops[start_index + kReshape0Idx], 0,
+                     ops[start_index + kQKCacheMatmulIdx], 0) &&
+    is_connected(ops[start_index + kReshape0Idx], 0,
+                     ops[start_index + kQKSliceMatmulIdx], 0) &&
+    convert_to_kslice_matmul &&
+    is_connected(ops[start_index + kQKCacheMatmulIdx], 0,
+                     ops[start_index + kQKConcatIdx], 0) &&
+    is_connected(ops[start_index + kQKSliceMatmulIdx], 0,
+                     ops[start_index + kQKConcatIdx], 1) &&
+    is_connected(ops[start_index + kQKConcatIdx], 0,
+                     ops[start_index + kMaskAddIdx], 0) &&
+    is_connected(ops[start_index + kMaskAddIdx], 0,
+                     ops[start_index + kSoftmaxIdx], 0) &&
+    is_connected(ops[start_index + kSoftmaxIdx], 0,
+                     ops[start_index + kQKVCacheSliceIdx], 0) &&
+    is_connected(ops[start_index + kSoftmaxIdx], 0,
+                     ops[start_index + kQKVSliceSliceIdx], 0) &&
+    is_connected(ops[start_index + kQKVCacheSliceIdx], 0,
+                     ops[start_index + kQKVCacheMatmulIdx], 0) &&
+    is_connected(ops[start_index + kQKVSliceSliceIdx], 0,
+                     ops[start_index + kQKVSliceMatmulIdx], 0) &&
+    convert_to_vslice_matmul &&
+    is_connected(ops[start_index + kQKVCacheMatmulIdx], 0,
+                     ops[start_index + kQKVAddIdx], 0) &&
+    is_connected(ops[start_index + kQKVSliceMatmulIdx], 0,
+                     ops[start_index + kQKVAddIdx], 1) &&
+    is_connected(ops[start_index + kQKVAddIdx], 0,
+                     ops[start_index + kConvertOutIdx], 0) &&
+    is_connected(ops[start_index + kConvertOutIdx], 0,
+                     ops[start_index + kReshape1Idx], 0) &&
+    is_connected(ops[start_index + kReshape1Idx], 0,
+                     ops[start_index + kTranspose1Idx], 0) &&
+    IsElementWiseAdd(ops[start_index + kMaskAddIdx]) &&
+    IsElementWiseAdd(ops[start_index + kQKVAddIdx]))) {
+    return 1;
+  }
+
+  constexpr size_t kQueryUnpackAxis = 2;  // H axis in [B,S,H,D]
+  constexpr size_t kKVUnpackAxis = 1;     // H axis in [B,H_kv,S_kv,D]
+  const size_t num_attn_heads =
+    ops[start_index + kTranspose0Idx].GetInputTensor(0).GetDimension(
+      kQueryUnpackAxis);
+  const size_t num_kv_heads =
+    ops[start_index + kQKCacheMatmulIdx].GetInputTensor(1).GetDimension(
+       kKVUnpackAxis);
+  if (num_kv_heads == 0 || num_attn_heads % num_kv_heads != 0) {
+    return 1;
+  }
+  const size_t num_attn_per_kv_heads = num_attn_heads / num_kv_heads;
+
+  std::vector<OpWrapper> new_ops;
+
+  // Unpack query from Transpose0's input [B,S,H,D] along axis 2 (H).
+  // Transpose0 [B,S,H,D]->[B,H,S,D] and Transpose1 [B,H,S,D]->[B,S,H,D]
+  // are both consumed and erased; no need to emit them into new_ops.
+  auto query_unpack_outputs = UnpackTensor(
+    tensor_pool, new_ops, ops[start_index + kTranspose0Idx].GetInputTensor(0), kQueryUnpackAxis);
+  auto k_cache_unpack_outputs = UnpackTensor(
+    tensor_pool, new_ops, ops[start_index + kQKCacheMatmulIdx].GetInputTensor(1), kKVUnpackAxis);
+  // When the optional Convert is present, the matmul's input(1) is the Convert's
+  // output (an intermediate tensor with id 0). We must unpack the Convert's
+  // input instead, which is the actual static KV weight tensor.
+  auto k_slice_unpack_outputs = UnpackTensor(
+    tensor_pool, new_ops,
+    has_k_slice_attn_update_convert? k_slice_attn_update_convert_op->GetInputTensor(0): ops[start_index + kQKSliceMatmulIdx].GetInputTensor(1),
+    kKVUnpackAxis);
+  auto v_cache_unpack_outputs = UnpackTensor(
+    tensor_pool, new_ops, ops[start_index + kQKVCacheMatmulIdx].GetInputTensor(1), kKVUnpackAxis);
+  auto v_slice_unpack_outputs = UnpackTensor(
+    tensor_pool, new_ops,
+    has_v_slice_attn_update_convert? v_slice_attn_update_convert_op->GetInputTensor(0) : ops[start_index + kQKVSliceMatmulIdx].GetInputTensor(1),
+    kKVUnpackAxis);
+
+  // Reshape mask from (1,1,512,2688) -> (1,num_attn_per_kv_heads,128,2688)
+  // so that unpacking on axis=1 gives one (1,128,2688) mask per query head.
+  const auto& mask_orig =
+    ops[start_index + kMaskAddIdx].GetInputTensor(1);
+  auto mask_reshaped_dims = mask_orig.GetDimensions();
+  mask_reshaped_dims[1] = static_cast<std::uint32_t>(num_attn_per_kv_heads);
+  mask_reshaped_dims[2] /= static_cast<std::uint32_t>(num_attn_per_kv_heads);
+  auto& mask_reshaped =
+    tensor_pool.CloneNativeTensorFrom(mask_orig, mask_reshaped_dims);
+  new_ops.emplace_back(CreateReshapeOp(mask_orig, mask_reshaped));
+  constexpr size_t kMaskUnpackAxis = 1;
+  auto mask_unpack_outputs =
+    UnpackTensor(tensor_pool, new_ops, mask_reshaped, kMaskUnpackAxis);
+
+  // Build num_attn_heads SHAs.
+  std::vector<ConstTensorWrapperRef> sha_outputs;
+  sha_outputs.reserve(num_attn_heads);
+  for (size_t i = 0; i < num_kv_heads; ++i) {
+    for (size_t j = 0; j < num_attn_per_kv_heads; ++j) {
+      const auto& query = query_unpack_outputs[i * num_attn_per_kv_heads + j];
+      sha_outputs.emplace_back(BuildSingleSHAGemma4B(
+        new_ops, tensor_pool, num_attn_per_kv_heads, query,
+        k_cache_unpack_outputs[i], k_slice_unpack_outputs[i],
+        v_cache_unpack_outputs[i], v_slice_unpack_outputs[i],
+        mask_unpack_outputs[j],
+        ops[start_index + kQKCacheMatmulIdx], k_slice_attn_update_convert_op,
+        ops[start_index + kQKSliceMatmulIdx],
+        ops[start_index + kQKConcatIdx],
+        ops[start_index + kMaskAddIdx],
+        ops[start_index + kSoftmaxIdx],
+        ops[start_index + kQKVCacheSliceIdx],
+        ops[start_index + kQKVSliceSliceIdx],
+        ops[start_index + kQKVCacheMatmulIdx], v_slice_attn_update_convert_op,
+        ops[start_index + kQKVSliceMatmulIdx],
+        ops[start_index + kQKVAddIdx],
+        ops[start_index + kConvertOutIdx]));
+    }
+  }
+
+  // Concat per-head outputs along axis=2 (D axis) into [B, S, H*D], then
+  // Reshape directly into transpose1's output [B, S, H, D].
+  // No Transpose1 needed: for each (b,s) the concat produces head 0's D values
+  // contiguously followed by head 1's, ..., head H-1's — exactly the row-major
+  // layout of [B, S, H, D].  This avoids both Pack and Transpose: Concat(axis=2)
+  // is a block-copy (no strided scatter), so it doesn't have the HTP accuracy
+  // issue that Pack(axis=2) exhibits.
+  // sha_outputs: num_attn_heads tensors of [B, S_per_head, D].
+  auto concat_dims = sha_outputs[0].get().GetDimensions();  // [B, S, D]
+  concat_dims[2] *= static_cast<std::uint32_t>(num_attn_heads);  // [B, S, H*D]
+  auto& concat_output = tensor_pool.CloneNativeTensorFrom(
+    ops[start_index + kReshape1Idx].GetOutputTensor(0), concat_dims);
+  new_ops.emplace_back(CreateConcatenationOp(sha_outputs, concat_output, 2));
+  new_ops.emplace_back(CreateReshapeOp(
+    concat_output,
+    ops[start_index + kTranspose1Idx].GetOutputTensor(0)));
+
+  // Validate new graph.
+  const bool is_valid =
+    std::all_of(new_ops.begin(), new_ops.end(),
+          [validate_op_config](OpWrapper& op_wrapper) -> bool {
+            return validate_op_config(op_wrapper);
+          });
+  if (is_valid) {
+    // Adjust the name to avoid a name collision in the Qnn JSON dump.
+    for (size_t i = 0; i < new_ops.size(); ++i) {
+      new_ops[i].AddSuffixToName(absl::StrCat("_qcg2g_", i));
+    }
+    // Insert new_ops after the matched pattern.
+    ops.insert(ops.begin() + start_index + pattern_size,
+      std::make_move_iterator(new_ops.begin()),
+      std::make_move_iterator(new_ops.end()));
+    // Erase the matched pattern except: the far-away kConvert (index 2),
+    // and (if present) the mask Concat+Reshape.
+    // Erase from mask_add through transpose1 (inclusive).
+    ops.erase(ops.begin() + start_index + kMaskAddIdx,
+        ops.begin() + start_index + kTranspose1Idx + 1);
+    // Erase from q_kcache_matmul through qk_concat (inclusive),
+    // which also covers the optional QK Quantize between them.
+    ops.erase(ops.begin() + start_index + kQKCacheMatmulIdx,
+         ops.begin() + start_index + kQKConcatIdx + 1);
+    // Erase Reshape0 and Transpose0.
+    ops.erase(ops.begin() + start_index + kReshape0Idx);
+    ops.erase(ops.begin() + start_index + kTranspose0Idx);
+
+    QNN_LOG_INFO("[G2G] GQA optimization on Gemma4B Prefill done.");
+    return new_ops.size();
+  }
+  return 1;
+}
+
 size_t OptimizeMHAFastVlmPrefill(
     std::function<bool(OpWrapper&)> validate_op_config,
     std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
@@ -582,6 +582,402 @@ size_t OptimizeMHADecode(std::function<bool(OpWrapper&)> validate_op_config,
   return 1;
 }
 
+namespace {
+
+// Builds a single SHA for Gemma4B prefill. Returns the output Convert tensor.
+// Pass k_slice_attn_update_convert_op=nullptr to skip the KSliceAttnUpdateConvert
+// Pass v_slice_attn_update_convert_op=nullptr to skip the VSliceAttnUpdateConvert.
+TensorWrapper& BuildSingleSHAGemma4B(
+    std::vector<OpWrapper>& new_ops, TensorPool& tensor_pool,
+    uint32_t num_attn_per_kv_heads, const TensorWrapper& query,
+    const TensorWrapper& k_cache, const TensorWrapper& k_slice,
+    const TensorWrapper& v_cache, const TensorWrapper& v_slice,
+    const TensorWrapper& mask, const OpWrapper& q_kcache_matmul,
+    const OpWrapper* k_slice_attn_update_convert_op, const OpWrapper& q_kslice_matmul,
+    const OpWrapper& qk_concat, const OpWrapper& mask_add,
+    const OpWrapper& softmax, const OpWrapper& qk_vcache_slice,
+    const OpWrapper& qk_vslice_slice, const OpWrapper& qk_vcache_matmul,
+    const OpWrapper* v_slice_attn_update_convert_op, const OpWrapper& qk_vslice_matmul,
+    const OpWrapper& qkv_add, const OpWrapper& convert_out) {
+  const auto head_dims = [num_attn_per_kv_heads](const OpWrapper& op) {
+    auto dims = op.GetOutputTensor(0).GetDimensions();
+    dims.erase(dims.begin() + 1);
+    dims[1] /= num_attn_per_kv_heads;
+    return dims;
+  };
+
+  const auto build_slice_ranges = [&tensor_pool, num_attn_per_kv_heads](const OpWrapper& slice) -> TensorWrapper& {
+    auto param = slice.GetTensorParam(0).GetTensor();
+    auto param_data = param.GetTensorData<std::int32_t>();
+    std::vector<std::int32_t> ranges(param_data.value().begin(),
+                                     param_data.value().end());
+    ranges.erase(ranges.begin() + 3, ranges.begin() + 6);
+    ranges[4] /= static_cast<std::int32_t>(num_attn_per_kv_heads);
+    const std::vector<std::uint32_t> ranges_dims = {
+        static_cast<std::uint32_t>(ranges.size() / 3), 3};
+    return tensor_pool.CreateStaticTensor(
+        param.GetDataType(), param.GetQuantParams(), ranges_dims,
+        sizeof(std::int32_t) * ranges.size(), ranges.data());
+  };
+  auto& vcache_slice_ranges = build_slice_ranges(qk_vcache_slice);
+  auto& vslice_slice_ranges = build_slice_ranges(qk_vslice_slice);
+
+  // Q x K cache.
+  auto& qk_cache_output = tensor_pool.CloneNativeTensorFrom(
+      q_kcache_matmul.GetOutputTensor(0), head_dims(q_kcache_matmul));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      q_kcache_matmul, {query, k_cache}, {qk_cache_output}));
+
+  // Optional KSliceAttnUpdateConvert: convert k_slice before q_kslice_matmul.
+  const TensorWrapper* k_slice_input = &k_slice;
+  if (k_slice_attn_update_convert_op != nullptr) {
+    auto& k_slice_cv_output = tensor_pool.CloneNativeTensorFrom(
+        k_slice_attn_update_convert_op->GetOutputTensor(0), k_slice.GetDimensions());
+    new_ops.emplace_back(
+        CreateOpWithSameParams(*k_slice_attn_update_convert_op, {k_slice}, {k_slice_cv_output}));
+    k_slice_input = &k_slice_cv_output;
+  }
+
+  // Q x K slice.
+  auto& qk_slice_output = tensor_pool.CloneNativeTensorFrom(
+      q_kslice_matmul.GetOutputTensor(0), head_dims(q_kslice_matmul));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      q_kslice_matmul, {query, *k_slice_input}, {qk_slice_output}));
+
+  // QK Concat.
+  auto& concat_output = tensor_pool.CloneNativeTensorFrom(
+      qk_concat.GetOutputTensor(0), head_dims(qk_concat));
+  new_ops.emplace_back(CreateConcatenationOp(
+      {qk_cache_output, qk_slice_output}, concat_output, 2));
+
+  // Mask add.
+  auto& mask_add_output = tensor_pool.CloneNativeTensorFrom(
+      mask_add.GetOutputTensor(0), head_dims(mask_add));
+  new_ops.emplace_back(
+      CreateElementWiseAddOp(concat_output, mask, mask_add_output));
+
+  // Softmax.
+  auto& softmax_output = tensor_pool.CloneNativeTensorFrom(
+      softmax.GetOutputTensor(0), head_dims(softmax));
+  new_ops.emplace_back(
+      CreateOpWithSameParams(softmax, {mask_add_output}, {softmax_output}));
+
+  // Slice V cache.
+  auto& vcache_slice_output = tensor_pool.CloneNativeTensorFrom(
+      qk_vcache_slice.GetOutputTensor(0), head_dims(qk_vcache_slice));
+  new_ops.emplace_back(
+      CreateSliceOp(softmax_output, vcache_slice_output, vcache_slice_ranges));
+
+  // Slice V slice.
+  auto& vslice_slice_output = tensor_pool.CloneNativeTensorFrom(
+      qk_vslice_slice.GetOutputTensor(0), head_dims(qk_vslice_slice));
+  new_ops.emplace_back(
+      CreateSliceOp(softmax_output, vslice_slice_output, vslice_slice_ranges));
+
+  // QK x V cache.
+  auto& qkv_cache_output = tensor_pool.CloneNativeTensorFrom(
+      qk_vcache_matmul.GetOutputTensor(0), head_dims(qk_vcache_matmul));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      qk_vcache_matmul, {vcache_slice_output, v_cache}, {qkv_cache_output}));
+
+  // Optional VSliceAttnUpdateConvert: convert v_slice before qk_vslice_matmul.
+  const TensorWrapper* v_slice_input = &v_slice;
+  if (v_slice_attn_update_convert_op != nullptr) {
+    auto& v_slice_cv_output = tensor_pool.CloneNativeTensorFrom(
+        v_slice_attn_update_convert_op->GetOutputTensor(0), v_slice.GetDimensions());
+    new_ops.emplace_back(
+        CreateOpWithSameParams(*v_slice_attn_update_convert_op, {v_slice}, {v_slice_cv_output}));
+    v_slice_input = &v_slice_cv_output;
+  }
+
+  // QK x V slice.
+  auto& qkv_slice_output = tensor_pool.CloneNativeTensorFrom(
+      qk_vslice_matmul.GetOutputTensor(0), head_dims(qk_vslice_matmul));
+  new_ops.emplace_back(CreateOpWithSameParams(
+      qk_vslice_matmul, {vslice_slice_output, *v_slice_input},
+      {qkv_slice_output}));
+
+  // QKV add.
+  auto& qkv_add_output = tensor_pool.CloneNativeTensorFrom(
+      qkv_add.GetOutputTensor(0), head_dims(qkv_add));
+  new_ops.emplace_back(CreateElementWiseAddOp(
+      qkv_cache_output, qkv_slice_output, qkv_add_output));
+
+  // Output Convert.
+  auto& convert_out_output = tensor_pool.CloneNativeTensorFrom(
+      convert_out.GetOutputTensor(0), head_dims(convert_out));
+  new_ops.emplace_back(
+      CreateOpWithSameParams(convert_out, {qkv_add_output}, {convert_out_output}));
+
+  return convert_out_output;
+}
+
+}  // namespace
+
+size_t OptimizeGQAGemma4BPrefill(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size) {
+  // Four pattern variants based on optional Convert nodes between matmuls:
+  //   Legend: T=Transpose, R=Reshape, Cv=Convert, M=MatMul, Cc=Concat,
+  //           Add=ElementWiseAdd, Sm=Softmax, Sl=StridedSlice
+  //   Case 1 (base):       T R Cv M  M  Cc Add Sm Sl Sl M  M  Add Cv R T   (16)
+  //   Case 2 (k_slice_cv): T R Cv M  Cv M  Cc Add Sm Sl Sl M  M  Add Cv R T (17)
+  //   Case 3 (v_slice_cv): T R Cv M  M  Cc Add Sm Sl Sl M  Cv M  Add Cv R T (17)
+  //   Case 4 (both):       T R Cv M  Cv M  Cc Add Sm Sl Sl M  Cv M  Add Cv R T (18)
+  // Case 1 also exists with a local/global mask (Concat+Reshape after
+  // the QK Concat, +2 ops).
+
+  constexpr size_t kTranspose0Idx = 0;
+  constexpr size_t kReshape0Idx = 1;
+  // Index 2 is the far-away Convert (always present, not locally connected).
+  constexpr size_t kQKCacheMatmulIdx = 3;
+
+  // Step 1: detect optional KSliceAttnUpdateConvert (between the two QK matmuls).
+  const bool has_k_slice_attn_update_convert =
+    ops[start_index + 4].IsOpCode(QnnOpCode::kConvert);
+  const size_t k_slice_attn_update_convert_idx = 4;  // valid only if has_k_slice_attn_update_convert
+  const size_t qk_slice_matmul_idx = has_k_slice_attn_update_convert ? 5 : 4;
+  const size_t qk_concat_idx = has_k_slice_attn_update_convert ? 6 : 5;
+
+  // Step 2: detect local/global mask (Concat+Reshape immediately after QK Concat).
+  const size_t after_qk_concat = qk_concat_idx + 1;
+  const bool has_mask =
+    ops[start_index + after_qk_concat].IsOpCode(QnnOpCode::kConcat) &&
+    ops[start_index + after_qk_concat + 1].IsOpCode(QnnOpCode::kReshape);
+  const size_t offset_mask = has_mask ? 2 : 0;
+
+  // Step 3: remaining indices after the optional mask.
+  const size_t mask_add_idx = after_qk_concat + offset_mask;
+  const size_t softmax_idx = mask_add_idx + 1;
+  const size_t qkv_cache_slice_idx = softmax_idx + 1;
+  const size_t qkv_slice_slice_idx = qkv_cache_slice_idx + 1;
+  const size_t qkv_cache_matmul_idx = qkv_slice_slice_idx + 1;
+
+  // Step 4: detect optional VSliceAttnUpdateConvert (between the two QKV matmuls).
+  const bool has_v_slice_attn_update_convert =
+    ops[start_index + qkv_cache_matmul_idx + 1].IsOpCode(QnnOpCode::kConvert);
+  const size_t v_slice_attn_update_convert_idx = qkv_cache_matmul_idx + 1;  // valid only if has_v_slice_attn_update_convert
+  const size_t qkv_slice_matmul_idx = qkv_cache_matmul_idx + (has_v_slice_attn_update_convert ? 2 : 1);
+
+  // Step 5: final indices.
+  const size_t qkv_add_idx = qkv_slice_matmul_idx + 1;
+  const size_t convert_out_idx = qkv_add_idx + 1;
+  const size_t reshape1_idx = convert_out_idx + 1;
+  const size_t transpose1_idx = reshape1_idx + 1;
+
+  QNN_LOG_INFO("[G2G] GQA optimization on Gemma4B Prefill");
+
+  const OpWrapper* k_slice_attn_update_convert_op =
+    has_k_slice_attn_update_convert ? &ops[start_index + k_slice_attn_update_convert_idx] : nullptr;
+  const OpWrapper* v_slice_attn_update_convert_op =
+    has_v_slice_attn_update_convert ? &ops[start_index + v_slice_attn_update_convert_idx] : nullptr;
+
+  // Validate both Transpose permutations are [0,2,1,3].
+  const auto validate_perm_0213 = [](const OpWrapper& transpose) -> bool {
+    const auto perm_param = transpose.GetTensorParam(0).GetTensor();
+    const auto perm_data = perm_param.GetTensorData<uint32_t>();
+    return perm_data.has_value() && perm_data->size() == 4 &&
+      (*perm_data)[0] == 0 && (*perm_data)[1] == 2 &&
+      (*perm_data)[2] == 1 && (*perm_data)[3] == 3;
+  };
+  if (!validate_perm_0213(ops[start_index + kTranspose0Idx]) ||
+    !validate_perm_0213(ops[start_index + transpose1_idx])) {
+    QNN_LOG_WARNING("[G2G] GQA Gemma4B Prefill skipped: "
+                    "Transpose permutation is not [0,2,1,3].");
+    return 1;
+  }
+
+  // Connection check.
+  const auto is_connected =
+    [](const OpWrapper& output, size_t output_tensor_index,
+           const OpWrapper& input, size_t input_tensor_index) -> bool {
+    return output.GetOutputTensor(output_tensor_index) ==
+      input.GetInputTensor(input_tensor_index);
+  };
+
+  // q_kcache_matmul -> (optional k_slice_attn_update_convert ->) qk_concat(0)
+  const bool convert_to_kslice_matmul = !has_k_slice_attn_update_convert ||
+    is_connected(*k_slice_attn_update_convert_op, 0,
+           ops[start_index + qk_slice_matmul_idx], 1);
+
+  // qkv_cache_matmul -> (optional v_slice_attn_update_convert ->) qkv_add(0)
+  const bool convert_to_vslice_matmul = !has_v_slice_attn_update_convert ||
+    is_connected(*v_slice_attn_update_convert_op, 0,
+          ops[start_index + qkv_slice_matmul_idx], 1);
+
+  if (!(is_connected(ops[start_index + kTranspose0Idx], 0,
+                     ops[start_index + kReshape0Idx], 0) &&
+    is_connected(ops[start_index + kReshape0Idx], 0,
+                     ops[start_index + kQKCacheMatmulIdx], 0) &&
+    is_connected(ops[start_index + kReshape0Idx], 0,
+                     ops[start_index + qk_slice_matmul_idx], 0) &&
+    convert_to_kslice_matmul &&
+    is_connected(ops[start_index + kQKCacheMatmulIdx], 0,
+                     ops[start_index + qk_concat_idx], 0) &&
+    is_connected(ops[start_index + qk_slice_matmul_idx], 0,
+                     ops[start_index + qk_concat_idx], 1) &&
+    is_connected(ops[start_index + qk_concat_idx], 0,
+                     ops[start_index + mask_add_idx], 0) &&
+    is_connected(ops[start_index + mask_add_idx], 0,
+                     ops[start_index + softmax_idx], 0) &&
+    is_connected(ops[start_index + softmax_idx], 0,
+                     ops[start_index + qkv_cache_slice_idx], 0) &&
+    is_connected(ops[start_index + softmax_idx], 0,
+                     ops[start_index + qkv_slice_slice_idx], 0) &&
+    is_connected(ops[start_index + qkv_cache_slice_idx], 0,
+                     ops[start_index + qkv_cache_matmul_idx], 0) &&
+    is_connected(ops[start_index + qkv_slice_slice_idx], 0,
+                     ops[start_index + qkv_slice_matmul_idx], 0) &&
+    convert_to_vslice_matmul &&
+    is_connected(ops[start_index + qkv_cache_matmul_idx], 0,
+                     ops[start_index + qkv_add_idx], 0) &&
+    is_connected(ops[start_index + qkv_slice_matmul_idx], 0,
+                     ops[start_index + qkv_add_idx], 1) &&
+    is_connected(ops[start_index + qkv_add_idx], 0,
+                     ops[start_index + convert_out_idx], 0) &&
+    is_connected(ops[start_index + convert_out_idx], 0,
+                     ops[start_index + reshape1_idx], 0) &&
+    is_connected(ops[start_index + reshape1_idx], 0,
+                     ops[start_index + transpose1_idx], 0) &&
+    IsElementWiseAdd(ops[start_index + mask_add_idx]) &&
+    IsElementWiseAdd(ops[start_index + qkv_add_idx]))) {
+    QNN_LOG_WARNING("[G2G] GQA Gemma4B Prefill skipped: "
+                    "Op connectivity check failed.");
+    return 1;
+  }
+
+  constexpr size_t kQueryUnpackAxis = 2;  // H axis in [B,S,H,D]
+  constexpr size_t kKVUnpackAxis = 1;     // H axis in [B,H_kv,S_kv,D]
+  const size_t num_attn_heads =
+    ops[start_index + kTranspose0Idx].GetInputTensor(0).GetDimension(
+      kQueryUnpackAxis);
+  const size_t num_kv_heads =
+    ops[start_index + kQKCacheMatmulIdx].GetInputTensor(1).GetDimension(
+       kKVUnpackAxis);
+  if (num_kv_heads == 0 || num_attn_heads % num_kv_heads != 0) {
+    QNN_LOG_WARNING("[G2G] GQA Gemma4B Prefill skipped: "
+                    "Invalid GQA head count (num_attn_heads=%zu, num_kv_heads=%zu).",
+                    num_attn_heads, num_kv_heads);
+    return 1;
+  }
+  const size_t num_attn_per_kv_heads = num_attn_heads / num_kv_heads;
+
+  std::vector<OpWrapper> new_ops;
+
+  // Unpack query from Transpose0's input [B,S,H,D] along axis 2 (H).
+  // Transpose0 [B,S,H,D]->[B,H,S,D] and Transpose1 [B,H,S,D]->[B,S,H,D]
+  // are both consumed and erased; no need to emit them into new_ops.
+  auto query_unpack_outputs = UnpackTensor(
+    tensor_pool, new_ops, ops[start_index + kTranspose0Idx].GetInputTensor(0), kQueryUnpackAxis);
+  auto k_cache_unpack_outputs = UnpackTensor(
+    tensor_pool, new_ops, ops[start_index + kQKCacheMatmulIdx].GetInputTensor(1), kKVUnpackAxis);
+  // When the optional Convert is present, the matmul's input(1) is the Convert's
+  // output (an intermediate tensor with id 0). We must unpack the Convert's
+  // input instead, which is the actual static KV weight tensor.
+  auto k_slice_unpack_outputs = UnpackTensor(
+    tensor_pool, new_ops,
+    has_k_slice_attn_update_convert? k_slice_attn_update_convert_op->GetInputTensor(0): ops[start_index + qk_slice_matmul_idx].GetInputTensor(1),
+    kKVUnpackAxis);
+  auto v_cache_unpack_outputs = UnpackTensor(
+    tensor_pool, new_ops, ops[start_index + qkv_cache_matmul_idx].GetInputTensor(1), kKVUnpackAxis);
+  auto v_slice_unpack_outputs = UnpackTensor(
+    tensor_pool, new_ops,
+    has_v_slice_attn_update_convert? v_slice_attn_update_convert_op->GetInputTensor(0) : ops[start_index + qkv_slice_matmul_idx].GetInputTensor(1),
+    kKVUnpackAxis);
+
+  // Reshape mask from (1,1,512,2688) -> (1,num_attn_per_kv_heads,128,2688)
+  // so that unpacking on axis=1 gives one (1,128,2688) mask per query head.
+  const auto& mask_orig =
+    ops[start_index + mask_add_idx].GetInputTensor(1);
+  auto mask_reshaped_dims = mask_orig.GetDimensions();
+  mask_reshaped_dims[1] = static_cast<std::uint32_t>(num_attn_per_kv_heads);
+  mask_reshaped_dims[2] /= static_cast<std::uint32_t>(num_attn_per_kv_heads);
+  auto& mask_reshaped =
+    tensor_pool.CloneNativeTensorFrom(mask_orig, mask_reshaped_dims);
+  new_ops.emplace_back(CreateReshapeOp(mask_orig, mask_reshaped));
+  constexpr size_t kMaskUnpackAxis = 1;
+  auto mask_unpack_outputs =
+    UnpackTensor(tensor_pool, new_ops, mask_reshaped, kMaskUnpackAxis);
+
+  // Build num_attn_heads SHAs.
+  std::vector<ConstTensorWrapperRef> sha_outputs;
+  sha_outputs.reserve(num_attn_heads);
+  for (size_t i = 0; i < num_kv_heads; ++i) {
+    for (size_t j = 0; j < num_attn_per_kv_heads; ++j) {
+      const auto& query = query_unpack_outputs[i * num_attn_per_kv_heads + j];
+      sha_outputs.emplace_back(BuildSingleSHAGemma4B(
+        new_ops, tensor_pool, num_attn_per_kv_heads, query,
+        k_cache_unpack_outputs[i], k_slice_unpack_outputs[i],
+        v_cache_unpack_outputs[i], v_slice_unpack_outputs[i],
+        mask_unpack_outputs[j],
+        ops[start_index + kQKCacheMatmulIdx], k_slice_attn_update_convert_op,
+        ops[start_index + qk_slice_matmul_idx],
+        ops[start_index + qk_concat_idx],
+        ops[start_index + mask_add_idx],
+        ops[start_index + softmax_idx],
+        ops[start_index + qkv_cache_slice_idx],
+        ops[start_index + qkv_slice_slice_idx],
+        ops[start_index + qkv_cache_matmul_idx], v_slice_attn_update_convert_op,
+        ops[start_index + qkv_slice_matmul_idx],
+        ops[start_index + qkv_add_idx],
+        ops[start_index + convert_out_idx]));
+    }
+  }
+
+  // Concat per-head outputs along axis=2 (D axis) into [B, S, H*D], then
+  // Reshape directly into transpose1's output [B, S, H, D].
+  // No Transpose1 needed: for each (b,s) the concat produces head 0's D values
+  // contiguously followed by head 1's, ..., head H-1's — exactly the row-major
+  // layout of [B, S, H, D].  This avoids both Pack and Transpose: Concat(axis=2)
+  // is a block-copy (no strided scatter), so it doesn't have the HTP accuracy
+  // issue that Pack(axis=2) exhibits.
+  // sha_outputs: num_attn_heads tensors of [B, S_per_head, D].
+  auto concat_dims = sha_outputs[0].get().GetDimensions();  // [B, S, D]
+  concat_dims[2] *= static_cast<std::uint32_t>(num_attn_heads);  // [B, S, H*D]
+  auto& concat_output = tensor_pool.CloneNativeTensorFrom(
+    ops[start_index + reshape1_idx].GetOutputTensor(0), concat_dims);
+  new_ops.emplace_back(CreateConcatenationOp(sha_outputs, concat_output, 2));
+  new_ops.emplace_back(CreateReshapeOp(
+    concat_output,
+    ops[start_index + transpose1_idx].GetOutputTensor(0)));
+
+  // Validate new graph.
+  const bool is_valid =
+    std::all_of(new_ops.begin(), new_ops.end(),
+          [validate_op_config](OpWrapper& op_wrapper) -> bool {
+            return validate_op_config(op_wrapper);
+          });
+  if (is_valid) {
+    // Adjust the name to avoid a name collision in the Qnn JSON dump.
+    for (size_t i = 0; i < new_ops.size(); ++i) {
+      new_ops[i].AddSuffixToName(absl::StrCat("_qcg2g_", i));
+    }
+    // Insert new_ops after the matched pattern.
+    ops.insert(ops.begin() + start_index + pattern_size,
+      std::make_move_iterator(new_ops.begin()),
+      std::make_move_iterator(new_ops.end()));
+    // Erase the matched pattern except: the far-away kConvert (index 2),
+    // and (if present) the mask Concat+Reshape.
+    // Erase from mask_add through transpose1 (inclusive).
+    ops.erase(ops.begin() + start_index + mask_add_idx,
+        ops.begin() + start_index + transpose1_idx + 1);
+    // Erase from q_kcache_matmul through qk_concat (inclusive),
+    // which also covers the optional QK Quantize between them.
+    ops.erase(ops.begin() + start_index + kQKCacheMatmulIdx,
+         ops.begin() + start_index + qk_concat_idx + 1);
+    // Erase Reshape0 and Transpose0.
+    ops.erase(ops.begin() + start_index + kReshape0Idx);
+    ops.erase(ops.begin() + start_index + kTranspose0Idx);
+
+    QNN_LOG_INFO("[G2G] GQA optimization on Gemma4B Prefill done.");
+    return new_ops.size();
+  }
+  QNN_LOG_WARNING("[G2G] GQA Gemma4B Prefill skipped: "
+                  "Op validation failed.")
+  return 1;
+}
+
 size_t OptimizeMHAFastVlmPrefill(
     std::function<bool(OpWrapper&)> validate_op_config,
     std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.cc
@@ -739,42 +739,42 @@ size_t OptimizeGQAGemma4BPrefill(
   // Step 1: detect optional KSliceAttnUpdateConvert (between the two QK matmuls).
   const bool has_k_slice_attn_update_convert =
     ops[start_index + 4].IsOpCode(QnnOpCode::kConvert);
-  const size_t kKSliceAttnUpdateConvertIdx = 4;  // valid only if has_k_slice_attn_update_convert
-  const size_t kQKSliceMatmulIdx = has_k_slice_attn_update_convert ? 5 : 4;
-  const size_t kQKConcatIdx = has_k_slice_attn_update_convert ? 6 : 5;
+  const size_t k_slice_attn_update_convert_idx = 4;  // valid only if has_k_slice_attn_update_convert
+  const size_t qk_slice_matmul_idx = has_k_slice_attn_update_convert ? 5 : 4;
+  const size_t qk_concat_idx = has_k_slice_attn_update_convert ? 6 : 5;
 
   // Step 2: detect local/global mask (Concat+Reshape immediately after QK Concat).
-  const size_t kAfterQKConcat = kQKConcatIdx + 1;
+  const size_t after_qk_concat = qk_concat_idx + 1;
   const bool has_mask =
-    ops[start_index + kAfterQKConcat].IsOpCode(QnnOpCode::kConcat) &&
-    ops[start_index + kAfterQKConcat + 1].IsOpCode(QnnOpCode::kReshape);
+    ops[start_index + after_qk_concat].IsOpCode(QnnOpCode::kConcat) &&
+    ops[start_index + after_qk_concat + 1].IsOpCode(QnnOpCode::kReshape);
   const size_t offset_mask = has_mask ? 2 : 0;
 
   // Step 3: remaining indices after the optional mask.
-  const size_t kMaskAddIdx = kAfterQKConcat + offset_mask;
-  const size_t kSoftmaxIdx = kMaskAddIdx + 1;
-  const size_t kQKVCacheSliceIdx = kSoftmaxIdx + 1;
-  const size_t kQKVSliceSliceIdx = kQKVCacheSliceIdx + 1;
-  const size_t kQKVCacheMatmulIdx = kQKVSliceSliceIdx + 1;
+  const size_t mask_add_idx = after_qk_concat + offset_mask;
+  const size_t softmax_idx = mask_add_idx + 1;
+  const size_t qkv_cache_slice_idx = softmax_idx + 1;
+  const size_t qkv_slice_slice_idx = qkv_cache_slice_idx + 1;
+  const size_t qkv_cache_matmul_idx = qkv_slice_slice_idx + 1;
 
   // Step 4: detect optional VSliceAttnUpdateConvert (between the two QKV matmuls).
   const bool has_v_slice_attn_update_convert =
-    ops[start_index + kQKVCacheMatmulIdx + 1].IsOpCode(QnnOpCode::kConvert);
-  const size_t kVSliceAttnUpdateConvertIdx = kQKVCacheMatmulIdx + 1;  // valid only if has_v_slice_attn_update_convert
-  const size_t kQKVSliceMatmulIdx = kQKVCacheMatmulIdx + (has_v_slice_attn_update_convert ? 2 : 1);
+    ops[start_index + qkv_cache_matmul_idx + 1].IsOpCode(QnnOpCode::kConvert);
+  const size_t v_slice_attn_update_convert_idx = qkv_cache_matmul_idx + 1;  // valid only if has_v_slice_attn_update_convert
+  const size_t qkv_slice_matmul_idx = qkv_cache_matmul_idx + (has_v_slice_attn_update_convert ? 2 : 1);
 
   // Step 5: final indices.
-  const size_t kQKVAddIdx = kQKVSliceMatmulIdx + 1;
-  const size_t kConvertOutIdx = kQKVAddIdx + 1;  // output Convert (always present)
-  const size_t kReshape1Idx = kConvertOutIdx + 1;
-  const size_t kTranspose1Idx = kReshape1Idx + 1;
+  const size_t qkv_add_idx = qkv_slice_matmul_idx + 1;
+  const size_t convert_out_idx = qkv_add_idx + 1;  // output Convert (always present)
+  const size_t reshape1_idx = convert_out_idx + 1;
+  const size_t transpose1_idx = reshape1_idx + 1;
 
   QNN_LOG_INFO("[G2G] GQA optimization on Gemma4B Prefill");
 
   const OpWrapper* k_slice_attn_update_convert_op =
-    has_k_slice_attn_update_convert ? &ops[start_index + kKSliceAttnUpdateConvertIdx] : nullptr;
+    has_k_slice_attn_update_convert ? &ops[start_index + k_slice_attn_update_convert_idx] : nullptr;
   const OpWrapper* v_slice_attn_update_convert_op =
-    has_v_slice_attn_update_convert ? &ops[start_index + kVSliceAttnUpdateConvertIdx] : nullptr;
+    has_v_slice_attn_update_convert ? &ops[start_index + v_slice_attn_update_convert_idx] : nullptr;
 
   // Validate both Transpose permutations are [0,2,1,3].
   const auto validate_perm_0213 = [](const OpWrapper& transpose) -> bool {
@@ -785,7 +785,7 @@ size_t OptimizeGQAGemma4BPrefill(
       (*perm_data)[2] == 1 && (*perm_data)[3] == 3;
   };
   if (!validate_perm_0213(ops[start_index + kTranspose0Idx]) ||
-    !validate_perm_0213(ops[start_index + kTranspose1Idx])) {
+    !validate_perm_0213(ops[start_index + transpose1_idx])) {
     return 1;
   }
 
@@ -800,49 +800,49 @@ size_t OptimizeGQAGemma4BPrefill(
   // q_kcache_matmul -> (optional k_slice_attn_update_convert ->) qk_concat(0)
   const bool convert_to_kslice_matmul = !has_k_slice_attn_update_convert ||
     is_connected(*k_slice_attn_update_convert_op, 0,
-           ops[start_index + kQKSliceMatmulIdx], 1);
+           ops[start_index + qk_slice_matmul_idx], 1);
 
   // qkv_cache_matmul -> (optional v_slice_attn_update_convert ->) qkv_add(0)
   const bool convert_to_vslice_matmul = !has_v_slice_attn_update_convert ||
     is_connected(*v_slice_attn_update_convert_op, 0,
-          ops[start_index + kQKVSliceMatmulIdx], 1);
+          ops[start_index + qkv_slice_matmul_idx], 1);
 
   if (!(is_connected(ops[start_index + kTranspose0Idx], 0,
                      ops[start_index + kReshape0Idx], 0) &&
     is_connected(ops[start_index + kReshape0Idx], 0,
                      ops[start_index + kQKCacheMatmulIdx], 0) &&
     is_connected(ops[start_index + kReshape0Idx], 0,
-                     ops[start_index + kQKSliceMatmulIdx], 0) &&
+                     ops[start_index + qk_slice_matmul_idx], 0) &&
     convert_to_kslice_matmul &&
     is_connected(ops[start_index + kQKCacheMatmulIdx], 0,
-                     ops[start_index + kQKConcatIdx], 0) &&
-    is_connected(ops[start_index + kQKSliceMatmulIdx], 0,
-                     ops[start_index + kQKConcatIdx], 1) &&
-    is_connected(ops[start_index + kQKConcatIdx], 0,
-                     ops[start_index + kMaskAddIdx], 0) &&
-    is_connected(ops[start_index + kMaskAddIdx], 0,
-                     ops[start_index + kSoftmaxIdx], 0) &&
-    is_connected(ops[start_index + kSoftmaxIdx], 0,
-                     ops[start_index + kQKVCacheSliceIdx], 0) &&
-    is_connected(ops[start_index + kSoftmaxIdx], 0,
-                     ops[start_index + kQKVSliceSliceIdx], 0) &&
-    is_connected(ops[start_index + kQKVCacheSliceIdx], 0,
-                     ops[start_index + kQKVCacheMatmulIdx], 0) &&
-    is_connected(ops[start_index + kQKVSliceSliceIdx], 0,
-                     ops[start_index + kQKVSliceMatmulIdx], 0) &&
+                     ops[start_index + qk_concat_idx], 0) &&
+    is_connected(ops[start_index + qk_slice_matmul_idx], 0,
+                     ops[start_index + qk_concat_idx], 1) &&
+    is_connected(ops[start_index + qk_concat_idx], 0,
+                     ops[start_index + mask_add_idx], 0) &&
+    is_connected(ops[start_index + mask_add_idx], 0,
+                     ops[start_index + softmax_idx], 0) &&
+    is_connected(ops[start_index + softmax_idx], 0,
+                     ops[start_index + qkv_cache_slice_idx], 0) &&
+    is_connected(ops[start_index + softmax_idx], 0,
+                     ops[start_index + qkv_slice_slice_idx], 0) &&
+    is_connected(ops[start_index + qkv_cache_slice_idx], 0,
+                     ops[start_index + qkv_cache_matmul_idx], 0) &&
+    is_connected(ops[start_index + qkv_slice_slice_idx], 0,
+                     ops[start_index + qkv_slice_matmul_idx], 0) &&
     convert_to_vslice_matmul &&
-    is_connected(ops[start_index + kQKVCacheMatmulIdx], 0,
-                     ops[start_index + kQKVAddIdx], 0) &&
-    is_connected(ops[start_index + kQKVSliceMatmulIdx], 0,
-                     ops[start_index + kQKVAddIdx], 1) &&
-    is_connected(ops[start_index + kQKVAddIdx], 0,
-                     ops[start_index + kConvertOutIdx], 0) &&
-    is_connected(ops[start_index + kConvertOutIdx], 0,
-                     ops[start_index + kReshape1Idx], 0) &&
-    is_connected(ops[start_index + kReshape1Idx], 0,
-                     ops[start_index + kTranspose1Idx], 0) &&
-    IsElementWiseAdd(ops[start_index + kMaskAddIdx]) &&
-    IsElementWiseAdd(ops[start_index + kQKVAddIdx]))) {
+    is_connected(ops[start_index + qkv_cache_matmul_idx], 0,
+                     ops[start_index + qkv_add_idx], 0) &&
+    is_connected(ops[start_index + qkv_slice_matmul_idx], 0,
+                     ops[start_index + qkv_add_idx], 1) &&
+    is_connected(ops[start_index + qkv_add_idx], 0,
+                     ops[start_index + convert_out_idx], 0) &&
+    is_connected(ops[start_index + convert_out_idx], 0,
+                     ops[start_index + reshape1_idx], 0) &&
+    is_connected(ops[start_index + reshape1_idx], 0,
+                     ops[start_index + transpose1_idx], 0) &&
+    IsElementWiseAdd(ops[start_index + mask_add_idx]) &&
+    IsElementWiseAdd(ops[start_index + qkv_add_idx]))) {
     return 1;
   }
 
@@ -873,19 +873,19 @@ size_t OptimizeGQAGemma4BPrefill(
   // input instead, which is the actual static KV weight tensor.
   auto k_slice_unpack_outputs = UnpackTensor(
     tensor_pool, new_ops,
-    has_k_slice_attn_update_convert? k_slice_attn_update_convert_op->GetInputTensor(0): ops[start_index + kQKSliceMatmulIdx].GetInputTensor(1),
+    has_k_slice_attn_update_convert? k_slice_attn_update_convert_op->GetInputTensor(0): ops[start_index + qk_slice_matmul_idx].GetInputTensor(1),
     kKVUnpackAxis);
   auto v_cache_unpack_outputs = UnpackTensor(
-    tensor_pool, new_ops, ops[start_index + kQKVCacheMatmulIdx].GetInputTensor(1), kKVUnpackAxis);
+    tensor_pool, new_ops, ops[start_index + qkv_cache_matmul_idx].GetInputTensor(1), kKVUnpackAxis);
   auto v_slice_unpack_outputs = UnpackTensor(
     tensor_pool, new_ops,
-    has_v_slice_attn_update_convert? v_slice_attn_update_convert_op->GetInputTensor(0) : ops[start_index + kQKVSliceMatmulIdx].GetInputTensor(1),
+    has_v_slice_attn_update_convert? v_slice_attn_update_convert_op->GetInputTensor(0) : ops[start_index + qkv_slice_matmul_idx].GetInputTensor(1),
     kKVUnpackAxis);
 
   // Reshape mask from (1,1,512,2688) -> (1,num_attn_per_kv_heads,128,2688)
   // so that unpacking on axis=1 gives one (1,128,2688) mask per query head.
   const auto& mask_orig =
-    ops[start_index + kMaskAddIdx].GetInputTensor(1);
+    ops[start_index + mask_add_idx].GetInputTensor(1);
   auto mask_reshaped_dims = mask_orig.GetDimensions();
   mask_reshaped_dims[1] = static_cast<std::uint32_t>(num_attn_per_kv_heads);
   mask_reshaped_dims[2] /= static_cast<std::uint32_t>(num_attn_per_kv_heads);
@@ -908,16 +908,16 @@ size_t OptimizeGQAGemma4BPrefill(
         v_cache_unpack_outputs[i], v_slice_unpack_outputs[i],
         mask_unpack_outputs[j],
         ops[start_index + kQKCacheMatmulIdx], k_slice_attn_update_convert_op,
-        ops[start_index + kQKSliceMatmulIdx],
-        ops[start_index + kQKConcatIdx],
-        ops[start_index + kMaskAddIdx],
-        ops[start_index + kSoftmaxIdx],
-        ops[start_index + kQKVCacheSliceIdx],
-        ops[start_index + kQKVSliceSliceIdx],
-        ops[start_index + kQKVCacheMatmulIdx], v_slice_attn_update_convert_op,
-        ops[start_index + kQKVSliceMatmulIdx],
-        ops[start_index + kQKVAddIdx],
-        ops[start_index + kConvertOutIdx]));
+        ops[start_index + qk_slice_matmul_idx],
+        ops[start_index + qk_concat_idx],
+        ops[start_index + mask_add_idx],
+        ops[start_index + softmax_idx],
+        ops[start_index + qkv_cache_slice_idx],
+        ops[start_index + qkv_slice_slice_idx],
+        ops[start_index + qkv_cache_matmul_idx], v_slice_attn_update_convert_op,
+        ops[start_index + qkv_slice_matmul_idx],
+        ops[start_index + qkv_add_idx],
+        ops[start_index + convert_out_idx]));
     }
   }
 
@@ -932,11 +932,11 @@ size_t OptimizeGQAGemma4BPrefill(
   auto concat_dims = sha_outputs[0].get().GetDimensions();  // [B, S, D]
   concat_dims[2] *= static_cast<std::uint32_t>(num_attn_heads);  // [B, S, H*D]
   auto& concat_output = tensor_pool.CloneNativeTensorFrom(
-    ops[start_index + kReshape1Idx].GetOutputTensor(0), concat_dims);
+    ops[start_index + reshape1_idx].GetOutputTensor(0), concat_dims);
   new_ops.emplace_back(CreateConcatenationOp(sha_outputs, concat_output, 2));
   new_ops.emplace_back(CreateReshapeOp(
     concat_output,
-    ops[start_index + kTranspose1Idx].GetOutputTensor(0)));
+    ops[start_index + transpose1_idx].GetOutputTensor(0)));
 
   // Validate new graph.
   const bool is_valid =
@@ -956,12 +956,12 @@ size_t OptimizeGQAGemma4BPrefill(
     // Erase the matched pattern except: the far-away kConvert (index 2),
     // and (if present) the mask Concat+Reshape.
     // Erase from mask_add through transpose1 (inclusive).
-    ops.erase(ops.begin() + start_index + kMaskAddIdx,
-        ops.begin() + start_index + kTranspose1Idx + 1);
+    ops.erase(ops.begin() + start_index + mask_add_idx,
+        ops.begin() + start_index + transpose1_idx + 1);
     // Erase from q_kcache_matmul through qk_concat (inclusive),
     // which also covers the optional QK Quantize between them.
     ops.erase(ops.begin() + start_index + kQKCacheMatmulIdx,
-         ops.begin() + start_index + kQKConcatIdx + 1);
+         ops.begin() + start_index + qk_concat_idx + 1);
     // Erase Reshape0 and Transpose0.
     ops.erase(ops.begin() + start_index + kReshape0Idx);
     ops.erase(ops.begin() + start_index + kTranspose0Idx);

--- a/litert/vendors/qualcomm/core/transformation/mha_to_sha.h
+++ b/litert/vendors/qualcomm/core/transformation/mha_to_sha.h
@@ -37,6 +37,11 @@ size_t OptimizeMHADecode(std::function<bool(OpWrapper&)> validate_op_config,
                          std::vector<OpWrapper>& ops, size_t start_index,
                          TensorPool& tensor_pool, size_t pattern_size);
 
+size_t OptimizeGQAGemma4BPrefill(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size);
+
 size_t OptimizeMHAFastVlmPrefill(
     std::function<bool(OpWrapper&)> validate_op_config,
     std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,


### PR DESCRIPTION
# What
- Add GQA to SHA optimization for **Gemma4-E4B**
- Improve **16%** performance on prefill model

**Before**
```mermaid
graph LR
  Query --> Transpose0["Transpose"]
  Transpose0 --> Reshape0["Reshape"]
  KCache --> MatMul0["MatMul"]
  Reshape0 --> MatMul0["MatMul"]
  Reshape0 --> MatMul1["MatMul"]
  KSlice --> MatMul1["MatMul"]
  MatMul0 --> Concat["Concat"]
  MatMul1 --> Concat["Concat"]
  Concat["Concat"] --> Add0["Add"]
  Mask --> Add0["Add"]
  Add0 --> Softmax["Softmax"]
  Softmax --> Slice0["Slice"]
  Softmax --> Slice1["Slice"]
  Slice0 --> MatMul2["MatMul"]
  VCache --> MatMul2["MatMul"]
  Slice1 --> MatMul3["MatMul"]
  VSlice --> MatMul3["MatMul"]
  MatMul2 --> Add1["Add"]
  MatMul3 --> Add1["Add"]
  Add1 --> Convert["Convert"]
  Convert --> Reshape1["Reshape"]
  Reshape1 --> Transpose1["Transpose"]
  Transpose1 --> Out

  Mask@{shape: text}
  Query@{shape: text}
  KCache@{shape: text}
  KSlice@{shape: text}
  VCache@{shape: text}
  VSlice@{shape: text}
  Out@{ shape: sm-circ}
```
**After**
```mermaid
graph TB
  Query@{shape: text}
  KCache@{shape: text}
  KSlice@{shape: text}
  VCache@{shape: text}
  VSlice@{shape: text}
  Mask@{shape: text}
  Out@{shape: sm-circ}

  Query --> UnpackQ["Unpack(axis=2)"]
  KCache --> UnpackKC["Unpack(axis=1)"]
  KSlice --> UnpackKS["Unpack(axis=1)"]
  VCache --> UnpackVC["Unpack(axis=1)"]
  VSlice --> UnpackVS["Unpack(axis=1)"]
  Mask --> ReshM["Reshape"]
  ReshM --> UnpackM["Unpack(axis=1)"]

  subgraph G0["KV Group 0 (i=0) — 4 SHA"]
    subgraph S0["SHA 0: Q[0], M[0]"]
      s0m1["Q·KC"] & s0m2["Q·KS"] --> s0cc["Concat"] --> s0ad["Add"] --> s0sf["Softmax"]
      s0sf --> s0s0["Slice"] --> s0m3["QK·VC"] --> s0a2["Add"] --> s0cv["Convert"]
      s0sf --> s0s1["Slice"] --> s0m4["QK·VS"] --> s0a2
    end
    subgraph S1["SHA 1: Q[1], M[1]"]
      s1m1["Q·KC"] & s1m2["Q·KS"] --> s1cc["Concat"] --> s1ad["Add"] --> s1sf["Softmax"]
      s1sf --> s1s0["Slice"] --> s1m3["QK·VC"] --> s1a2["Add"] --> s1cv["Convert"]
      s1sf --> s1s1["Slice"] --> s1m4["QK·VS"] --> s1a2
    end
    dotsG0["... (SHA 2, 3)"]
  end

  subgraph G1["KV Group 1 (i=1) — 4 SHA"]
    subgraph S2["SHA 4: Q[4], M[0]"]
      s2m1["Q·KC"] & s2m2["Q·KS"] --> s2cc["Concat"] --> s2ad["Add"] --> s2sf["Softmax"]
      s2sf --> s2s0["Slice"] --> s2m3["QK·VC"] --> s2a2["Add"] --> s2cv["Convert"]
      s2sf --> s2s1["Slice"] --> s2m4["QK·VS"] --> s2a2
    end
    dotsG1["... (SHA 5, 6, 7)"]
  end

  %% Q fan-out
  UnpackQ -- "Q[0]" --> s0m1 & s0m2
  UnpackQ -- "Q[1]" --> s1m1 & s1m2
  UnpackQ -- "Q[4]" --> s2m1 & s2m2

  %% KC/KS shared within KV group
  UnpackKC -- "KC[0]" --> s0m1 & s1m1
  UnpackKC -- "KC[1]" --> s2m1

  UnpackKS -- "KS[0]" --> s0m2 & s1m2
  UnpackKS -- "KS[1]" --> s2m2

  %% VC/VS shared within KV group
  UnpackVC -- "VC[0]" --> s0m3 & s1m3
  UnpackVC -- "VC[1]" --> s2m3

  UnpackVS -- "VS[0]" --> s0m4 & s1m4
  UnpackVS -- "VS[1]" --> s2m4

  %% Mask shared by j index
  UnpackM -- "M[0]" --> s0ad & s2ad
  UnpackM -- "M[1]" --> s1ad

  %% Gather outputs
  s0cv & s1cv & s2cv --> dotsCat["..."] --> FConcat["Concat(axis=2)"]
  FConcat --> FReshape["Reshape"]
  FReshape --> Out
```

# Verification
- [x] Developer Verified

# Test
- Passed x86 unit test.
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test       PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test        PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test      PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test               PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test                 PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test                  PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 23.2s
```
- Passed android unit test. (HTP)
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (18 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 21 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 33 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (3 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 22 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 10 tests from 4 test suites ran. (24 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (378 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (301 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (399 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (994 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1010 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (753 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1408 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 14 tests from 3 test suites ran. (496 ms total)
[  PASSED  ] 14 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1661 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (27 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (8 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (493 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (419 ms total)
[  PASSED  ] 2 tests.
```