### PR TITLE
Qualcomm AI Engine Direct - Fix QNN native path doc.

### DIFF
--- a/litert/vendors/qualcomm/README.md
+++ b/litert/vendors/qualcomm/README.md
@@ -1,18 +1,12 @@
-# LiteRT Qualcomm Integration 🚀
+# LiteRT Qualcomm Integration
 
-This directory contains the LiteRT integration for Qualcomm AI Engine Direct (QAIRT)
-accelerators. It enables LiteRT to offload machine learning models to Qualcomm
-NPUs, GPUs, and DSPs for hardware-accelerated inference.
+The LiteRT integration for Qualcomm AI Engine Direct (QAIRT), offloading models
+to Qualcomm NPUs, GPUs, and DSPs for accelerated inference. It has two
+components:
 
-## Overview ℹ️
-
-The LiteRT Qualcomm integration consists of two main components: 1. **Compiler
-Plugin**: Legalizes and compiles LiteRT graphs into QNN graphs, supporting both
-online and offline compilation. 2. **Dispatch API**: Manages the execution of
-compiled QNN graphs on the target device.
-
-By using this integration, developers can leverage the high performance and
-energy efficiency of Qualcomm NPUs in their LiteRT applications.
+*   **Compiler Plugin**: legalizes and compiles LiteRT graphs into QNN graphs
+    (online and offline compilation).
+*   **Dispatch API**: manages execution of the compiled QNN graphs on device.
 
 ## Getting Started 🚀
 
@@ -22,51 +16,37 @@ The build and run docs live in [doc/](./doc/). Read them in this order:
 flowchart LR
     A[PREREQUISITES.md<br/>Install toolchain] --> B[QAIRT_SDK.md<br/>QNN concepts and libraries]
     B --> C[HTP_INSTRUCTIONS.md<br/>Compile and execute]
+    B -. "QNN Native Path" .-> G[LITERT_QNN_NATIVE_RUN.md<br/>Run a .dlc via qnn-net-run]
     C -. "IoT target" .-> D[IOT_DEVICE_SETUP.md<br/>Flash oe-linux device]
     C -. "LPAI target" .-> E[LPAI_INSTRUCTIONS.md<br/>Always-on low-power engine]
