### PR TITLE
Move ml_dtypes from model-utils extra to base dependency

### DIFF
--- a/ci/tools/python/wheel/setup_with_binary.py
+++ b/ci/tools/python/wheel/setup_with_binary.py
@@ -197,6 +197,7 @@ setuptools.setup(
         'typing-extensions',
         # TODO(b/445163709): remove this once litert_lm has a pypi package.
         'protobuf',
+        'ml_dtypes',
     ],
     extras_require={
         'npu-intel': [
@@ -213,7 +214,6 @@ setuptools.setup(
         ],
         'model-utils': [
             'lark',
-            'ml_dtypes',
             'xdsl==0.28.0',
         ],
     },


### PR DESCRIPTION
# What
Fix #8906 
Move ml_dtypes from model-utils extra to base dependency

# Why
tensor_buffer.py imports ml_dtypes at module load time, and is itself imported by compiled_model.py.
This means importing CompiledModel always requires ml_dtypes, regardless of whether the model-utils extra is installed.

A plain `pip install ai-edge-litert` currently fails with ModuleNotFoundError: No module named 'ml_dtypes' as soon as CompiledModel is imported.