### PR TITLE
Qualcomm AI Engine Direct - Fallback custom op if custom op package is not registered.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -1495,6 +1495,13 @@ LiteRtStatus BuildCustomOp(const litert::compiler::Op& litert_op,
                            std::vector<::qnn::TensorWrapperRef>& output_tensors,
                            std::vector<::qnn::OpWrapper>& op_wrappers,
                            const ::qnn::CustomOpPackage& custom_op_package) {
+  if (custom_op_package.name.empty()) {
+    LITERT_LOG(LITERT_WARNING,
+               "No custom package registered for custom op, won't create QNN "
+               "custom op.");
+    return kLiteRtStatusOk;
+  }
+
   // Use tflite custom code as op type in QNN custom op package.
   auto custom_code = litert_op.CustomCode();
   if (!custom_code.HasValue() || custom_code->empty()) {
@@ -1508,9 +1515,7 @@ LiteRtStatus BuildCustomOp(const litert::compiler::Op& litert_op,
     return kLiteRtStatusErrorInvalidArgument;
   }
 
-  const char* package_name = custom_op_package.name.empty()
-                                 ? QNN_OP_PACKAGE_NAME_QTI_AISW
-                                 : custom_op_package.name.c_str();
+  const char* package_name = custom_op_package.name.c_str();
   auto& custom_op = op_wrappers.emplace_back(
       ::qnn::CreateCustomOp(package_name, custom_code->data(),
                             std::vector<::qnn::ConstTensorWrapperRef>(

--- a/litert/vendors/qualcomm/doc/CUSTOM_OP_INSTRUCTIONS.md
+++ b/litert/vendors/qualcomm/doc/CUSTOM_OP_INSTRUCTIONS.md
@@ -173,8 +173,8 @@ pkg.target = "HTP";
 options.SetCustomOpPackage(pkg);
 ```
 
--   When the package `name` is left empty, the plugin falls back to the built-in
-    `qti.aisw` package.
+-   When the package `name` is left empty, no custom op package is registered,
+    and TFLite custom ops are not offloaded to QNN.
 
 -   The runtime registers the package by calling `backendRegisterOpPackage` with
     the `dispatch_package_path`, `interface_provider`, and `target`.


### PR DESCRIPTION
Summary:
1. `BuildCustomOp` check custom op package before creating QNN custom op.
2. Update doc.

```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 23 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 23 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (11 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 36 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 27 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 27 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (11 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (527 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (437 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (494 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (825 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1227 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (541 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1904 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (34 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (546 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (448 ms total)
[  PASSED  ] 2 tests.
```

```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 31.3s
```