+    C -. "Custom TFLite op" .-> F[CUSTOM_OP_INSTRUCTIONS.md<br/>Build and use a QNN custom op package]
 ```
 
--   [PREREQUISITES.md](./doc/PREREQUISITES.md): read once when setting up a new
-    host. Skip if your toolchain is already installed.
--   [QAIRT_SDK.md](./doc/QAIRT_SDK.md): read to understand QNN backends,
-    platforms, and how to locate the required QNN libraries. Refer back to it
-    whenever you need to find a specific shared library(`.so`).
--   [HTP_INSTRUCTIONS.md](./doc/HTP_INSTRUCTIONS.md): the main guide for
-    compiling and running a model. Covers AOT on the host (Bazel and CMake) and
-    JIT on the device (Real JIT and On-device AOT).
--   [IOT_DEVICE_SETUP.md](./doc/IOT_DEVICE_SETUP.md): only when targeting an IoT
-    device (e.g. IQ-8275 / QCS8275) with either oe-linux or Ubuntu images. Flash
-    the device first, then follow
-    [Run on device (IoT device with oe-linux)](./doc/HTP_INSTRUCTIONS.md#run-on-device-iot-device-with-oe-linux)
-    in HTP_INSTRUCTIONS.md.
--   [LPAI_INSTRUCTIONS.md](./doc/LPAI_INSTRUCTIONS.md): only when targeting the
-    LPAI (Low Power AI) backend, a low-power ML engine for always-on embedded
-    use cases.
+| Doc | Type | What it covers |
+|-----|------------------|----------------|
+| [PREREQUISITES.md](./doc/PREREQUISITES.md) | Always | Install the toolchain. Skip if already installed. |
+| [QAIRT_SDK.md](./doc/QAIRT_SDK.md) | Always | QNN backends, platforms, and how to locate the QNN libraries (`.so`), plus QAIRT native tools. |
+| [HTP_INSTRUCTIONS.md](./doc/HTP_INSTRUCTIONS.md) | Always | Compile and run a model: AOT on host (Bazel / CMake) and JIT on device. |
+| [IOT_DEVICE_SETUP.md](./doc/IOT_DEVICE_SETUP.md) | Conditional | Flash an IoT device (with Qualcomm oe-linux or Qualcomm Ubuntu), then follow [Run on device (IoT device with oe-linux)](./doc/HTP_INSTRUCTIONS.md#run-on-device-iot-device-with-oe-linux) in HTP_INSTRUCTIONS.md. |
+| [LPAI_INSTRUCTIONS.md](./doc/LPAI_INSTRUCTIONS.md) | Conditional | Target the LPAI (Low Power AI) backend for always-on embedded use cases. |
+| [CUSTOM_OP_INSTRUCTIONS.md](./doc/CUSTOM_OP_INSTRUCTIONS.md) | Conditional | Build a QNN custom op package and run TFLite custom ops on the NPU. |
+| [LITERT_QNN_NATIVE_RUN.md](./doc/LITERT_QNN_NATIVE_RUN.md) | Conditional | Compile a `.tflite` to a `.dlc` with LiteRT, then run the QNN graph natively through the QAIRT native tools (`qnn-context-binary-generator` → `qnn-net-run`) on host or device. |
+| [OPTIONS_REFERENCE.md](./doc/OPTIONS_REFERENCE.md) | Reference | Every `--qualcomm_*` option: values, defaults, compile vs. dispatch, and how to set it from CLI / TOML / C / C++. |
 
 ## Debug Features 🐞
 
 Three compile-time knobs emit QNN native artifacts during AOT compilation:
 
-*   `--qualcomm_saver_output_dir`: Use the **Saver Backend** to record QNN API
-    calls as `saver_output.c` + `params.bin` for offline replay.
-*   `--qualcomm_ir_json_dir`: Dump the composed QNN graph as `<graph>.json` for
-    quick inspection.
-*   `--qualcomm_dlc_dir`: Use the **IR Backend** to produce Qualcomm `.dlc`
-    files consumable by QNN native tools.
+| Flag | Emits |
+|------|-------|
+| `--qualcomm_saver_output_dir` | Saver Backend: records QNN API calls as `saver_output.c` + `params.bin` for offline replay. |
+| `--qualcomm_ir_json_dir` | Dumps the composed QNN graph as `<graph>.json` for quick inspection. |
 
 See [DEBUG_FEATURES.md](./doc/DEBUG_FEATURES.md) for full usage and details.
 
-## Custom Op Package 🧩
-
-Covers building a QNN custom op package and using it with the Qualcomm compiler
-and dispatch plugins to support TFLite custom ops on the NPU. See
-[CUSTOM_OP_INSTRUCTIONS.md](./doc/CUSTOM_OP_INSTRUCTIONS.md).
-
 ## Supported Devices 📱
 
-LiteRT supports a wide range of Qualcomm SoCs through the QNN SDK.
-
-### Top-Tier Supported SoCs:
+LiteRT supports a wide range of Qualcomm SoCs through the QNN SDK. Top tier:
 
 *   **Snapdragon 8 Gen 5** (SM8850)
 *   **Snapdragon 8 Elite** (SM8750)
@@ -75,44 +55,13 @@ LiteRT supports a wide range of Qualcomm SoCs through the QNN SDK.
 For a complete and up-to-date list of supported devices, please refer to
 [supported_soc.csv](./supported_soc.csv).
 
-## Configuration Options ⚙️
-
-You can configure the Qualcomm backend using `LrtQualcommOptions`. Below are the
-available options defined in
-[litert_qualcomm_options.h](../../c/options/litert_qualcomm_options.h).
-
-### General Settings
-
-*   **Log Level**: Set the logging level for Qualcomm SDK libraries.
-
-### Compilation Options
-
-*   **Use INT64 Bias as INT32**: Convert bias tensors from `int64` to `int32`
-    for `FullyConnected` and `Conv2D` ops. Defaults to `true`.
-*   **Enable Weight Sharing**: Allow different subgraphs to share weight tensors
-    (supported on x86 AOT).
-*   **Use Conv HMX**: Enable short convolution HMX for better performance (may
-    affect accuracy).
-*   **Use Fold ReLU**: Enable folding ReLU operations into convolutions.
-*   **VTCM Size**: Configure Vector Tightly Coupled Memory size.
-*   **Num HVX Threads**: Set the number of HVX threads.
-*   **Optimization Level**: Set optimization level for inference or prepare.
-
-### Dispatch Options
-
-*   **Backend**: Select the target backend (`GPU` (not yet supported), `HTP`,
-    `DSP`, `IR`).
-*   **HTP/DSP Performance Mode**: Configure for performance or power efficiency.
-*   **Profiling**: Set profiling level (Off, Basic, Detailed, Linting, Optrace).
-*   **Graph Priority**: Set execution priority for the graph.
-
 ## Tooling 🛠️
 
 *   **Optrace Profiling**: See [optrace_profiling](./debugger/optrace_profiling)
     for details on debugging and profiling.
 *   **LiteRT Tools**: Refer to `litert/tools` for general LiteRT tools.
-*   **QAIRT Native Tools**: You can also use native tools provided by the
-    Qualcomm AI Rule Toolkit (QAIRT).
+*   **QAIRT Native Tools**: You can also use the native tools that ship with the
+    Qualcomm AI Runtime (QAIRT) SDK. See [QAIRT_SDK.md](./doc/QAIRT_SDK.md).
 
 ## References & Links 🔗
 
@@ -122,7 +71,8 @@ available options defined in
 *   **Google Dev Site**:
     [LiteRT Qualcomm Documentation](https://ai.google.dev/edge/litert/next/qualcomm)
 *   **Blog Posts**:
-    *   [Unlocking Peak Performance on Qualcomm NPU with LiteRT](https://developers.googleblog.com/unlocking-peak-performance-on-qualcomm-npu-with-litert/)
-    *   [Building Real-World On-Device AI with LiteRT and NPU](https://developers.googleblog.com/building-real-world-on-device-ai-with-litert-and-npu/)
+    1.  [Bring state-of-the-art agentic skills to the edge with Gemma 4](https://developers.googleblog.com/bring-state-of-the-art-agentic-skills-to-the-edge-with-gemma-4/) (April 2, 2026)
+    2.  [Unlocking Peak Performance on Qualcomm NPU with LiteRT](https://developers.googleblog.com/unlocking-peak-performance-on-qualcomm-npu-with-litert/) (November 24, 2025)
+    3.  [Building Real-World On-Device AI with LiteRT and NPU](https://developers.googleblog.com/building-real-world-on-device-ai-with-litert-and-npu/) (April 23, 2026)
 *   **Partner Library Documentation**:
     [LiteRT LM NPU Qualcomm](https://ai.google.dev/edge/litert/next/litert_lm_npu#qualcomm)

--- a/litert/vendors/qualcomm/doc/LITERT_QNN_NATIVE_RUN.md
+++ b/litert/vendors/qualcomm/doc/LITERT_QNN_NATIVE_RUN.md
@@ -18,14 +18,14 @@ flowchart LR
     B -->|"3.1 qnn-net-run --retrieve_context<br/>(QAIRT)"| R
 ```
 
