### PR TITLE
Samsung Exynos AI LiteCore  : add samsung backend in init

### DIFF
--- a/litert/python/aot/vendors/__init__.py
+++ b/litert/python/aot/vendors/__init__.py
@@ -19,3 +19,4 @@ from litert.python.aot.vendors.google_tensor import google_tensor_backend as _
 from litert.python.aot.vendors.intel_openvino import intel_openvino_backend as _
 from litert.python.aot.vendors.mediatek import mediatek_backend as _
 from litert.python.aot.vendors.qualcomm import qualcomm_backend as _
+from litert.python.aot.vendors.samsung import samsung_backend as _


### PR DESCRIPTION
Fixed missing samsung_backend in __init__ for python interface

cc : @jl45G 

