### PR TITLE
Qualcomm AI Engine Direct - Add More Complete Unit Test for CustomOpPackage

### DIFF
--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -15,6 +15,7 @@
 # Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//litert/build_common:litert_build_defs.bzl", "gtest_main_no_heapcheck_deps", "litert_bin", "litert_dynamic_lib", "litert_lib", "litert_test", "make_rpaths")
 load("//litert/build_common:special_rule.bzl", "litert_android_linkopts")
@@ -335,6 +336,19 @@ litert_lib(
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
         "@flatbuffers",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+cc_test(
+    name = "qnn_compose_graph_test",
+    srcs = ["qnn_compose_graph_test.cc"],
+    deps = [
+        ":qnn_compose_graph",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "@flatbuffers",
+        "@com_google_googletest//:gtest_main",
         "@qairt//:qnn_lib_headers",
     ],
 )

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -359,6 +359,107 @@ LiteRtStatus ConvertTensor(const litert::compiler::Tensor& litert_tensor,
   return kLiteRtStatusOk;
 }
 
+LiteRtStatus AddCustomOpOptionsAsParams(
+    absl::Span<const uint8_t> custom_options, ::qnn::TensorPool& tensor_pool,
+    ::qnn::OpWrapper& custom_op) {
+  // Custom ops may legitimately omit custom options, and since the smallest
+  // valid flexbuffer is 3 bytes, anything smaller cannot be one.
+  if (custom_options.size() < 3) {
+    LITERT_LOG(
+        LITERT_WARNING,
+        "Custom options are too small to be a valid flexbuffer map, ignoring "
+        "it.");
+    return kLiteRtStatusOk;
+  }
+
+  if (!flexbuffers::VerifyBuffer(custom_options.data(),
+                                 custom_options.size())) {
+    LITERT_LOG(LITERT_ERROR,
+               "Custom op custom options are not a valid flexbuffer.");
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  const auto root =
+      flexbuffers::GetRoot(custom_options.data(), custom_options.size());
+  if (!root.IsMap()) {
+    LITERT_LOG(LITERT_ERROR,
+               "Custom op custom options are not a flexbuffer "
+               "map.");
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  const auto map = root.AsMap();
+  const auto keys = map.Keys();
+  const auto values = map.Values();
+  for (size_t i = 0; i < map.size(); ++i) {
+    const char* key = keys[i].AsKey();
+    const auto& value = values[i];
+
+    if (value.IsUntypedVector() || value.IsTypedVector() ||
+        value.IsFixedTypedVector()) {
+      const auto dimensions = ::qnn::InferShape(value);
+      if (!dimensions.has_value()) {
+        LITERT_LOG(LITERT_ERROR,
+                   "BuildCustomOp: custom options key '%s' has ragged vector "
+                   "dimensions.",
+                   key);
+        return kLiteRtStatusErrorUnsupported;
+      }
+
+      const uint32_t num_elements =
+          std::accumulate(dimensions->begin(), dimensions->end(), uint32_t{1},
+                          std::multiplies<uint32_t>());
+
+      // Resolve the uniform scalar type once, then fill with the matching T.
+      auto fill_vector = [&](auto type_tag, Qnn_DataType_t qnn_dtype) {
+        using T = decltype(type_tag);
+        std::vector<T> data;
+        data.reserve(num_elements);
+        ::qnn::FillBuffer<T>(value, data);
+        auto& tensor = tensor_pool.CreateStaticTensor(
+            qnn_dtype, {}, dimensions.value(),
+            static_cast<uint32_t>(num_elements * sizeof(T)), data.data());
+        custom_op.AddTensorParam(key, tensor);
+      };
+
+      switch (::qnn::GetUniformScalarType(value)) {
+        case ::qnn::FlexbufferScalarType::kBool:
+          fill_vector(uint8_t{}, QNN_DATATYPE_BOOL_8);
+          break;
+        case ::qnn::FlexbufferScalarType::kInt:
+          fill_vector(int32_t{}, QNN_DATATYPE_INT_32);
+          break;
+        case ::qnn::FlexbufferScalarType::kUint:
+          fill_vector(uint32_t{}, QNN_DATATYPE_UINT_32);
+          break;
+        case ::qnn::FlexbufferScalarType::kFloat:
+          fill_vector(float{}, QNN_DATATYPE_FLOAT_32);
+          break;
+        default:
+          LITERT_LOG(LITERT_ERROR,
+                     "BuildCustomOp: unsupported scalar type for vector "
+                     "param key '%s'.",
+                     key);
+          return kLiteRtStatusErrorUnsupported;
+      }
+    } else if (value.IsBool()) {
+      custom_op.AddScalarParam<bool>(key, value.AsBool());
+    } else if (value.IsInt()) {
+      custom_op.AddScalarParam<std::int32_t>(key, value.AsInt32());
+    } else if (value.IsUInt()) {
+      custom_op.AddScalarParam<std::uint32_t>(key, value.AsUInt32());
+    } else if (value.IsFloat()) {
+      custom_op.AddScalarParam<float>(key, value.AsFloat());
+    } else {
+      LITERT_LOG(LITERT_ERROR,
+                 "BuildCustomOp: unsupported scalar type for param key '%s'.",
+                 key);
+      return kLiteRtStatusErrorUnsupported;
+    }
+  }
+  return kLiteRtStatusOk;
+}
+
 namespace {
 
 using OpBuilder = LiteRtStatus (*)(
@@ -1519,104 +1620,7 @@ LiteRtStatus BuildCustomOp(const litert::compiler::Op& litert_op,
                             std::vector<::qnn::ConstTensorWrapperRef>(
                                 output_tensors.begin(), output_tensors.end())));
 
-  // TODO(weilhuan): Will cause seg fault if checked by
-  // flexbuffers::GetRoot().IsNull for some reason, use < 2 here to avoid this.
-  if (custom_options->size() < 2) {
-    LITERT_LOG(
-        LITERT_WARNING,
-        "Custom op custom options are too small to be a flexbuffer map, maybe "
-        "there is no custom options in custom op.");
-    return kLiteRtStatusOk;
-  }
-
-  // GetRoot trusts the buffer's internal offsets; validate first since custom
-  // options come from the .tflite (external input).
-  if (!flexbuffers::VerifyBuffer(custom_options->data(),
-                                 custom_options->size())) {
-    LITERT_LOG(LITERT_ERROR,
-               "Custom op custom options are not a valid flexbuffer.");
-    return kLiteRtStatusErrorInvalidArgument;
-  }
-
-  const auto root =
-      flexbuffers::GetRoot(custom_options->data(), custom_options->size());
-  if (!root.IsMap()) {
-    LITERT_LOG(LITERT_ERROR,
-               "Custom op custom options are not a flexbuffer "
-               "map.");
-    return kLiteRtStatusErrorInvalidArgument;
-  }
-
-  const auto map = root.AsMap();
-  const auto keys = map.Keys();
-  const auto values = map.Values();
-  for (size_t i = 0; i < map.size(); ++i) {
-    const char* key = keys[i].AsKey();
-    const auto& value = values[i];
-
-    if (value.IsUntypedVector() || value.IsTypedVector() ||
-        value.IsFixedTypedVector()) {
-      const auto dimensions = ::qnn::InferShape(value);
-      if (!dimensions.has_value()) {
-        LITERT_LOG(LITERT_ERROR,
-                   "BuildCustomOp: custom options key '%s' has ragged vector "
-                   "dimensions.",
-                   key);
-        return kLiteRtStatusErrorUnsupported;
-      }
-
-      const uint32_t num_elements =
-          std::accumulate(dimensions->begin(), dimensions->end(), uint32_t{1},
-                          std::multiplies<uint32_t>());
-
-      // Resolve the uniform scalar type once, then fill with the matching T.
-      auto fill_vector = [&](auto type_tag, Qnn_DataType_t qnn_dtype) {
-        using T = decltype(type_tag);
-        std::vector<T> data;
-        data.reserve(num_elements);
-        ::qnn::FillBuffer<T>(value, data);
-        auto& tensor = tensor_pool.CreateStaticTensor(
-            qnn_dtype, {}, dimensions.value(),
-            static_cast<uint32_t>(num_elements * sizeof(T)), data.data());
-        custom_op.AddTensorParam(key, tensor);
-      };
-
-      switch (::qnn::GetUniformScalarType(value)) {
-        case ::qnn::FlexbufferScalarType::kBool:
-          fill_vector(uint8_t{}, QNN_DATATYPE_BOOL_8);
-          break;
-        case ::qnn::FlexbufferScalarType::kInt:
-          fill_vector(int32_t{}, QNN_DATATYPE_INT_32);
-          break;
-        case ::qnn::FlexbufferScalarType::kUint:
-          fill_vector(uint32_t{}, QNN_DATATYPE_UINT_32);
-          break;
-        case ::qnn::FlexbufferScalarType::kFloat:
-          fill_vector(float{}, QNN_DATATYPE_FLOAT_32);
-          break;
-        default:
-          LITERT_LOG(LITERT_ERROR,
-                     "BuildCustomOp: unsupported scalar type for vector "
-                     "param key '%s'.",
-                     key);
-          return kLiteRtStatusErrorUnsupported;
-      }
-    } else if (value.IsBool()) {
-      custom_op.AddScalarParam<bool>(key, value.AsBool());
-    } else if (value.IsInt()) {
-      custom_op.AddScalarParam<std::int32_t>(key, value.AsInt32());
-    } else if (value.IsUInt()) {
-      custom_op.AddScalarParam<std::uint32_t>(key, value.AsUInt32());
-    } else if (value.IsFloat()) {
-      custom_op.AddScalarParam<float>(key, value.AsFloat());
-    } else {
-      LITERT_LOG(LITERT_ERROR,
-                 "BuildCustomOp: unsupported scalar type for param key '%s'.",
-                 key);
-      return kLiteRtStatusErrorUnsupported;
-    }
-  }
-  return kLiteRtStatusOk;
+  return AddCustomOpOptionsAsParams(*custom_options, tensor_pool, custom_op);
 }
 
 std::string DescribeUnsupportedOp(size_t op_index,

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
@@ -23,6 +23,7 @@
 #include "QnnTypes.h"  // from @qairt
 #include "absl/container/flat_hash_set.h"  // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
+#include "absl/types/span.h"  // from @com_google_absl
 #include "litert/c/internal/litert_compiler_context.h"
 #include "litert/c/litert_common.h"
 #include "litert/cc/litert_element_type.h"
@@ -44,6 +45,10 @@ LiteRtStatus ConvertTensor(
     ::qnn::TensorPool& tensor_pool, ::qnn::TensorWrapper*& tensor_wrapper,
     const absl::flat_hash_set<std::int32_t>& ids_to_dump = {},
     bool is_tensor_output = false);
+
+LiteRtStatus AddCustomOpOptionsAsParams(
+    absl::Span<const uint8_t> custom_options, ::qnn::TensorPool& tensor_pool,
+    ::qnn::OpWrapper& custom_op);
 
 // `op_index` is the topological index of the op within its subgraph; it is
 // included in the "unsupported op" error message so a specific op can be

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph_test.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph_test.cc
@@ -1,0 +1,189 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/compiler/qnn_compose_graph.h"
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "flatbuffers/flexbuffers.h"  // from @flatbuffers
+
+namespace litert::qnn {
+namespace {
+
+const Qnn_Param_t* FindParam(const Qnn_OpConfig_t& op_config,
+                             const char* name) {
+  for (uint32_t i = 0; i < op_config.v1.numOfParams; ++i) {
+    if (std::strcmp(op_config.v1.params[i].name, name) == 0) {
+      return &op_config.v1.params[i];
+    }
+  }
+  return nullptr;
+}
+
+TEST(AddCustomOpOptionsAsParamsTest, EmptyOptionsAddsNoParams) {
+  ::qnn::TensorPool tensor_pool;
+  ::qnn::OpWrapper custom_op{"test_op", "TestOp", ::qnn::QnnOpCode::kUnknown};
+
+  const std::vector<uint8_t> custom_options;
+  EXPECT_EQ(AddCustomOpOptionsAsParams(custom_options, tensor_pool, custom_op),
+            kLiteRtStatusOk);
+
+  const Qnn_OpConfig_t op_config = custom_op.GetOpConfig();
+  EXPECT_EQ(op_config.v1.numOfParams, 0);
+}
+
+TEST(AddCustomOpOptionsAsParamsTest, InvalidOptionsRejected) {
+  ::qnn::TensorPool tensor_pool;
+  ::qnn::OpWrapper custom_op{"test_op", "TestOp", ::qnn::QnnOpCode::kUnknown};
+
+  const std::vector<uint8_t> custom_options = {'x', 'y'};
+  EXPECT_EQ(AddCustomOpOptionsAsParams(custom_options, tensor_pool, custom_op),
+            kLiteRtStatusErrorInvalidArgument);
+}
+
+TEST(AddCustomOpOptionsAsParamsTest, NonMapOptionsRejected) {
+  flexbuffers::Builder fbb;
+  fbb.Int(42);
+  fbb.Finish();
+  const auto custom_options = fbb.GetBuffer();
+
+  ::qnn::TensorPool tensor_pool;
+  ::qnn::OpWrapper custom_op{"test_op", "TestOp", ::qnn::QnnOpCode::kUnknown};
+
+  EXPECT_EQ(AddCustomOpOptionsAsParams(custom_options, tensor_pool, custom_op),
+            kLiteRtStatusErrorInvalidArgument);
+}
+
+TEST(AddCustomOpOptionsAsParamsTest, AddsScalarParams) {
+  flexbuffers::Builder fbb;
+  auto map_start = fbb.StartMap();
+  fbb.Bool("bool_param", true);
+  fbb.Int("int_param", -7);
+  fbb.UInt("uint_param", 9);
+  fbb.Float("float_param", 1.5f);
+  fbb.EndMap(map_start);
+  fbb.Finish();
+  const auto custom_options = fbb.GetBuffer();
+
+  ::qnn::TensorPool tensor_pool;
+  ::qnn::OpWrapper custom_op{"test_op", "TestOp", ::qnn::QnnOpCode::kUnknown};
+
+  EXPECT_EQ(AddCustomOpOptionsAsParams(custom_options, tensor_pool, custom_op),
+            kLiteRtStatusOk);
+
+  const Qnn_OpConfig_t op_config = custom_op.GetOpConfig();
+  ASSERT_EQ(op_config.v1.numOfParams, 4);
+
+  const Qnn_Param_t* bool_param = FindParam(op_config, "bool_param");
+  ASSERT_NE(bool_param, nullptr);
+  EXPECT_EQ(bool_param->paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(bool_param->scalarParam.dataType, QNN_DATATYPE_BOOL_8);
+  EXPECT_TRUE(bool_param->scalarParam.bool8Value);
+
+  const Qnn_Param_t* int_param = FindParam(op_config, "int_param");
+  ASSERT_NE(int_param, nullptr);
+  EXPECT_EQ(int_param->paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(int_param->scalarParam.dataType, QNN_DATATYPE_INT_32);
+  EXPECT_EQ(int_param->scalarParam.int32Value, -7);
+
+  const Qnn_Param_t* uint_param = FindParam(op_config, "uint_param");
+  ASSERT_NE(uint_param, nullptr);
+  EXPECT_EQ(uint_param->paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(uint_param->scalarParam.dataType, QNN_DATATYPE_UINT_32);
+  EXPECT_EQ(uint_param->scalarParam.uint32Value, 9);
+
+  const Qnn_Param_t* float_param = FindParam(op_config, "float_param");
+  ASSERT_NE(float_param, nullptr);
+  EXPECT_EQ(float_param->paramType, QNN_PARAMTYPE_SCALAR);
+  EXPECT_EQ(float_param->scalarParam.dataType, QNN_DATATYPE_FLOAT_32);
+  EXPECT_FLOAT_EQ(float_param->scalarParam.floatValue, 1.5f);
+}
+
+TEST(AddCustomOpOptionsAsParamsTest, AddsVectorParamAsStaticTensor) {
+  flexbuffers::Builder fbb;
+  auto map_start = fbb.StartMap();
+  fbb.Vector("weights", [&fbb]() {
+    fbb.Vector([&fbb]() {
+      fbb.Int(1);
+      fbb.Int(2);
+    });
+    fbb.Vector([&fbb]() {
+      fbb.Int(3);
+      fbb.Int(4);
+    });
+  });
+  fbb.EndMap(map_start);
+  fbb.Finish();
+  const auto custom_options = fbb.GetBuffer();
+
+  ::qnn::TensorPool tensor_pool;
+  ::qnn::OpWrapper custom_op{"test_op", "TestOp", ::qnn::QnnOpCode::kUnknown};
+
+  EXPECT_EQ(AddCustomOpOptionsAsParams(custom_options, tensor_pool, custom_op),
+            kLiteRtStatusOk);
+
+  const Qnn_OpConfig_t op_config = custom_op.GetOpConfig();
+  ASSERT_EQ(op_config.v1.numOfParams, 1);
+
+  const Qnn_Param_t* weights = FindParam(op_config, "weights");
+  ASSERT_NE(weights, nullptr);
+  ASSERT_EQ(weights->paramType, QNN_PARAMTYPE_TENSOR);
+
+  const Qnn_Tensor_t& tensor = weights->tensorParam;
+  EXPECT_EQ(tensor.v2.type, QNN_TENSOR_TYPE_STATIC);
+  EXPECT_EQ(tensor.v2.dataType, QNN_DATATYPE_INT_32);
+  ASSERT_EQ(tensor.v2.rank, 2);
+  EXPECT_EQ(tensor.v2.dimensions[0], 2);
+  EXPECT_EQ(tensor.v2.dimensions[1], 2);
+  EXPECT_EQ(tensor.v2.clientBuf.dataSize, 4 * sizeof(int32_t));
+  ASSERT_NE(tensor.v2.clientBuf.data, nullptr);
+
+  const auto* data = static_cast<const int32_t*>(tensor.v2.clientBuf.data);
+  EXPECT_EQ(std::vector<int32_t>(data, data + 4),
+            (std::vector<int32_t>{1, 2, 3, 4}));
+}
+
+TEST(AddCustomOpOptionsAsParamsTest, RaggedVectorRejected) {
+  flexbuffers::Builder fbb;
+  auto map_start = fbb.StartMap();
+  fbb.Vector("ragged", [&fbb]() {
+    fbb.Vector([&fbb]() {
+      fbb.Int(1);
+      fbb.Int(2);
+    });
+    fbb.Vector([&fbb]() { fbb.Int(3); });
+  });
+  fbb.EndMap(map_start);
+  fbb.Finish();
+  const auto custom_options = fbb.GetBuffer();
+
+  ::qnn::TensorPool tensor_pool;
+  ::qnn::OpWrapper custom_op{"test_op", "TestOp", ::qnn::QnnOpCode::kUnknown};
+
+  EXPECT_EQ(AddCustomOpOptionsAsParams(custom_options, tensor_pool, custom_op),
+            kLiteRtStatusErrorUnsupported);
+}
+
+TEST(AddCustomOpOptionsAsParamsTest, MixedVectorRejected) {
+  flexbuffers::Builder fbb;
+  auto map_start = fbb.StartMap();
+  fbb.Vector("mixed", [&fbb]() {
+    fbb.Int(1);
+    fbb.Float(2.0f);
+  });
+  fbb.EndMap(map_start);
+  fbb.Finish();
+  const auto custom_options = fbb.GetBuffer();
+
+  ::qnn::TensorPool tensor_pool;
+  ::qnn::OpWrapper custom_op{"test_op", "TestOp", ::qnn::QnnOpCode::kUnknown};
+
+  EXPECT_EQ(AddCustomOpOptionsAsParams(custom_options, tensor_pool, custom_op),
+            kLiteRtStatusErrorUnsupported);
+}
+
+}  // namespace
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/tests/CMakeLists.txt
+++ b/litert/vendors/qualcomm/tests/CMakeLists.txt
@@ -56,6 +56,23 @@ target_link_libraries(qnn_compiler_plugin_test
         GTest::gtest_main
 )
 
+# QNN compose graph test
+add_executable(qnn_compose_graph_test)
+
+target_sources(qnn_compose_graph_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../compiler/qnn_compose_graph_test.cc
+)
+
+target_link_libraries(qnn_compose_graph_test
+    PRIVATE
+        qnn_compiler_plugin
+        qnn_tensor_pool
+        qnn_wrappers
+        flatbuffers::flatbuffers
+        GTest::gtest_main
+)
+
 # QNN manager test
 add_executable(qnn_manager_test)
 
@@ -210,6 +227,21 @@ target_sources(quantize_params_wrapper_test
 target_link_libraries(quantize_params_wrapper_test
     PRIVATE
         qnn_wrappers
+        GTest::gtest_main
+)
+
+# Flexbuffer helpers test
+add_executable(flexbuffer_helpers_test)
+
+target_sources(flexbuffer_helpers_test
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../core/utils/flexbuffer_helpers_test.cc
+)
+
+target_link_libraries(flexbuffer_helpers_test
+    PRIVATE
+        qnn_flexbuffer_helpers
+        flatbuffers::flatbuffers
         GTest::gtest_main
 )
 


### PR DESCRIPTION
# WHAT
- Add more complete unit test for the custom op package related pass.
- Add target in bazel BUILD and Cmake CmakeList.

# Verification
- [x] Developer-Verified

# TEST
device
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 25 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 25 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 18 tests from 12 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (12 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 22 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 22 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 36 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 29 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 29 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (16 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (375 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (1922 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (1898 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 3 tests from 1 test suite ran. (885 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1279 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/compiler:qnn_compose_graph_test
[==========] 7 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 7 tests.

SM8850: //litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test
[==========] 21 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (31 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 6 tests from 2 test suites ran. (614 ms total)
[  PASSED  ] 6 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 28 tests from 7 test suites ran. (6823 ms total)
[  PASSED  ] 26 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (29 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (565 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (8 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (527 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (435 ms total)
[  PASSED  ] 2 tests.

```
x86
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.1s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compose_graph_test
//litert/vendors/qualcomm/compiler:qnn_compose_graph_test                PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test
//litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test             PASSED in 0.0s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.9s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.0s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 30.8s
```
