### PR TITLE
Qualcomm AI Engine Direct - Fall back to sdk_path_from_env when strip_prefix subdir is absent.

### DIFF
--- a/litert/sdk_util/repo.bzl
+++ b/litert/sdk_util/repo.bzl
@@ -39,8 +39,13 @@ def _prepare_repo_files(ctx):
                 fail("Local path must be absolute.")
 
             if ctx.path(sdk_path_from_env).is_dir:
-                for child in ctx.path(sdk_path_from_env + ctx.attr.strip_prefix).readdir():
-                    ctx.symlink(child, child.basename)
+                sdk_path_with_prefix = sdk_path_from_env + ctx.attr.strip_prefix
+                if ctx.attr.strip_prefix and ctx.path(sdk_path_with_prefix).is_dir:
+                    for child in ctx.path(sdk_path_with_prefix).readdir():
+                        ctx.symlink(child, child.basename)
+                else:
+                    for child in ctx.path(sdk_path_from_env).readdir():
+                        ctx.symlink(child, child.basename)
 
             elif not sdk_path_from_env.endswith(".gz"):  # MTK gives us .gz instead of .tar.gz
                 fail("Local path is not a dir or a tarball")


### PR DESCRIPTION
# What
- Modified `_prepare_repo_files()` in **litert/sdk_util/repo.bzl** to make the `strip_prefix` handling more robust when a local SDK directory is specified via the **local_path_env** environment variable.
    - `LITERT_QAIRT_SDK=qairt/2.46.0.260424/ bazel build //litert/tools:apply_plugin_main`
    - `LITERT_QAIRT_SDK=qairt/2.47.0.260601/ bazel build //litert/tools:apply_plugin_main`
- Previously, the code unconditionally appended `ctx.attr.strip_prefix` to the SDK path before calling `readdir()`. This assumed the SDK directory always contained a subdirectory matching `strip_prefix`, causing a hard failure when the local SDK was structured differently (e.g. the archive was extracted with a different top-level directory name than the one declared in the .bzl rule).
- The new logic first attempts the prefixed path (sdk_path_from_env + strip_prefix). If strip_prefix is non-empty and that path exists as a directory, it symlinks from there as before. Otherwise, it falls back to symlinking directly from **sdk_path_from_env**. If `strip_prefix` is empty the two paths are identical, so the fallback is taken immediately with **no behavioural change**.
                                      
# Motivation                                                                
-   The QAIRT SDK zip archive structure changed between releases: newer releases extract to a `qairt/2.xx.xxxx` instead. When a developer points `LITERT_QAIRT_SDK` at a locally extracted SDK whose top-level directory does not match the declared `strip_prefix`, Bazel would error with Prefix was given, but not found in the archive.
- This fix allows developers to point `LITERT_QAIRT_SDK` directly at a local SDK directory regardless of its internal layout, **without needing to modify the strip_prefix in the .bzl file**.

# Verification
- [x] Developer Verified
- Build succeed with the command:
    - `bazel build //litert/tools:apply_plugin_main`
    - `LITERT_QAIRT_SDK=qairt/2.46.0.260424/ bazel build //litert/tools:apply_plugin_main`
    - `LITERT_QAIRT_SDK=qairt/2.47.0.260601/ bazel build //litert/tools:apply_plugin_main`

# Test
- Passed x86 unit test.
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 22.8s
```

- Passed android unit test. (HTP)
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 22 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 14 tests from 10 test suites ran. (0 ms total)
[  PASSED  ] 14 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (11 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 21 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 33 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 33 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 22 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 9 tests from 4 test suites ran. (19 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (337 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (379 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (378 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (967 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 3 tests from 1 test suite ran. (992 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (731 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1395 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 14 tests from 3 test suites ran. (484 ms total)
[  PASSED  ] 14 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 11 tests from 3 test suites ran. (1645 ms total)
[  PASSED  ] 11 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 2 tests from 1 test suite ran. (22 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 10 tests from 2 test suites ran. (5 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (487 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (399 ms total)
[  PASSED  ] 2 tests.

```