### PR TITLE
Fix Google-Tensor AOT crash on blockwise-quantized models (freed scales tensor in OutlinePartition)

### DIFF
--- a/litert/compiler/plugin/algo.cc
+++ b/litert/compiler/plugin/algo.cc
@@ -212,6 +212,10 @@ class GraphSlicer {
 
   void RerouteTensorsThroughCustomOp(const LiteRtSubgraphT& root);
 
+  // Clones blockwise-quantization scales/zero_points tensors into the slice and
+  // remaps the Qparams pointers, so they survive DCE of the root subgraph.
+  void CloneBlockwiseScales();
+
   LiteRtSubgraph slice_;
   // Maps tensor in old subgraph to tensor in new subgraph.
   InsertOrderMap<LiteRtTensor, LiteRtTensor> tensor_map_;
@@ -257,6 +261,11 @@ LiteRtOp GraphSlicer::SlicePartitionFromGraph(
   ABSL_DCHECK(slicer.dispatch_op_->Outputs().empty());
   MakeDispatchOp(*slicer.dispatch_op_);
   slicer.RerouteTensorsThroughCustomOp(root);
+
+  // Blockwise scales/zero_points are referenced only via Qparams (not op I/O),
+  // so the op clone above leaves them in `root`; clone+remap them into the slice
+  // before DCE frees them.
+  slicer.CloneBlockwiseScales();
 
   DCE(root);
 
@@ -316,6 +325,34 @@ void GraphSlicer::CloneInto(const LiteRtOpT& old_op) {
 
     // Update the values defined in scope of the new subgraph.
     tensor_map_.InsertOrAssign(old_output, new_output);
+  }
+}
+
+void GraphSlicer::CloneBlockwiseScales() {
+  // Blockwise-quantized weights reference their `scales` (and optional
+  // `zero_points`) tensors via Qparams rather than as op inputs/outputs, so the
+  // op clone does not bring them into the slice. Clone them in and remap the
+  // Qparams pointers to the clones; otherwise they dangle when `root` is DCE'd,
+  // which crashes serialization of the outlined partition.
+  std::vector<LiteRtTensor> cloned_tensors(slice_->Tensors().cbegin(),
+                                           slice_->Tensors().cend());
+  for (auto* tensor : cloned_tensors) {
+    if (tensor->Qparams().first != kLiteRtQuantizationBlockWise) {
+      continue;
+    }
+    auto& block_wise = tensor->Qparams().second.block_wise;
+    for (LiteRtTensor* field : {&block_wise.scales, &block_wise.zero_points}) {
+      if (*field == nullptr) {
+        continue;
+      }
+      if (tensor_map_.Contains(*field)) {
+        *field = tensor_map_.Find(*field)->get().second;
+      } else {
+        auto* cloned = &MakeClone(*slice_, **field);
+        tensor_map_.InsertOrAssign(*field, cloned);
+        *field = cloned;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #8831.

### Problem
`aot_compile` of a **blockwise (group) quantized** model on the Google-Tensor NPU backend crashes — a segfault in `apply_plugin_main` right after `Serializing model`, or (on some paths) `litert_to_flatbuffer.cc: Failed to find scales tensor in map`. Reproduces with `ai_edge_quantizer` recipes `dynamic_wi4b32_afp32` / `dynamic_wi2b32_afp32` (int4/int2 block-32). Affects Tensor G3–G6.

### Root cause
`GraphSlicer::SlicePartitionFromGraph` (`OutlinePartition`, `litert/compiler/plugin/algo.cc`) slices the selected ops into a new subgraph, cloning the ops and their **op-I/O** tensors, then calls `DCE(root)`. A blockwise-quantized weight is cloned (it's an op input), but its `scales`/`zero_points` tensors are referenced **only via `Qparams`** — not as op inputs/outputs — so they stay in `root` and are **freed by `DCE(root)`**. The cloned weight's `.scales` then dangles, and serializing the outlined partition dereferences freed memory.

### Fix
`GraphSlicer::CloneBlockwiseScales()`: before `DCE(root)`, clone any blockwise `scales`/`zero_points` tensors into the slice and remap the weight's `Qparams` pointers to the clones — mirroring the existing blockwise remap in `litert/core/model/shape_inference.cc`. Once the scales survive the copy, serialization finds them and packs the model correctly. Pure addition (no behavior change for non-blockwise models).

### Validation
Built a patched `apply_plugin_main` and ran `aot_compile` of a blockwise-quantized `FULLY_CONNECTED` model on the Google-Tensor backend:
- **Before:** segfault during serialization of the outlined partition.
- **After (`dynamic_wi4b32_afp32`, int4 block-32):** no crash — the backend compiler runs and emits a valid DGC (`AOT models: 1 failed: []`, ~35 KB output `.tflite`).

Note: `dynamic_wi2b32_afp32` (int2 block-32) gets past serialization with this fix too, but then fails *inside the backend compiler* with `INTERNAL` — a separate backend-codegen limitation (int4-blockwise is supported, int2-blockwise apparently isn't), not this graph-copy bug.