### PR TITLE
Qualcomm AI Engine Direct - Align IR JSON dump format with the converter.

### DIFF
--- a/litert/vendors/qualcomm/core/dump/dump_graph.cc
+++ b/litert/vendors/qualcomm/core/dump/dump_graph.cc
@@ -20,6 +20,65 @@
 namespace qnn {
 
 namespace {
+
+// Returns the bitwidth implied by a QNN data type (8, 16, 32, or 64), or 0 if
+// unknown / not applicable.
+uint32_t GetBitwidthFromDataType(Qnn_DataType_t dt) {
+  switch (dt) {
+    case QNN_DATATYPE_INT_8:
+    case QNN_DATATYPE_UINT_8:
+    case QNN_DATATYPE_BOOL_8:
+    case QNN_DATATYPE_SFIXED_POINT_8:
+    case QNN_DATATYPE_UFIXED_POINT_8:
+      return 8;
+    case QNN_DATATYPE_INT_16:
+    case QNN_DATATYPE_UINT_16:
+    case QNN_DATATYPE_FLOAT_16:
+    case QNN_DATATYPE_SFIXED_POINT_16:
+    case QNN_DATATYPE_UFIXED_POINT_16:
+      return 16;
+    case QNN_DATATYPE_INT_32:
+    case QNN_DATATYPE_UINT_32:
+    case QNN_DATATYPE_FLOAT_32:
+    case QNN_DATATYPE_SFIXED_POINT_32:
+    case QNN_DATATYPE_UFIXED_POINT_32:
+      return 32;
+    case QNN_DATATYPE_INT_64:
+    case QNN_DATATYPE_UINT_64:
+    case QNN_DATATYPE_FLOAT_64:
+      return 64;
+    default:
+      return 0;
+  }
+}
+
+// Returns true for SFIXED_POINT_* and UFIXED_POINT_* data types.
+bool IsFixedPointType(Qnn_DataType_t dt) {
+  switch (dt) {
+    case QNN_DATATYPE_SFIXED_POINT_8:
+    case QNN_DATATYPE_SFIXED_POINT_16:
+    case QNN_DATATYPE_SFIXED_POINT_32:
+    case QNN_DATATYPE_UFIXED_POINT_8:
+    case QNN_DATATYPE_UFIXED_POINT_16:
+    case QNN_DATATYPE_UFIXED_POINT_32:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Returns true for SFIXED_POINT_* (signed fixed-point) data types.
+bool IsSignedFixedPointType(Qnn_DataType_t dt) {
+  switch (dt) {
+    case QNN_DATATYPE_SFIXED_POINT_8:
+    case QNN_DATATYPE_SFIXED_POINT_16:
+    case QNN_DATATYPE_SFIXED_POINT_32:
+      return true;
+    default:
+      return false;
+  }
+}
+
 template <typename T>
 nlohmann::json ReshapeDataRecursive(uint32_t& cur_index, T* data,
                                     uint32_t num_elements,
@@ -60,22 +119,45 @@ nlohmann::json ReshapeData(void* buffer_data, uint32_t buffer_size,
 }  // namespace
 
 nlohmann::json SerializeQuantParamToJson(
-    const Qnn_QuantizeParams_t& quant_params) {
+    const Qnn_QuantizeParams_t& quant_params, Qnn_DataType_t data_type) {
   nlohmann::json qnn_quant_params = {
       {"definition", quant_params.encodingDefinition},
       {"encoding", quant_params.quantizationEncoding}};
   // TODO (jiunkaiy): Support more quant encoding.
   if (quant_params.quantizationEncoding ==
       QNN_QUANTIZATION_ENCODING_SCALE_OFFSET) {
+    const float scale = quant_params.scaleOffsetEncoding.scale;
+    const int32_t offset = quant_params.scaleOffsetEncoding.offset;
+    const uint32_t bw = GetBitwidthFromDataType(data_type);
+    const bool signed_fp = IsSignedFixedPointType(data_type);
+    const int64_t min_q = signed_fp ? -(int64_t(1) << (bw - 1)) : 0;
+    const int64_t max_q =
+        signed_fp ? (int64_t(1) << (bw - 1)) - 1 : (int64_t(1) << bw) - 1;
     qnn_quant_params["scale_offset"] = {
-        {"scale", quant_params.scaleOffsetEncoding.scale},
-        {"offset", quant_params.scaleOffsetEncoding.offset}};
+        {"bitwidth", bw},
+        {"minimum", static_cast<float>(scale * (min_q + offset))},
+        {"maximum", static_cast<float>(scale * (max_q + offset))},
+        {"scale", scale},
+        {"offset", offset},
+        {"is_symmetric", signed_fp && (offset == 0)},
+        {"is_fixed_point", IsFixedPointType(data_type)}};
   } else if (quant_params.quantizationEncoding ==
              QNN_QUANTIZATION_ENCODING_BW_SCALE_OFFSET) {
+    const float scale = quant_params.bwScaleOffsetEncoding.scale;
+    const int32_t offset = quant_params.bwScaleOffsetEncoding.offset;
+    const uint32_t bw = quant_params.bwScaleOffsetEncoding.bitwidth;
+    const bool signed_fp = IsSignedFixedPointType(data_type);
+    const int64_t min_q = signed_fp ? -(int64_t(1) << (bw - 1)) : 0;
+    const int64_t max_q =
+        signed_fp ? (int64_t(1) << (bw - 1)) - 1 : (int64_t(1) << bw) - 1;
     qnn_quant_params["scale_offset"] = {
-        {"bitwidth", quant_params.bwScaleOffsetEncoding.bitwidth},
-        {"scale", quant_params.bwScaleOffsetEncoding.scale},
-        {"offset", quant_params.bwScaleOffsetEncoding.offset}};
+        {"bitwidth", bw},
+        {"minimum", static_cast<float>(scale * (min_q + offset))},
+        {"maximum", static_cast<float>(scale * (max_q + offset))},
+        {"scale", scale},
+        {"offset", offset},
+        {"is_symmetric", signed_fp && (offset == 0)},
+        {"is_fixed_point", IsFixedPointType(data_type)}};
   } else if (quant_params.quantizationEncoding ==
              QNN_QUANTIZATION_ENCODING_AXIS_SCALE_OFFSET) {
     std::vector<nlohmann::json> scale_offsets;
@@ -115,6 +197,7 @@ nlohmann::json SerializeQuantParamToJson(
         "Json dump",
         quant_params.quantizationEncoding);
   }
+  qnn_quant_params["is_overridden"] = true;
   return qnn_quant_params;
 }
 
@@ -124,15 +207,31 @@ nlohmann::json SerializeTensorToJson(const Qnn_TensorV1_t& qnn_tensor) {
   qnn_tensor_json["type"] = qnn_tensor.type;
   qnn_tensor_json["dataFormat"] = qnn_tensor.dataFormat;
   qnn_tensor_json["data_type"] = qnn_tensor.dataType;
-  qnn_tensor_json["dims"] =
-      absl::Span<uint32_t>(qnn_tensor.dimensions, qnn_tensor.rank);
+  // Unquantized (pre-quantization) data type: fixed-point types originated from
+  // float32 in TFLite; all other types map to themselves.
+  qnn_tensor_json["unquantized_data_type"] = static_cast<uint32_t>(
+      IsFixedPointType(qnn_tensor.dataType) ? QNN_DATATYPE_FLOAT_32
+                                            : qnn_tensor.dataType);
+  // Identity permutation: LiteRT uses the same layout as TFLite, so no
+  // axis reordering is needed.
+  nlohmann::json permute = nlohmann::json::array();
+  for (uint32_t i = 0; i < qnn_tensor.rank; ++i) {
+    permute.push_back(i);
+  }
+  qnn_tensor_json["permute_order_to_src"] = permute;
 
   const Qnn_QuantizeParams_t& quant_params = qnn_tensor.quantizeParams;
-  if (quant_params.encodingDefinition != QNN_DEFINITION_DEFINED) {
-    return qnn_tensor_json;
+  if (quant_params.encodingDefinition == QNN_DEFINITION_DEFINED) {
+    qnn_tensor_json["quant_params"] =
+        SerializeQuantParamToJson(quant_params, qnn_tensor.dataType);
   }
-  // Add basic key-value pairs for quant_params.
-  qnn_tensor_json["quant_params"] = SerializeQuantParamToJson(quant_params);
+
+  qnn_tensor_json["dims"] =
+      absl::Span<uint32_t>(qnn_tensor.dimensions, qnn_tensor.rank);
+  qnn_tensor_json["is_dynamic_dims"] = nlohmann::json::array();
+  qnn_tensor_json["is_quantizable"] =
+      (quant_params.encodingDefinition == QNN_DEFINITION_DEFINED);
+  qnn_tensor_json["is_updateable"] = false;
   return qnn_tensor_json;
 }
 
@@ -231,9 +330,16 @@ nlohmann::json SerializeOpToJson(const Qnn_OpConfig_t& op_config) {
     qnn_node_json["output_names"].emplace_back(
         op_config.v1.outputTensors[i].v1.name);
   }
-  // Create macs_per_inferences and op type.
-  qnn_node_json["macs_per_inference"] = "";
+  // Create type, package, and param_map.
+  // LiteRT compile flow does not retrieve "macs_per_inference".
+  qnn_node_json["macs_per_inference"] = "0";
   qnn_node_json["type"] = op_config.v1.typeName;
+  qnn_node_json["package"] = op_config.v1.packageName;
+  nlohmann::json param_map = nlohmann::json::object();
+  for (uint32_t i = 0; i < op_config.v1.numOfParams; ++i) {
+    param_map[op_config.v1.params[i].name] = 1;
+  }
+  qnn_node_json["param_map"] = param_map;
   // Create scalar_params and tensor_params.
   qnn_node_json["scalar_params"] = nlohmann::json::object();
   qnn_node_json["tensor_params"] = nlohmann::json::object();

--- a/litert/vendors/qualcomm/core/dump/dump_graph.h
+++ b/litert/vendors/qualcomm/core/dump/dump_graph.h
@@ -15,7 +15,7 @@
 namespace qnn {
 nlohmann::json SerializeTensorToJson(const Qnn_TensorV1_t& qnn_tensor);
 nlohmann::json SerializeQuantParamToJson(
-    const Qnn_QuantizeParams_t& quant_params);
+    const Qnn_QuantizeParams_t& quant_params, Qnn_DataType_t data_type);
 nlohmann::json SerializeScalarParamToJson(const Qnn_Scalar_t& scalar);
 nlohmann::json SerializeTensorParamToJson(const Qnn_TensorV1_t& qnn_tensor);
 nlohmann::json SerializeOpToJson(const Qnn_OpConfig_t& op_config);

--- a/litert/vendors/qualcomm/core/dump/dump_graph_test.cc
+++ b/litert/vendors/qualcomm/core/dump/dump_graph_test.cc
@@ -54,6 +54,18 @@ TEST(IrJsonDump, SerializeOpToJson) {
   ASSERT_TRUE(qnn_op.contains("tensor_params"));
   ASSERT_TRUE(qnn_op.contains("type"));
   EXPECT_EQ(qnn_op["type"], "MatMul");
+  // package: op package name from op_config.v1.packageName.
+  ASSERT_TRUE(qnn_op.contains("package"));
+  EXPECT_EQ(qnn_op["package"], QNN_OP_PACKAGE_NAME_QTI_AISW);
+  // param_map: all LiteRT params are IR_ATTR_USAGE_CORE (1).
+  ASSERT_TRUE(qnn_op.contains("param_map"));
+  ASSERT_TRUE(qnn_op["param_map"].contains("transpose_in0"));
+  EXPECT_EQ(qnn_op["param_map"]["transpose_in0"], 1);
+  ASSERT_TRUE(qnn_op["param_map"].contains("transpose_in1"));
+  EXPECT_EQ(qnn_op["param_map"]["transpose_in1"], 1);
+  // macs_per_inference: hardcoded "0" placeholder.
+  ASSERT_TRUE(qnn_op.contains("macs_per_inference"));
+  EXPECT_EQ(qnn_op["macs_per_inference"], "0");
 }
 
 TEST(IrJsonDump, SerializeQuantParamToJson) {
@@ -64,14 +76,45 @@ TEST(IrJsonDump, SerializeQuantParamToJson) {
           0.003f, /*scale*/
           0       /*offset*/
       }}};
-  nlohmann::json quant_info = SerializeQuantParamToJson(quant_params);
+  // UFIXED_POINT_8: unsigned 8-bit, min=0, max=255*scale, is_symmetric=false.
+  nlohmann::json quant_info =
+      SerializeQuantParamToJson(quant_params, QNN_DATATYPE_UFIXED_POINT_8);
   ASSERT_TRUE(quant_info.contains("definition"));
   ASSERT_TRUE(quant_info.contains("encoding"));
   ASSERT_TRUE(quant_info.contains("scale_offset"));
-  ASSERT_TRUE(quant_info["scale_offset"].contains("scale"));
-  ASSERT_TRUE(quant_info["scale_offset"].contains("offset"));
-  EXPECT_EQ(quant_info["scale_offset"]["scale"], 0.003f);
-  EXPECT_EQ(quant_info["scale_offset"]["offset"], 0);
+  const auto& so = quant_info["scale_offset"];
+  ASSERT_TRUE(so.contains("scale"));
+  EXPECT_EQ(so["scale"], 0.003f);
+  ASSERT_TRUE(so.contains("offset"));
+  EXPECT_EQ(so["offset"], 0);
+  ASSERT_TRUE(so.contains("bitwidth"));
+  EXPECT_EQ(so["bitwidth"], 8u);
+  ASSERT_TRUE(so.contains("minimum"));
+  EXPECT_FLOAT_EQ(so["minimum"].get<float>(), 0.0f);  // 0.003 * (0 + 0)
+  ASSERT_TRUE(so.contains("maximum"));
+  EXPECT_FLOAT_EQ(so["maximum"].get<float>(),
+                  0.003f * 255);  // 0.003 * (255 + 0)
+  ASSERT_TRUE(so.contains("is_symmetric"));
+  EXPECT_FALSE(so["is_symmetric"].get<bool>());  // unsigned → never symmetric
+  ASSERT_TRUE(so.contains("is_fixed_point"));
+  EXPECT_TRUE(so["is_fixed_point"].get<bool>());
+  // is_overridden: always true since quant params come from TFLite (external).
+  ASSERT_TRUE(quant_info.contains("is_overridden"));
+  EXPECT_TRUE(quant_info["is_overridden"].get<bool>());
+
+  // SFIXED_POINT_8 with offset=0: signed symmetric, min=-128*scale,
+  // max=127*scale.
+  const Qnn_QuantizeParams_t signed_quant_params = {
+      QNN_DEFINITION_DEFINED,
+      QNN_QUANTIZATION_ENCODING_SCALE_OFFSET,
+      {{0.003f, 0}}};
+  nlohmann::json signed_info = SerializeQuantParamToJson(
+      signed_quant_params, QNN_DATATYPE_SFIXED_POINT_8);
+  EXPECT_TRUE(signed_info["scale_offset"]["is_symmetric"].get<bool>());
+  EXPECT_FLOAT_EQ(signed_info["scale_offset"]["minimum"].get<float>(),
+                  0.003f * (-128));
+  EXPECT_FLOAT_EQ(signed_info["scale_offset"]["maximum"].get<float>(),
+                  0.003f * 127);
 }
 
 TEST(IrJsonDump, SerializeScalarParamToJson) {
@@ -108,6 +151,23 @@ TEST(IrJsonDump, SerializeTensorAndParamToJson) {
   EXPECT_EQ(tensor_info["type"], qnn_tensor.type);
   ASSERT_EQ(tensor_info["dims"].size(), dims.size());
   EXPECT_EQ(tensor_info["dims"][0], dims[0]);
+
+  ASSERT_TRUE(tensor_info.contains("unquantized_data_type"));
+  EXPECT_EQ(tensor_info["unquantized_data_type"],
+            static_cast<uint32_t>(QNN_DATATYPE_UINT_32));
+
+  ASSERT_TRUE(tensor_info.contains("permute_order_to_src"));
+  ASSERT_EQ(tensor_info["permute_order_to_src"].size(), 1u);
+  EXPECT_EQ(tensor_info["permute_order_to_src"][0], 0u);
+
+  ASSERT_TRUE(tensor_info.contains("is_dynamic_dims"));
+  EXPECT_TRUE(tensor_info["is_dynamic_dims"].empty());
+
+  ASSERT_TRUE(tensor_info.contains("is_quantizable"));
+  EXPECT_FALSE(tensor_info["is_quantizable"].get<bool>());
+
+  ASSERT_TRUE(tensor_info.contains("is_updateable"));
+  EXPECT_FALSE(tensor_info["is_updateable"].get<bool>());
 
   nlohmann::json data = SerializeTensorParamToJson(qnn_tensor);
   ASSERT_EQ(data.size(), axes.size());
@@ -193,6 +253,29 @@ TEST(IrJsonDump, MatMul) {
     double scale = quant_params["scale_offset"]["scale"].get<double>();
     EXPECT_EQ(std::abs(scale - 1e-3) < 1e-4, true);
     EXPECT_EQ(quant_params["scale_offset"]["offset"], 0);
+    ASSERT_TRUE(quant_params["scale_offset"].contains("bitwidth"));
+    EXPECT_EQ(quant_params["scale_offset"]["bitwidth"], 16u);
+    ASSERT_TRUE(quant_params["scale_offset"].contains("is_symmetric"));
+    EXPECT_TRUE(quant_params["scale_offset"]["is_symmetric"].get<bool>());
+    ASSERT_TRUE(quant_params["scale_offset"].contains("is_fixed_point"));
+    EXPECT_TRUE(quant_params["scale_offset"]["is_fixed_point"].get<bool>());
+    ASSERT_TRUE(quant_params.contains("is_overridden"));
+    EXPECT_TRUE(quant_params["is_overridden"].get<bool>());
+    // Check tensor.
+    ASSERT_TRUE(tensor[op_name].contains("unquantized_data_type"));
+    EXPECT_EQ(tensor[op_name]["unquantized_data_type"],
+              static_cast<uint32_t>(QNN_DATATYPE_FLOAT_32));
+    ASSERT_TRUE(tensor[op_name].contains("permute_order_to_src"));
+    ASSERT_EQ(tensor[op_name]["permute_order_to_src"].size(), 4u);
+    for (uint32_t i = 0; i < 4; ++i) {
+      EXPECT_EQ(tensor[op_name]["permute_order_to_src"][i], i);
+    }
+    ASSERT_TRUE(tensor[op_name].contains("is_dynamic_dims"));
+    EXPECT_TRUE(tensor[op_name]["is_dynamic_dims"].empty());
+    ASSERT_TRUE(tensor[op_name].contains("is_quantizable"));
+    EXPECT_TRUE(tensor[op_name]["is_quantizable"].get<bool>());
+    ASSERT_TRUE(tensor[op_name].contains("is_updateable"));
+    EXPECT_FALSE(tensor[op_name]["is_updateable"].get<bool>());
     // Check type.
     ASSERT_TRUE(tensor[op_name].contains("type"));
     EXPECT_EQ(tensor[op_name]["type"], 3);
@@ -211,6 +294,14 @@ TEST(IrJsonDump, MatMul) {
   EXPECT_EQ(node["output_names"][0], "2_qnn");
   // Check macs_per_inference.
   ASSERT_TRUE(node.contains("macs_per_inference"));
+  EXPECT_EQ(node["macs_per_inference"], "0");
+  // Check package.
+  ASSERT_TRUE(node.contains("package"));
+  EXPECT_EQ(node["package"], QNN_OP_PACKAGE_NAME_QTI_AISW);
+  // Check param_map.
+  ASSERT_TRUE(node.contains("param_map"));
+  EXPECT_EQ(node["param_map"]["transpose_in0"], 1);
+  EXPECT_EQ(node["param_map"]["transpose_in1"], 1);
   // Check scalar_params.
   ASSERT_TRUE(node.contains("scalar_params"));
   ASSERT_TRUE(node["scalar_params"].contains("transpose_in0"));


### PR DESCRIPTION
Summary:
- Add missing node fields: `package`, `param_map`, fix `macs_per_inference` placeholder from `""` to `"0"`.
- Add missing tensor fields: `unquantized_data_type`, `permute_order_to_src`, `is_dynamic_dims`, `is_quantizable`, `is_updateable`.
- Extend `scale_offset` quant_params with `bitwidth`, `minimum`, `maximum`, `is_symmetric`, `is_fixed_point`, and `is_overridden`.
- Update unit tests to cover the new fields.

Test:

x86 test:
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.9s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 31.2s
```

on-device test:
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 25 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 25 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 18 tests from 12 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (19 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 36 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 29 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 29 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (18 ms total)
[  PASSED  ] 13 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (486 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (232 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (447 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1921 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1866 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (1173 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1904 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (35 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (618 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (7083 ms total)
[  PASSED  ] 26 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (39 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (16 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (478 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (513 ms total)
[  PASSED  ] 2 tests.
```