### PR TITLE
converter: add per-pattern filtering and skip control for tfl-optimize

### DIFF
--- a/litert/compiler/mlir/converter_api_core.cc
+++ b/litert/compiler/mlir/converter_api_core.cc
@@ -75,6 +75,8 @@
 #include "tflite/converter/quantization/common/quantization_lib/quantization_config.h"
 #include "tflite/converter/stablehlo/transforms/stablehlo_passes.h"
 #include "tflite/converter/transforms/optimize_pass.h"
+#include "tflite/converter/transforms/optimize_pass_options.h"
+#include "tflite/converter/transforms/pass_registry_utils.h"
 #include "tflite/converter/transforms/passes.h"
 #include "tflite/converter/types.pb.h"
 #include "tensorflow/compiler/mlir/quantization/stablehlo/quantization_config.pb.h"
@@ -242,6 +244,9 @@ GetTFLConverterFlagsAndPassConfig(mlir::ModuleOp module_op,
         converter_flags.unsafe_fuse_dynamic_shaped_broadcast();
     pass_config.unsafe_single_batch_rank_reduction =
         converter_flags.unsafe_single_batch_rank_reduction();
+    pass_config.skip_optimize_pass = config.skip_optimize_pass;
+    pass_config.optimize_disabled_patterns = config.optimize_disabled_patterns;
+    pass_config.optimize_enabled_patterns = config.optimize_enabled_patterns;
 
     pass_config.enable_hlo_to_tf_conversion = true;
 
@@ -298,8 +303,9 @@ void RegisterPasses() {
   mlir::stablehlo::registerOptimizationPasses();
 
   mlir::odml::registerLegalizeStablehloToVhloPass();
-  mlir::PassRegistration<mlir::TFL::OptimizePass>(
-      []() { return mlir::TFL::CreateOptimizePass(); });
+  // Register tfl-optimize with its options so textual pipelines can configure
+  // it, e.g. `tfl-optimize{enabled-patterns=FuseFullyConnectedAndAdd}`.
+  mlir::TFL::Register<mlir::TFL::OptimizePass, mlir::TFL::OptimizePassOptions>();
   mlir::PassRegistration<mlir::OperationPass<mlir::func::FuncOp>>(
       []() { return mlir::TFL::CreatePrepareQuantizePass(); });
   mlir::PassRegistration<mlir::OperationPass<mlir::ModuleOp>>(

--- a/litert/compiler/mlir/converter_api_core.h
+++ b/litert/compiler/mlir/converter_api_core.h
@@ -62,6 +62,21 @@ struct ConvertToTFLConfig {
 
   // If true, enable unsafe single batch rank reduction.
   bool unsafe_single_batch_rank_reduction = false;
+
+  // If true, the `tfl-optimize` pass is not added to the conversion pipeline
+  // (including its post-quantization instances). Individual optimizations can
+  // then be applied selectively by running the registered
+  // `tfl-optimize{enabled-patterns=...}` pass standalone.
+  bool skip_optimize_pass = false;
+
+  // Substring filters over the debug names of the rewrite patterns inside the
+  // `tfl-optimize` pass. A pattern is skipped if its debug name contains any
+  // entry of `optimize_disabled_patterns`. If `optimize_enabled_patterns` is
+  // non-empty, only patterns whose debug name contains one of its entries are
+  // run (allowlist mode). Pattern debug names can be discovered with the
+  // pass's `list-patterns` option.
+  std::vector<std::string> optimize_disabled_patterns;
+  std::vector<std::string> optimize_enabled_patterns;
 };
 
 struct NumpyArrayMeta {

--- a/litert/python/mlir/_mlir_libs/converter_api_ext.cc
+++ b/litert/python/mlir/_mlir_libs/converter_api_ext.cc
@@ -78,7 +78,23 @@ NB_MODULE(converter_api_ext, m) {
 
       .def_rw("unsafe_single_batch_rank_reduction",
             &litert::ConvertToTFLConfig::unsafe_single_batch_rank_reduction,
-            "Allows single batch rank reduction");
+            "Allows single batch rank reduction")
+
+      .def_rw("skip_optimize_pass",
+              &litert::ConvertToTFLConfig::skip_optimize_pass,
+              "If True, do not add the tfl-optimize pass to the conversion "
+              "pipeline at all. Selected optimizations can then be applied "
+              "standalone via tfl-optimize{enabled-patterns=...}")
+
+      .def_rw("optimize_disabled_patterns",
+              &litert::ConvertToTFLConfig::optimize_disabled_patterns,
+              "Skip rewrite patterns inside tfl-optimize whose debug name "
+              "contains any of these substrings")
+
+      .def_rw("optimize_enabled_patterns",
+              &litert::ConvertToTFLConfig::optimize_enabled_patterns,
+              "If non-empty, run only rewrite patterns inside tfl-optimize "
+              "whose debug name contains one of these substrings");
 
   m.def(
       "prepare_mlir_context",

--- a/tflite/converter/common/tfl_pass_config.h
+++ b/tflite/converter/common/tfl_pass_config.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "absl/strings/str_join.h"  // from @com_google_absl
 #include "llvm/ADT/ArrayRef.h"
@@ -115,6 +116,20 @@ struct PassConfig {
 
   // When set to true, enable unsafe single batch rank reduction.
   bool unsafe_single_batch_rank_reduction = false;
+
+  // When set to true, the `tfl-optimize` pass is not added to the pipeline at
+  // all (including the post-quantization instances). The resulting model is
+  // still valid but unoptimized; individual optimizations can then be applied
+  // selectively by running `tfl-optimize{enabled-patterns=...}` standalone.
+  bool skip_optimize_pass = false;
+
+  // Substring filters applied to the debug names of the rewrite patterns
+  // inside the `tfl-optimize` pass. A pattern is skipped if its debug name
+  // contains any entry of `optimize_disabled_patterns`. If
+  // `optimize_enabled_patterns` is non-empty, only patterns whose debug name
+  // contains one of its entries are run (allowlist mode).
+  std::vector<std::string> optimize_disabled_patterns;
+  std::vector<std::string> optimize_enabled_patterns;
 };
 
 inline llvm::raw_ostream& operator<<(llvm::raw_ostream& os,

--- a/tflite/converter/tf_tfl_passes.cc
+++ b/tflite/converter/tf_tfl_passes.cc
@@ -81,16 +81,18 @@ void AddOptimizationPasses(const tflite::ConverterFlags& converter_flags,
   }
 
   // Add TFLite optimize pass.
-  mlir::TFL::OptimizePassOptions optimize_pass_options;
-  optimize_pass_options.enable_strict_qdq_mode =
-      (pass_config.quant_specs.qdq_conversion_mode ==
-       mlir::TFL::QDQConversionMode::kQDQStrict);
-  std::unique_ptr<mlir::Pass> optimize_pass =
-      mlir::TFL::Create<mlir::TFL::OptimizePass>(optimize_pass_options);
-  auto pass_ptr =
-      dynamic_cast<mlir::TFL::MutableOptionsPass*>(optimize_pass.get());
-  if (pass_ptr) pass_ptr->ApplyOptionsVisitor(converter_pass_options_setter);
-  pass_manager->addNestedPass<mlir::func::FuncOp>(std::move(optimize_pass));
+  if (!pass_config.skip_optimize_pass) {
+    mlir::TFL::OptimizePassOptions optimize_pass_options;
+    optimize_pass_options.enable_strict_qdq_mode =
+        (pass_config.quant_specs.qdq_conversion_mode ==
+         mlir::TFL::QDQConversionMode::kQDQStrict);
+    std::unique_ptr<mlir::Pass> optimize_pass =
+        mlir::TFL::Create<mlir::TFL::OptimizePass>(optimize_pass_options);
+    auto pass_ptr =
+        dynamic_cast<mlir::TFL::MutableOptionsPass*>(optimize_pass.get());
+    if (pass_ptr) pass_ptr->ApplyOptionsVisitor(converter_pass_options_setter);
+    pass_manager->addNestedPass<mlir::func::FuncOp>(std::move(optimize_pass));
+  }
 
   if (!pass_config.unfold_batch_matmul) {
     // Enable an optimization pass that transforms BatchMatmul to FC only
@@ -170,8 +172,15 @@ void AddQuantizationPasses(const mlir::TFL::PassConfig& pass_config,
   // Add optimization pass after quantization for additional fusing
   // opportunities.
   // Add TFLite optimize pass.
-  pass_manager.addNestedPass<mlir::func::FuncOp>(
-      mlir::TFL::CreateOptimizePass());
+  if (!pass_config.skip_optimize_pass) {
+    mlir::TFL::OptimizePassOptions optimize_pass_options;
+    optimize_pass_options.disabled_patterns =
+        pass_config.optimize_disabled_patterns;
+    optimize_pass_options.enabled_patterns =
+        pass_config.optimize_enabled_patterns;
+    pass_manager.addNestedPass<mlir::func::FuncOp>(
+        mlir::TFL::Create<mlir::TFL::OptimizePass>(optimize_pass_options));
+  }
 
   if (!pass_config.unfold_batch_matmul) {
     // Enable an optimization pass that transforms BatchMatmul to FC only when
@@ -226,8 +235,15 @@ void AddDynamicRangeQuantizationPasses(const mlir::TFL::PassConfig& pass_config,
   // Add optimization pass after quantization for additional fusing
   // opportunities.
   // Add TFLite optimize pass.
-  pass_manager.addNestedPass<mlir::func::FuncOp>(
-      mlir::TFL::CreateOptimizePass());
+  if (!pass_config.skip_optimize_pass) {
+    mlir::TFL::OptimizePassOptions optimize_pass_options;
+    optimize_pass_options.disabled_patterns =
+        pass_config.optimize_disabled_patterns;
+    optimize_pass_options.enabled_patterns =
+        pass_config.optimize_enabled_patterns;
+    pass_manager.addNestedPass<mlir::func::FuncOp>(
+        mlir::TFL::Create<mlir::TFL::OptimizePass>(optimize_pass_options));
+  }
 
   if (!pass_config.unfold_batch_matmul) {
     // Enable an optimization pass that transforms BatchMatmul to FC only when

--- a/tflite/converter/transforms/converter_pass_options_setter.cc
+++ b/tflite/converter/transforms/converter_pass_options_setter.cc
@@ -27,6 +27,8 @@ void ConverterPassOptionsSetter::SetOptions(
     OptimizePassOptions& options) const {
   options.enable_canonicalization = true;
   options.disable_fuse_mul_and_fc = converter_flags_.disable_fuse_mul_and_fc();
+  options.disabled_patterns = pass_config_.optimize_disabled_patterns;
+  options.enabled_patterns = pass_config_.optimize_enabled_patterns;
 }
 
 void ConverterPassOptionsSetter::SetOptions(

--- a/tflite/converter/transforms/optimize_pass.cc
+++ b/tflite/converter/transforms/optimize_pass.cc
@@ -28,6 +28,7 @@ limitations under the License.
 #include <memory>
 #include <numeric>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -39,6 +40,7 @@ limitations under the License.
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"  // from @llvm-project
 #include "mlir/Dialect/Func/IR/FuncOps.h"  // from @llvm-project
 #include "mlir/Dialect/Quant/IR/QuantTypes.h"  // from @llvm-project
@@ -3292,12 +3294,67 @@ void AddCanonicalizationPatterns(MLIRContext* context,
   for (auto op : context->getRegisteredOperations())
     op.getCanonicalizationPatterns(*patterns, context);
 }
+
+// Returns true if `name` contains any of the substrings in `filters`. Empty
+// filter entries are ignored.
+bool MatchesAnyPatternFilter(llvm::StringRef name,
+                             llvm::ArrayRef<std::string> filters) {
+  for (const std::string& filter : filters) {
+    if (!filter.empty() && name.contains(filter)) return true;
+  }
+  return false;
+}
+
+// Removes rewrite patterns filtered out by `enabled_patterns` (allowlist;
+// no-op when empty) and `disabled_patterns` (blocklist) from `patterns`.
+// Patterns are matched by substring against their debug name (the C++ class
+// name for natively added patterns, the TableGen def name for generated
+// ones). Optionally prints every pattern with its filter verdict.
+void FilterPatterns(RewritePatternSet& patterns,
+                    llvm::ArrayRef<std::string> enabled_patterns,
+                    llvm::ArrayRef<std::string> disabled_patterns,
+                    bool list_patterns, llvm::StringRef phase_name) {
+  auto is_kept = [&](const RewritePattern& pattern) {
+    llvm::StringRef name = pattern.getDebugName();
+    if (!enabled_patterns.empty() &&
+        !MatchesAnyPatternFilter(name, enabled_patterns))
+      return false;
+    return !MatchesAnyPatternFilter(name, disabled_patterns);
+  };
+
+  if (list_patterns) {
+    for (const std::unique_ptr<RewritePattern>& pattern :
+         patterns.getNativePatterns()) {
+      llvm::errs() << "[tfl-optimize] " << phase_name << " "
+                   << (is_kept(*pattern) ? "keep" : "skip") << ": "
+                   << pattern->getDebugName() << "\n";
+    }
+  }
+
+  if (enabled_patterns.empty() && disabled_patterns.empty()) return;
+  llvm::erase_if(patterns.getNativePatterns(),
+                 [&](const std::unique_ptr<RewritePattern>& pattern) {
+                   return !is_kept(*pattern);
+                 });
+}
 }  // namespace
 
 void OptimizePass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   auto* ctx = &getContext();
   auto func = getOperation();
+
+  const llvm::ArrayRef<std::string> enabled_patterns =
+      *GetOptions().enabled_patterns;
+  const llvm::ArrayRef<std::string> disabled_patterns =
+      *GetOptions().disabled_patterns;
+  const bool list_patterns = GetOptions().list_patterns;
+  auto filter_and_apply = [&](RewritePatternSet&& pattern_set,
+                              llvm::StringRef phase_name) {
+    FilterPatterns(pattern_set, enabled_patterns, disabled_patterns,
+                   list_patterns, phase_name);
+    (void)applyPatternsGreedily(func, std::move(pattern_set));
+  };
 
   // Merge reshapes into fully connected ops before we start moving them past
   // binary ops.
@@ -3310,7 +3367,7 @@ void OptimizePass::runOnOperation() {
            FuseReshapesAroundBatchMatMulLHS, FuseReshapesAroundBatchMatMulLHS1,
            FuseInputReshape_BatchMatMulWithFlattenedRhsDims,
            PushTransposeThroughSqueeze>(ctx);
-  (void)applyPatternsGreedily(func, std::move(phase_0_patterns));
+  filter_and_apply(std::move(phase_0_patterns), "phase 0");
 
   // Potentially the binary ops might be fused together, like hard_swish, thus
   // we explore these potentially first and then fuse the binary ops with the
@@ -3329,7 +3386,7 @@ void OptimizePass::runOnOperation() {
   if (GetOptions().enable_canonicalization) {
     AddCanonicalizationPatterns(ctx, &patterns);
   }
-  (void)applyPatternsGreedily(func, std::move(patterns));
+  filter_and_apply(std::move(patterns), "phase 1");
 
   // Fuse the binary ops with the following ops.
   RewritePatternSet phase_2_patterns(&getContext());
@@ -3358,7 +3415,7 @@ void OptimizePass::runOnOperation() {
   if (!GetOptions().enable_strict_qdq_mode) {
     phase_2_patterns.add<EliminateQDQPairs>(ctx);
   }
-  (void)applyPatternsGreedily(func, std::move(phase_2_patterns));
+  filter_and_apply(std::move(phase_2_patterns), "phase 2");
 }
 
 }  // namespace TFL

--- a/tflite/converter/transforms/optimize_pass_options.h
+++ b/tflite/converter/transforms/optimize_pass_options.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef TENSORFLOW_COMPILER_MLIR_LITE_TRANSFORMS_OPTIMIZE_PASS_OPTIONS_H_
 #define TENSORFLOW_COMPILER_MLIR_LITE_TRANSFORMS_OPTIMIZE_PASS_OPTIONS_H_
 
+#include <string>
+
 #include "llvm/Support/CommandLine.h"
 #include "mlir/Pass/PassOptions.h"  // from @llvm-project
 
@@ -38,6 +40,28 @@ struct OptimizePassOptions : public mlir::detail::PassOptions {
   mlir::detail::PassOptions::Option<bool> enable_strict_qdq_mode{
       *this, "enable-strict-qdq-mode",
       llvm::cl::desc("Enable strict QDQ mode in the optimize pass"),
+      llvm::cl::init(false)};
+  // Skips every rewrite pattern whose debug name (usually the C++ class name
+  // of the pattern, or the TableGen def name for generated patterns) contains
+  // any of the given substrings. Applies to all phases of this pass,
+  // including canonicalization patterns when enabled.
+  mlir::detail::PassOptions::ListOption<std::string> disabled_patterns{
+      *this, "disabled-patterns",
+      llvm::cl::desc("Skip rewrite patterns whose debug name contains any of "
+                     "these substrings")};
+  // If non-empty, only rewrite patterns whose debug name contains one of the
+  // given substrings are run (allowlist mode); `disabled-patterns` is still
+  // applied on top. Note this also filters canonicalization patterns.
+  mlir::detail::PassOptions::ListOption<std::string> enabled_patterns{
+      *this, "enabled-patterns",
+      llvm::cl::desc("If non-empty, run only rewrite patterns whose debug "
+                     "name contains one of these substrings")};
+  // Prints the debug name of every pattern considered by this pass (per
+  // phase) to stderr, annotated with whether the filters kept or skipped it.
+  mlir::detail::PassOptions::Option<bool> list_patterns{
+      *this, "list-patterns",
+      llvm::cl::desc("Print the debug names of all rewrite patterns in this "
+                     "pass and whether they are kept by the filters"),
       llvm::cl::init(false)};
 };
 


### PR DESCRIPTION
# Per-pattern filtering and skip control for `tfl-optimize`

## Summary

`tfl-optimize` bundles a large set of rewrite patterns (~40 hand-written C++ patterns, the TableGen-generated set from `optimize_patterns.td`, and — when canonicalization is enabled — every registered op's canonicalizers) that today run all-or-nothing. The only pattern-level control that exists is the single hand-added `disable-fuse-mul-and-fc` option.

This PR adds **generic, name-based pattern filtering** to `tfl-optimize`, plus a pipeline-level switch to omit the pass entirely so a *selected subset* of optimizations can be run standalone:

1. **`disabled-patterns`** (pass option / `PassConfig::optimize_disabled_patterns`) — skip every rewrite pattern whose debug name contains one of the given substrings (blocklist).
2. **`enabled-patterns`** (pass option / `PassConfig::optimize_enabled_patterns`) — if non-empty, run *only* patterns whose debug name contains one of the given substrings (allowlist; the blocklist still applies on top).
3. **`list-patterns`** (pass option) — print every pattern considered by the pass, per phase, with its keep/skip verdict, to stderr. This is the discovery mechanism for pattern names.
4. **`PassConfig::skip_optimize_pass` / `ConvertToTFLConfig::skip_optimize_pass`** — do not add `tfl-optimize` to the conversion pipeline at all (all three sites: the main optimization stage and both post-quantization instances).
5. `tfl-optimize` is now registered together with its options (`TFL::Register<OptimizePass, OptimizePassOptions>()`), so textual pipelines can configure it: `tfl-optimize{enabled-patterns=FuseFullyConnectedAndAdd}`.

Default behavior is **unchanged**: with empty filters the pass builds and applies exactly the same pattern sets as before.

## Motivation

* **Debugging miscompilations**: when a converted model is wrong or slow, the current workflow is all-or-nothing. With this change a specific fusion can be bisected and disabled (`disabled-patterns=FuseBinaryOpToFollowingConv2D`) without giving up the rest of the pass.
* **Controlled/minimal optimization**: running only a vetted subset of patterns (`enabled-patterns=...`), e.g. for hardware backends whose op coverage regresses under certain fusions, or to keep a model structurally close to its source for inspection.
* **Model-specific workarounds** without forking the converter or patching source.

## How it works

MLIR already assigns every rewrite pattern a **debug name** at `RewritePatternSet::add<T>()` time — the C++ class name for native patterns (e.g. `mlir::TFL::(anonymous namespace)::FuseAddAndFullyConnected`) and the generated class name (the TableGen `def` name) for DRR patterns. The filter exploits this: after each of the three phases of `OptimizePass::runOnOperation()` builds its `RewritePatternSet`, a new `FilterPatterns()` step `llvm::erase_if`s patterns whose debug name fails the filters, before `applyPatternsGreedily` is invoked. A skipped pattern is simply absent from the set the greedy driver sees.

Matching is **case-sensitive substring** matching, so users write `FuseAddAndFullyConnected` rather than the full anonymous-namespace-qualified name, and can address whole families at once (`enabled-patterns=FullyConnected` keeps every FC-related pattern; `FuseFullyConnectedAndReluX` covers all three template instantiations).

Filter semantics: `kept = (enabled.empty() || name contains-any enabled) && !(name contains-any disabled)`.

Plumbing follows the existing flag pattern end to end:

```
ConvertToTFLConfig (python binding)
  -> GetTFLConverterFlagsAndPassConfig()        (litert/compiler/mlir/converter_api_core.cc)
  -> mlir::TFL::PassConfig                      (tflite/converter/common/tfl_pass_config.h)
  -> tf_tfl_passes.cc (3 OptimizePass sites) + ConverterPassOptionsSetter
  -> OptimizePassOptions                        (tflite/converter/transforms/optimize_pass_options.h)
  -> FilterPatterns() in OptimizePass           (tflite/converter/transforms/optimize_pass.cc)
```

## Usage

Textual pipeline (mlir-opt style tools, or the MLIR Python `PassManager`):

```
# skip two fusions inside the standard pass
tfl-optimize{disabled-patterns=FuseAddAndFullyConnected,OptimizeTopK}

# run ONLY the reshape cleanup patterns
builtin.module(func.func(tfl-optimize{enabled-patterns=RemoveReshape}))

# discover pattern names
tfl-optimize{list-patterns=true}
#   [tfl-optimize] phase 1 keep: mlir::TFL::(anonymous namespace)::FuseFullyConnectedAndAdd
#   [tfl-optimize] phase 1 skip: mlir::TFL::(anonymous namespace)::OptimizeTopK
```

Python converter bindings:

```python
config = converter_api_ext.ConvertToTFLConfig()
config.optimize_disabled_patterns = ["FuseBinaryOpToFollowingConv2D"]
# or run an unoptimized conversion, then apply selected patterns later:
config.skip_optimize_pass = True
converter_api_ext.run_convert_to_tfl_passes(module, pass_manager, config)
```

## Behavior notes

* **No-op by default** — empty filters change nothing; `skip_optimize_pass` defaults to `false`.
* Filters apply to **all three phases** of the pass and to all three pipeline instances (main + 2 post-quantization).
* In **allowlist mode**, canonicalization patterns are filtered too (they are part of the same pattern sets); the greedy driver's built-in constant folding and dead-op erasure still run regardless, since those are not patterns.
* Unknown filter entries match nothing and are silently ignored — `list-patterns` is the intended way to verify a filter hits what you expect.
* The TAC (`experimental/tac`) use of `CreateOptimizePass()` is intentionally untouched.
* `ConverterPassOptionsSetter::SetOptions(OptimizePassOptions&)` now forwards the two filter lists from `PassConfig`, so any pass instance receiving the visitor picks them up.

## Testing status

* Authored and reviewed on a machine without a Bazel/Linux toolchain; **not yet compiled** — needs a `bazel build` on a supported platform and a pass over any API drift.
* Python-side plumbing has a companion litert-torch PR that exercises the new config fields end to end: google-ai-edge/litert-torch#1113
* Suggested tests (happy to add on request):
  * FileCheck test: module with `add(fully_connected(...))`; `tfl-optimize{disabled-patterns=FuseAddAndFullyConnected}` keeps the ops unfused, default pass fuses them.
  * Allowlist test: `tfl-optimize{enabled-patterns=<one pattern>}` leaves everything else untouched.
  * `skip_optimize_pass=true` pipeline test: converted flatbuffer is valid and contains no fused variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
