### PR TITLE
Qualcomm AI Engine Direct - Add option to specify kDispatchLibraryDir in unit test.

### DIFF
--- a/litert/vendors/qualcomm/core/utils/test_main.cc
+++ b/litert/vendors/qualcomm/core/utils/test_main.cc
@@ -17,6 +17,7 @@ namespace {
 // Simple argument parser for --backend flag.
 bool ParseArgs(int argc, char** argv) {
   constexpr absl::string_view kBackendFlag = "--backend=";
+  constexpr absl::string_view kDispatchLibraryDirFlag = "--dispatch_library_dir=";
   constexpr absl::string_view kHelpFlag = "--help";
   constexpr absl::string_view kShortHelpFlag = "-h";
 
@@ -35,12 +36,18 @@ bool ParseArgs(int argc, char** argv) {
         std::cerr << "Unknown backend: " << backend_str << std::endl;
         return false;
       }
+    } else if (absl::StartsWith(arg, kDispatchLibraryDirFlag)) {
+      qnn::SetTestDispatchLibraryDir(
+          std::string(arg.substr(kDispatchLibraryDirFlag.size())));
     } else if (arg == kHelpFlag || arg == kShortHelpFlag) {
       std::cout << "Test specific options:\n"
                 << "  " << kBackendFlag << "[BACKEND_NAME]\n"
                 << "      Specify the backend to run tests against. Supported "
                    "backends: htp, dsp.\n"
                 << "      Default is htp.\n"
+                << "  " << kDispatchLibraryDirFlag << "[PATH]\n"
+                << "      Specify the dispatch library directory.\n"
+                << "      Default is /data/local/tmp.\n"
                 << std::endl;
       exit(0);
     }

--- a/litert/vendors/qualcomm/core/utils/test_utils.cc
+++ b/litert/vendors/qualcomm/core/utils/test_utils.cc
@@ -25,4 +25,19 @@ void SetTestBackend(BackendType backend_type) {
   GetTestBackend() = backend_type;
 }
 
+namespace {
+std::string& GetTestDispatchLibraryDirMutable() {
+  static std::string dir = "/data/local/tmp";
+  return dir;
+}
+}  // namespace
+
+const std::string& GetTestDispatchLibraryDir() {
+  return GetTestDispatchLibraryDirMutable();
+}
+
+void SetTestDispatchLibraryDir(const std::string& dir) {
+  GetTestDispatchLibraryDirMutable() = dir;
+}
+
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/utils/test_utils.h
+++ b/litert/vendors/qualcomm/core/utils/test_utils.h
@@ -4,6 +4,8 @@
 #ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_UTILS_TEST_UTILS_H_
 #define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_UTILS_TEST_UTILS_H_
 
+#include <string>
+
 #include "litert/vendors/qualcomm/core/common.h"
 
 namespace qnn {
@@ -20,6 +22,10 @@ bool IsTestGpuBackend();
 // Sets the target backend for testing.
 // This should be called by the test main.
 void SetTestBackend(BackendType backend_type);
+
+// Gets/sets the dispatch library directory for testing.
+const std::string& GetTestDispatchLibraryDir();
+void SetTestDispatchLibraryDir(const std::string& dir);
 
 }  // namespace qnn
 

--- a/litert/vendors/qualcomm/dispatch/dispatch_api_qualcomm_test.cc
+++ b/litert/vendors/qualcomm/dispatch/dispatch_api_qualcomm_test.cc
@@ -52,13 +52,11 @@ using ::litert::Options;
 using ::testing::Pointwise;
 static constexpr const float kTol = 5e-2;
 
-constexpr absl::string_view kDispatchLibraryDir = "/data/local/tmp";
-
 litert::Expected<Environment> CreateDefaultEnvironment() {
   const std::vector<litert::EnvironmentOptions::Option> environment_options = {
       litert::EnvironmentOptions::Option{
           litert::EnvironmentOptions::Tag::kDispatchLibraryDir,
-          kDispatchLibraryDir,
+          qnn::GetTestDispatchLibraryDir(),
       },
   };
   return litert::Environment::Create(


### PR DESCRIPTION
### Problem
- `dispatch_api_qualcomm_test` hardcoded `/data/local/tmp` as the dispatch library search directory.
- When multiple `libLiteRtDispatch_*.so` files exist under `/data/local/tmp` (e.g. from different users' test runs), `FindLiteRtDispatchSharedLibs` picks one non-deterministically, potentially loading the wrong library and causing spurious test failures.

### Solution
- Add `GetTestDispatchLibraryDir()` / `SetTestDispatchLibraryDir()` to test_utils.h/cc to hold the dispatch library directory for tests, defaulting `to /data/local/tmp`
- Add `--dispatch_library_dir=<path>` CLI flag in **test_main.cc** so callers can specify the exact directory
- Replace the hardcoded kDispatchLibraryDir in dispatch_api_qualcomm_test.cc with `qnn::GetTestDispatchLibraryDir()`

### Test
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (9 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 21 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 33 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 22 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 10 tests from 4 test suites ran. (20 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (346 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (390 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (393 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (1005 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (1009 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 14 tests from 3 test suites ran. (489 ms total)
[  PASSED  ] 14 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1721 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (20 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (480 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (419 ms total)
[  PASSED  ] 2 tests.
```
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 22.9s

```