-Step | Tool                                   | Owner  | Input                              | Output                                   | Notes
----- | -------------------------------------- | ------ | ---------------------------------- | ---------------------------------------- | -----
-1.1  | `apply_plugin_main --qualcomm_dlc_dir` | LiteRT | `.tflite`                          | `qnn_partition_<N>.dlc`                  | Compiles the graph into a `.dlc`.
-1.2  | `apply_plugin_main`                    | LiteRT | `.tflite`                          | compiled `.tflite`                       | Compiles the graph into a LiteRT `.tflite` with the QNN context binary embedded. Feeds step 2.2.
-2.1  | `qnn-context-binary-generator`         | QAIRT  | `.dlc` (from step 1.1)             | `qnn_partition_<N>.bin` (context binary) | Offline prepare from a `.dlc`.
-2.2  | `extract_bytecode`                     | LiteRT | compiled `.tflite` (from step 1.2) | `qnn_partition_<N>.bin` (context binary) | Extracts the embedded context binary. Skips step 1.1/2.1 if you already have a LiteRT-compiled `.tflite`.
-3.1  | `qnn-net-run --retrieve_context`       | QAIRT  | context binary (from step 2)       | `Result_*/` (output tensors)             | Run the pre-built context binary (solid path).
-3.2  | `qnn-net-run --dlc_path`               | QAIRT  | `.dlc` (from step 1.1)             | `Result_*/` (output tensors)             | Prepare the `.dlc` online (dotted path).
+| Step | Tool | Owner | Input | Output | Notes |
+| ---- | ---- | ----- | ----- | ------ | ----- |
+| 1.1 | `apply_plugin_main --qualcomm_dlc_dir` | LiteRT | `.tflite` | `qnn_partition_<N>.dlc` | Compiles the graph into a `.dlc`. |
+| 1.2 | `apply_plugin_main` | LiteRT | `.tflite` | compiled `.tflite` | Compiles the graph into a LiteRT `.tflite` with the QNN context binary embedded. Feeds step 2.2. |
+| 2.1 | `qnn-context-binary-generator` | QAIRT | `.dlc` (from step 1.1) | `qnn_partition_<N>.bin` (context binary) | Offline prepare from a `.dlc`. |
+| 2.2 | `extract_bytecode` | LiteRT | compiled `.tflite` (from step 1.2) | `qnn_partition_<N>.bin` (context binary) | Extracts the embedded context binary. Skips step 1.1/2.1 if you already have a LiteRT-compiled `.tflite`. |
+| 3.1 | `qnn-net-run --retrieve_context` | QAIRT | context binary (from step 2) | `Result_*/` (output tensors) | Run the pre-built context binary (solid path). |
+| 3.2 | `qnn-net-run --dlc_path` | QAIRT | `.dlc` (from step 1.1) | `Result_*/` (output tensors) | Prepare the `.dlc` online (dotted path). |
 
 > 💡 Once LiteRT has compiled the `.dlc`, the whole QNN/QAIRT toolchain is open
 > to you: the `.dlc` is a standard Qualcomm artifact, so in principle every QNN
@@ -46,50 +46,28 @@ libraries in [QAIRT_SDK.md](./QAIRT_SDK.md) are understood.
 The commands below refer to the following `${}` variables. Configure them for
 your environment before running any step.
 
