### PR TITLE
Qualcomm AI Engine Direct - Add Squeeze Op Builder.

### DIFF
--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -312,6 +312,7 @@ litert_lib(
         "//litert/vendors/qualcomm/core/builders:spatial_transform_op_builder",
         "//litert/vendors/qualcomm/core/builders:split_op_builder",
         "//litert/vendors/qualcomm/core/builders:splitv_op_builder",
+        "//litert/vendors/qualcomm/core/builders:squeeze_op_builder",
         "//litert/vendors/qualcomm/core/builders:strided_slice_op_builder",
         "//litert/vendors/qualcomm/core/builders:tanh_op_builder",
         "//litert/vendors/qualcomm/core/builders:tile_op_builder",

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -98,6 +98,7 @@
 #include "litert/vendors/qualcomm/core/builders/spatial_transform_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/split_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/splitv_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/squeeze_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/strided_slice_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/tanh_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/tile_op_builder.h"
@@ -856,6 +857,31 @@ LiteRtStatus BuildSplitVOp(const litert::compiler::Op& litert_op,
   return kLiteRtStatusOk;
 }
 
+LiteRtStatus BuildSqueezeOp(
+    const litert::compiler::Op& litert_op, ::qnn::TensorPool& tensor_pool,
+    std::vector<::qnn::TensorWrapperRef>& input_tensors,
+    std::vector<::qnn::TensorWrapperRef>& output_tensors,
+    std::vector<::qnn::OpWrapper>& op_wrappers) {
+  auto options =
+      litert::compiler::GetOptionsAs<litert::compiler::SqueezeOptions>(
+          litert_op.ctx(), litert_op.Get());
+  if (!options) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  ::qnn::TensorWrapper& squeeze_dims_tensor_param = tensor_pool.CreateStaticTensor(
+    QNN_DATATYPE_UINT_32, {},
+    {static_cast<std::uint32_t>(options->squeeze_dims.size())},
+    sizeof(std::uint32_t)* options->squeeze_dims.size(),
+    options->squeeze_dims.data());
+
+  op_wrappers.clear();
+  op_wrappers.emplace_back(::qnn::CreateSqueezeOp(
+      input_tensors[0], output_tensors[0], squeeze_dims_tensor_param)
+  );
+  return kLiteRtStatusOk;
+}
+
 LiteRtStatus BuildTopkV2Op(const litert::compiler::Op& litert_op,
                            ::qnn::TensorPool& tensor_pool,
                            std::vector<::qnn::TensorWrapperRef>& input_tensors,
@@ -1408,6 +1434,7 @@ GetOpBuilders() {
   builders[kLiteRtOpCodeTflResizeBilinear] = Adapt<BuildResizeBilinearOp>;
   builders[kLiteRtOpCodeTflSoftmax] = Adapt<BuildSoftmaxOp>;
   builders[kLiteRtOpCodeTflSpaceToDepth] = Adapt<BuildSpaceToDepthOp>;
+  builders[kLiteRtOpCodeTflSqueeze] = Adapt<BuildSqueezeOp>;
   builders[kLiteRtOpCodeTflTanh] = Adapt<BuildTanhOp>;
   builders[kLiteRtOpCodeTflPad] = Adapt<BuildConstantPadOp>;
   builders[kLiteRtOpCodeTflGather] = Adapt<BuildGatherOp>;

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -100,6 +100,7 @@
 #include "litert/vendors/qualcomm/core/builders/spatial_transform_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/split_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/splitv_op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/squeeze_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/strided_slice_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/tanh_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/tile_op_builder.h"
@@ -957,6 +958,23 @@ LiteRtStatus BuildSplitVOp(const litert::compiler::Op& litert_op,
   return kLiteRtStatusOk;
 }
 
+LiteRtStatus BuildSqueezeOp(
+    const litert::compiler::Op& litert_op, ::qnn::TensorPool& tensor_pool,
+    std::vector<::qnn::TensorWrapperRef>& input_tensors,
+    std::vector<::qnn::TensorWrapperRef>& output_tensors,
+    std::vector<::qnn::OpWrapper>& op_wrappers) {
+  auto options =
+      litert::compiler::GetOptionsAs<litert::compiler::SqueezeOptions>(
+          litert_op.ctx(), litert_op.Get());
+  if (!options) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  op_wrappers = ::qnn::BuildSqueezeOp(tensor_pool, input_tensors,
+                                      output_tensors, options->squeeze_dims);
+  return kLiteRtStatusOk;
+}
+
 LiteRtStatus BuildTopkV2Op(const litert::compiler::Op& litert_op,
                            ::qnn::TensorPool& tensor_pool,
                            std::vector<::qnn::TensorWrapperRef>& input_tensors,
@@ -1511,6 +1529,7 @@ GetOpBuilders() {
   builders[kLiteRtOpCodeTflSpaceToDepth] = Adapt<BuildSpaceToDepthOp>;
   builders[kLiteRtOpCodeTflBatchToSpaceNd] = Adapt<BuildBatchToSpaceNdOp>;
   builders[kLiteRtOpCodeTflSpaceToBatchNd] = Adapt<BuildSpaceToBatchNdOp>;
+  builders[kLiteRtOpCodeTflSqueeze] = Adapt<BuildSqueezeOp>;
   builders[kLiteRtOpCodeTflTanh] = Adapt<BuildTanhOp>;
   builders[kLiteRtOpCodeTflPad] = Adapt<BuildConstantPadOp>;
   builders[kLiteRtOpCodeTflGather] = Adapt<BuildGatherOp>;

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -348,6 +348,18 @@ cc_library(
 )
 
 cc_library(
+    name = "squeeze_op_builder",
+    srcs = ["squeeze_op_builder.cc"],
+    hdrs = ["squeeze_op_builder.h"],
+    deps = [
+        ":op_builder",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+cc_library(
     name = "tanh_op_builder",
     srcs = ["tanh_op_builder.cc"],
     hdrs = ["tanh_op_builder.h"],

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -348,6 +348,17 @@ cc_library(
 )
 
 cc_library(
+    name = "squeeze_op_builder",
+    srcs = ["squeeze_op_builder.cc"],
+    hdrs = ["squeeze_op_builder.h"],
+    deps = [
+        ":op_builder",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+    ]
+)
+
+cc_library(
     name = "tanh_op_builder",
     srcs = ["tanh_op_builder.cc"],
     hdrs = ["tanh_op_builder.h"],

--- a/litert/vendors/qualcomm/core/builders/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/builders/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(qnn_builders
         spatial_transform_op_builder.cc
         split_op_builder.cc
         splitv_op_builder.cc
+        squeeze_op_builder.cc
         strided_slice_op_builder.cc
         tanh_op_builder.cc
         tile_op_builder.cc

--- a/litert/vendors/qualcomm/core/builders/squeeze_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/squeeze_op_builder.cc
@@ -1,0 +1,45 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/squeeze_op_builder.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "QnnOpDef.h"  // from @qairt
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildSqueezeOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs,
+    const std::vector<int32_t>& squeeze_dims) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_SQUEEZE), QNN_OP_SQUEEZE,
+               QnnOpCode::kSqueeze);
+  op.AddInputTensor(inputs[0]);
+  op.AddOutputTensor(outputs[0]);
+
+  if (!squeeze_dims.empty()) {
+    const std::uint32_t input_rank = inputs[0].get().GetRank();
+    std::vector<std::uint32_t> resolved_dims;
+    resolved_dims.reserve(squeeze_dims.size());
+    for (int32_t dim : squeeze_dims) {
+      resolved_dims.emplace_back(dim < 0
+                                    ? static_cast<std::uint32_t>(dim + input_rank)
+                                    : static_cast<std::uint32_t>(dim));
+    }
+    TensorWrapper& axes_tensor = tensor_pool.CreateStaticTensor(
+        QNN_DATATYPE_UINT_32, {},
+        {static_cast<std::uint32_t>(resolved_dims.size())},
+        sizeof(resolved_dims[0]) * resolved_dims.size(), resolved_dims.data());
+    op.AddTensorParam(QNN_OP_SQUEEZE_PARAM_AXES, axes_tensor);
+  }
+
+  return MakeVector(std::move(op));
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/squeeze_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/squeeze_op_builder.cc
@@ -1,0 +1,25 @@
+// Copyright (c) Qualcomm Innovation Center, Inc.
+// All Rights Reserved.
+
+#include "litert/vendors/qualcomm/core/builders/squeeze_op_builder.h"
+
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+
+#include "QnnOpDef.h"
+
+namespace qnn {
+
+OpWrapper CreateSqueezeOp(
+    const TensorWrapper& input,
+    const TensorWrapper& output,
+    const TensorWrapper& squeeze_dims) {
+    OpWrapper op(GetUniqueOpName(QNN_OP_SQUEEZE), QNN_OP_SQUEEZE,
+                 QnnOpCode::kSqueeze);
+
+    op.AddInputTensor(input);
+    op.AddOutputTensor(output);
+    op.AddTensorParam(QNN_OP_SQUEEZE_PARAM_AXES, squeeze_dims);
+    return op;
+}
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/squeeze_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/squeeze_op_builder.h
@@ -1,0 +1,25 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SQUEEZE_OP_BUILDER_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SQUEEZE_OP_BUILDER_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+// Builds a Squeeze op, resolving any negative values in squeeze_dims relative
+// to the input rank before passing them to QNN.
+std::vector<OpWrapper> BuildSqueezeOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs,
+    const std::vector<int32_t>& squeeze_dims);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SQUEEZE_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/core/builders/squeeze_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/squeeze_op_builder.h
@@ -1,0 +1,18 @@
+// Copyright (c) Qualcomm Innovation Center, Inc.
+// All Rights Reserved.
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SQUEEZE_OP_BUILDER_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SQUEEZE_OP_BUILDER_H_
+
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+OpWrapper CreateSqueezeOp(const TensorWrapper& input,
+                          const TensorWrapper& output,
+                          const TensorWrapper& squeeze_dims);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_SQUEEZE_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -267,6 +267,39 @@ litert_test(
 )
 
 litert_test(
+    name = "squeeze_test",
+    srcs = [
+        "squeeze_test.cc",
+    ],
+    linkopts = select({
+        "//litert:android": [],
+        "//conditions:default": [
+            make_rpaths([
+                "//litert/c:litert_runtime_c_api_so",
+            ]),
+        ],
+    }),
+    linkstatic = True,
+    no_main = True,
+    tags = [
+        "noasan",
+        "nomsan",
+        "nosan",
+        "notsan",
+    ],
+    target_compatible_with = _COMPATIBLE_OS,
+    ungrte = True,
+    use_sys_malloc = True,
+    deps = [
+        "//litert/vendors/qualcomm/core/builders:squeeze_op_builder",
+        "//litert/vendors/qualcomm/core/utils:test_main",
+        "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "@qairt//:qnn_lib_headers",
+    ] + _QNN_DEPS,
+)
+
+litert_test(
     name = "splitv_test",
     srcs = [
         "splitv_test.cc",

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/squeeze_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/squeeze_test.cc
@@ -1,0 +1,175 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include "QnnTypes.h"  // from @qairt
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "litert/vendors/qualcomm/core/builders/squeeze_op_builder.h"
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+
+namespace litert::qnn {
+namespace {
+using testing::FloatNear;
+using testing::Pointwise;
+
+INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
+                         QnnTestPrinter);
+
+//   Input shape: {1, 2, 1, 3}, axes=[0, 2]
+//   Output shape: {2, 3}
+TEST_P(QnnModelTest, SqueezeRemovesMultipleDims) {
+  static constexpr std::array<std::uint32_t, 4> kInputDims{1, 2, 1, 3};
+  static constexpr std::array<std::uint32_t, 2> kOutputDims{2, 3};
+
+  auto& input_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input", QNN_DATATYPE_FLOAT_32, {},
+      {kInputDims.begin(), kInputDims.end()});
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_FLOAT_32, {},
+      {kOutputDims.begin(), kOutputDims.end()});
+
+  auto ops = ::qnn::BuildSqueezeOp(tensor_pool_, {input_tensor}, {output_tensor},
+                                   {0, 2});
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+  qnn_model_.SetInputData<float>(input_idx,
+                                 {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<float>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_THAT(output_data.value(),
+              Pointwise(FloatNear(1e-3), {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}));
+}
+
+// Verifies that Squeeze accepts quantized (int8) tensors
+TEST_P(QnnModelTest, SqueezeQuantizedInt8) {
+  static constexpr std::array<std::uint32_t, 2> kInputDims{1, 4};
+  static constexpr std::array<std::uint32_t, 1> kOutputDims{4};
+  const ::qnn::QuantizeParamsWrapperVariant kQuant{
+      std::in_place_type<::qnn::ScaleOffsetQuantizeParamsWrapper>,
+      /*scale=*/0.1f, /*zero_point=*/0};
+
+  auto& input_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input", QNN_DATATYPE_SFIXED_POINT_8, kQuant,
+      {kInputDims.begin(), kInputDims.end()});
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_SFIXED_POINT_8, kQuant,
+      {kOutputDims.begin(), kOutputDims.end()});
+
+  auto ops = ::qnn::BuildSqueezeOp(tensor_pool_, {input_tensor}, {output_tensor},
+                                   {0});
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+  // Quantized values (scale=0.1, zero_point=0): {10, 20, 30, 40} → {1.0, 2.0,
+  // 3.0, 4.0} in float.
+  qnn_model_.SetInputData<std::int8_t>(input_idx, {10, 20, 30, 40});
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<std::int8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_THAT(output_data.value(),
+              Pointwise(testing::Eq(), std::vector<std::int8_t>{10, 20, 30, 40}));
+}
+
+// Verifies that negative squeeze axes (e.g. -4, -2 on a rank-4 tensor) are
+// correctly resolved to positive indices inside BuildSqueezeOp.
+//   Input shape: {1, 2, 1, 3}, axes=[-4, -2] → resolved=[0, 2]
+//   Output shape: {2, 3}
+TEST_P(QnnModelTest, SqueezeNegativeDims) {
+  static constexpr std::array<std::uint32_t, 4> kInputDims{1, 2, 1, 3};
+  static constexpr std::array<std::uint32_t, 2> kOutputDims{2, 3};
+
+  auto& input_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input", QNN_DATATYPE_FLOAT_32, {},
+      {kInputDims.begin(), kInputDims.end()});
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_FLOAT_32, {},
+      {kOutputDims.begin(), kOutputDims.end()});
+
+  auto ops = ::qnn::BuildSqueezeOp(tensor_pool_, {input_tensor}, {output_tensor},
+                                   {-4, -2});
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+  qnn_model_.SetInputData<float>(input_idx,
+                                 {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<float>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_THAT(output_data.value(),
+              Pointwise(FloatNear(1e-3), {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}));
+}
+
+// Verifies that empty squeeze_dims omits the axes param, causing QNN to squeeze
+// all size-1 dimensions.
+//   Input shape: {1, 2, 1, 3}, axes=[]
+//   Output shape: {2, 3}
+TEST_P(QnnModelTest, SqueezeEmptyDims) {
+  static constexpr std::array<std::uint32_t, 4> kInputDims{1, 2, 1, 3};
+  static constexpr std::array<std::uint32_t, 2> kOutputDims{2, 3};
+
+  auto& input_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input", QNN_DATATYPE_FLOAT_32, {},
+      {kInputDims.begin(), kInputDims.end()});
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_FLOAT_32, {},
+      {kOutputDims.begin(), kOutputDims.end()});
+
+  auto ops = ::qnn::BuildSqueezeOp(tensor_pool_, {input_tensor}, {output_tensor},
+                                   {});
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+  qnn_model_.SetInputData<float>(input_idx,
+                                 {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f});
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<float>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_THAT(output_data.value(),
+              Pointwise(FloatNear(1e-3), {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f}));
+}
+
+}  // namespace
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/tests/CMakeLists.txt
+++ b/litert/vendors/qualcomm/tests/CMakeLists.txt
@@ -119,6 +119,7 @@ target_sources(builder_test
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/spatial_transform_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/spatial_transform_nd_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/splitv_test.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/squeeze_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/topk_test.cc
 )
 


### PR DESCRIPTION
# What
- Add Squeeze Op Builder
- Add corresponding unit test

# Motivation
- Prevent CPU Fallback on Squeeze Op

# Verification
- [x] Developer Verified

# Test
- Passed x86 unit test.
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.1s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 53.9s

//litert/vendors/qualcomm/compiler:qnn_compose_graph_test
//litert/vendors/qualcomm/compiler:qnn_compose_graph_test                PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:backend_factory_test
//litert/vendors/qualcomm/core/backends:backend_factory_test    (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:dsp_backend_test
//litert/vendors/qualcomm/core/backends:dsp_backend_test        (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:gpu_backend_test
//litert/vendors/qualcomm/core/backends:gpu_backend_test        (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:graph_config_builder_test
//litert/vendors/qualcomm/core/backends:graph_config_builder_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 1.2s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/schema:soc_table_test
//litert/vendors/qualcomm/core/schema:soc_table_test            (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:embedding_gemma_test
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:graph_to_graph_test
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test
//litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test    (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:hadamard_transform_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:hadamard_transform_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:onehot_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:onehot_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pad_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pad_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:squeeze_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:squeeze_test     PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s
```

- Passed android unit test. (HTP)
```
======================== Test Summary ========================
SM8750: //litert/c/options:litert_qualcomm_options_test
[==========] 25 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 25 tests.

SM8750: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (368 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 18 tests from 12 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8750: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (10 ms total)
[  PASSED  ] 9 tests.

SM8750: //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[==========] 268 tests from 4 test suites ran. (57334 ms total)
[  PASSED  ] 252 tests.

SM8750: //litert/vendors/qualcomm/compiler:qnn_compose_graph_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

SM8750: //litert/vendors/qualcomm/core:common_test
[==========] 29 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 29 tests.

SM8750: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8750: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (483 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (614 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (8 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/core/backends:graph_config_builder_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (3880 ms total)
[  PASSED  ] 26 tests.

SM8750: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (12 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/core/schema:soc_table_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (12 ms total)
[  PASSED  ] 13 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test
[==========] 21 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8750: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (11 ms total)
[  PASSED  ] 16 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 36 tests.

SM8750: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (401 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (251 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1166 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
[==========] 2 tests from 1 test suite ran. (563 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1193 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:hadamard_transform_test
[==========] 1 test from 1 test suite ran. (320 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:onehot_test
[==========] 1 test from 1 test suite ran. (283 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (600 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pad_test
[==========] 7 tests from 2 test suites ran. (884 ms total)
[  PASSED  ] 7 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (119 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (554 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test
[==========] 2 tests from 1 test suite ran. (572 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1150 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:squeeze_test
[==========] 2 tests from 1 test suite ran. (556 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (288 ms total)
[  PASSED  ] 1 test.
```