### PR TITLE
Qualcomm AI Engine Direct - Register MemHandle to Correct QNN Context.

### DIFF
--- a/litert/vendors/qualcomm/dispatch/dispatch_api.cc
+++ b/litert/vendors/qualcomm/dispatch/dispatch_api.cc
@@ -286,7 +286,6 @@ LiteRtStatus InvocationContextCreate(
     return context.Error().Status();
   }
   *invocation_context = context->release();
-  device_context->SetInvocationContext(*invocation_context);
   return kLiteRtStatusOk;
 }
 

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_device_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_device_context.cc
@@ -53,6 +53,31 @@ LiteRtDispatchDeviceContextT::Create(
       new LiteRtDispatchDeviceContextT(runtime_context, qnn, qnn_backend));
 }
 
+Expected<LiteRtTensorBufferHandle>
+LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
+    LiteRtTensorBuffer tensor_buffer) {
+  return tensor_buffer_registry_.Register(
+      TensorBufferRegistryEntry(tensor_buffer));
+}
+
+Expected<void> LiteRtDispatchDeviceContextT::UnregisterTensorBuffer(
+    LiteRtTensorBufferHandle tensor_buffer_handle) {
+  auto registry_entry = tensor_buffer_registry_.Get(tensor_buffer_handle);
+  if (!registry_entry) {
+    return Unexpected(registry_entry.Error());
+  }
+
+  if (!(*registry_entry)->qnn_mem_handles.empty()) {
+    LITERT_LOG(LITERT_WARNING,
+               "Postponing tensor buffer unregister: %zu active QNN mem "
+               "handles remain.",
+               (*registry_entry)->qnn_mem_handles.size());
+    return {};
+  }
+
+  return tensor_buffer_registry_.Unregister(tensor_buffer_handle);
+}
+
 Expected<LiteRtTensorBuffer> LiteRtDispatchDeviceContextT::GetTensorBuffer(
     LiteRtTensorBufferHandle tensor_buffer_handle) {
   auto registry_entry = tensor_buffer_registry_.Get(tensor_buffer_handle);
@@ -63,28 +88,22 @@ Expected<LiteRtTensorBuffer> LiteRtDispatchDeviceContextT::GetTensorBuffer(
   return (*registry_entry)->tensor_buffer;
 }
 
-Expected<Qnn_MemHandle_t> LiteRtDispatchDeviceContextT::GetMemHandle(
-    LiteRtTensorBufferHandle tensor_buffer_handle, const Qnn_Tensor_t& tensor) {
+Expected<Qnn_MemHandle_t> LiteRtDispatchDeviceContextT::RegisterMemHandle(
+    LiteRtTensorBufferHandle tensor_buffer_handle,
+    Qnn_ContextHandle_t context_handle) {
   auto registry_entry = tensor_buffer_registry_.Get(tensor_buffer_handle);
   if (!registry_entry) {
     return Unexpected(registry_entry.Error());
   }
 
-  if (!(*registry_entry)->qnn_mem_handle) {
-    auto qnn_mem_handle =
-        RegisterTensorBuffer((*registry_entry)->tensor_buffer, tensor);
-    if (!qnn_mem_handle) {
-      return Unexpected(qnn_mem_handle.Error());
-    }
-    (*registry_entry)->qnn_mem_handle = *qnn_mem_handle;
+  auto mem_handle_iter =
+      (*registry_entry)->qnn_mem_handles.find(context_handle);
+  if (mem_handle_iter != (*registry_entry)->qnn_mem_handles.end()) {
+    ++mem_handle_iter->second.ref_count;
+    return mem_handle_iter->second.mem_handle;
   }
 
-  return (*registry_entry)->qnn_mem_handle;
-}
-
-Expected<Qnn_MemHandle_t> LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
-    LiteRtTensorBuffer tensor_buffer, const Qnn_Tensor_t& tensor) {
-  LITERT_LOG(LITERT_DEBUG, "Registering tensor buffer %p", tensor_buffer);
+  auto tensor_buffer = (*registry_entry)->tensor_buffer;
   LiteRtTensorBufferType tensor_buffer_type;
   if (auto status = runtime_context_->get_tensor_buffer_type(
           tensor_buffer, &tensor_buffer_type);
@@ -177,7 +196,6 @@ Expected<Qnn_MemHandle_t> LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
     case ::qnn::BackendType::kDspBackend:
       mem_descriptor.memType = QNN_MEM_TYPE_ION;
       mem_descriptor.ionInfo.fd = buffer_fd;
-
       break;
     case ::qnn::BackendType::kHtpBackend:
       [[fallthrough]];
@@ -202,16 +220,8 @@ Expected<Qnn_MemHandle_t> LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
           QnnHtpMem_SharedBufferConfig_t{buffer_fd, tensor_buffer_offset};
       mem_descriptor.memType = QNN_MEM_TYPE_CUSTOM;
       mem_descriptor.customInfo = &mem_htp_descriptor;
-
       break;
   }
-
-  if (invocation_context_ == nullptr) {
-    return Unexpected(kLiteRtStatusErrorRuntimeFailure,
-                      "Missing invocation context");
-  }
-
-  Qnn_ContextHandle_t context_handle = invocation_context_->GetContextHandle();
 
   Qnn_MemHandle_t mem_handle = nullptr;
   if (auto status = qnn_manager_.Api()->memRegister(
@@ -219,15 +229,19 @@ Expected<Qnn_MemHandle_t> LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
       status != QNN_SUCCESS) {
     return Unexpected(
         kLiteRtStatusErrorRuntimeFailure,
-        absl::StrFormat("Failed to register tensor buffer, QNN error code: %d",
+        absl::StrFormat("Failed to register mem_handle, QNN error code: %d",
                         status));
   }
 
   if (!mem_handle) {
     return Unexpected(kLiteRtStatusErrorRuntimeFailure,
-                      "Failed to register buffer: null mem_handle");
+                      "Failed to register mem_handle: null mem_handle");
   }
 
+  (*registry_entry)
+      ->qnn_mem_handles.emplace(
+          context_handle,
+          TensorBufferRegistryEntry::QnnMemHandleInfo{mem_handle, 1});
   return mem_handle;
 }
 
@@ -260,21 +274,35 @@ LiteRtDispatchDeviceContextT::GetOrCreateContext(
   return *(context_cache_[key]);
 }
 
-litert::Expected<void> LiteRtDispatchDeviceContextT::UnregisterTensorBuffer(
-    LiteRtTensorBufferHandle tensor_buffer_handle, const Qnn_Tensor_t& tensor) {
-  LITERT_ASSIGN_OR_RETURN(auto tensor_buffer,
-                          GetTensorBuffer(tensor_buffer_handle));
-  LITERT_LOG(LITERT_DEBUG, "Unregistering tensor buffer %p", tensor_buffer);
-  LITERT_RETURN_IF_ERROR(
-      tensor_buffer_registry_.Unregister(tensor_buffer_handle));
-  LITERT_ASSIGN_OR_RETURN(auto mem_handle,
-                          GetMemHandle(tensor_buffer_handle, tensor));
-  if (auto status = qnn_manager_.Api()->memDeRegister(&mem_handle, 1UL);
+litert::Expected<void> LiteRtDispatchDeviceContextT::UnregisterMemHandle(
+    LiteRtTensorBufferHandle tensor_buffer_handle,
+    Qnn_ContextHandle_t context_handle) {
+  auto registry_entry = tensor_buffer_registry_.Get(tensor_buffer_handle);
+  if (!registry_entry) {
+    return Unexpected(registry_entry.Error());
+  }
+
+  auto mem_handle_iter =
+      (*registry_entry)->qnn_mem_handles.find(context_handle);
+  if (mem_handle_iter == (*registry_entry)->qnn_mem_handles.end() ||
+      mem_handle_iter->second.mem_handle == nullptr) {
+    return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                      "mem_handle is not initialized in registry.");
+  }
+
+  if (--mem_handle_iter->second.ref_count > 0) {
+    return {};
+  }
+
+  if (auto status = qnn_manager_.Api()->memDeRegister(
+          &mem_handle_iter->second.mem_handle, 1UL);
       status != QNN_SUCCESS) {
     return Unexpected(
         kLiteRtStatusErrorRuntimeFailure,
         absl::StrFormat(
             "Failed to unregister tensor buffer, QNN error code: %d", status));
   }
+
+  (*registry_entry)->qnn_mem_handles.erase(mem_handle_iter);
   return {};
 }

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_device_context.h
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_device_context.h
@@ -16,6 +16,7 @@
 #define ODML_LITERT_LITERT_VENDORS_QUALCOMM_DISPATCH_LITERT_DISPATCH_DEVICE_CONTEXT_H_
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <utility>
 
@@ -41,31 +42,13 @@ class LiteRtDispatchDeviceContextT {
       litert::qnn::QnnManager& qnn_manager, ::qnn::QnnBackend& qnn_backend);
 
   litert::Expected<LiteRtTensorBufferHandle> RegisterTensorBuffer(
-      LiteRtTensorBuffer tensor_buffer) {
-    return tensor_buffer_registry_.Register(
-        TensorBufferRegistryEntry(tensor_buffer));
-  }
+      LiteRtTensorBuffer tensor_buffer);
 
   litert::Expected<void> UnregisterTensorBuffer(
-      LiteRtTensorBufferHandle tensor_buffer_handle) {
-    return tensor_buffer_registry_.Unregister(tensor_buffer_handle);
-  }
-
-  litert::Expected<void> UnregisterTensorBuffer(
-      LiteRtTensorBufferHandle tensor_buffer_handle,
-      const Qnn_Tensor_t& tensor);
+      LiteRtTensorBufferHandle tensor_buffer_handle);
 
   litert::Expected<LiteRtTensorBuffer> GetTensorBuffer(
       LiteRtTensorBufferHandle tensor_buffer_handle);
-
-  litert::Expected<Qnn_MemHandle_t> GetMemHandle(
-      LiteRtTensorBufferHandle tensor_buffer_handle,
-      const Qnn_Tensor_t& tensor);
-
-  void SetInvocationContext(
-      LiteRtDispatchInvocationContextT* invocation_context) {
-    invocation_context_ = invocation_context;
-  }
 
   litert::Expected<const litert::qnn::QnnManager::ContextHandle&>
   GetOrCreateContext(const void* bytecode_ptr, size_t bytecode_size,
@@ -75,12 +58,27 @@ class LiteRtDispatchDeviceContextT {
     return runtime_context_;
   }
 
+  litert::Expected<Qnn_MemHandle_t> RegisterMemHandle(
+      LiteRtTensorBufferHandle tensor_buffer_handle,
+      Qnn_ContextHandle_t context_handle);
+
+  litert::Expected<void> UnregisterMemHandle(
+      LiteRtTensorBufferHandle tensor_buffer_handle,
+      Qnn_ContextHandle_t context_handle);
+
  private:
   struct TensorBufferRegistryEntry {
-    LiteRtTensorBuffer tensor_buffer;
-    Qnn_MemHandle_t qnn_mem_handle = nullptr;
+    struct QnnMemHandleInfo {
+      Qnn_MemHandle_t mem_handle = nullptr;
+      uint32_t ref_count = 0;
+    };
+
+    LiteRtTensorBuffer tensor_buffer = nullptr;
+    absl::flat_hash_map<Qnn_ContextHandle_t, QnnMemHandleInfo> qnn_mem_handles;
+
     explicit TensorBufferRegistryEntry(LiteRtTensorBuffer tensor_buffer_)
         : tensor_buffer(tensor_buffer_) {}
+
     bool operator==(const TensorBufferRegistryEntry& other) const {
       return tensor_buffer == other.tensor_buffer;
     }
@@ -96,14 +94,10 @@ class LiteRtDispatchDeviceContextT {
         qnn_manager_(qnn_manager),
         qnn_backend_(qnn_backend) {}
 
-  litert::Expected<Qnn_MemHandle_t> RegisterTensorBuffer(
-      LiteRtTensorBuffer tensor_buffer, const Qnn_Tensor_t& tensor);
-
   const LiteRtRuntimeContext* runtime_context_;
   litert::qnn::QnnManager& qnn_manager_;
   ::qnn::QnnBackend& qnn_backend_;
   TensorBufferRegistry tensor_buffer_registry_;
-  LiteRtDispatchInvocationContextT* invocation_context_ = nullptr;
 
   struct ContextCacheKey {
     const void* ptr;

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
@@ -448,7 +448,8 @@ Expected<void> LiteRtDispatchInvocationContextT::AttachBuffer(
     return {};
   }
 
-  auto mem_handle = device_context_->GetMemHandle(tensor_buffer_handle, tensor);
+  auto mem_handle = device_context_->RegisterMemHandle(tensor_buffer_handle,
+                                                       GetContextHandle());
   if (!mem_handle) {
     return Unexpected(mem_handle.Error());
   }
@@ -478,10 +479,10 @@ Expected<void> LiteRtDispatchInvocationContextT::DetachBuffer(
                             ? tensor.v1.memType
                             : tensor.v2.memType;
   if (mem_type == QNN_TENSORMEMTYPE_RAW) {
-    return device_context_->UnregisterTensorBuffer(tensor_buffer_handle);
+    return {};
   }
-  LITERT_RETURN_IF_ERROR(
-      device_context_->UnregisterTensorBuffer(tensor_buffer_handle, tensor));
+  LITERT_RETURN_IF_ERROR(device_context_->UnregisterMemHandle(
+      tensor_buffer_handle, GetContextHandle()));
   return {};
 }
 
@@ -520,10 +521,20 @@ Expected<void> LiteRtDispatchInvocationContextT::Execute() {
     *(outputs + i) = outputs_.at(i).GetQnnTensor();
   }
 
-  if (auto status = qnn_manager_.Api()->graphExecute(
-          graph_handle_, inputs, num_ins, outputs, num_outs, profile_handle_,
-          /*signalHandle=*/nullptr);
+  const auto* qnn_api = qnn_manager_.Api();
+  if (auto status = qnn_api->graphExecute(graph_handle_, inputs, num_ins,
+                                          outputs, num_outs, profile_handle_,
+                                          /*signalHandle=*/nullptr);
       status != QNN_SUCCESS) {
+    const char* error_message = nullptr;
+    if (qnn_api->errorGetMessage(status, &error_message) == QNN_SUCCESS &&
+        error_message != nullptr) {
+      LITERT_LOG(LITERT_ERROR, "QNN graphExecute failed with status: %llu, %s",
+                 static_cast<unsigned long long>(status), error_message);
+    } else {
+      LITERT_LOG(LITERT_ERROR, "QNN graphExecute failed with status: %llu",
+                 static_cast<unsigned long long>(status));
+    }
     return Unexpected(kLiteRtStatusErrorRuntimeFailure,
                       "Failed to execute graph");
   }

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h
@@ -89,7 +89,6 @@ class LiteRtDispatchInvocationContextT {
   }
 
   Qnn_ContextHandle_t GetContextHandle() { return raw_context_handle_; }
-  Qnn_ContextHandle_t ContextHandle() { return raw_context_handle_; }
 
  private:
   LiteRtDispatchInvocationContextT(


### PR DESCRIPTION
# Summary:
1. For device context, only register tensor buffer and unregister tensor buffer if there is no mem handle.
2. For invocation context, only register/unregister mem handle during attach/detach tensor buffer.
3. For invocation contexts belong to the same QNN context, increase the reference count of mem handle.
4. For invocation contexts belong to the different QNN context, register new mem handle and use QNN context as key to store in map.


---


# LiteRT Dispatch Buffer Flow With Multiple NPU Partitions

## Objects

```text
DispatchDelegate
  owns one LiteRtDispatchDeviceContext

DispatchDelegateKernel
  owns N LiteRtDispatchInvocationContext objects

LiteRtDispatchDeviceContext
  owns tensor buffer registry:
    LiteRtTensorBufferHandle -> LiteRtTensorBuffer
                             -> QNN mem handles by QNN context

LiteRtDispatchInvocationContext
  owns one QNN graph handle
  owns one QNN context handle
```

## Example Graph

```text
Input A
  |
Partition 0
  |
Tensor X
  |
Partition 1
  |
Tensor Y
  |
Partition 2
  |
Output B
```

## Init Phase

For each NPU partition, LiteRT creates one invocation context.

```text
Create invocation_context_0 for Partition 0
Create invocation_context_1 for Partition 1
Create invocation_context_2 for Partition 2
```

Each invocation context has its own QNN context handle:

```text
invocation_context_0 -> QNN context C0
invocation_context_1 -> QNN context C1
invocation_context_2 -> QNN context C2
```

## Register Tensor Buffers

Before execution, LiteRT creates or finds tensor buffers and registers them with
the device context.

```text
RegisterTensorBuffer(Input A)  -> handle H0
RegisterTensorBuffer(Tensor X) -> handle H1
RegisterTensorBuffer(Tensor Y) -> handle H2
RegisterTensorBuffer(Output B) -> handle H3
```

At this point, this is only LiteRT device-context registration:

```text
device_context registry:
  H0 -> Input A buffer
  H1 -> Tensor X buffer
  H2 -> Tensor Y buffer
  H3 -> Output B buffer
```

No QNN mem handle is necessarily created yet.

## Attach Buffers

Then LiteRT attaches each registered buffer handle to every partition port that
uses it.

```text
AttachInput(partition 0, H0)
AttachOutput(partition 0, H1)

AttachInput(partition 1, H1)
AttachOutput(partition 1, H2)

AttachInput(partition 2, H2)
AttachOutput(partition 2, H3)
```

A tensor between two partitions is attached twice:

```text
Tensor X / H1:
  partition 0 output
  partition 1 input
```

## QNN Mem Handle Registration During Attach

For MEMHANDLE tensors, Qualcomm registers a QNN mem handle during attach.

```text
AttachOutput(partition 0, H1)
  RegisterMemHandle(H1, C0)

AttachInput(partition 1, H1)
  RegisterMemHandle(H1, C1)
```

The device context stores QNN mem handles per QNN context:

```text
H1:
  C0 -> qnn_mem_handle_x0, ref_count = 1
  C1 -> qnn_mem_handle_x1, ref_count = 1
```

If the same handle is attached again to the same QNN context:

```text
RegisterMemHandle(H1, C1)
  existing handle found
  ref_count++
```

## Execute

Partitions execute in order:

```text
Invoke(partition 0)
Invoke(partition 1)
Invoke(partition 2)
```

If one partition fails, execution stops and the error propagates back to
TFLite/LiteRT.

## Detach Buffers

During cleanup, LiteRT detaches per port connection.

```text
DetachInput(partition 0, H0)
DetachOutput(partition 0, H1)

DetachInput(partition 1, H1)
DetachOutput(partition 1, H2)

DetachInput(partition 2, H2)
DetachOutput(partition 2, H3)
```

Detach is per port, so the same handle may appear multiple times.

## QNN Mem Handle Deregistration During Detach

For MEMHANDLE tensors, Qualcomm deregisters by buffer handle and QNN context.

```text
DetachOutput(partition 0, H1)
  UnregisterMemHandle(H1, C0)

DetachInput(partition 1, H1)
  UnregisterMemHandle(H1, C1)
```

Ref count behavior:

```text
UnregisterMemHandle(H1, C1)
  ref_count--
  if ref_count > 0:
    keep QNN mem handle
  else:
    QNN memDeRegister()
    erase C1 entry
```

After all detaches:

```text
H1:
  qnn_mem_handles should be empty
```

## Unregister Tensor Buffers

Finally, LiteRT unregisters the tensor buffer handle from the device context.

```text
UnregisterTensorBuffer(H0)
UnregisterTensorBuffer(H1)
UnregisterTensorBuffer(H2)
UnregisterTensorBuffer(H3)
```

Expected state:

```text
qnn_mem_handles is empty
```

If it is not empty, Qualcomm logs a warning and postpones unregister:

```text
Postponing tensor buffer unregister:
  active QNN mem handles remain
```

## Key Rule

```text
RegisterTensorBuffer / UnregisterTensorBuffer:
  device-context buffer-handle lifetime

AttachBuffer / DetachBuffer:
  invocation-context port lifetime

RegisterMemHandle / UnregisterMemHandle:
  QNN context-specific memory lifetime
```

## Correct Ownership Model

```text
LiteRT buffer handle:
  shared across partitions

QNN mem handle:
  one per QNN context for that LiteRT buffer handle

Ref count:
  one count per (LiteRT buffer handle, QNN context)
```


# TEST
x86
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test       PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test               PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test                 PASSED in 0.9s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test                  PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 31.9s
```
device
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 25 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 25 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 18 tests from 12 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (16 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 22 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 36 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 29 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 29 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (18 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (605 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (501 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (497 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (885 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1548 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (28 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 6 tests from 2 test suites ran. (615 ms total)
[  PASSED  ] 6 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 28 tests from 7 test suites ran. (5708 ms total)
[  PASSED  ] 26 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (36 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (16 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (5 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (952 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (455 ms total)
[  PASSED  ] 2 tests.
```