-| Variable                      | Description                             |
-| ----------------------------- | --------------------------------------- |
-| `${LITERT}`                   | The path of the LiteRT source code.     |
-| `${QAIRT}`                    | The root of the unzipped QAIRT SDK      |
-:                               : (holds `bin/`, `lib/`). For example     :
-:                               : `${LITERT}/third_party/qairt/<version>` :
-:                               : (the SDK folder is named after its      :
-:                               : version, e.g. `2.47.0.xxxxxx`. Symlink  :
-:                               : it to a stable name yourself if you     :
-:                               : prefer).                                :
-| `${SOURCE_MODEL_PATH}`        | The input `.tflite` model to compile.   |
-| `${X86_HOST_ARTIFACT_FOLDER}` | Host working directory that holds       |
-:                               : everything produced on x86\: the `.dlc` :
-:                               : files (step 1.1), the LiteRT-compiled   :
-:                               : `.tflite` (step 1.2), the extracted /   :
-:                               : generated context binaries, and the raw :
-:                               : input tensors and input list.           :
-| `${SOC_MODEL}`                | Target SoC, e.g. `SM8850`.              |
-| `${HTP_ARCH}`                 | HTP architecture of `${SOC_MODEL}`.     |
-:                               : Used in two casings\: uppercase in QNN  :
-:                               : library names (`${HTP_ARCH}` = `V81`)   :
-:                               : and lowercase in the `hexagon-vXX`      :
-:                               : directory name (`${HEXAGON_ARCH}` =     :
-:                               : `v81`). See [QAIRT_SDK.md → Hexagon     :
-:                               : Arch](./QAIRT_SDK.md#hexagon-arch) for  :
-:                               : how to look this up.                    :
-| `${ANDROID_TEST_FOLDER}`      | Working directory on the device, e.g.   |
-:                               : `/data/local/tmp/qnn_native`. Only      :
-:                               : needed for the [Android device          :
-:                               : run](#android-device-aarch64).          :
+Variable                | Description
+----------------------- | -----------
+`${LITERT}`             | The path of the LiteRT source code.
+`${QAIRT}`              | The root of the unzipped QAIRT SDK (holds `bin/`, `lib/`). For example `${LITERT}/third_party/qairt/<version>` (the SDK folder is named after its version, e.g. `2.47.0.xxxxxx`. Symlink it to a stable name yourself if you prefer).
+`${SOURCE_MODEL_PATH}`  | The input `.tflite` model to compile.
+`${X86_HOST_ARTIFACT_FOLDER}` | Host working directory that holds everything produced on x86: the `.dlc` files (step 1.1), the LiteRT-compiled `.tflite` (step 1.2), the extracted / generated context binaries, and the raw input tensors and input list.
+`${SOC_MODEL}`          | Target SoC, e.g. `SM8850`.
+`${HTP_ARCH}`           | HTP architecture of `${SOC_MODEL}`. Used in two casings: uppercase in QNN library names (`${HTP_ARCH}` = `V81`) and lowercase in the `hexagon-vXX` directory name (`${HEXAGON_ARCH}` = `v81`). See [QAIRT_SDK.md → Hexagon Arch](./QAIRT_SDK.md#hexagon-arch) for how to look this up.
+`${ANDROID_TEST_FOLDER}` | Working directory on the device, e.g. `/data/local/tmp/qnn_native`. Only needed for the [Android device run](#android-device-aarch64).
 
-> 💡 LiteRT names each compiled partition `qnn_partition_0`, `qnn_partition_1`, …
-> The examples below use `qnn_partition_0` (a single-partition model).
+> 💡 LiteRT names each compiled partition `qnn_partition_0`, `qnn_partition_1`,
+> … The examples below use `qnn_partition_0` (a single-partition model).
 > Substitute the relevant partition name if your model splits into several.
 
 --------------------------------------------------------------------------------
 
 ## 1. Compile the .tflite with LiteRT
 
-LiteRT compiles the `.tflite` in one of two ways, matching the two
-context-binary sources in [§2](#2-build-a-context-binary-on-the-x86-host). Both
-invoke the same `apply_plugin_main`. The only difference is whether
-`--qualcomm_dlc_dir` is set. You only need the one that feeds the §2 path you
-plan to use.
+LiteRT compiles the `.tflite` in one of two ways, matching the two context-binary
+sources in [§2](#2-build-a-context-binary-on-the-x86-host). Both invoke the same
+`apply_plugin_main`. The only difference is whether `--qualcomm_dlc_dir` is set.
+You only need the one that feeds the §2 path you plan to use.
 
 Build the tool and the plugin once (used by both):
 
@@ -102,18 +80,17 @@ bazel build -c opt --cxxopt=--std=c++17 --nocheck_visibility //litert/vendors/qu
 export LD_LIBRARY_PATH=${QAIRT}/lib/x86_64-linux-clang
 ```
 
-> **`--libs` must point at `bazel-bin/`, not the source tree** — the plugin
-> `.so` lives under `bazel-bin/litert/vendors/qualcomm/compiler/` after the
-> build above. The commands below use the explicit `${LITERT}/bazel-bin/...`
-> path for that reason.
+> **`--libs` must point at `bazel-bin/`, not the source tree** — the plugin `.so`
+> lives under `bazel-bin/litert/vendors/qualcomm/compiler/` after the build
+> above. The commands below use the explicit `${LITERT}/bazel-bin/...` path for
+> that reason.
 
 ### 1.1 Compile to a .dlc (`--qualcomm_dlc_dir`)
 
 `--qualcomm_dlc_dir=<dir>` makes LiteRT switch to the QNN **IR Backend** at
 compile time and serialize each composed graph to a `.dlc` in that directory.
 The flag takes a **directory**. If empty (the default), the feature is off. Use
-this to feed the `qnn-context-binary-generator` path
-([§2.1](#21-from-a-dlc-with-qnn-context-binary-generator)).
+this to feed the `qnn-context-binary-generator` path ([§2.1](#21-from-a-dlc-with-qnn-context-binary-generator)).
 
 ```bash
 bazel-bin/litert/tools/apply_plugin_main \
@@ -131,8 +108,8 @@ partitions yields multiple `.dlc` files (one per QNN graph). A single-partition
 model yields just `qnn_partition_0.dlc`. Run / inspect each `.dlc` separately in
 the steps below.
 
-> ⚠️ **Backend override side effect.** When `--qualcomm_dlc_dir` is non-empty,
-> the compiler forces the backend to the IR Backend (a warning is logged). The
+> ⚠️ **Backend override side effect.** When `--qualcomm_dlc_dir` is non-empty, the
+> compiler forces the backend to the IR Backend (a warning is logged). The
 > resulting `-o` `.tflite` reflects IR-Backend semantics, **not** HTP/CPU/GPU
 > execution. This flag is for artifact extraction, not for producing a
 > deployable model.
@@ -155,8 +132,7 @@ bazel-bin/litert/tools/apply_plugin_main \
 
 This is the standard HTP compile flow. See
 [HTP_INSTRUCTIONS.md](./HTP_INSTRUCTIONS.md) for the full walkthrough (including
-the CMake build and on-device options). The `-o` `compiled.tflite` is what §2.2
-reads.
+the CMake build and on-device options). The `-o` `compiled.tflite` is what §2.2 reads.
 
 --------------------------------------------------------------------------------
 
@@ -167,10 +143,10 @@ run it on device. This moves the (slow) graph-prepare step off the device's
 critical path. There are two ways to produce the same `.bin`, both run on the
 x86 host:
 
-Source you have                                                 | Tool                           | Owner  | When to use
---------------------------------------------------------------- | ------------------------------ | ------ | -----------
-`.dlc` from step 1.1                                            | `qnn-context-binary-generator` | QAIRT  | You went through step 1.1 specifically to emit a `.dlc`.
-A LiteRT-compiled `.tflite` (step 1.2, no `--qualcomm_dlc_dir`) | `extract_bytecode`             | LiteRT | You already have a LiteRT-compiled model and want the embedded context binary, no need to recompile.
+| Source you have | Tool | Owner | When to use |
+| --------------- | ---- | ----- | ----------- |
+| `.dlc` from step 1.1 | `qnn-context-binary-generator` | QAIRT | You went through step 1.1 specifically to emit a `.dlc`. |
+| A LiteRT-compiled `.tflite` (step 1.2, no `--qualcomm_dlc_dir`) | `extract_bytecode` | LiteRT | You already have a LiteRT-compiled model and want the embedded context binary, no need to recompile. |
 
 ### 2.1 From a .dlc with qnn-context-binary-generator
 
@@ -196,11 +172,12 @@ binary is the common path.
 ### 2.2 From a LiteRT-compiled .tflite with extract_bytecode
 
 Use this when you already have a `.tflite` **compiled by LiteRT**
-([step 1.2](#12-compile-to-a-litert-tflite), `apply_plugin_main` output, no
-`--qualcomm_dlc_dir`). Such a `.tflite` already embeds the QNN context binary
-inside its dispatch op, so steps 1.1 / 2.1 are not needed. The tool writes one
-`<name>_<index>.bin` per dispatch op into `${X86_HOST_ARTIFACT_FOLDER}`. Feed
-each `.bin` to `qnn-net-run --retrieve_context` exactly as in §3.
+([step 1.2](#12-compile-to-a-litert-tflite),
+`apply_plugin_main` output, no `--qualcomm_dlc_dir`). Such a `.tflite` already
+embeds the QNN context binary inside its dispatch op, so steps 1.1 / 2.1 are not
+needed. The tool writes one `<name>_<index>.bin` per dispatch op into
+`${X86_HOST_ARTIFACT_FOLDER}`. Feed each `.bin` to `qnn-net-run
+--retrieve_context` exactly as in §3.
 
 Build and run with Bazel:
 
@@ -237,22 +214,19 @@ Android.** The choice is about *when* the graph is prepared, not *where* it
 runs. The x86 and device sections below are example environments, not a
 restriction.
 
-| Input flag          | Prepare           | Typical use                     |
-| ------------------- | ----------------- | ------------------------------- |
-| `--dlc_path <dlc>`  | Online, at load   | Convenient on the host          |
-: (with `--model      :                   :                                 :
-: libQnnModelDlc.so`) :                   :                                 :
-| `--retrieve_context | Offline (step 2), | On-device HTP, to skip the slow |
-: <bin>`              : pre-built         : prepare at run                  :
+| Input flag | Prepare | Typical use |
+| ---------- | ------- | ----------- |
+| `--dlc_path <dlc>` (with `--model libQnnModelDlc.so`) | Online, at load | Convenient on the host |
+| `--retrieve_context <bin>` | Offline (step 2), pre-built | On-device HTP, to skip the slow prepare at run |
 
 Also pass these so raw tensors keep the graph's **native** dtype. Without them
 `qnn-net-run` reads inputs as float32 and writes float32 outputs, silently
 misreading a quantized (`uint8` / `int8`) graph.
 
-Flag                        | Effect
---------------------------- | -----------------------------------------------
-`--use_native_input_files`  | Read input `.raw` in the graph's native dtype
-`--use_native_output_files` | Write output `.raw` in the graph's native dtype
+| Flag | Effect |
+| ---- | ------ |
+| `--use_native_input_files` | Read input `.raw` in the graph's native dtype |
+| `--use_native_output_files` | Write output `.raw` in the graph's native dtype |
 
 ### x86 host
 
@@ -280,8 +254,8 @@ input / output file formats.
 The example uses **`${HTP_ARCH}` = `V81`** (SM8850). Substitute the values for
 your SoC from the Prerequisites table. It runs the pre-built context binary from
 step 2. To prepare the `.dlc` online on device instead, push the `.dlc` and swap
-`--retrieve_context ./qnn_partition_0.bin` for `--model ./libQnnModelDlc.so
---dlc_path ./qnn_partition_0.dlc`.
+`--retrieve_context ./qnn_partition_0.bin` for
+`--model ./libQnnModelDlc.so --dlc_path ./qnn_partition_0.dlc`.
 
 ```bash
 adb shell "mkdir -p ${ANDROID_TEST_FOLDER}"
@@ -338,9 +312,9 @@ Each `.raw` is the raw little-endian bytes of one input tensor in the graph's
 expected dtype and layout (e.g. quantized `uint8` / `int8`, or `float32`). This
 is the format the native-dtype flags in [§3](#3-run-natively-with-qnn-net-run)
 expect. Inspect the expected I/O with `qairt-dlc-info`
-([§5](#5-inspecting-a-dlc-and-further-reading)) to get each tensor's exact shape
-and dtype, then write a matching `.raw`. For example, for a `float32 [1,64,128]`
-input:
+([§5](#5-inspecting-a-dlc-and-further-reading)) to get each tensor's exact
+shape and dtype, then write a matching `.raw`. For example, for a
+`float32 [1,64,128]` input:
 
 ```bash
 python3 -c "import numpy as np; \

--- a/litert/vendors/qualcomm/doc/OPTIONS_REFERENCE.md
+++ b/litert/vendors/qualcomm/doc/OPTIONS_REFERENCE.md
@@ -10,7 +10,7 @@ flag, TOML config, C API, C++ API).
 > TOML key and C / C++ API. Internal-only knobs that have no public surface are
 > omitted, since you cannot set them.
 
---------------------------------------------------------------------------------
+---
 
 ## 1. How an option flows through the stack
 
@@ -29,18 +29,13 @@ flowchart LR
 Every option ultimately lands in the internal `::qnn::Options` object, which is
 consumed at two distinct moments:
 
-| Phase             | Who reads it              | Examples                |
-| ----------------- | ------------------------- | ----------------------- |
-| **Compile time**  | Compiler plugin           | `use_conv_hmx`,         |
-:                   : (`apply_plugin_main`, AOT : `optimization_level`,   :
-:                   : / JIT graph build)        : `vtcm_size`,            :
-:                   :                           : `graph_priority`        :
-| **Dispatch time** | Runtime dispatcher        | `htp_performance_mode`  |
-:                   : (on-device execution)     :                         :
-| **Both**          | Compiler plugin and       | `log_level`, `backend`, |
-:                   : runtime dispatcher        : `profiling`             :
+| Phase | Who reads it | Examples |
+|-------|--------------|----------|
+| **Compile time** | Compiler plugin (`apply_plugin_main`, AOT / JIT graph build) | `use_conv_hmx`, `optimization_level`, `vtcm_size`, `graph_priority` |
+| **Dispatch time** | Runtime dispatcher (on-device execution) | `htp_performance_mode` |
+| **Both** | Compiler plugin and runtime dispatcher | `log_level`, `backend`, `profiling` |
 
---------------------------------------------------------------------------------
+---
 
 ## 2. Categories at a glance
 
@@ -65,19 +60,14 @@ flowchart TB
     ROW1 ~~~ ROW2
 ```
 
-| Category          | Options                                            |
-| ----------------- | -------------------------------------------------- |
-| **General / SDK** | `log_level`, `backend`, `graph_priority`,          |
-:                   : `custom_op_package`, `enable_just_in_time`,        :
-:                   : `graph_io_tensor_mem_type`, `profiling`            :
-| **HTP**           | `use_conv_hmx`, `use_fold_relu`, `htp_p_point`,    |
-:                   : `htp_performance_mode`, `optimization_level`,      :
-:                   : `vtcm_size`, `num_hvx_threads`,                    :
-:                   : `use_int64_bias_as_int32`, `enable_weight_sharing` :
-| **DSP**           | `dsp_performance_mode`                             |
-| **IR**            | `dlc_dir`                                          |
-| **SAVER**         | `saver_output_dir`                                 |
-| **Debug**         | `dump_tensor_ids`, `ir_json_dir`                   |
+| Category | Options |
+|----------|---------|
+| **General / SDK** | `log_level`, `backend`, `graph_priority`, `custom_op_package`, `enable_just_in_time`, `graph_io_tensor_mem_type`, `profiling` |
+| **HTP** | `use_conv_hmx`, `use_fold_relu`, `htp_p_point`, `htp_performance_mode`, `optimization_level`, `vtcm_size`, `num_hvx_threads`, `use_int64_bias_as_int32`, `enable_weight_sharing` |
+| **DSP** | `dsp_performance_mode` |
+| **IR** | `dlc_dir` |
+| **SAVER** | `saver_output_dir` |
+| **Debug** | `dump_tensor_ids`, `ir_json_dir` |
 
 ### A note on surfaces
 
@@ -86,38 +76,37 @@ flag, TOML key, C API, and C++ API. The tables list the CLI flag name; the TOML
 key and the C / C++ setters follow the same name (see §10 for examples), with
 **two exceptions** where the TOML key differs from the flag:
 
-CLI flag                    | TOML key
---------------------------- | -----------------
-`--qualcomm_backend`        | `qnn_backend`
-`--qualcomm_num_hvx_thread` | `num_hvx_threads`
+| CLI flag | TOML key |
+|----------|----------|
+| `--qualcomm_backend` | `qnn_backend` |
+| `--qualcomm_num_hvx_thread` | `num_hvx_threads` |
 
---------------------------------------------------------------------------------
+---
 
 ## 3. General / SDK options
 
-Option             | CLI flag (`--qualcomm_…`)  | Default     | Phase   | Notes
------------------- | -------------------------- | ----------- | ------- | -----
-Log level          | `log_level`                | `info`      | both    | `off` · `error` · `warn` · `info` · `verbose` · `debug`. SDK libs only — not LiteRT's own logging.
-Backend            | `backend`                  | `htp`       | both    | `gpu` · `htp` · `dsp` · `ir`.
-Graph priority     | `graph_priority`           | `default`   | compile | `default` · `low` · `normal` · `normal_high` · `high`. `default` maps to normal.
-Just-In-Time       | `enable_just_in_time`      | `false`     | compile | Pass QNN context plugin→dispatcher in-memory, skipping serialization.
-Graph I/O mem type | `graph_io_tensor_mem_type` | `memhandle` | compile | `raw` · `memhandle`. Mem type for graph I/O tensors at graph-creation.
-Profiling          | `profiling`                | `off`       | both    | `off` · `basic` · `detailed` · `linting` · `optrace`. Higher = more detailed report. Read at compile (context creation) and dispatch (graph execution).
-Custom op package  | `custom_op_package`        | *(empty)*   | both    | See note below.
+| Option | CLI flag (`--qualcomm_…`) | Default | Phase | Notes |
+|--------|------|---------|-------|----------------|
+| Log level | `log_level` | `info` | both | `off` · `error` · `warn` · `info` · `verbose` · `debug`. SDK libs only — not LiteRT's own logging. |
+| Backend | `backend` | `htp` | both | `gpu` · `htp` · `dsp` · `ir`. |
+| Graph priority | `graph_priority` | `default` | compile | `default` · `low` · `normal` · `normal_high` · `high`. `default` maps to normal. |
+| Just-In-Time | `enable_just_in_time` | `false` | compile | Pass QNN context plugin→dispatcher in-memory, skipping serialization. |
+| Graph I/O mem type | `graph_io_tensor_mem_type` | `memhandle` | compile | `raw` · `memhandle`. Mem type for graph I/O tensors at graph-creation. |
+| Profiling | `profiling` | `off` | both | `off` · `basic` · `detailed` · `linting` · `optrace`. Higher = more detailed report. Read at compile (context creation) and dispatch (graph execution). |
+| Custom op package | `custom_op_package` | *(empty)* | both | See note below. |
 
 ### `custom_op_package` details
 
 Registers a custom QNN op package. The value is a `;`-separated list of
 `key:value` pairs, with these keys:
 
-| Key                     | Meaning                                        |
-| ----------------------- | ---------------------------------------------- |
-| `name`                  | Op package name                                |
-| `interface_provider`    | Interface provider symbol                      |
-| `compile_package_path`  | `.so` used at compile time                     |
-| `dispatch_package_path` | `.so` used at dispatch time                    |
-| `target`                | QNN backend — **must** match `backend` (`HTP`, |
-:                         : `GPU`, …)                                      :
+| Key | Meaning |
+|-----|---------|
+| `name` | Op package name |
+| `interface_provider` | Interface provider symbol |
+| `compile_package_path` | `.so` used at compile time |
+| `dispatch_package_path` | `.so` used at dispatch time |
+| `target` | QNN backend — **must** match `backend` (`HTP`, `GPU`, …) |
 
 ```bash
 --qualcomm_custom_op_package="\
@@ -128,101 +117,70 @@ dispatch_package_path:libQnnTestPackage.so;\
 target:HTP"
 ```
 
---------------------------------------------------------------------------------
+---
 
 ## 4. HTP options
 
-Option             | CLI flag (`--qualcomm_…`) | Default    | Phase    | Notes
------------------- | ------------------------- | ---------- | -------- | -----
-Short Conv HMX     | `use_conv_hmx`            | `true`     | compile  | Faster, but short-depth / non-symmetric weights may be inaccurate.
-Fold ReLU          | `use_fold_relu`           | `true`     | compile  | Faster. Correct only when conv's quant range ⊆ the ReLU's.
-P-point            | `htp_p_point`             | `0`        | compile  | **Experimental** (HTP + `O3` only). Predefined configs trading latency vs. DRAM bandwidth.
-Optimization level | `optimization_level`      | `O3`       | compile  | `O1` (inference) · `O2` (prepare) · `O3` (inference, aggressive).
-HTP perf mode      | `htp_performance_mode`    | `default`  | dispatch | `default` · `sustained_high_performance` · `burst` · `high_performance` · `power_saver` · `low_power_saver` · `high_power_saver` · `low_balanced` · `balanced` · `extreme_power_saver`.
-VTCM size          | `vtcm_size`               | `0` (=max) | compile  | VTCM size (MB) of target device. `0` → device max.
-HVX threads        | `num_hvx_thread`          | `0` (=max) | compile  | HVX threads for target device. `0` → device max.
-INT64→INT32 bias   | `use_int64_bias_as_int32` | `true`     | compile  | Convert FullyConnected/Conv2D bias int64 → int32.
-Weight sharing     | `enable_weight_sharing`   | `false`    | compile  | Subgraphs share weight tensors. **x86 AOT only** — unsupported on device.
+| Option | CLI flag (`--qualcomm_…`) | Default | Phase | Notes |
+|--------|------|---------|-------|----------------|
+| Short Conv HMX | `use_conv_hmx` | `true` | compile | Faster, but short-depth / non-symmetric weights may be inaccurate. |
+| Fold ReLU | `use_fold_relu` | `true` | compile | Faster. Correct only when conv's quant range ⊆ the ReLU's. |
+| P-point | `htp_p_point` | `0` | compile | **Experimental** (HTP + `O3` only). Predefined configs trading latency vs. DRAM bandwidth. |
+| Optimization level | `optimization_level` | `O3` | compile | `O1` (inference) · `O2` (prepare) · `O3` (inference, aggressive). |
+| HTP perf mode | `htp_performance_mode` | `default` | dispatch | `default` · `sustained_high_performance` · `burst` · `high_performance` · `power_saver` · `low_power_saver` · `high_power_saver` · `low_balanced` · `balanced` · `extreme_power_saver`. |
+| VTCM size | `vtcm_size` | `0` (=max) | compile | VTCM size (MB) of target device. `0` → device max. |
+| HVX threads | `num_hvx_thread` | `0` (=max) | compile | HVX threads for target device. `0` → device max. |
+| INT64→INT32 bias | `use_int64_bias_as_int32` | `true` | compile | Convert FullyConnected/Conv2D bias int64 → int32. |
+| Weight sharing | `enable_weight_sharing` | `false` | compile | Subgraphs share weight tensors. **x86 AOT only** — unsupported on device. |
 
---------------------------------------------------------------------------------
+---
 
 ## 5. DSP options
 
-Option        | CLI flag (`--qualcomm_…`) | Default   | Phase    | Notes
-------------- | ------------------------- | --------- | -------- | -----
-DSP perf mode | `dsp_performance_mode`    | `default` | dispatch | `default` · `sustained_high_performance` · `burst` · `high_performance` · `power_saver` · `low_power_saver` · `high_power_saver` · `low_balanced` · `balanced`.
+| Option | CLI flag (`--qualcomm_…`) | Default | Phase | Notes |
+|--------|------|---------|-------|----------------|
+| DSP perf mode | `dsp_performance_mode` | `default` | dispatch | `default` · `sustained_high_performance` · `burst` · `high_performance` · `power_saver` · `low_power_saver` · `high_power_saver` · `low_balanced` · `balanced`. |
 
---------------------------------------------------------------------------------
+---
 
 ## 6. IR options
 
-QNN intermediate-representation dumps — diagnostic artifacts produced at compile
-time.
+QNN intermediate-representation dumps — diagnostic artifacts produced at compile time.
 
-| Option  | CLI flag         | Default   | Phase   | Notes                 |
-:         : (`--qualcomm_…`) :           :         :                       :
-| ------- | ---------------- | --------- | ------- | --------------------- |
-| DLC dir | `dlc_dir`        | *(empty)* | compile | If set, compile QNN   |
-:         :                  :           :         : graphs as DLC to this :
-:         :                  :           :         : dir.                  :
+| Option | CLI flag (`--qualcomm_…`) | Default | Phase | Notes |
+|--------|------|---------|-------|----------------|
+| DLC dir | `dlc_dir` | *(empty)* | compile | If set, compile QNN graphs as DLC to this dir. |
 
---------------------------------------------------------------------------------
+---
 
 ## 7. SAVER options
 
-| Option       | CLI flag           | Default   | Phase   | Notes              |
-:              : (`--qualcomm_…`)   :           :         :                    :
-| ------------ | ------------------ | --------- | ------- | ------------------ |
-| Saver output | `saver_output_dir` | *(empty)* | compile | If set, compile    |
-: dir          :                    :           :         : `saver_output.c` + :
-:              :                    :           :         : `params.bin`       :
-:              :                    :           :         : (records all QNN   :
-:              :                    :           :         : API calls for      :
-:              :                    :           :         : replay). See QAIRT :
-:              :                    :           :         : SDK docs.          :
+| Option | CLI flag (`--qualcomm_…`) | Default | Phase | Notes |
+|--------|------|---------|-------|----------------|
+| Saver output dir | `saver_output_dir` | *(empty)* | compile | If set, compile `saver_output.c` + `params.bin` (records all QNN API calls for replay). See QAIRT SDK docs. |
 
---------------------------------------------------------------------------------
+---
 
 ## 8. Debug options
 
-| Option          | CLI flag          | Default   | Phase   | Notes           |
-:                 : (`--qualcomm_…`)  :           :         :                 :
-| --------------- | ----------------- | --------- | ------- | --------------- |
-| Dump tensor IDs | `dump_tensor_ids` | *(empty)* | compile | Comma-separated |
-:                 :                   :           :         : tensor IDs to   :
-:                 :                   :           :         : mark as extra   :
-:                 :                   :           :         : graph outputs   :
-:                 :                   :           :         : (per-layer dump :
-:                 :                   :           :         : for the         :
-:                 :                   :           :         : accuracy        :
-:                 :                   :           :         : debugger).      :
-:                 :                   :           :         : `-1` = dump all :
-:                 :                   :           :         : op outputs.     :
-| IR JSON dir     | `ir_json_dir`     | *(empty)* | compile | If set, compile |
-:                 :                   :           :         : QNN IR as QNN   :
-:                 :                   :           :         : JSON to this    :
-:                 :                   :           :         : dir.            :
+| Option | CLI flag (`--qualcomm_…`) | Default | Phase | Notes |
+|--------|------|---------|-------|----------------|
+| Dump tensor IDs | `dump_tensor_ids` | *(empty)* | compile | Comma-separated tensor IDs to mark as extra graph outputs (per-layer dump for the accuracy debugger). `-1` = dump all op outputs. |
+| IR JSON dir | `ir_json_dir` | *(empty)* | compile | If set, compile QNN IR as QNN JSON to this dir. |
 
---------------------------------------------------------------------------------
+---
 
 ## 9. Deprecated / retired options
 
 These remain as **no-ops** purely to preserve the C ABI contract. Setting them
 does nothing.
 
-| Option                  | CLI flag                           | Notes         |
-| ----------------------- | ---------------------------------- | ------------- |
-| `use_htp_preference`    | `--qualcomm_use_htp_preference`    | Transform a   |
-:                         : (retired)                          : LiteRT op     :
-:                         :                                    : into the      :
-:                         :                                    : HTP-preferred :
-:                         :                                    : pattern       :
-| `use_qint16_as_quint16` | `--qualcomm_use_qint16_as_quint16` | Auto-convert  |
-:                         : (retired)                          : quantized     :
-:                         :                                    : int16 model → :
-:                         :                                    : quint16       :
+| Option | CLI flag | Notes |
+|--------|----------|--------|
+| `use_htp_preference` | `--qualcomm_use_htp_preference` (retired) | Transform a LiteRT op into the HTP-preferred pattern |
+| `use_qint16_as_quint16` | `--qualcomm_use_qint16_as_quint16` (retired) | Auto-convert quantized int16 model → quint16 |
 
---------------------------------------------------------------------------------
+---
 
 ## 10. Worked examples
 
@@ -257,8 +215,7 @@ above (e.g. `burst`, `O3`, `detailed`).
 Unlike the CLI, the TOML parser reads enums as **integers** (the enum's
 underlying value), *not* their string names — see the `ParseTomlInt` calls in
 `litert/c/options/litert_qualcomm_options.cc`. Bools are `true`/`false`. This is
-what `LrtCreateQualcommOptionsFromToml` consumes (and what the C API
-serializes).
+what `LrtCreateQualcommOptionsFromToml` consumes (and what the C API serializes).
 
 ```toml
 # enum values are integers, see the enum tables in each section


### PR DESCRIPTION
# What
- Fix the document for LiteRT compile + QNN native run.

## Verification

- [x] Developer-Verified
- Re-produced in local machine and passed.
- Successfully ran traditional mode and direct mode.

# Test

- Document update, no need to test unit tests