### PR TITLE
Qualcomm AI Engine Direct - Support BatchToSpaceNd and SpaceToBatchNd.

### DIFF
--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -308,6 +308,7 @@ litert_lib(
         "//litert/vendors/qualcomm/core/builders:select_op_builder",
         "//litert/vendors/qualcomm/core/builders:slice_op_builder",
         "//litert/vendors/qualcomm/core/builders:softmax_op_builder",
+        "//litert/vendors/qualcomm/core/builders:spatial_transform_nd_op_builder",
         "//litert/vendors/qualcomm/core/builders:spatial_transform_op_builder",
         "//litert/vendors/qualcomm/core/builders:split_op_builder",
         "//litert/vendors/qualcomm/core/builders:splitv_op_builder",

--- a/litert/vendors/qualcomm/compiler/Qualcomm_QNN_Compiler.md
+++ b/litert/vendors/qualcomm/compiler/Qualcomm_QNN_Compiler.md
@@ -47,6 +47,7 @@ provides the corresponding QNN operation it is legalized to.
 | `kLiteRtOpCodeTflArgMin` | Legalized to `QNN_OP_ARGMIN`. |
 | `kLiteRtOpCodeTflAveragePool2d` | Legalized to `QNN_OP_POOL_AVG_2D`. Supports fused activation. |
 | `kLiteRtOpCodeTflBatchMatmul` | Legalized to `QNN_OP_MAT_MUL`. |
+| `kLiteRtOpCodeTflBatchToSpaceNd` | Legalized to `QNN_OP_BATCH_TO_SPACE` with `block_size` and `crops` tensor params derived from the static `block_shape` and `crops` inputs. |
 | `kLiteRtOpCodeTflBroadcastTo` | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (ADD) or `QNN_OP_ELEMENT_WISE_BINARY` (OR) with a static tensor. |
 | `kLiteRtOpCodeTflCast` | Legalized to `QNN_OP_CAST`. |
 | `kLiteRtOpCodeTflCeil` | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (CEIL). |
@@ -117,6 +118,7 @@ provides the corresponding QNN operation it is legalized to.
 | `kLiteRtOpCodeTflSin` | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (SIN). |
 | `kLiteRtOpCodeTflSlice` | Legalized to `QNN_OP_STRIDED_SLICE`. |
 | `kLiteRtOpCodeTflSoftmax` | Legalized to `QNN_OP_SOFTMAX`. |
+| `kLiteRtOpCodeTflSpaceToBatchNd` | Legalized to `QNN_OP_SPACE_TO_BATCH` with `block_size` and `pad_amount` tensor params derived from the static `block_shape` and `paddings` inputs. |
 | `kLiteRtOpCodeTflSpaceToDepth` | Legalized to `QNN_OP_SPACE_TO_DEPTH`. |
 | `kLiteRtOpCodeTflSplit` | Legalized to `QNN_OP_SPLIT`. |
 | `kLiteRtOpCodeTflSplitV` | Legalized to `QNN_OP_SPLIT` with a cumulative `split_index` derived from the static `size_splits` input. |

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -95,6 +95,7 @@
 #include "litert/vendors/qualcomm/core/builders/select_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/slice_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/softmax_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/spatial_transform_nd_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/spatial_transform_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/split_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/splitv_op_builder.h"
@@ -455,6 +456,8 @@ REGISTER_SIMPLE_OP_BUILDER(BuildNegOp, BuildElementwiseNegOp)
 REGISTER_SIMPLE_OP_BUILDER(BuildRoundOp, BuildElementwiseRoundOp)
 REGISTER_SIMPLE_OP_BUILDER(BuildSignOp, BuildElementwiseSignOp)
 REGISTER_SIMPLE_OP_BUILDER(BuildScatterNdOp, BuildScatterNdOp)
+REGISTER_SIMPLE_OP_BUILDER(BuildBatchToSpaceNdOp, BuildBatchToSpaceNdOp)
+REGISTER_SIMPLE_OP_BUILDER(BuildSpaceToBatchNdOp, BuildSpaceToBatchNdOp)
 
 #undef REGISTER_SIMPLE_OP_BUILDER
 
@@ -1409,6 +1412,8 @@ GetOpBuilders() {
   builders[kLiteRtOpCodeTflResizeBilinear] = Adapt<BuildResizeBilinearOp>;
   builders[kLiteRtOpCodeTflSoftmax] = Adapt<BuildSoftmaxOp>;
   builders[kLiteRtOpCodeTflSpaceToDepth] = Adapt<BuildSpaceToDepthOp>;
+  builders[kLiteRtOpCodeTflBatchToSpaceNd] = Adapt<BuildBatchToSpaceNdOp>;
+  builders[kLiteRtOpCodeTflSpaceToBatchNd] = Adapt<BuildSpaceToBatchNdOp>;
   builders[kLiteRtOpCodeTflTanh] = Adapt<BuildTanhOp>;
   builders[kLiteRtOpCodeTflPad] = Adapt<BuildConstantPadOp>;
   builders[kLiteRtOpCodeTflGather] = Adapt<BuildGatherOp>;

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -529,6 +529,21 @@ cc_library(
 )
 
 cc_library(
+    name = "spatial_transform_nd_op_builder",
+    srcs = ["spatial_transform_nd_op_builder.cc"],
+    hdrs = ["spatial_transform_nd_op_builder.h"],
+    deps = [
+        ":op_builder",
+        "//litert/vendors/qualcomm/core:op_code",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/utils:log",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+cc_library(
     name = "spatial_transform_op_builder",
     srcs = ["spatial_transform_op_builder.cc"],
     hdrs = ["spatial_transform_op_builder.h"],

--- a/litert/vendors/qualcomm/core/builders/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/builders/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(qnn_builders
         select_op_builder.cc
         slice_op_builder.cc
         softmax_op_builder.cc
+        spatial_transform_nd_op_builder.cc
         spatial_transform_op_builder.cc
         split_op_builder.cc
         splitv_op_builder.cc

--- a/litert/vendors/qualcomm/core/builders/spatial_transform_nd_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/spatial_transform_nd_op_builder.cc
@@ -1,0 +1,105 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/spatial_transform_nd_op_builder.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/op_code.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "QnnOpDef.h"  // from @qairt
+
+namespace qnn {
+
+namespace {
+constexpr size_t kInputIndex = 0;
+constexpr size_t kBlockShapeIndex = 1;
+constexpr size_t kCropsOrPaddingsIndex = 2;
+constexpr size_t kOutputIndex = 0;
+
+bool ConvertBlockAndSpatialParams(TensorPool& tensor_pool,
+                                  const std::vector<TensorWrapperRef>& inputs,
+                                  TensorWrapper*& block_param,
+                                  TensorWrapper*& spatial_param) {
+  if (inputs.size() <= kCropsOrPaddingsIndex) {
+    QNN_LOG_ERROR("Invalid number of inputs for BatchToSpaceNd/SpaceToBatchNd.");
+    return false;
+  }
+  const TensorWrapper& block_shape = inputs[kBlockShapeIndex];
+  const TensorWrapper& spatial = inputs[kCropsOrPaddingsIndex];
+  if (!block_shape.IsTensorStatic() || !spatial.IsTensorStatic()) {
+    QNN_LOG_ERROR("QNN only supports static block_shape and crops/paddings.");
+    return false;
+  }
+  block_param = tensor_pool.ConvertStaticTensorFrom<std::uint32_t>(block_shape);
+  if (block_param == nullptr) {
+    QNN_LOG_ERROR("Failed to convert block_shape to uint32.");
+    return false;
+  }
+  spatial_param = tensor_pool.ConvertStaticTensorFrom<std::uint32_t>(spatial);
+  if (spatial_param == nullptr) {
+    QNN_LOG_ERROR("Failed to convert crops/paddings to uint32.");
+    return false;
+  }
+  return true;
+}
+}  // namespace
+
+std::vector<OpWrapper> BuildBatchToSpaceNdOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  TensorWrapper* block_size = nullptr;
+  TensorWrapper* crops = nullptr;
+  if (!ConvertBlockAndSpatialParams(tensor_pool, inputs, block_size, crops)) {
+    return {};
+  }
+  return MakeVector(CreateBatchToSpaceNdOp(
+      inputs[kInputIndex], outputs[kOutputIndex], *block_size, *crops));
+}
+
+std::vector<OpWrapper> BuildSpaceToBatchNdOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  TensorWrapper* block_size = nullptr;
+  TensorWrapper* pad_amount = nullptr;
+  if (!ConvertBlockAndSpatialParams(tensor_pool, inputs, block_size,
+                                    pad_amount)) {
+    return {};
+  }
+  return MakeVector(CreateSpaceToBatchNdOp(
+      inputs[kInputIndex], outputs[kOutputIndex], *block_size, *pad_amount));
+}
+
+OpWrapper CreateBatchToSpaceNdOp(const TensorWrapper& input,
+                                 const TensorWrapper& output,
+                                 const TensorWrapper& block_size,
+                                 const TensorWrapper& crops) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_BATCH_TO_SPACE), QNN_OP_BATCH_TO_SPACE,
+               QnnOpCode::kBatchToSpace);
+  op.AddInputTensor(input);
+  op.AddOutputTensor(output);
+  op.AddTensorParam(QNN_OP_BATCH_TO_SPACE_PARAM_BLOCK_SIZE, block_size);
+  op.AddTensorParam(QNN_OP_BATCH_TO_SPACE_PARAM_CROPS, crops);
+  return op;
+}
+
+OpWrapper CreateSpaceToBatchNdOp(const TensorWrapper& input,
+                                 const TensorWrapper& output,
+                                 const TensorWrapper& block_size,
+                                 const TensorWrapper& pad_amount) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_SPACE_TO_BATCH), QNN_OP_SPACE_TO_BATCH,
+               QnnOpCode::kSpaceToBatch);
+  op.AddInputTensor(input);
+  op.AddOutputTensor(output);
+  op.AddTensorParam(QNN_OP_SPACE_TO_BATCH_PARAM_BLOCK_SIZE, block_size);
+  op.AddTensorParam(QNN_OP_SPACE_TO_BATCH_PARAM_PAD_AMOUNT, pad_amount);
+  return op;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/spatial_transform_nd_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/spatial_transform_nd_op_builder.h
@@ -1,0 +1,35 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SPATIAL_TRANSFORM_ND_OP_BUILDER_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SPATIAL_TRANSFORM_ND_OP_BUILDER_H_
+
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildBatchToSpaceNdOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+std::vector<OpWrapper> BuildSpaceToBatchNdOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+OpWrapper CreateBatchToSpaceNdOp(const TensorWrapper& input,
+                                 const TensorWrapper& output,
+                                 const TensorWrapper& block_size,
+                                 const TensorWrapper& crops);
+
+OpWrapper CreateSpaceToBatchNdOp(const TensorWrapper& input,
+                                 const TensorWrapper& output,
+                                 const TensorWrapper& block_size,
+                                 const TensorWrapper& pad_amount);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SPATIAL_TRANSFORM_ND_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -300,6 +300,40 @@ litert_test(
 )
 
 litert_test(
+    name = "spatial_transform_nd_test",
+    srcs = [
+        "spatial_transform_nd_test.cc",
+    ],
+    linkopts = select({
+        "//litert:android": [],
+        "//conditions:default": [
+            make_rpaths([
+                "//litert/c:litert_runtime_c_api_so",
+            ]),
+        ],
+    }),
+    linkstatic = True,
+    no_main = True,
+    tags = [
+        "noasan",
+        "nomsan",
+        "nosan",
+        "notsan",
+    ],
+    target_compatible_with = _COMPATIBLE_OS,
+    ungrte = True,
+    use_sys_malloc = True,
+    deps = [
+        "//litert/vendors/qualcomm/core:op_code",
+        "//litert/vendors/qualcomm/core/builders:spatial_transform_nd_op_builder",
+        "//litert/vendors/qualcomm/core/utils:test_main",
+        "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "@qairt//:qnn_lib_headers",
+    ] + _QNN_DEPS,
+)
+
+litert_test(
     name = "fully_connected_int2_test",
     srcs = [
         "fully_connected_int2_test.cc",

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/spatial_transform_nd_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/spatial_transform_nd_test.cc
@@ -1,0 +1,118 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "QnnTypes.h"  // from @qairt
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "litert/vendors/qualcomm/core/builders/spatial_transform_nd_op_builder.h"
+#include "litert/vendors/qualcomm/core/op_code.h"
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+
+namespace litert::qnn {
+namespace {
+
+INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
+                         QnnTestPrinter);
+
+TEST_P(QnnModelTest, BatchToSpaceNdUint8) {
+  const std::vector<std::uint32_t> kInputDims{2, 2, 1, 1};
+  const std::vector<std::uint32_t> kOutputDims{1, 2, 2, 1};
+  const std::vector<std::uint32_t> kBlockDims{2};
+  const std::vector<std::uint32_t> kCropsDims{2, 2};
+  constexpr std::array<std::int32_t, 2> kBlockData{1, 2};
+  constexpr std::array<std::int32_t, 4> kCropsData{0, 0, 0, 0};
+  const ::qnn::QuantizeParamsWrapperVariant kQuantParams{
+      std::in_place_type<::qnn::ScaleOffsetQuantizeParamsWrapper>, 1.0f, 0};
+
+  auto& input_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input", QNN_DATATYPE_UFIXED_POINT_8, kQuantParams, kInputDims);
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_UFIXED_POINT_8, kQuantParams, kOutputDims);
+  auto& block_tensor = tensor_pool_.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, kBlockDims,
+      sizeof(std::int32_t) * kBlockData.size(), kBlockData.data());
+  auto& crops_tensor = tensor_pool_.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, kCropsDims,
+      sizeof(std::int32_t) * kCropsData.size(), kCropsData.data());
+
+  auto ops = ::qnn::BuildBatchToSpaceNdOp(
+      tensor_pool_, {input_tensor, block_tensor, crops_tensor},
+      {output_tensor});
+  ASSERT_FALSE(ops.empty());
+  EXPECT_EQ(ops[0].GetOpCode(), ::qnn::QnnOpCode::kBatchToSpace);
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+  qnn_model_.SetInputData<std::uint8_t>(input_idx, {1, 2, 3, 4});
+
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<std::uint8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  EXPECT_THAT(output_data.value(), testing::ElementsAre(1, 3, 2, 4));
+}
+
+TEST_P(QnnModelTest, SpaceToBatchNdUint8) {
+  const std::vector<std::uint32_t> kInputDims{1, 2, 2, 1};
+  const std::vector<std::uint32_t> kOutputDims{2, 2, 1, 1};
+  const std::vector<std::uint32_t> kBlockDims{2};
+  const std::vector<std::uint32_t> kPaddingsDims{2, 2};
+  constexpr std::array<std::int32_t, 2> kBlockData{1, 2};
+  constexpr std::array<std::int32_t, 4> kPaddingsData{0, 0, 0, 0};
+  const ::qnn::QuantizeParamsWrapperVariant kQuantParams{
+      std::in_place_type<::qnn::ScaleOffsetQuantizeParamsWrapper>, 1.0f, 0};
+
+  auto& input_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input", QNN_DATATYPE_UFIXED_POINT_8, kQuantParams, kInputDims);
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_UFIXED_POINT_8, kQuantParams, kOutputDims);
+  auto& block_tensor = tensor_pool_.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, kBlockDims,
+      sizeof(std::int32_t) * kBlockData.size(), kBlockData.data());
+  auto& paddings_tensor = tensor_pool_.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, {}, kPaddingsDims,
+      sizeof(std::int32_t) * kPaddingsData.size(), kPaddingsData.data());
+
+  auto ops = ::qnn::BuildSpaceToBatchNdOp(
+      tensor_pool_, {input_tensor, block_tensor, paddings_tensor},
+      {output_tensor});
+  ASSERT_FALSE(ops.empty());
+  EXPECT_EQ(ops[0].GetOpCode(), ::qnn::QnnOpCode::kSpaceToBatch);
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+  qnn_model_.SetInputData<std::uint8_t>(input_idx, {1, 2, 3, 4});
+
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<std::uint8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  EXPECT_THAT(output_data.value(), testing::ElementsAre(1, 3, 2, 4));
+}
+
+}  // namespace
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/tests/CMakeLists.txt
+++ b/litert/vendors/qualcomm/tests/CMakeLists.txt
@@ -100,6 +100,7 @@ target_sources(builder_test
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/pad_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/relu_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/spatial_transform_test.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/spatial_transform_nd_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/splitv_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/topk_test.cc
 )


