### PR TITLE
[OV][Windows] Zero-copy tensor sharing between NPU/GPU.

### DIFF
--- a/litert/vendors/intel_openvino/dispatch/BUILD
+++ b/litert/vendors/intel_openvino/dispatch/BUILD
@@ -25,6 +25,7 @@ package(
 litert_dynamic_lib(
     name = "dispatch_api",
     srcs = [
+        "d3d12_shared_buffer.cc",
         "device_context.cc",
         "dispatch_api.cc",
         "invocation_context.cc",
@@ -32,6 +33,7 @@ litert_dynamic_lib(
         "openvino_tensor_buffer.cc",
     ],
     hdrs = [
+        "d3d12_shared_buffer.h",
         "device_context.h",
         "invocation_context.h",
         "openvino_shared_core.h",
@@ -61,6 +63,13 @@ litert_dynamic_lib(
         "-Wl,-soname=libLiteRtDispatch_IntelOpenvino.so",
     ] + select({
         "//litert:android": ["-Wl,-lc++abi"],
+        "//conditions:default": [],
+    }) + select({
+        # D3D12 is the neutral allocator for the cross-device shared buffer.
+        "//litert:windows": [
+            "d3d12.lib",
+            "dxgi.lib",
+        ],
         "//conditions:default": [],
     }),
     shared_lib_name = "dispatch_api_so",
@@ -106,6 +115,7 @@ litert_dynamic_lib(
 litert_bin(
     name = "LiteRtDispatch",
     srcs = [
+        "d3d12_shared_buffer.cc",
         "device_context.cc",
         "dispatch_api.cc",
         "invocation_context.cc",
@@ -124,7 +134,14 @@ litert_bin(
         "//conditions:default": [],
     }),
     features = ["-use_header_modules"],  # Incompatible with -fexceptions.
-    linkopts = litert_android_linkopts(),
+    linkopts = litert_android_linkopts() + select({
+        # D3D12 is the neutral allocator for the cross-device shared buffer.
+        "//litert:windows": [
+            "d3d12.lib",
+            "dxgi.lib",
+        ],
+        "//conditions:default": [],
+    }),
     linkshared = 1,
     visibility = ["//visibility:public"],  # Allows LiteRT-LM packaging.
     deps = [
@@ -166,6 +183,7 @@ litert_bin(
 litert_lib(
     name = "litert_dispatch_api",
     hdrs = [
+        "d3d12_shared_buffer.h",
         "device_context.h",
         "invocation_context.h",
         "openvino_shared_core.h",
@@ -238,6 +256,78 @@ cc_test(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "d3d12_shared_buffer_test",
+    srcs = [
+        "d3d12_shared_buffer.cc",
+        "d3d12_shared_buffer.h",
+        "d3d12_shared_buffer_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
+    linkopts = select({
+        "//litert:windows": [
+            "d3d12.lib",
+            "dxgi.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    linkstatic = 1,
+    tags = [
+        "manual",
+        "no-remote-exec",
+        "no_oss",
+        "notap",
+    ],
+    deps = [
+        "//litert/c:litert_common",
+        "//litert/cc:litert_expected",
+        "//litert/cc:litert_macros",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "openvino_tensor_buffer_test",
+    srcs = [
+        "d3d12_shared_buffer.cc",
+        "d3d12_shared_buffer.h",
+        "openvino_shared_core.cc",
+        "openvino_shared_core.h",
+        "openvino_tensor_buffer.cc",
+        "openvino_tensor_buffer.h",
+        "openvino_tensor_buffer_test.cc",
+    ],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
+    linkopts = select({
+        "//litert:windows": [
+            "d3d12.lib",
+            "dxgi.lib",
+        ],
+        "//conditions:default": [],
+    }),
+    linkstatic = 1,
+    tags = [
+        "manual",
+        "no-remote-exec",
+        "no_oss",
+        "notap",
+    ],
+    deps = [
+        "//litert/c:litert_common",
+        "//litert/c:litert_layout",
+        "//litert/c:litert_model_types",
+        "//litert/cc:litert_expected",
+        "//litert/cc:litert_macros",
+        "//litert/vendors/intel_openvino:ov_utils",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest_main",
+        "@intel_openvino//:openvino",
     ],
 )
 

--- a/litert/vendors/intel_openvino/dispatch/d3d12_shared_buffer.cc
+++ b/litert/vendors/intel_openvino/dispatch/d3d12_shared_buffer.cc
@@ -1,0 +1,194 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "litert/vendors/intel_openvino/dispatch/d3d12_shared_buffer.h"
+
+#include "litert/c/litert_common.h"
+
+#if defined(LITERT_WINDOWS_OS)
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+
+// clang-format off
+#include <windows.h>
+#include <d3d12.h>
+#include <dxgi1_6.h>
+#include <wrl/client.h>
+// clang-format on
+
+#include "litert/cc/litert_expected.h"
+#include "litert/cc/litert_macros.h"
+
+namespace litert {
+namespace openvino {
+
+using Microsoft::WRL::ComPtr;
+
+struct D3D12SharedBuffer::Impl {
+  ComPtr<ID3D12Device> device;
+  ComPtr<ID3D12Heap> heap;
+  HANDLE nt_handle = nullptr;
+  void* cpu_ptr = nullptr;  // VirtualAlloc'd system memory that backs `heap`
+  size_t size = 0;
+
+  ~Impl() {
+    // Release the heap before the backing pages are handed back to the OS.
+    heap.Reset();
+    if (cpu_ptr) ::VirtualFree(cpu_ptr, 0, MEM_RELEASE);
+    if (nt_handle) CloseHandle(nt_handle);
+  }
+};
+
+namespace {
+
+// D3D12 allocates buffer resources in multiples of 64 KiB; the shared heap must
+// match so the whole allocation is importable by the external-memory APIs.
+constexpr uint64_t kHeapAlignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+
+uint64_t RoundUpToHeapAlignment(uint64_t size) {
+  return (size + kHeapAlignment - 1) & ~(kHeapAlignment - 1);
+}
+
+// Selects the first hardware (non-software/WARP) DXGI adapter. On a UMA system
+// with a single Intel adapter this is the iGPU that both the NPU and GPU
+// OpenVINO plugins resolve to; picking the hardware adapter guarantees the
+// shared handle is importable by the GPU OpenCL device.
+litert::Expected<ComPtr<IDXGIAdapter1>> PickHardwareAdapter() {
+  ComPtr<IDXGIFactory6> factory;
+  if (FAILED(CreateDXGIFactory2(0, IID_PPV_ARGS(&factory)))) {
+    return litert::Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                              "Failed to create DXGI factory");
+  }
+  ComPtr<IDXGIAdapter1> adapter;
+  for (UINT i = 0;
+       factory->EnumAdapters1(i, &adapter) != DXGI_ERROR_NOT_FOUND; ++i) {
+    DXGI_ADAPTER_DESC1 desc;
+    adapter->GetDesc1(&desc);
+    if (!(desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)) {
+      return adapter;
+    }
+    adapter.Reset();
+  }
+  return litert::Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                            "No hardware DXGI adapter found");
+}
+
+}  // namespace
+
+// static
+litert::Expected<std::unique_ptr<D3D12SharedBuffer>> D3D12SharedBuffer::Create(
+    size_t size) {
+  // D3D12 rounds buffer allocations up to 64 KiB; size the heap to match.
+  const uint64_t alloc_size = RoundUpToHeapAlignment(size);
+
+  LITERT_ASSIGN_OR_RETURN(ComPtr<IDXGIAdapter1> adapter, PickHardwareAdapter());
+
+  auto impl = std::make_unique<Impl>();
+  impl->size = static_cast<size_t>(alloc_size);
+
+  if (FAILED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0,
+                               IID_PPV_ARGS(&impl->device)))) {
+    return litert::Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                              "Failed to create D3D12 device");
+  }
+
+  // ID3D12Device3::OpenExistingHeapFromAddress is the only way on a UMA part to
+  // obtain a heap that is simultaneously CPU-visible and OS-shareable: a plain
+  // DEFAULT heap is shareable but not CPU-mappable, and a CPU-visible CUSTOM
+  // heap rejects the SHARED flag. Chromium's D3D shared-image backing uses this
+  // exact technique for its GPU/NPU (WebNN/ORT) interop path, which is proven
+  // to import into both the OpenVINO GPU (OpenCL) and NPU (Level Zero) plugins,
+  // So we reference its implementation here:
+  // https://source.chromium.org/chromium/chromium/src/+/main:gpu/command_buffer/service/shared_image/d3d_image_backing_factory.cc;drc=4863ce7e2ffd140f7765530e45d67903fd964a69
+  ComPtr<ID3D12Device3> device3;
+  if (FAILED(impl->device.As(&device3))) {
+    return litert::Unexpected(
+        kLiteRtStatusErrorRuntimeFailure,
+        "ID3D12Device3 unavailable (OpenExistingHeapFromAddress required)");
+  }
+
+  // A UMA part that is not cache-coherent benefits from write-combined CPU
+  // pages for faster device-visible writes.
+  D3D12_FEATURE_DATA_ARCHITECTURE arch = {};
+  arch.NodeIndex = 0;
+  impl->device->CheckFeatureSupport(D3D12_FEATURE_ARCHITECTURE, &arch,
+                                    sizeof(arch));
+  DWORD page_protection = PAGE_READWRITE;
+  if (!arch.UMA || !arch.CacheCoherentUMA) {
+    page_protection |= PAGE_WRITECOMBINE;
+  }
+
+  // Reserve the system memory that backs the shared heap. This same pointer is
+  // handed to the CPU (Lock/Unlock) -- host and device observe one allocation.
+  impl->cpu_ptr = ::VirtualAlloc(nullptr, static_cast<SIZE_T>(alloc_size),
+                                 MEM_RESERVE | MEM_COMMIT, page_protection);
+  if (impl->cpu_ptr == nullptr) {
+    return litert::Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                              "Failed to reserve system memory for D3D12 heap");
+  }
+
+  HRESULT heap_hr = device3->OpenExistingHeapFromAddress(
+      impl->cpu_ptr, IID_PPV_ARGS(&impl->heap));
+  if (FAILED(heap_hr)) {
+    char msg[128];
+    snprintf(msg, sizeof(msg),
+             "Failed to open D3D12 heap from system-memory address: 0x%08lX",
+             static_cast<unsigned long>(heap_hr));
+    return litert::Unexpected(kLiteRtStatusErrorRuntimeFailure, msg);
+  }
+
+  // Export the heap's NT handle for import into the NPU and GPU remote
+  // contexts. The heap -- not a placed resource -- is the shareable object:
+  // CreateSharedHandle only accepts heaps, committed resources and fences, and
+  // a CPU-visible heap rejects a UAV placed resource anyway (E_INVALIDARG).
+  // External-memory importers consume the raw heap allocation, so no D3D12
+  // resource is needed on our side.
+  HRESULT handle_hr = impl->device->CreateSharedHandle(
+      impl->heap.Get(), nullptr, GENERIC_ALL, nullptr, &impl->nt_handle);
+  if (FAILED(handle_hr) || impl->nt_handle == nullptr) {
+    char msg[128];
+    snprintf(msg, sizeof(msg),
+             "Failed to create D3D12 shared NT handle: 0x%08lX",
+             static_cast<unsigned long>(handle_hr));
+    return litert::Unexpected(kLiteRtStatusErrorRuntimeFailure, msg);
+  }
+
+  auto buffer = std::unique_ptr<D3D12SharedBuffer>(new D3D12SharedBuffer());
+  buffer->impl_ = std::move(impl);
+  return buffer;
+}
+
+D3D12SharedBuffer::D3D12SharedBuffer() = default;
+D3D12SharedBuffer::~D3D12SharedBuffer() = default;
+
+void* D3D12SharedBuffer::cpu_ptr() const { return impl_->cpu_ptr; }
+void* D3D12SharedBuffer::nt_handle() const { return impl_->nt_handle; }
+size_t D3D12SharedBuffer::size() const { return impl_->size; }
+
+// The shared heap *is* the CPU allocation (VirtualAlloc'd system memory opened
+// via OpenExistingHeapFromAddress), so host and device observe the same bytes.
+// On cache-coherent UMA no copy or flush is required; these remain to satisfy
+// the LiteRT Lock/Unlock contract.
+litert::Expected<void> D3D12SharedBuffer::SyncToHost() { return {}; }
+
+litert::Expected<void> D3D12SharedBuffer::SyncFromHost() { return {}; }
+
+}  // namespace openvino
+}  // namespace litert
+
+#endif  // LITERT_WINDOWS_OS

--- a/litert/vendors/intel_openvino/dispatch/d3d12_shared_buffer.h
+++ b/litert/vendors/intel_openvino/dispatch/d3d12_shared_buffer.h
@@ -1,0 +1,103 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ODML_LITERT_LITERT_VENDORS_OPENVINO_DISPATCH_D3D12_SHARED_BUFFER_H_
+#define ODML_LITERT_LITERT_VENDORS_OPENVINO_DISPATCH_D3D12_SHARED_BUFFER_H_
+
+#include "litert/c/litert_common.h"
+
+// Cross-device shared allocation is implemented with Direct3D 12 on Windows,
+// where D3D12 is the neutral allocator able to produce an OS-shareable NT
+// handle that both the OpenVINO NPU (Level Zero) and GPU (OpenCL) plugins can
+// import.  The whole facility is therefore Windows-only.
+#if defined(LITERT_WINDOWS_OS)
+
+#include <cstddef>
+#include <memory>
+
+#include "litert/cc/litert_expected.h"
+
+namespace litert {
+namespace openvino {
+
+// Owns a cross-device shared D3D12 allocation that is both CPU-mappable and
+// OS-shareable, so no host<->device staging copy is required.
+//
+// Hardware reality (measured on Intel UMA): a single committed D3D12 resource
+// cannot be both OS-shareable and CPU-mappable -- `D3D12_HEAP_FLAG_SHARED` is
+// rejected for any CPU-visible heap. The way around this (the same technique
+// Chromium's D3D shared-image backing uses for its proven GPU/NPU WebNN/ORT
+// interop path) is `ID3D12Device3::OpenExistingHeapFromAddress`:
+//   1. Reserve system memory with VirtualAlloc.
+//   2. Wrap it as a D3D12 heap via OpenExistingHeapFromAddress -- on UMA this
+//      is the only way to get a heap that is simultaneously CPU-visible and
+//      SHARED.
+//   3. Export the heap's NT handle. The heap owns the backing memory and is the
+//      shareable object (CreateSharedHandle only accepts heaps, committed
+//      resources and fences); external-memory importers consume the raw heap
+//      allocation, so no D3D12 resource is needed on our side.
+// The VirtualAlloc'd pointer serves the LiteRT Lock/Unlock host contract
+// directly, while the heap's NT handle is imported (zero-copy) into the NPU
+// (Level Zero) and GPU (OpenCL) remote contexts. Host and device therefore see
+// one allocation; on cache-coherent UMA there is nothing to copy or flush.
+//
+// COM types are hidden behind a PIMPL so consumers need not include <d3d12.h>.
+class D3D12SharedBuffer {
+ public:
+  // Allocates a shared buffer of at least `size` bytes (rounded up internally
+  // to the 4 KiB page granularity required for external-memory import).
+  // Returns an error if any D3D12 object creation, handle creation or mapping
+  // fails; callers should fall back to the host-tensor path in that case.
+  static litert::Expected<std::unique_ptr<D3D12SharedBuffer>> Create(
+      size_t size);
+
+  ~D3D12SharedBuffer();
+
+  D3D12SharedBuffer(const D3D12SharedBuffer&) = delete;
+  D3D12SharedBuffer& operator=(const D3D12SharedBuffer&) = delete;
+
+  // Host-visible pointer to the shared allocation (the VirtualAlloc'd memory
+  // backing the D3D12 heap). Directly reflects device-side writes on
+  // cache-coherent UMA. Never null on a created buffer.
+  void* cpu_ptr() const;
+
+  // Win32 NT handle (as void*) of the shared heap, for the OpenVINO remote-
+  // context create_tensor import overloads. Owned by this object.
+  void* nt_handle() const;
+
+  // Allocation size in bytes (rounded up to the 64 KiB D3D12 buffer
+  // granularity).
+  size_t size() const;
+
+  // No-op on cache-coherent UMA: the CPU pointer and the device buffer alias
+  // the same memory. Retained to satisfy the LiteRT Lock/Unlock contract and
+  // as a hook for an explicit flush on non-coherent parts.
+  litert::Expected<void> SyncToHost();
+
+  // No-op on cache-coherent UMA (see SyncToHost).
+  litert::Expected<void> SyncFromHost();
+
+ private:
+  D3D12SharedBuffer();
+
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace openvino
+}  // namespace litert
+
+#endif  // LITERT_WINDOWS_OS
+#endif  // ODML_LITERT_LITERT_VENDORS_OPENVINO_DISPATCH_D3D12_SHARED_BUFFER_H_

--- a/litert/vendors/intel_openvino/dispatch/d3d12_shared_buffer_test.cc
+++ b/litert/vendors/intel_openvino/dispatch/d3d12_shared_buffer_test.cc
@@ -1,0 +1,197 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "litert/vendors/intel_openvino/dispatch/d3d12_shared_buffer.h"
+
+#include <gtest/gtest.h>
+
+#include "litert/c/litert_common.h"
+
+// The shared allocator is Windows-only. On other platforms this translation
+// unit contributes no tests (gtest_main still provides main()).
+#if defined(LITERT_WINDOWS_OS)
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+// clang-format off
+#include <windows.h>
+#include <d3d12.h>
+#include <dxgi1_6.h>
+// clang-format on
+
+namespace litert {
+namespace openvino {
+namespace {
+
+// Diagnostic: probe which (heap-type, shared) combinations D3D12 accepts on
+// this machine, whether the resource is CPU-mappable, and whether a shared NT
+// handle can be created. Prints results; never fails. Guides the final design.
+TEST(D3D12Probe, ConfigurationMatrix) {
+  IDXGIFactory6* factory = nullptr;
+  ASSERT_EQ(CreateDXGIFactory2(0, IID_PPV_ARGS(&factory)), S_OK);
+  IDXGIAdapter1* adapter = nullptr;
+  for (UINT i = 0;
+       factory->EnumAdapters1(i, &adapter) != DXGI_ERROR_NOT_FOUND; ++i) {
+    DXGI_ADAPTER_DESC1 d;
+    adapter->GetDesc1(&d);
+    if (!(d.Flags & DXGI_ADAPTER_FLAG_SOFTWARE)) break;
+    adapter->Release();
+    adapter = nullptr;
+  }
+  ASSERT_NE(adapter, nullptr);
+
+  ID3D12Device* device = nullptr;
+  ASSERT_EQ(D3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_11_0,
+                              IID_PPV_ARGS(&device)),
+            S_OK);
+  adapter->Release();
+  factory->Release();
+
+  D3D12_FEATURE_DATA_ARCHITECTURE arch = {};
+  arch.NodeIndex = 0;
+  device->CheckFeatureSupport(D3D12_FEATURE_ARCHITECTURE, &arch, sizeof(arch));
+  std::printf("[probe] UMA=%d CacheCoherentUMA=%d\n", arch.UMA,
+              arch.CacheCoherentUMA);
+
+  struct Case {
+    const char* name;
+    D3D12_HEAP_TYPE type;
+    D3D12_CPU_PAGE_PROPERTY page;
+    D3D12_MEMORY_POOL pool;
+    D3D12_HEAP_FLAGS flags;
+  };
+  const Case cases[] = {
+      {"DEFAULT+SHARED", D3D12_HEAP_TYPE_DEFAULT,
+       D3D12_CPU_PAGE_PROPERTY_UNKNOWN, D3D12_MEMORY_POOL_UNKNOWN,
+       D3D12_HEAP_FLAG_SHARED},
+      {"CUSTOM/WB/L0+SHARED", D3D12_HEAP_TYPE_CUSTOM,
+       D3D12_CPU_PAGE_PROPERTY_WRITE_BACK, D3D12_MEMORY_POOL_L0,
+       D3D12_HEAP_FLAG_SHARED},
+      {"CUSTOM/WB/L0+NONE", D3D12_HEAP_TYPE_CUSTOM,
+       D3D12_CPU_PAGE_PROPERTY_WRITE_BACK, D3D12_MEMORY_POOL_L0,
+       D3D12_HEAP_FLAG_NONE},
+      {"CUSTOM/WC/L0+SHARED", D3D12_HEAP_TYPE_CUSTOM,
+       D3D12_CPU_PAGE_PROPERTY_WRITE_COMBINE, D3D12_MEMORY_POOL_L0,
+       D3D12_HEAP_FLAG_SHARED},
+  };
+
+  D3D12_RESOURCE_DESC desc = {};
+  desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+  desc.Width = 4096;
+  desc.Height = 1;
+  desc.DepthOrArraySize = 1;
+  desc.MipLevels = 1;
+  desc.Format = DXGI_FORMAT_UNKNOWN;
+  desc.SampleDesc.Count = 1;
+  desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+
+  for (const auto& c : cases) {
+    D3D12_HEAP_PROPERTIES hp = {};
+    hp.Type = c.type;
+    hp.CPUPageProperty = c.page;
+    hp.MemoryPoolPreference = c.pool;
+    hp.CreationNodeMask = 1;
+    hp.VisibleNodeMask = 1;
+    ID3D12Resource* res = nullptr;
+    HRESULT hr = device->CreateCommittedResource(
+        &hp, c.flags, &desc, D3D12_RESOURCE_STATE_COMMON, nullptr,
+        IID_PPV_ARGS(&res));
+    bool mappable = false, shareable = false;
+    if (SUCCEEDED(hr)) {
+      void* p = nullptr;
+      mappable = SUCCEEDED(res->Map(0, nullptr, &p)) && p != nullptr;
+      if (mappable) res->Unmap(0, nullptr);
+      HANDLE h = nullptr;
+      shareable = SUCCEEDED(device->CreateSharedHandle(res, nullptr,
+                                                       GENERIC_ALL, nullptr,
+                                                       &h)) &&
+                  h != nullptr;
+      if (h) CloseHandle(h);
+      res->Release();
+    }
+    std::printf("[probe] %-22s create=0x%08lX mappable=%d shareable=%d\n",
+                c.name, static_cast<unsigned long>(hr), mappable, shareable);
+  }
+  device->Release();
+}
+
+TEST(D3D12SharedBuffer, CreateExposesHandleAndMappedPointer) {
+  constexpr size_t kSize = 4096;
+  auto buffer = D3D12SharedBuffer::Create(kSize);
+  ASSERT_TRUE(buffer) << buffer.Error().Message();
+
+  const auto& buf = buffer.Value();
+  ASSERT_NE(buf->cpu_ptr(), nullptr);
+  ASSERT_NE(buf->nt_handle(), nullptr);
+  EXPECT_GE(buf->size(), kSize);
+}
+
+TEST(D3D12SharedBuffer, CpuPointerRoundTrips) {
+  constexpr size_t kSize = 2048;
+  auto buffer = D3D12SharedBuffer::Create(kSize);
+  ASSERT_TRUE(buffer) << buffer.Error().Message();
+
+  auto* data = static_cast<uint8_t*>(buffer.Value()->cpu_ptr());
+  ASSERT_NE(data, nullptr);
+  for (size_t i = 0; i < kSize; ++i) {
+    data[i] = static_cast<uint8_t>(i & 0xFF);
+  }
+  for (size_t i = 0; i < kSize; ++i) {
+    EXPECT_EQ(data[i], static_cast<uint8_t>(i & 0xFF));
+  }
+}
+
+TEST(D3D12SharedBuffer, SizeIsPageRounded) {
+  // A sub-page request is rounded up to the 4 KiB page granularity required
+  // for external-memory import.
+  auto buffer = D3D12SharedBuffer::Create(1);
+  ASSERT_TRUE(buffer) << buffer.Error().Message();
+  EXPECT_EQ(buffer.Value()->size() % 4096, 0u);
+  EXPECT_GE(buffer.Value()->size(), 4096u);
+}
+
+// Exercises the copy-on-lock machinery: write to the CPU staging resource,
+// push it to the device-local shared resource (SyncFromHost), wipe staging,
+// then pull it back (SyncToHost). Data must survive the round trip through the
+// shared resource, proving the D3D12 copy queue + fence path works.
+TEST(D3D12SharedBuffer, SyncRoundTripThroughSharedResource) {
+  constexpr size_t kSize = 4096;
+  auto buffer = D3D12SharedBuffer::Create(kSize);
+  ASSERT_TRUE(buffer) << buffer.Error().Message();
+  const auto& buf = buffer.Value();
+
+  auto* data = static_cast<uint8_t*>(buf->cpu_ptr());
+  ASSERT_NE(data, nullptr);
+  for (size_t i = 0; i < kSize; ++i) {
+    data[i] = static_cast<uint8_t>((i * 7) & 0xFF);
+  }
+
+  ASSERT_TRUE(buf->SyncFromHost());       // staging -> shared
+  std::memset(data, 0, kSize);            // clobber staging
+  ASSERT_TRUE(buf->SyncToHost());         // shared -> staging
+
+  for (size_t i = 0; i < kSize; ++i) {
+    EXPECT_EQ(data[i], static_cast<uint8_t>((i * 7) & 0xFF));
+  }
+}
+
+}  // namespace
+}  // namespace openvino
+}  // namespace litert
+
+#endif  // LITERT_WINDOWS_OS

--- a/litert/vendors/intel_openvino/dispatch/device_context.cc
+++ b/litert/vendors/intel_openvino/dispatch/device_context.cc
@@ -225,9 +225,10 @@ LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
       OpenVinoTensorBuffer* custom_tensor_buffer =
           reinterpret_cast<OpenVinoTensorBuffer*>(hw_memory_handle);
 
-      LITERT_ASSIGN_OR_RETURN(auto openvino_tensor,
-                              custom_tensor_buffer->GetOVTensor());
-      return InsertTensor(RegisteredTensor{.tensor = openvino_tensor});
+      // Store the buffer itself; the concrete ov::Tensor to bind is resolved
+      // per-device at attach time (see getOVTensor(handle, device)), which is
+      // what lets one shared allocation be imported into both NPU and GPU.
+      return InsertTensor(RegisteredTensor{.ov_buffer = custom_tensor_buffer});
     }
     case kLiteRtTensorBufferTypeDmaBuf: {
 #if LITERT_HAS_DMABUF_SUPPORT
@@ -310,6 +311,28 @@ LiteRtDispatchDeviceContextT::RegisterTensorBuffer(
       return litert::Unexpected(kLiteRtStatusErrorRuntimeFailure,
                                 "Unsupported tensor buffer type");
   }
+}
+
+litert::Expected<ov::Tensor> LiteRtDispatchDeviceContextT::getOVTensor(
+    const LiteRtTensorBufferHandle& handle, const std::string& device) const {
+  // Resolve the registration under the lock, then release it before calling
+  // into OpenVINO (import can be heavy and take its own locks).
+  OpenVinoTensorBuffer* ov_buffer = nullptr;
+  ov::Tensor direct_tensor;
+  {
+    absl::MutexLock lock(&tensor_handle_mutex_);
+    auto it = tensor_handle_map_.find(handle);
+    if (it == tensor_handle_map_.end()) {
+      return litert::Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                                "Failed to get Remote Tensor");
+    }
+    ov_buffer = it->second.ov_buffer;
+    direct_tensor = it->second.tensor;
+  }
+  if (ov_buffer != nullptr) {
+    return ov_buffer->GetOVTensor(device);
+  }
+  return direct_tensor;
 }
 
 litert::Expected<void> LiteRtDispatchDeviceContextT::UnregisterTensorBuffer(

--- a/litert/vendors/intel_openvino/dispatch/device_context.h
+++ b/litert/vendors/intel_openvino/dispatch/device_context.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <utility>
 
@@ -39,6 +40,10 @@
 #include "litert/cc/litert_macros.h"
 #include "litert/vendors/c/litert_dispatch.h"
 #include "litert/vendors/intel_openvino/dispatch/openvino_shared_core.h"
+
+// Forward declaration: the OpenVINO custom tensor buffer is stored by pointer
+// so that per-device remote tensors can be produced on demand.
+class OpenVinoTensorBuffer;
 
 class LiteRtDispatchDeviceContextT {
  public:
@@ -64,6 +69,13 @@ class LiteRtDispatchDeviceContextT {
                                 "Failed to get Remote Tensor");
     }
   }
+
+  // Device-aware variant. For OpenVINO custom buffers the tensor bound to a
+  // given device is produced from the registered OpenVinoTensorBuffer (which
+  // may import a shared allocation into that device's remote context). For
+  // directly-registered tensors (DMA-BUF/AHWB) the device is ignored.
+  litert::Expected<ov::Tensor> getOVTensor(
+      const LiteRtTensorBufferHandle& handle, const std::string& device) const;
 
   // Return the core shared_pointer.
   std::shared_ptr<ov::Core> getCore() const {
@@ -108,6 +120,10 @@ class LiteRtDispatchDeviceContextT {
   struct RegisteredTensor {
     ov::Tensor tensor;
     CleanupAction cleanup;
+    // Set for OpenVINO custom buffers: the tensor is produced per-device from
+    // this buffer instead of being stored directly in `tensor`. Not owned;
+    // the buffer outlives the registration (unregister precedes destroy).
+    OpenVinoTensorBuffer* ov_buffer = nullptr;
   };
 
   // Inserts `tensor` under a freshly allocated handle while holding

--- a/litert/vendors/intel_openvino/dispatch/dispatch_api.cc
+++ b/litert/vendors/intel_openvino/dispatch/dispatch_api.cc
@@ -80,6 +80,13 @@ LiteRtStatus DestroyOpenVinoTensorBuffer(HwMemoryInfoPtr hw_memory_info) {
 }
 
 LiteRtStatus UnlockOpenVinoTensorBuffer(HwMemoryInfoPtr hw_memory_info) {
+  OpenVinoTensorBuffer* custom_tensor_buffer =
+      reinterpret_cast<OpenVinoTensorBuffer*>(hw_memory_info->memory_handle);
+  if (auto result = custom_tensor_buffer->Unlock(); !result) {
+    LITERT_LOG(LITERT_ERROR, "Failed to unlock tensor buffer: %s",
+               result.Error().Message().c_str());
+    return result.Error().Status();
+  }
   return kLiteRtStatusOk;
 }
 
@@ -88,7 +95,7 @@ LiteRtStatus LockOpenVinoTensorBuffer(HwMemoryInfoPtr hw_memory_info,
                                       void** host_memory_ptr) {
   OpenVinoTensorBuffer* custom_tensor_buffer =
       reinterpret_cast<OpenVinoTensorBuffer*>(hw_memory_info->memory_handle);
-  auto result = custom_tensor_buffer->GetTensorData();
+  auto result = custom_tensor_buffer->Lock(mode);
   if (!result) {
     LITERT_LOG(LITERT_ERROR, "Failed to lock tensor buffer: %s",
                result.Error().Message().c_str());

--- a/litert/vendors/intel_openvino/dispatch/invocation_context.cc
+++ b/litert/vendors/intel_openvino/dispatch/invocation_context.cc
@@ -200,6 +200,9 @@ LiteRtDispatchInvocationContextT::Create(
   LITERT_LOG(LITERT_INFO, "Using Intel OpenVINO device: %s", device.c_str());
 
   OpenVINOSharedCore::GetInstance()->SetDevice(device);
+  // Record the device so the tensor-buffer allocator can detect models whose
+  // partitions span both NPU and GPU (which need the shared-allocation path).
+  OpenVINOSharedCore::GetInstance()->NoteDeviceRequested(device);
 
   if (!exec_bytecode_ptr || exec_bytecode_size == 0) {
     return litert::Error(kLiteRtStatusErrorRuntimeFailure,
@@ -222,8 +225,8 @@ LiteRtDispatchInvocationContextT::Create(
   auto infer_request = compiled_model.create_infer_request();
   LITERT_LOG(LITERT_INFO, "Openvino InvocationContext Initialize SUCCESS");
   // TODO: add support for loading cached model
-  return Ptr(new LiteRtDispatchInvocationContextT(infer_request, device_context,
-                                                  num_inputs, num_outputs));
+  return Ptr(new LiteRtDispatchInvocationContextT(
+      infer_request, device_context, num_inputs, num_outputs, device));
 }
 
 litert::Expected<LiteRtTensorBufferRequirements>
@@ -271,8 +274,9 @@ LiteRtDispatchInvocationContextT::GetOutputRequirements(
 
 litert::Expected<void> LiteRtDispatchInvocationContextT::AttachInput(
     int graph_input_index, LiteRtTensorBufferHandle tensor_buffer_handle) {
-  LITERT_ASSIGN_OR_RETURN(ov::Tensor ov_tensor,
-                          device_context_.getOVTensor(tensor_buffer_handle));
+  LITERT_ASSIGN_OR_RETURN(
+      ov::Tensor ov_tensor,
+      device_context_.getOVTensor(tensor_buffer_handle, device_));
   // TODO: visit this if need to maintain graph indices for inputs and outputs
   // in dispatch_api
   infer_request_.set_input_tensor(graph_input_index, ov_tensor);
@@ -281,8 +285,9 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::AttachInput(
 
 litert::Expected<void> LiteRtDispatchInvocationContextT::AttachOutput(
     int graph_output_index, LiteRtTensorBufferHandle tensor_buffer_handle) {
-  LITERT_ASSIGN_OR_RETURN(ov::Tensor ov_tensor,
-                          device_context_.getOVTensor(tensor_buffer_handle));
+  LITERT_ASSIGN_OR_RETURN(
+      ov::Tensor ov_tensor,
+      device_context_.getOVTensor(tensor_buffer_handle, device_));
   // TODO: visit this if need to maintain graph indices for inputs and outputs
   // in dispatch_api
   infer_request_.set_output_tensor(graph_output_index, ov_tensor);

--- a/litert/vendors/intel_openvino/dispatch/invocation_context.h
+++ b/litert/vendors/intel_openvino/dispatch/invocation_context.h
@@ -17,6 +17,8 @@
 #define ODML_LITERT_LITERT_VENDORS_OPENVINO_DISPATCH_LITERT_DISPATCH_INVOCATION_CONTEXT_H_
 
 #include <optional>
+#include <string>
+#include <utility>
 
 #include "openvino/runtime/infer_request.hpp"
 #include "litert/c/internal/litert_scheduling_info.h"
@@ -84,10 +86,16 @@ class LiteRtDispatchInvocationContextT {
  private:
   LiteRtDispatchInvocationContextT(ov::InferRequest& infer_request,
                                    LiteRtDispatchDeviceContextT& device_context,
-                                   int num_inputs, int num_outputs)
-      : device_context_(device_context), infer_request_(infer_request) {}
+                                   int num_inputs, int num_outputs,
+                                   std::string device)
+      : device_context_(device_context),
+        infer_request_(infer_request),
+        device_(std::move(device)) {}
   LiteRtDispatchDeviceContextT& device_context_;
   ov::InferRequest infer_request_;
+  // Target device ("NPU"/"GPU"/"CPU") this partition was compiled for. Used to
+  // select the correct per-device tensor at attach time.
+  std::string device_;
   // Timeout is in milliseconds
   static constexpr int kInferRequestTimeoutMs = 10000;
 

--- a/litert/vendors/intel_openvino/dispatch/openvino_shared_core.h
+++ b/litert/vendors/intel_openvino/dispatch/openvino_shared_core.h
@@ -18,7 +18,9 @@
 #include <memory>
 #include <mutex>  // NOLINT
 #include <optional>
+#include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "openvino/runtime/core.hpp"
@@ -56,6 +58,36 @@ class OpenVINOSharedCore {
     return *remote_context_;
   }
 
+  // Returns (and lazily caches) the default remote context for a specific
+  // device.  Unlike the single-device GetRemoteContext()/SetDevice() pair,
+  // this keeps NPU and GPU contexts alive simultaneously, which is required to
+  // import one shared allocation into both devices for a mixed partition.
+  ov::RemoteContext GetRemoteContext(const std::string& device) {
+    absl::MutexLock lock(&state_mutex_);
+    auto it = remote_contexts_.find(device);
+    if (it == remote_contexts_.end()) {
+      it = remote_contexts_.emplace(device, core_->get_default_context(device))
+               .first;
+    }
+    return it->second;
+  }
+
+  // Records that a partition targeting `device` has been created. Used to
+  // detect models whose partitions span both the NPU and the GPU, which is the
+  // only case that needs the cross-device shared allocation path.
+  void NoteDeviceRequested(const std::string& device) {
+    absl::MutexLock lock(&state_mutex_);
+    requested_devices_.insert(device);
+  }
+
+  // True when partitions targeting both "NPU" and "GPU" have been created for
+  // the current model.
+  bool SpansNpuAndGpu() {
+    absl::MutexLock lock(&state_mutex_);
+    return requested_devices_.count("NPU") != 0 &&
+           requested_devices_.count("GPU") != 0;
+  }
+
   // Returns the list of OpenVINO devices reported by `core_->
   // get_available_devices()`.  Queried lazily on first call and cached for
   // the lifetime of the process (the set of installed devices does not
@@ -73,6 +105,11 @@ class OpenVINOSharedCore {
   std::string device_ ABSL_GUARDED_BY(state_mutex_) = "NPU";  // Default device
   std::optional<ov::RemoteContext> remote_context_
       ABSL_GUARDED_BY(state_mutex_);
+  // Per-device remote-context cache; lets NPU and GPU contexts coexist.
+  std::unordered_map<std::string, ov::RemoteContext> remote_contexts_
+      ABSL_GUARDED_BY(state_mutex_);
+  // Set of devices targeted by the current model's partitions.
+  std::set<std::string> requested_devices_ ABSL_GUARDED_BY(state_mutex_);
   std::once_flag available_devices_once_;
   std::vector<std::string> available_devices_;
 };

--- a/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.cc
+++ b/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.cc
@@ -16,14 +16,26 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <vector>
 
+#include "openvino/core/any.hpp"
+#include "openvino/core/except.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
-#include "openvino/runtime/intel_npu/level_zero/level_zero.hpp"
+// Only the lightweight property headers are needed (they pull in just
+// properties.hpp). The typed ocl.hpp / level_zero.hpp wrappers are avoided on
+// purpose: ocl.hpp transitively requires the OpenCL SDK headers (CL/cl2.hpp),
+// which are not on the include path. The generic
+// RemoteContext::create_tensor(type, shape, AnyMap) below does exactly what
+// those wrappers do internally.
+#include "openvino/runtime/intel_gpu/remote_properties.hpp"
+#include "openvino/runtime/intel_npu/remote_properties.hpp"
+#include "openvino/runtime/remote_context.hpp"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_model_types.h"
 #include "litert/cc/litert_expected.h"
+#include "litert/cc/litert_macros.h"
 #include "litert/vendors/intel_openvino/dispatch/openvino_shared_core.h"
 #include "litert/vendors/intel_openvino/utils.h"
 
@@ -35,20 +47,37 @@ litert::Expected<void> OpenVinoTensorBuffer::Alloc(
   }
 
   // TODO:: Release the shared OpenVINO Core.
-  std::string device = OpenVINOSharedCore::GetInstance()->GetDevice();
-  ov::element::Type ov_element_type =
-      litert::openvino::MapLiteTypeToOV(tensor_type.element_type);
+  auto* shared_core = OpenVINOSharedCore::GetInstance();
+  std::string device = shared_core->GetDevice();
+  element_type_ = litert::openvino::MapLiteTypeToOV(tensor_type.element_type);
 
-  std::vector<int32_t> ov_shape_vec(tensor_type.layout.rank);
+  std::vector<size_t> ov_shape_vec(tensor_type.layout.rank);
   for (size_t i = 0; i < ov_shape_vec.size(); i++)
     ov_shape_vec[i] = tensor_type.layout.dimensions[i];
-  ov::Shape ov_shape{ov_shape_vec.begin(), ov_shape_vec.end()};
+  shape_ = ov::Shape{ov_shape_vec.begin(), ov_shape_vec.end()};
+
+#if defined(LITERT_WINDOWS_OS)
+  // Cross-device shared allocation: only when the model spans both NPU and GPU.
+  // Do NOT fall back to a host tensor on failure -- the NPU must use the exact
+  // same shared allocation as the GPU so any import problem surfaces loudly and
+  // both devices stay aligned for debugging.
+  if (shared_core->SpansNpuAndGpu()) {
+    auto shared = litert::openvino::D3D12SharedBuffer::Create(size);
+    if (!shared) {
+      return litert::Unexpected(shared.Error());
+    }
+    shared_ = std::move(*shared);
+    shared_path_ = true;
+    allocated_ = true;
+    return {};
+  }
+#endif  // LITERT_WINDOWS_OS
 
   if (device == "NPU" || device == "GPU") {
-    auto context = OpenVINOSharedCore::GetInstance()->GetRemoteContext();
-    ov_tensor_ = context.create_host_tensor(ov_element_type, ov_shape);
+    auto context = shared_core->GetRemoteContext();
+    host_tensor_ = context.create_host_tensor(element_type_, shape_);
   } else if (device == "CPU") {
-    ov_tensor_ = ov::Tensor(ov_element_type, ov_shape);
+    host_tensor_ = ov::Tensor(element_type_, shape_);
   } else {
     return litert::Unexpected(kLiteRtStatusErrorInvalidArgument,
                               "Unsupported OpenVINO device: " + device);
@@ -63,13 +92,106 @@ litert::Expected<void*> OpenVinoTensorBuffer::GetTensorData() {
     return litert::Unexpected(kLiteRtStatusErrorInvalidArgument,
                               "The tensor didn't allocate.");
   }
-  return ov_tensor_.data();
+#if defined(LITERT_WINDOWS_OS)
+  if (shared_path_) {
+    // The mapped D3D12 resource is host-visible; its pointer never throws
+    // (unlike ov::RemoteTensor::data()).
+    return shared_->cpu_ptr();
+  }
+#endif  // LITERT_WINDOWS_OS
+  return host_tensor_.data();
 }
 
-litert::Expected<ov::Tensor> OpenVinoTensorBuffer::GetOVTensor() {
+litert::Expected<void*> OpenVinoTensorBuffer::Lock(
+    LiteRtTensorBufferLockMode mode) {
+  if (!allocated_) {
+    return litert::Unexpected(kLiteRtStatusErrorInvalidArgument,
+                              "The tensor didn't allocate.");
+  }
+#if defined(LITERT_WINDOWS_OS)
+  if (shared_path_) {
+    last_lock_mode_ = mode;
+    // A read (or read-write) lock needs the device's latest bytes copied into
+    // the CPU-visible staging resource first.
+    if (mode == kLiteRtTensorBufferLockModeRead ||
+        mode == kLiteRtTensorBufferLockModeReadWrite) {
+      LITERT_RETURN_IF_ERROR(shared_->SyncToHost());
+    }
+    return shared_->cpu_ptr();
+  }
+#endif  // LITERT_WINDOWS_OS
+  return host_tensor_.data();
+}
+
+litert::Expected<void> OpenVinoTensorBuffer::Unlock() {
+#if defined(LITERT_WINDOWS_OS)
+  if (shared_path_) {
+    // Push CPU writes back to the device-local shared resource.
+    if (last_lock_mode_ == kLiteRtTensorBufferLockModeWrite ||
+        last_lock_mode_ == kLiteRtTensorBufferLockModeReadWrite) {
+      LITERT_RETURN_IF_ERROR(shared_->SyncFromHost());
+    }
+  }
+#endif  // LITERT_WINDOWS_OS
+  return {};
+}
+
+litert::Expected<ov::Tensor> OpenVinoTensorBuffer::GetOVTensor(
+    const std::string& device) {
   if (!allocated_) {
     return litert::Unexpected(kLiteRtStatusErrorInvalidArgument,
                               "Failed to get tensor.");
   }
-  return ov_tensor_;
+
+#if defined(LITERT_WINDOWS_OS)
+  if (shared_path_) {
+    if (auto it = device_imports_.find(device); it != device_imports_.end()) {
+      return it->second;
+    }
+    try {
+      auto* shared_core = OpenVINOSharedCore::GetInstance();
+      void* handle = shared_->nt_handle();
+      ov::Tensor imported;
+      if (device == "NPU") {
+        // Import the shared NT handle as a Level Zero SHARED_BUF tensor usable
+        // as both input and output (BINDED).
+        ov::AnyMap params = {
+            {ov::intel_npu::mem_type.name(), ov::intel_npu::MemType::SHARED_BUF},
+            {ov::intel_npu::mem_handle.name(),
+             static_cast<ov::intel_npu::npu_handle_param>(handle)},
+            {ov::intel_npu::tensor_type.name(),
+             ov::intel_npu::TensorType::BINDED},
+        };
+        imported = shared_core->GetRemoteContext(device).create_tensor(
+            element_type_, shape_, params);
+      } else if (device == "GPU") {
+        // Import the shared NT handle via the GPU BUFFER_FROM_HANDLE path.
+        ov::AnyMap params = {
+            {ov::intel_gpu::shared_mem_type.name(),
+             ov::intel_gpu::SharedMemType::BUFFER_FROM_HANDLE},
+            {ov::intel_gpu::os_handle.name(),
+             static_cast<ov::intel_gpu::os_handle_param>(handle)},
+        };
+        imported = shared_core->GetRemoteContext(device).create_tensor(
+            element_type_, shape_, params);
+      } else if (device == "CPU") {
+        // A CPU partition reads/writes the shared allocation directly through
+        // its host mapping (no remote import / remote context needed).
+        imported = ov::Tensor(element_type_, shape_, shared_->cpu_ptr());
+      } else {
+        return litert::Unexpected(
+            kLiteRtStatusErrorInvalidArgument,
+            "Unsupported device for shared OpenVINO tensor: " + device);
+      }
+      auto [it, inserted] = device_imports_.emplace(device, imported);
+      return it->second;
+    } catch (const ov::Exception& e) {
+      return litert::Unexpected(kLiteRtStatusErrorRuntimeFailure, e.what());
+    }
+  }
+#endif  // LITERT_WINDOWS_OS
+
+  // Single-device path: the host tensor is device independent.
+  (void)device;
+  return host_tensor_;
 }

--- a/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.h
+++ b/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.h
@@ -16,11 +16,32 @@
 #define ODML_LITERT_LITERT_VENDORS_OPENVINO_DISPATCH_OPENVINO_TENSOR_BUFFER_H_
 
 #include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
 
+#include "openvino/core/shape.hpp"
+#include "openvino/core/type/element_type.hpp"
 #include "openvino/runtime/tensor.hpp"
+#include "litert/c/litert_common.h"
 #include "litert/c/litert_model_types.h"
 #include "litert/cc/litert_expected.h"
+#include "litert/vendors/intel_openvino/dispatch/d3d12_shared_buffer.h"
 
+// A dispatch-owned tensor buffer for an OpenVINO partition I/O tensor.
+//
+// There are two allocation strategies:
+//   * Single-device (default): one OpenVINO host tensor created from the target
+//     device's remote context (NPU/GPU) or a plain host tensor (CPU). This is
+//     the historical behaviour.
+//   * Cross-device shared (Windows, model spans both NPU and GPU): one D3D12
+//     shared allocation whose CPU pointer serves Lock and whose NT handle is
+//     imported into each device's remote context on demand. Both devices then
+//     alias one physical allocation, so an NPU->GPU (or GPU->NPU) partition
+//     boundary is zero-copy regardless of which partition was created first.
+//
+// In both cases GetTensorData() returns a host pointer that never throws,
+// preserving the LiteRT custom-buffer Lock/Unlock contract.
 class OpenVinoTensorBuffer {
  public:
   OpenVinoTensorBuffer(const OpenVinoTensorBuffer&) = delete;
@@ -28,7 +49,7 @@ class OpenVinoTensorBuffer {
   OpenVinoTensorBuffer(OpenVinoTensorBuffer&&) = default;
   OpenVinoTensorBuffer& operator=(OpenVinoTensorBuffer&&) = default;
 
-  OpenVinoTensorBuffer() : ov_tensor_(), allocated_(false) {};
+  OpenVinoTensorBuffer() : host_tensor_(), allocated_(false) {};
   ~OpenVinoTensorBuffer() = default;
 
   litert::Expected<void> Alloc(const LiteRtRankedTensorType& tensor_type,
@@ -36,11 +57,36 @@ class OpenVinoTensorBuffer {
 
   litert::Expected<void*> GetTensorData();
 
-  litert::Expected<ov::Tensor> GetOVTensor();
+  // Locks the buffer for CPU access and returns a host pointer. For the shared
+  // (D3D12) path a read lock first copies device->host; the mode is remembered
+  // so Unlock() can copy host->device after a write. For the single-device path
+  // this is equivalent to GetTensorData() and Unlock() is a no-op.
+  litert::Expected<void*> Lock(LiteRtTensorBufferLockMode mode);
+  litert::Expected<void> Unlock();
+
+  // Returns the OpenVINO tensor to bind for a given target device. For the
+  // shared path the NT handle is imported into that device's remote context
+  // (lazily, cached); for the single-device path the device argument is ignored
+  // and the host tensor is returned.
+  litert::Expected<ov::Tensor> GetOVTensor(const std::string& device);
+
+  // True when this buffer uses the cross-device D3D12 shared allocation.
+  bool is_shared() const { return shared_path_; }
 
  private:
-  ov::Tensor ov_tensor_;
+  ov::Tensor host_tensor_;
   bool allocated_;
+
+  // Cross-device shared allocation state (populated only on the shared path).
+  bool shared_path_ = false;
+  LiteRtTensorBufferLockMode last_lock_mode_ = kLiteRtTensorBufferLockModeRead;
+  ov::element::Type element_type_;
+  ov::Shape shape_;
+  // Imported remote tensors keyed by device ("NPU"/"GPU"), aliasing shared_.
+  std::unordered_map<std::string, ov::Tensor> device_imports_;
+#if defined(LITERT_WINDOWS_OS)
+  std::unique_ptr<litert::openvino::D3D12SharedBuffer> shared_;
+#endif
 };
 
 #endif  // ODML_LITERT_LITERT_VENDORS_OPENVINO_DISPATCH_OPENVINO_TENSOR_BUFFER_H_

--- a/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer_test.cc
+++ b/litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer_test.cc
@@ -1,0 +1,216 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "litert/vendors/intel_openvino/dispatch/openvino_tensor_buffer.h"
+
+#include <gtest/gtest.h>
+
+#include "litert/c/litert_common.h"
+
+// The cross-device shared allocation path is Windows-only. On other platforms
+// this translation unit contributes no tests (gtest_main still provides main).
+#if defined(LITERT_WINDOWS_OS)
+
+#include <cstdint>
+
+#include "openvino/core/shape.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/remote_tensor.hpp"
+#include "openvino/runtime/tensor.hpp"
+#include "litert/c/litert_layout.h"
+#include "litert/c/litert_model_types.h"
+#include "litert/vendors/intel_openvino/dispatch/openvino_shared_core.h"
+
+namespace {
+
+LiteRtRankedTensorType MakeFloat32Vector(int32_t n) {
+  LiteRtRankedTensorType type = {};
+  type.element_type = kLiteRtElementTypeFloat32;
+  type.layout.rank = 1;
+  type.layout.has_strides = 0;
+  type.layout.dimensions[0] = n;
+  return type;
+}
+
+// Forces the "model spans both NPU and GPU" condition so Alloc() takes the
+// D3D12 shared-allocation path. State is process-global on the shared-core
+// singleton; every test here sets it, so the tests are order-independent.
+void ForceCrossDevice() {
+  OpenVINOSharedCore::GetInstance()->NoteDeviceRequested("NPU");
+  OpenVINOSharedCore::GetInstance()->NoteDeviceRequested("GPU");
+}
+
+TEST(OpenVinoTensorBufferShared, AllocUsesSharedPathAndExposesHostPtr) {
+  ForceCrossDevice();
+  constexpr int32_t kN = 16;
+  OpenVinoTensorBuffer buffer;
+  auto alloc = buffer.Alloc(MakeFloat32Vector(kN), kN * sizeof(float));
+  ASSERT_TRUE(alloc) << alloc.Error().Message();
+  EXPECT_TRUE(buffer.is_shared());
+
+  auto data = buffer.GetTensorData();
+  ASSERT_TRUE(data) << data.Error().Message();
+  EXPECT_NE(data.Value(), nullptr);
+}
+
+TEST(OpenVinoTensorBufferShared, DoubleAllocFails) {
+  ForceCrossDevice();
+  OpenVinoTensorBuffer buffer;
+  ASSERT_TRUE(buffer.Alloc(MakeFloat32Vector(4), 4 * sizeof(float)));
+  EXPECT_FALSE(buffer.Alloc(MakeFloat32Vector(4), 4 * sizeof(float)));
+}
+
+// Write through a write-lock (Unlock copies host->shared), then read through a
+// read-lock (Lock copies shared->host). The bytes must survive the round trip
+// through the device-local shared resource, proving the copy-on-lock direction
+// logic and the D3D12 sync are wired correctly end to end.
+TEST(OpenVinoTensorBufferShared, LockUnlockRoundTripThroughSharedResource) {
+  ForceCrossDevice();
+  constexpr int32_t kN = 16;
+  OpenVinoTensorBuffer buffer;
+  ASSERT_TRUE(buffer.Alloc(MakeFloat32Vector(kN), kN * sizeof(float)));
+
+  auto w = buffer.Lock(kLiteRtTensorBufferLockModeWrite);
+  ASSERT_TRUE(w) << w.Error().Message();
+  auto* wptr = static_cast<float*>(w.Value());
+  for (int32_t i = 0; i < kN; ++i) {
+    wptr[i] = static_cast<float>(i) + 0.5f;
+  }
+  ASSERT_TRUE(buffer.Unlock());
+
+  auto r = buffer.Lock(kLiteRtTensorBufferLockModeRead);
+  ASSERT_TRUE(r) << r.Error().Message();
+  auto* rptr = static_cast<float*>(r.Value());
+  for (int32_t i = 0; i < kN; ++i) {
+    EXPECT_FLOAT_EQ(rptr[i], static_cast<float>(i) + 0.5f);
+  }
+  ASSERT_TRUE(buffer.Unlock());
+}
+
+// A CPU-targeted partition binds the shared allocation directly through its
+// host mapping, so the returned tensor must alias the Lock/GetTensorData
+// pointer (no import, no copy).
+TEST(OpenVinoTensorBufferShared, GetOVTensorCpuAliasesHostPtr) {
+  ForceCrossDevice();
+  constexpr int32_t kN = 8;
+  OpenVinoTensorBuffer buffer;
+  ASSERT_TRUE(buffer.Alloc(MakeFloat32Vector(kN), kN * sizeof(float)));
+
+  auto host = buffer.GetTensorData();
+  ASSERT_TRUE(host) << host.Error().Message();
+  auto tensor = buffer.GetOVTensor("CPU");
+  ASSERT_TRUE(tensor) << tensor.Error().Message();
+  EXPECT_EQ(tensor.Value().data(), host.Value());
+}
+
+// ---------------------------------------------------------------------------
+// The tests below require BOTH an Intel NPU and GPU to be present, since they
+// import the shared D3D12 NT handle into each device's OpenVINO remote context
+// (the driver-gated create_tensor path). Run manually on such hardware:
+//   openvino_tensor_buffer_test.exe --gtest_filter=*CrossDevice*
+// (with the OpenVINO runtime on PATH, e.g. via setupvars.bat).
+// ---------------------------------------------------------------------------
+
+// Importing the same shared NT handle must succeed into both the NPU (Level
+// Zero SHARED_BUF) and GPU (BUFFER_FROM_HANDLE) contexts, yielding tensors of
+// the expected byte size. This is the driver-capability gate.
+TEST(OpenVinoTensorBufferCrossDevice, ImportsIntoNpuAndGpu) {
+  ForceCrossDevice();
+  constexpr int32_t kN = 16;
+  OpenVinoTensorBuffer buffer;
+  ASSERT_TRUE(buffer.Alloc(MakeFloat32Vector(kN), kN * sizeof(float)));
+
+  auto npu = buffer.GetOVTensor("NPU");
+  ASSERT_TRUE(npu) << npu.Error().Message();
+  EXPECT_EQ(npu.Value().get_byte_size(), kN * sizeof(float));
+
+  auto gpu = buffer.GetOVTensor("GPU");
+  ASSERT_TRUE(gpu) << gpu.Error().Message();
+  EXPECT_EQ(gpu.Value().get_byte_size(), kN * sizeof(float));
+}
+
+// Proof of zero-copy sharing: a pattern written by the CPU into the device
+// -local shared resource is read back through BOTH the NPU and GPU imports.
+// They observe the same physical allocation (the NT handle aliases it).
+TEST(OpenVinoTensorBufferCrossDevice, NpuAndGpuAliasTheSharedAllocation) {
+  ForceCrossDevice();
+  constexpr int32_t kN = 16;
+  const ov::Shape shape{static_cast<size_t>(kN)};
+  OpenVinoTensorBuffer buffer;
+  ASSERT_TRUE(buffer.Alloc(MakeFloat32Vector(kN), kN * sizeof(float)));
+
+  // CPU write -> device-local shared resource (Unlock runs SyncFromHost).
+  auto w = buffer.Lock(kLiteRtTensorBufferLockModeWrite);
+  ASSERT_TRUE(w) << w.Error().Message();
+  auto* wptr = static_cast<float*>(w.Value());
+  for (int32_t i = 0; i < kN; ++i) {
+    wptr[i] = static_cast<float>(i) * 2.0f + 1.0f;
+  }
+  ASSERT_TRUE(buffer.Unlock());
+
+  auto npu = buffer.GetOVTensor("NPU");
+  ASSERT_TRUE(npu) << npu.Error().Message();
+  ov::Tensor npu_host(ov::element::f32, shape);
+  npu.Value().as<ov::RemoteTensor>().copy_to(npu_host);
+  const auto* np = static_cast<const float*>(npu_host.data());
+  for (int32_t i = 0; i < kN; ++i) {
+    EXPECT_FLOAT_EQ(np[i], static_cast<float>(i) * 2.0f + 1.0f);
+  }
+
+  auto gpu = buffer.GetOVTensor("GPU");
+  ASSERT_TRUE(gpu) << gpu.Error().Message();
+  ov::Tensor gpu_host(ov::element::f32, shape);
+  gpu.Value().as<ov::RemoteTensor>().copy_to(gpu_host);
+  const auto* gp = static_cast<const float*>(gpu_host.data());
+  for (int32_t i = 0; i < kN; ++i) {
+    EXPECT_FLOAT_EQ(gp[i], static_cast<float>(i) * 2.0f + 1.0f);
+  }
+}
+
+// The full boundary direction: a write issued through the GPU import must be
+// visible to the CPU read path (and thus to the NPU) -- i.e. GPU-produced
+// output is consumed downstream without a copy. Mirrors an NPU<->GPU boundary.
+TEST(OpenVinoTensorBufferCrossDevice, GpuWriteVisibleToCpu) {
+  ForceCrossDevice();
+  constexpr int32_t kN = 16;
+  const ov::Shape shape{static_cast<size_t>(kN)};
+  OpenVinoTensorBuffer buffer;
+  ASSERT_TRUE(buffer.Alloc(MakeFloat32Vector(kN), kN * sizeof(float)));
+
+  auto gpu = buffer.GetOVTensor("GPU");
+  ASSERT_TRUE(gpu) << gpu.Error().Message();
+  ov::Tensor src(ov::element::f32, shape);
+  auto* sp = static_cast<float*>(src.data());
+  for (int32_t i = 0; i < kN; ++i) {
+    sp[i] = 100.0f + static_cast<float>(i);
+  }
+  // Host -> device-local shared resource, via the GPU import. (copy_from is
+  // non-const, so bind the imported tensor to a mutable RemoteTensor first.)
+  ov::RemoteTensor gpu_remote = gpu.Value().as<ov::RemoteTensor>();
+  gpu_remote.copy_from(src);
+
+  // CPU read path: Lock(Read) runs SyncToHost (shared -> staging).
+  auto r = buffer.Lock(kLiteRtTensorBufferLockModeRead);
+  ASSERT_TRUE(r) << r.Error().Message();
+  const auto* rp = static_cast<const float*>(r.Value());
+  for (int32_t i = 0; i < kN; ++i) {
+    EXPECT_FLOAT_EQ(rp[i], 100.0f + static_cast<float>(i));
+  }
+  ASSERT_TRUE(buffer.Unlock());
+}
+
+}  // namespace
+
+#endif  // LITERT_WINDOWS_OS


### PR DESCRIPTION
Adds support of importing the same D3D12 resource for both NPU and GPU to an OV tensor. The underlying shared resource is an aligned heap that is opened as shared handle for NPU/GPU importing.