### PR TITLE
Qualcomm AI Engine Direct - Fix the release order of CompiledModelT members.

### DIFF
--- a/litert/runtime/compiled_model.h
+++ b/litert/runtime/compiled_model.h
@@ -471,26 +471,11 @@ class LiteRtCompiledModelT {
   // NOTE: Any fields that must be destroyed after the TFL interpreter
   // is destroyed must be listed before field interp_.
 
-  std::vector<Delegate> delegates_;
-  // The loader that manages external weight metadata and bindings.
-  std::unique_ptr<weight_loader::WeightLoader> weight_loader_owned_;
-  // It may point to weight_loader_owned_ or the weight loader owned by the
-  // client. If there are no external weights to use, this will be nullptr.
-  weight_loader::WeightLoader* weight_loader_ = nullptr;
-
-  std::vector<std::unique_ptr<litert::internal::CustomOpDispatcher>>
-      custom_op_dispatchers_;
-
-  // The TFL interpreter.
-  std::unique_ptr<::tflite::Interpreter> interp_;
-
-  // NOTE: List below TFL interpreter related objects used to run the
-  // model. Note that these fields will be destroyed before the TFL interpreter
-  // is destroyed.
+  // File system hints about the originating model location.
+  std::optional<std::string> model_directory_;
 
   std::unique_ptr<::tflite::FlatBufferModel> fb_model_;
   litert::OwningBufferRef<uint8_t> model_buf_;
-  std::vector<const std::string*> signature_keys_;
   // If JIT compilation hasn't happened, the flatbuffer fd belongs to the
   // incoming literal model. If JIT compilation has happened, the fd belongs to
   // a newly serialized flatbuffer owned by the compiled model. If the model is
@@ -510,6 +495,25 @@ class LiteRtCompiledModelT {
   std::vector<litert::internal::CompilerPlugin> maybe_compiled_plugins_;
   std::optional<litert::internal::ApplyPluginsResult> apply_plugins_result_;
 #endif  // !defined(LITERT_DISABLE_NPU)
+
+  std::vector<Delegate> delegates_;
+  // The loader that manages external weight metadata and bindings.
+  std::unique_ptr<weight_loader::WeightLoader> weight_loader_owned_;
+  // It may point to weight_loader_owned_ or the weight loader owned by the
+  // client. If there are no external weights to use, this will be nullptr.
+  weight_loader::WeightLoader* weight_loader_ = nullptr;
+
+  std::vector<std::unique_ptr<litert::internal::CustomOpDispatcher>>
+      custom_op_dispatchers_;
+
+  // The TFL interpreter.
+  std::unique_ptr<::tflite::Interpreter> interp_;
+
+  // NOTE: List below TFL interpreter related objects used to run the
+  // model. Note that these fields will be destroyed before the TFL interpreter
+  // is destroyed.
+
+  std::vector<const std::string*> signature_keys_;
 
   // The buffer requirement maps for CPU buffers. For delegates with CPU
   // buffers, they don't register TensorBufferRequirements. Instead, the
@@ -546,9 +550,6 @@ class LiteRtCompiledModelT {
   // Fabric runtime path state (non-null when CompiledModel runs Fabric).
   std::unique_ptr<litert::internal::FabricRuntimeState> fabric_runtime_;
 #endif  // defined(LITERT_ENABLE_FABRIC_INTEGRATION)
-
-  // File system hints about the originating model location.
-  std::optional<std::string> model_directory_;
 
   // The set of CPU Tensors. This is used to manage TensorBufferRequirements
   // for shared CPU Tensors.

--- a/litert/runtime/compiled_model.h
+++ b/litert/runtime/compiled_model.h
@@ -481,31 +481,15 @@ class LiteRtCompiledModelT {
   // NOTE: Any fields that must be destroyed after the TFL interpreter
   // is destroyed must be listed before field interp_.
 
-  std::vector<Delegate> delegates_;
-  // The loader that manages external weight metadata and bindings.
-  std::unique_ptr<weight_loader::WeightLoader> weight_loader_owned_;
-  // It may point to weight_loader_owned_ or the weight loader owned by the
-  // client. If there are no external weights to use, this will be nullptr.
-  weight_loader::WeightLoader* weight_loader_ = nullptr;
+  // File system hints about the originating model location.
+  std::optional<std::string> model_directory_;
 
-  std::vector<std::unique_ptr<litert::internal::CustomOpDispatcher>>
-      custom_op_dispatchers_;
-
-  // The TFL interpreter.
-  std::unique_ptr<::tflite::Interpreter> interp_;
-
-  // NOTE: List below TFL interpreter related objects used to run the
-  // model. Note that these fields will be destroyed before the TFL interpreter
-  // is destroyed.
-
-  std::unique_ptr<::tflite::FlatBufferModel> fb_model_;
   litert::OwningBufferRef<uint8_t> model_buf_;
-  std::vector<const std::string*> signature_keys_;
-  // All subgraphs when no signature selection is configured; otherwise the
-  // deduplicated signature root set. Transitive expansion is a follow-up.
-  std::vector<int> active_subgraph_indices_;
-  // Empty means every signature is active.
-  absl::flat_hash_set<std::string> selected_signature_keys_;
+#if !defined(LITERT_DISABLE_NPU)
+  std::optional<LiteRtModelT::Ptr> cached_model_;
+#endif  // !defined(LITERT_DISABLE_NPU)
+  std::unique_ptr<::tflite::FlatBufferModel> fb_model_;
+
   // If JIT compilation hasn't happened, the flatbuffer fd belongs to the
   // incoming literal model. If JIT compilation has happened, the fd belongs to
   // a newly serialized flatbuffer owned by the compiled model. If the model is
@@ -521,10 +505,39 @@ class LiteRtCompiledModelT {
   // found in the cache, the compiled model will be loaded from the cache.
   // Otherwise, the compiled model will be compiled and saved to the cache.
   std::optional<litert::internal::CompilationCache> compilation_cache_;
-  std::optional<LiteRtModelT::Ptr> cached_model_;
   std::vector<litert::internal::CompilerPlugin> maybe_compiled_plugins_;
   std::optional<litert::internal::ApplyPluginsResult> apply_plugins_result_;
 #endif  // !defined(LITERT_DISABLE_NPU)
+
+  std::vector<Delegate> delegates_;
+  // The loader that manages external weight metadata and bindings.
+  std::unique_ptr<weight_loader::WeightLoader> weight_loader_owned_;
+  // It may point to weight_loader_owned_ or the weight loader owned by the
+  // client. If there are no external weights to use, this will be nullptr.
+  weight_loader::WeightLoader* weight_loader_ = nullptr;
+
+  std::vector<std::unique_ptr<litert::internal::CustomOpDispatcher>>
+      custom_op_dispatchers_;
+
+  // The ExternalLiteRtBufferContext used to register tensor buffers with
+  // Delegates.
+  // Note: The ExternalLiteRtBufferContext must be destroyed after the
+  // Interpreter.
+  std::unique_ptr<LiteRtExternalLiteRtBufferContextT> buffer_context_;
+
+  // The TFL interpreter.
+  std::unique_ptr<::tflite::Interpreter> interp_;
+
+  // NOTE: List below TFL interpreter related objects used to run the
+  // model. Note that these fields will be destroyed before the TFL interpreter
+  // is destroyed.
+
+  std::vector<const std::string*> signature_keys_;
+  // All subgraphs when no signature selection is configured; otherwise the
+  // deduplicated signature root set. Transitive expansion is a follow-up.
+  std::vector<int> active_subgraph_indices_;
+  // Empty means every signature is active.
+  absl::flat_hash_set<std::string> selected_signature_keys_;
 
   // The buffer requirement maps for CPU buffers. For delegates with CPU
   // buffers, they don't register TensorBufferRequirements. Instead, the
@@ -543,12 +556,6 @@ class LiteRtCompiledModelT {
   absl::flat_hash_map<const tflite::SignatureRunner*, bool>
       signature_needs_allocation_;
 
-  // The ExternalLiteRtBufferContext used to register tensor buffers with
-  // Delegates.
-  // Note: The ExternalLiteRtBufferContext must be destroyed after the
-  // Interpreter.
-  std::unique_ptr<LiteRtExternalLiteRtBufferContextT> buffer_context_;
-
   // Model-level scheduling info overrides (bitmask in `fields_mask` indicates
   // which fields are set).
   LiteRtSchedulingInfo model_scheduling_info_{};
@@ -558,9 +565,6 @@ class LiteRtCompiledModelT {
   std::string model_debug_feature_id_;
 
 
-
-  // File system hints about the originating model location.
-  std::optional<std::string> model_directory_;
 
   // The set of CPU Tensors. This is used to manage TensorBufferRequirements
   // for shared CPU Tensors.


### PR DESCRIPTION
# Summary:

Fix the `LiteRtCompiledModelT` member declaration order so resources referenced by the TFLite interpreter stay alive until after interpreter teardown.

This moves the model backing storage, cached model, `FlatBufferModel`, compiler/plugin state, delegates, weight loader, custom op dispatchers, and LiteRT buffer context before `interp_`, relying on C++ reverse member destruction order.

- keep JIT/cache flatbuffer backing storage alive until after `fb_model_`
- keep `fb_model_` alive until after the interpreter
- keep delegate/plugin/buffer context resources alive until after interpreter destruction

# TEST:
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 27 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 27 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 24 tests from 15 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (16 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 38 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 38 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (3 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 31 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 17 tests from 6 test suites ran. (15 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (455 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (188 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (523 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (2120 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1227 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (630 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (2044 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (23 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (606 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:graph_config_builder_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (5689 ms total)
[  PASSED  ] 26 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (28 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:lpai_backend_test
[==========] 6 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 6 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (7 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (558 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (531 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (440 ms total)
[  PASSED  ] 2 tests.
```

```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.1s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.1s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.1s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test       PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.4s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test        PASSED in 0.4s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test      PASSED in 0.6s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.4s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:graph_config_builder_test
//litert/vendors/qualcomm/core/backends:graph_config_builder_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 1.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:lpai_backend_test
//litert/vendors/qualcomm/core/backends:lpai_backend_test       (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.2s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 115.6s
```