### PR DESCRIPTION
## Summary
- Add spatial_transform_nd_op_builder that legalizes TFLite BatchToSpaceNd and SpaceToBatchNd to QNN_OP_BATCH_TO_SPACE / QNN_OP_SPACE_TO_BATCH, deriving the block_size and crops/pad_amount params from the static inputs.
- Add UINT8 builder tests and document the new legalizations in Qualcomm_QNN_Compiler.md.
## Test
- x86
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 25.1s
```
- on device
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 23 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 23 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (16 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 22 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 36 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (3 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 27 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 27 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (13 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (615 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (379 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (465 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (829 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1323 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (739 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1123 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (896 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (564 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2167 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (29 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (778 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (756 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/c/options:litert_qualcomm_options_test
[==========] 23 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 23 tests.

SM8750: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8750: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (7 ms total)
[  PASSED  ] 16 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 36 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8750: //litert/vendors/qualcomm/core:common_test
[==========] 27 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 27 tests.

SM8750: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (24 ms total)
[  PASSED  ] 13 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (318 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (353 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (357 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (871 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1232 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (626 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1197 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (576 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (497 ms total)
[  PASSED  ] 9 tests.

SM8750: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1664 ms total)
[  PASSED  ] 11 tests.

SM8750: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (12 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (408 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (380 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 23 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 23 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (16 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 22 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (7 ms total)
[  PASSED  ] 36 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 27 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 27 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (12 ms total)
[  PASSED  ] 13 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (375 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (379 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (383 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (976 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1467 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (809 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1477 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (691 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (699 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (2231 ms total)
[  PASSED  ] 11 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (22 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (506 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (443 ms total)
[  PASSED  ] 2 tests.
```