### PR TITLE
Qualcomm AI Engine Direct - Enhance validation failure log.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -498,6 +498,9 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
           // partitions.
           compiler_plugin->ctx()->push_op(selected_ops, op.Get(),
                                           kDefaultPartitionIndex));
+    } else {
+      LITERT_LOG(LITERT_ERROR, "%s",
+                 litert::qnn::DescribeUnsupportedOp(op_index, op).c_str());
     }
   }
 

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -1618,6 +1618,8 @@ LiteRtStatus BuildCustomOp(const litert::compiler::Op& litert_op,
   return kLiteRtStatusOk;
 }
 
+}  // namespace
+
 std::string DescribeUnsupportedOp(size_t op_index,
                                   const litert::compiler::Op& litert_op) {
   const auto op_code = litert_op.Code();
@@ -1642,8 +1644,6 @@ std::string DescribeUnsupportedOp(size_t op_index,
   }
   return dump.str();
 }
-
-}  // namespace
 
 LiteRtStatus ConvertOp(const ::qnn::Options& options,
                        const litert::compiler::Op& litert_op,

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include "QnnCommon.h"  // from @qairt
@@ -33,6 +34,9 @@
 #include "litert/vendors/qualcomm/qnn_manager.h"
 
 namespace litert::qnn {
+
+std::string DescribeUnsupportedOp(size_t op_index,
+                                  const litert::compiler::Op& litert_op);
 
 LiteRtStatus ConvertDataType(const litert::ElementType litert_type,
                              const bool is_quantized, Qnn_DataType_t& qnn_type);

--- a/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/op_wrapper.cc
@@ -27,6 +27,101 @@
 
 namespace qnn {
 
+namespace {
+const char* ElementWiseOperationName(const OpWrapper& op) {
+  const QnnOpCode code = op.GetOpCode();
+  if (code != QnnOpCode::kElementWiseUnary &&
+      code != QnnOpCode::kElementWiseBinary &&
+      code != QnnOpCode::kElementWiseNeuron) {
+    return nullptr;
+  }
+
+  // The operation is stored as scalar param 0 for all three op types.
+  auto scalar = op.GetScalarParam(0);
+  if (!scalar.has_value()) {
+    return nullptr;
+  }
+  Qnn_Param_t p;
+  scalar->CloneTo(p);
+  if (p.paramType != QNN_PARAMTYPE_SCALAR ||
+      p.scalarParam.dataType != QNN_DATATYPE_UINT_32) {
+    return nullptr;
+  }
+  const std::uint32_t v = p.scalarParam.uint32Value;
+  switch (code) {
+    case QnnOpCode::kElementWiseUnary:
+      switch (v) {
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_ABS: return "Abs";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_ASIN: return "Asin";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_ATAN: return "Atan";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_CEIL: return "Ceil";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_COS: return "Cos";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_EXP: return "Exp";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_FLOOR: return "Floor";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_LOG: return "Log";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_NEG: return "Neg";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_NOT: return "Not";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_RECIPROCAL:
+          return "Reciprocal";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_ROUND: return "Round";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_RSQRT: return "Rsqrt";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_SIGN: return "Sign";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_SIN: return "Sin";
+        case QNN_OP_ELEMENT_WISE_UNARY_OPERATION_SQRT: return "Sqrt";
+        default: return nullptr;
+      }
+    case QnnOpCode::kElementWiseBinary:
+      switch (v) {
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD: return "Add";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_AND: return "And";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_DIVIDE: return "Divide";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_EQUAL: return "Equal";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_FLOOR_DIV:
+          return "FloorDiv";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_FMOD: return "Fmod";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_GREATER: return "Greater";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_GREATER_EQUAL:
+          return "GreaterEqual";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_LESS: return "Less";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_LESS_EQUAL:
+          return "LessEqual";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MAXIMUM: return "Maximum";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MINIMUM: return "Minimum";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MOD: return "Mod";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_MULTIPLY: return "Multiply";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_NOT_EQUAL:
+          return "NotEqual";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_OR: return "Or";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_POWER: return "Power";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_SQUARED_DIFFERENCE:
+          return "SquaredDifference";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_SUBTRACT: return "Subtract";
+        case QNN_OP_ELEMENT_WISE_BINARY_OPERATION_XOR: return "Xor";
+        default: return nullptr;
+      }
+    case QnnOpCode::kElementWiseNeuron:
+      switch (v) {
+        case QNN_OP_ELEMENT_WISE_NEURON_OPERATION_ELU: return "Elu";
+        case QNN_OP_ELEMENT_WISE_NEURON_OPERATION_GELU: return "Gelu";
+        case QNN_OP_ELEMENT_WISE_NEURON_OPERATION_HARD_SIGMOID:
+          return "HardSigmoid";
+        case QNN_OP_ELEMENT_WISE_NEURON_OPERATION_HARD_SWISH:
+          return "HardSwish";
+        case QNN_OP_ELEMENT_WISE_NEURON_OPERATION_RELU: return "Relu";
+        case QNN_OP_ELEMENT_WISE_NEURON_OPERATION_RELU_MIN_MAX:
+          return "ReluMinMax";
+        case QNN_OP_ELEMENT_WISE_NEURON_OPERATION_SIGMOID: return "Sigmoid";
+        case QNN_OP_ELEMENT_WISE_NEURON_OPERATION_SOFTPLUS:
+          return "Softplus";
+        case QNN_OP_ELEMENT_WISE_NEURON_OPERATION_TANH: return "Tanh";
+        default: return nullptr;
+      }
+    default:
+      return nullptr;
+  }
+}
+}  // namespace
+
 bool OpWrapper::operator==(const OpWrapper& other) const {
   if (op_code_ != other.op_code_) return false;
   if (!miscs::IsStrEq(type_name_, other.type_name_)) return false;
@@ -174,7 +269,11 @@ void OpWrapper::AddSuffixToName(absl::string_view suffix) {
 std::string OpWrapper::ToString() const {
   std::ostringstream out;
   out << "'" << GetName()
-      << "' (type=" << (GetTypeName() ? GetTypeName() : "<null>") << ")";
+      << "' (type=" << (GetTypeName() ? GetTypeName() : "<null>");
+  if (const char* operation_name = ElementWiseOperationName(*this)) {
+    out << ", operation=" << operation_name;
+  }
+  out << ")";
   out << "\n  Inputs:";
   for (size_t i = 0; i < input_tensors_.size(); ++i) {
     out << "\n    [" << i << "] " << input_tensors_[i].get().ToString();

--- a/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/op_wrapper_test.cc
@@ -521,5 +521,45 @@ TEST(OpWrapperTest, ToString) {
       "(no quantization)");
 }
 
+TEST(OpWrapperTest, ToStringElementWiseOperation) {
+  OpWrapper binary{"add", QNN_OP_ELEMENT_WISE_BINARY,
+                   QnnOpCode::kElementWiseBinary};
+  binary.AddScalarParam<std::uint32_t>(
+      QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION,
+      QNN_OP_ELEMENT_WISE_BINARY_OPERATION_ADD);
+  EXPECT_NE(binary.ToString().find("operation=Add"), std::string::npos);
+
+  OpWrapper unary{"not", QNN_OP_ELEMENT_WISE_UNARY,
+                  QnnOpCode::kElementWiseUnary};
+  unary.AddScalarParam<std::uint32_t>(QNN_OP_ELEMENT_WISE_UNARY_PARAM_OPERATION,
+                                      QNN_OP_ELEMENT_WISE_UNARY_OPERATION_NOT);
+  EXPECT_NE(unary.ToString().find("operation=Not"), std::string::npos);
+
+  OpWrapper neuron{"tanh", QNN_OP_ELEMENT_WISE_NEURON,
+                   QnnOpCode::kElementWiseNeuron};
+  neuron.AddScalarParam<std::uint32_t>(
+      QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION,
+      QNN_OP_ELEMENT_WISE_NEURON_OPERATION_TANH);
+  EXPECT_NE(neuron.ToString().find("operation=Tanh"), std::string::npos);
+}
+
+TEST(OpWrapperTest, ToStringNoOperationSuffix) {
+  // Non-elementwise ops get no "operation=" suffix.
+  OpWrapper other{"reshape", QNN_OP_RESHAPE, QnnOpCode::kReshape};
+  EXPECT_EQ(other.ToString().find("operation="), std::string::npos);
+
+  // An elementwise op with an unknown operation value also omits the suffix
+  OpWrapper unknown{"weird", QNN_OP_ELEMENT_WISE_BINARY,
+                    QnnOpCode::kElementWiseBinary};
+  unknown.AddScalarParam<std::uint32_t>(
+      QNN_OP_ELEMENT_WISE_BINARY_PARAM_OPERATION, 9999);
+  EXPECT_EQ(unknown.ToString().find("operation="), std::string::npos);
+
+  // An elementwise op missing its scalar param also omits the suffix.
+  OpWrapper no_param{"missing", QNN_OP_ELEMENT_WISE_UNARY,
+                     QnnOpCode::kElementWiseUnary};
+  EXPECT_EQ(no_param.ToString().find("operation="), std::string::npos);
+}
+
 }  // namespace
 }  // namespace qnn


### PR DESCRIPTION
# What
- Add litert op code & idx, litert tensor name & idx to the debug log when validation fails.
- Add operation name for e-wise binary/unary/neuron.

# Sample log
```
ERROR: [qnn_manager.cc:491] 
QNN op validation failed: 'ElementWiseBinary_24' (type=ElementWiseBinary, operation=Or)
  Inputs:
    [0] name="0_litert_250" dtype=QNN_DATATYPE_BOOL_8 dims=[1,1,17,1,24] (no quantization)
    [1] name="3_qnn" dtype=QNN_DATATYPE_BOOL_8 dims=[1,1,1,12,1] (no quantization)
  Outputs:
    [0] name="2_litert_251" dtype=QNN_DATATYPE_BOOL_8 dims=[1,1,17,12,24] (no quantization)
  QNN error=3110. See the QNN validator log lines above for the specific reason.
ERROR: [qnn_compiler_plugin.cc:503] 
LiteRT Op #24 'BroadcastTo' (code=130) is not supported in Qualcomm Compiler.
  Inputs:
    [0] name="jit(wrapper)/ConformerEncoder/ConformerEncoder.get_pos_and_mask/broadcast_in_dim2"  tensor_idx=250
    [1] name="arith.constant42"  tensor_idx=107
  Outputs:
    [0] name="jit(wrapper)/ConformerEncoder/ConformerEncoder.get_pos_and_mask/and"  tensor_idx=251
```

# Verification
- [x] Developer verified
# Test

```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test       PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.4s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test        PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test      PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.2s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test               PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test                 PASSED in 1.2s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test                  PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 57.6s
```

```
======================== Test Summary ========================
SM8750: //litert/c/options:litert_qualcomm_options_test
[==========] 25 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 25 tests.

SM8750: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 18 tests from 12 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8750: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (11 ms total)
[  PASSED  ] 16 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 36 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (0 ms total)
[  PASSED  ] 66 tests.

SM8750: //litert/vendors/qualcomm/core:common_test
[==========] 29 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 29 tests.

SM8750: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (19 ms total)
[  PASSED  ] 13 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (264 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (296 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (303 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (817 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1201 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (604 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1177 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (489 ms total)
[  PASSED  ] 9 tests.

SM8750: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 6 tests from 2 test suites ran. (611 ms total)
[  PASSED  ] 6 tests.

SM8750: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 28 tests from 7 test suites ran. (4118 ms total)
[  PASSED  ] 26 tests.

SM8750: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (12 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (8 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (402 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (374 ms total)
[  PASSED  ] 2 tests.
```