### PR TITLE
Fix handling of BATCH_MATMUL(adj_y=true)

### DIFF
--- a/tflite/delegates/gpu/cl/kernels/BUILD
+++ b/tflite/delegates/gpu/cl/kernels/BUILD
@@ -46,6 +46,25 @@ cc_test(
 )
 
 cc_test(
+    name = "batch_matmul_test",
+    srcs = ["batch_matmul_test.cc"],
+    linkstatic = True,
+    tags = tf_gpu_tests_tags() + [
+        "linux",
+        "local",
+    ],
+    deps = [
+        "//tflite:framework",
+        "//tflite/delegates/gpu:delegate",
+        "//tflite/kernels:test_main",
+        "//tflite/kernels:test_util",
+        "//tflite/schema:schema_fbs",
+        "@com_google_googletest//:gtest",
+        "@flatbuffers",
+    ],
+)
+
+cc_test(
     name = "cast_test",
     srcs = ["cast_test.cc"],
     tags = [

--- a/tflite/delegates/gpu/cl/kernels/batch_matmul_test.cc
+++ b/tflite/delegates/gpu/cl/kernels/batch_matmul_test.cc
@@ -31,9 +31,10 @@ using ::testing::Pointwise;
 
 class BatchMatMulOpModel : public SingleOpModel {
  public:
-  explicit BatchMatMulOpModel(bool use_gpu) {
-    lhs_ = AddInput({TensorType_FLOAT32, {1, 2, 3}});
-    rhs_ = AddInput({TensorType_FLOAT32, {1, 4, 3}});
+  BatchMatMulOpModel(bool use_gpu, const std::vector<int>& lhs_shape,
+                     const std::vector<int>& rhs_shape) {
+    lhs_ = AddInput({TensorType_FLOAT32, lhs_shape});
+    rhs_ = AddInput({TensorType_FLOAT32, rhs_shape});
     output_ = AddOutput(TensorType_FLOAT32);
     SetBuiltinOp(
         BuiltinOperator_BATCH_MATMUL, BuiltinOptions_BatchMatMulOptions,
@@ -81,13 +82,15 @@ TEST(BatchMatMulOpenClTest, AdjointRhsMatchesCpu) {
   };
   const std::vector<float> expected = {1, 2, 3, 6, 4, 5, 6, 15};
 
-  BatchMatMulOpModel cpu(/*use_gpu=*/false);
+  BatchMatMulOpModel cpu(/*use_gpu=*/false, /*lhs_shape=*/{1, 2, 3},
+                         /*rhs_shape=*/{1, 4, 3});
   cpu.SetInputs(lhs, rhs);
   ASSERT_EQ(cpu.Invoke(), kTfLiteOk);
   EXPECT_THAT(cpu.GetOutput(), ElementsAreArray(expected));
   EXPECT_THAT(cpu.GetOutputShape(), ElementsAreArray({1, 2, 4}));
 
-  BatchMatMulOpModel gpu(/*use_gpu=*/true);
+  BatchMatMulOpModel gpu(/*use_gpu=*/true, /*lhs_shape=*/{1, 2, 3},
+                         /*rhs_shape=*/{1, 4, 3});
   ASSERT_EQ(gpu.ApplyDelegate(), kTfLiteOk);
   gpu.SetInputs(lhs, rhs);
   ASSERT_EQ(gpu.Invoke(), kTfLiteOk);
@@ -95,6 +98,34 @@ TEST(BatchMatMulOpenClTest, AdjointRhsMatchesCpu) {
   EXPECT_THAT(gpu.GetOutput(),
               Pointwise(FloatNear(1.0e-5f), cpu.GetOutput()));
   EXPECT_THAT(gpu.GetOutputShape(), ElementsAreArray({1, 2, 4}));
+}
+
+TEST(BatchMatMulOpenClTest, AdjointRhsRankTwoMatchesCpu) {
+  const std::vector<float> lhs = {1, 2, 3, 4, 5, 6};
+  const std::vector<float> rhs = {
+      1, 0, 0,  //
+      0, 1, 0,  //
+      0, 0, 1,  //
+      1, 1, 1,
+  };
+  const std::vector<float> expected = {1, 2, 3, 6, 4, 5, 6, 15};
+
+  BatchMatMulOpModel cpu(/*use_gpu=*/false, /*lhs_shape=*/{2, 3},
+                         /*rhs_shape=*/{4, 3});
+  cpu.SetInputs(lhs, rhs);
+  ASSERT_EQ(cpu.Invoke(), kTfLiteOk);
+  EXPECT_THAT(cpu.GetOutput(), ElementsAreArray(expected));
+  EXPECT_THAT(cpu.GetOutputShape(), ElementsAreArray({2, 4}));
+
+  BatchMatMulOpModel gpu(/*use_gpu=*/true, /*lhs_shape=*/{2, 3},
+                         /*rhs_shape=*/{4, 3});
+  ASSERT_EQ(gpu.ApplyDelegate(), kTfLiteOk);
+  gpu.SetInputs(lhs, rhs);
+  ASSERT_EQ(gpu.Invoke(), kTfLiteOk);
+  EXPECT_EQ(gpu.CpuKernelCount(), 0);
+  EXPECT_THAT(gpu.GetOutput(),
+              Pointwise(FloatNear(1.0e-5f), cpu.GetOutput()));
+  EXPECT_THAT(gpu.GetOutputShape(), ElementsAreArray({2, 4}));
 }
 
 }  // namespace

--- a/tflite/delegates/gpu/cl/kernels/batch_matmul_test.cc
+++ b/tflite/delegates/gpu/cl/kernels/batch_matmul_test.cc
@@ -1,0 +1,101 @@
+/* Copyright 2026 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "flatbuffers/flatbuffers.h"  // from @flatbuffers
+#include "tflite/delegates/gpu/delegate.h"
+#include "tflite/kernels/test_util.h"
+#include "tflite/schema/schema_generated.h"
+
+namespace tflite {
+namespace {
+
+using ::testing::ElementsAreArray;
+using ::testing::FloatNear;
+using ::testing::Pointwise;
+
+class BatchMatMulOpModel : public SingleOpModel {
+ public:
+  explicit BatchMatMulOpModel(bool use_gpu) {
+    lhs_ = AddInput({TensorType_FLOAT32, {1, 2, 3}});
+    rhs_ = AddInput({TensorType_FLOAT32, {1, 4, 3}});
+    output_ = AddOutput(TensorType_FLOAT32);
+    SetBuiltinOp(
+        BuiltinOperator_BATCH_MATMUL, BuiltinOptions_BatchMatMulOptions,
+        CreateBatchMatMulOptions(builder_, /*adj_x=*/false, /*adj_y=*/true)
+            .Union());
+    BuildInterpreter({GetShape(lhs_), GetShape(rhs_)}, /*num_threads=*/-1,
+                     /*allow_fp32_relax_to_fp16=*/false,
+                     /*apply_delegate=*/false);
+
+    if (use_gpu) {
+      auto options = TfLiteGpuDelegateOptionsV2Default();
+      options.experimental_flags |= TFLITE_GPU_EXPERIMENTAL_FLAGS_CL_ONLY;
+      SetDelegate(
+          {TfLiteGpuDelegateV2Create(&options), TfLiteGpuDelegateV2Delete});
+    }
+  }
+
+  void SetInputs(const std::vector<float>& lhs,
+                 const std::vector<float>& rhs) {
+    PopulateTensor(lhs_, lhs);
+    PopulateTensor(rhs_, rhs);
+  }
+
+  std::vector<float> GetOutput() { return ExtractVector<float>(output_); }
+
+  std::vector<int32_t> GetOutputShape() {
+    return GetTensorShape(output_);
+  }
+
+  int CpuKernelCount() { return CountOpsExecutedByCpuKernel(); }
+
+ private:
+  int lhs_;
+  int rhs_;
+  int output_;
+};
+
+TEST(BatchMatMulOpenClTest, AdjointRhsMatchesCpu) {
+  const std::vector<float> lhs = {1, 2, 3, 4, 5, 6};
+  const std::vector<float> rhs = {
+      1, 0, 0,  //
+      0, 1, 0,  //
+      0, 0, 1,  //
+      1, 1, 1,
+  };
+  const std::vector<float> expected = {1, 2, 3, 6, 4, 5, 6, 15};
+
+  BatchMatMulOpModel cpu(/*use_gpu=*/false);
+  cpu.SetInputs(lhs, rhs);
+  ASSERT_EQ(cpu.Invoke(), kTfLiteOk);
+  EXPECT_THAT(cpu.GetOutput(), ElementsAreArray(expected));
+  EXPECT_THAT(cpu.GetOutputShape(), ElementsAreArray({1, 2, 4}));
+
+  BatchMatMulOpModel gpu(/*use_gpu=*/true);
+  ASSERT_EQ(gpu.ApplyDelegate(), kTfLiteOk);
+  gpu.SetInputs(lhs, rhs);
+  ASSERT_EQ(gpu.Invoke(), kTfLiteOk);
+  EXPECT_EQ(gpu.CpuKernelCount(), 0);
+  EXPECT_THAT(gpu.GetOutput(),
+              Pointwise(FloatNear(1.0e-5f), cpu.GetOutput()));
+  EXPECT_THAT(gpu.GetOutputShape(), ElementsAreArray({1, 2, 4}));
+}
+
+}  // namespace
+}  // namespace tflite

--- a/tflite/delegates/gpu/cl/kernels/batch_matmul_test.cc
+++ b/tflite/delegates/gpu/cl/kernels/batch_matmul_test.cc
@@ -32,14 +32,18 @@ using ::testing::Pointwise;
 class BatchMatMulOpModel : public SingleOpModel {
  public:
   BatchMatMulOpModel(bool use_gpu, const std::vector<int>& lhs_shape,
-                     const std::vector<int>& rhs_shape) {
+                     const std::vector<int>& rhs_shape, bool adj_x,
+                     bool adj_y,
+                     const std::vector<float>* constant_rhs = nullptr)
+      : rhs_is_constant_(constant_rhs != nullptr) {
     lhs_ = AddInput({TensorType_FLOAT32, lhs_shape});
-    rhs_ = AddInput({TensorType_FLOAT32, rhs_shape});
+    rhs_ = rhs_is_constant_
+               ? AddConstInput({TensorType_FLOAT32, rhs_shape}, *constant_rhs)
+               : AddInput({TensorType_FLOAT32, rhs_shape});
     output_ = AddOutput(TensorType_FLOAT32);
     SetBuiltinOp(
         BuiltinOperator_BATCH_MATMUL, BuiltinOptions_BatchMatMulOptions,
-        CreateBatchMatMulOptions(builder_, /*adj_x=*/false, /*adj_y=*/true)
-            .Union());
+        CreateBatchMatMulOptions(builder_, adj_x, adj_y).Union());
     BuildInterpreter({GetShape(lhs_), GetShape(rhs_)}, /*num_threads=*/-1,
                      /*allow_fp32_relax_to_fp16=*/false,
                      /*apply_delegate=*/false);
@@ -55,7 +59,9 @@ class BatchMatMulOpModel : public SingleOpModel {
   void SetInputs(const std::vector<float>& lhs,
                  const std::vector<float>& rhs) {
     PopulateTensor(lhs_, lhs);
-    PopulateTensor(rhs_, rhs);
+    if (!rhs_is_constant_) {
+      PopulateTensor(rhs_, rhs);
+    }
   }
 
   std::vector<float> GetOutput() { return ExtractVector<float>(output_); }
@@ -70,63 +76,108 @@ class BatchMatMulOpModel : public SingleOpModel {
   int lhs_;
   int rhs_;
   int output_;
+  const bool rhs_is_constant_;
 };
 
-TEST(BatchMatMulOpenClTest, AdjointRhsMatchesCpu) {
-  const std::vector<float> lhs = {1, 2, 3, 4, 5, 6};
-  const std::vector<float> rhs = {
-      1, 0, 0,  //
-      0, 1, 0,  //
-      0, 0, 1,  //
-      1, 1, 1,
-  };
-  const std::vector<float> expected = {1, 2, 3, 6, 4, 5, 6, 15};
+struct BatchMatMulTestCase {
+  const char* name;
+  int rank;
+  bool adj_x;
+  bool adj_y;
+  bool square = false;
+  bool broadcast_rhs = false;
+  bool constant_rhs = false;
+};
 
-  BatchMatMulOpModel cpu(/*use_gpu=*/false, /*lhs_shape=*/{1, 2, 3},
-                         /*rhs_shape=*/{1, 4, 3});
+std::vector<int> MatrixShape(int rank, int rows, int columns,
+                             int batch_size) {
+  if (rank == 2) {
+    return {rows, columns};
+  }
+  if (rank == 3) {
+    return {batch_size, rows, columns};
+  }
+  return {1, batch_size, rows, columns};
+}
+
+std::vector<float> MakeInput(const std::vector<int>& shape, int seed) {
+  int size = 1;
+  for (int dimension : shape) {
+    size *= dimension;
+  }
+  std::vector<float> values(size);
+  for (int i = 0; i < size; ++i) {
+    values[i] = static_cast<float>((i * seed) % 17 - 8) * 0.125f;
+  }
+  return values;
+}
+
+class BatchMatMulOpenClTest
+    : public ::testing::TestWithParam<BatchMatMulTestCase> {};
+
+TEST_P(BatchMatMulOpenClTest, MatchesCpu) {
+  const BatchMatMulTestCase& test = GetParam();
+  const int rows = test.square ? 3 : 2;
+  const int depth = 3;
+  const int columns = test.square ? 3 : 4;
+  const int batch_size = 2;
+  const std::vector<int> lhs_shape =
+      MatrixShape(test.rank, test.adj_x ? depth : rows,
+                  test.adj_x ? rows : depth, batch_size);
+  const std::vector<int> rhs_shape =
+      MatrixShape(test.rank, test.adj_y ? columns : depth,
+                  test.adj_y ? depth : columns,
+                  test.broadcast_rhs ? 1 : batch_size);
+  const std::vector<int> output_shape =
+      MatrixShape(test.rank, rows, columns, batch_size);
+  const std::vector<float> lhs = MakeInput(lhs_shape, 5);
+  const std::vector<float> rhs = MakeInput(rhs_shape, 7);
+
+  const std::vector<float>* constant_rhs =
+      test.constant_rhs ? &rhs : nullptr;
+  BatchMatMulOpModel cpu(/*use_gpu=*/false, lhs_shape, rhs_shape, test.adj_x,
+                         test.adj_y, constant_rhs);
   cpu.SetInputs(lhs, rhs);
   ASSERT_EQ(cpu.Invoke(), kTfLiteOk);
-  EXPECT_THAT(cpu.GetOutput(), ElementsAreArray(expected));
-  EXPECT_THAT(cpu.GetOutputShape(), ElementsAreArray({1, 2, 4}));
+  EXPECT_THAT(cpu.GetOutputShape(), ElementsAreArray(output_shape));
 
-  BatchMatMulOpModel gpu(/*use_gpu=*/true, /*lhs_shape=*/{1, 2, 3},
-                         /*rhs_shape=*/{1, 4, 3});
+  BatchMatMulOpModel gpu(/*use_gpu=*/true, lhs_shape, rhs_shape, test.adj_x,
+                         test.adj_y, constant_rhs);
   ASSERT_EQ(gpu.ApplyDelegate(), kTfLiteOk);
   gpu.SetInputs(lhs, rhs);
   ASSERT_EQ(gpu.Invoke(), kTfLiteOk);
   EXPECT_EQ(gpu.CpuKernelCount(), 0);
   EXPECT_THAT(gpu.GetOutput(),
-              Pointwise(FloatNear(1.0e-5f), cpu.GetOutput()));
-  EXPECT_THAT(gpu.GetOutputShape(), ElementsAreArray({1, 2, 4}));
+              Pointwise(FloatNear(1.0e-4f), cpu.GetOutput()));
+  EXPECT_THAT(gpu.GetOutputShape(), ElementsAreArray(output_shape));
 }
 
-TEST(BatchMatMulOpenClTest, AdjointRhsRankTwoMatchesCpu) {
-  const std::vector<float> lhs = {1, 2, 3, 4, 5, 6};
-  const std::vector<float> rhs = {
-      1, 0, 0,  //
-      0, 1, 0,  //
-      0, 0, 1,  //
-      1, 1, 1,
-  };
-  const std::vector<float> expected = {1, 2, 3, 6, 4, 5, 6, 15};
-
-  BatchMatMulOpModel cpu(/*use_gpu=*/false, /*lhs_shape=*/{2, 3},
-                         /*rhs_shape=*/{4, 3});
-  cpu.SetInputs(lhs, rhs);
-  ASSERT_EQ(cpu.Invoke(), kTfLiteOk);
-  EXPECT_THAT(cpu.GetOutput(), ElementsAreArray(expected));
-  EXPECT_THAT(cpu.GetOutputShape(), ElementsAreArray({2, 4}));
-
-  BatchMatMulOpModel gpu(/*use_gpu=*/true, /*lhs_shape=*/{2, 3},
-                         /*rhs_shape=*/{4, 3});
-  ASSERT_EQ(gpu.ApplyDelegate(), kTfLiteOk);
-  gpu.SetInputs(lhs, rhs);
-  ASSERT_EQ(gpu.Invoke(), kTfLiteOk);
-  EXPECT_EQ(gpu.CpuKernelCount(), 0);
-  EXPECT_THAT(gpu.GetOutput(),
-              Pointwise(FloatNear(1.0e-5f), cpu.GetOutput()));
-  EXPECT_THAT(gpu.GetOutputShape(), ElementsAreArray({2, 4}));
-}
+INSTANTIATE_TEST_SUITE_P(
+    AllOptionsAndRanks, BatchMatMulOpenClTest,
+    ::testing::Values(
+        BatchMatMulTestCase{"Rank2NN", 2, false, false},
+        BatchMatMulTestCase{"Rank2NT", 2, false, true},
+        BatchMatMulTestCase{"Rank2TN", 2, true, false},
+        BatchMatMulTestCase{"Rank2TT", 2, true, true},
+        BatchMatMulTestCase{"Rank2ConstNN", 2, false, false,
+                           /*square=*/false, /*broadcast_rhs=*/false,
+                           /*constant_rhs=*/true},
+        BatchMatMulTestCase{"Rank2ConstTT", 2, true, true,
+                           /*square=*/false, /*broadcast_rhs=*/false,
+                           /*constant_rhs=*/true},
+        BatchMatMulTestCase{"Rank3NN", 3, false, false},
+        BatchMatMulTestCase{"Rank3NT", 3, false, true},
+        BatchMatMulTestCase{"Rank3TN", 3, true, false},
+        BatchMatMulTestCase{"Rank3TT", 3, true, true},
+        BatchMatMulTestCase{"Rank3TTBroadcastRhs", 3, true, true,
+                           /*square=*/false, /*broadcast_rhs=*/true},
+        BatchMatMulTestCase{"Rank4NN", 4, false, false, /*square=*/true},
+        BatchMatMulTestCase{"Rank4NT", 4, false, true, /*square=*/true},
+        BatchMatMulTestCase{"Rank4TN", 4, true, false, /*square=*/true},
+        BatchMatMulTestCase{"Rank4TT", 4, true, true, /*square=*/true}),
+    [](const ::testing::TestParamInfo<BatchMatMulTestCase>& info) {
+      return info.param.name;
+    });
 
 }  // namespace
 }  // namespace tflite

--- a/tflite/delegates/gpu/common/model_builder.cc
+++ b/tflite/delegates/gpu/common/model_builder.cc
@@ -317,22 +317,96 @@ bool IsLogicalOp(tflite::gpu::OperationType op_type) {
          op_type == tflite::gpu::OperationType::NOT_EQUAL;
 }
 
+absl::Status AddMatrixTransposeNode(GraphFloat32* graph, Value* input,
+                                    int input_rank, Value** output) {
+  TransposeAttributes attr;
+  if (input_rank == 2) {
+    // A rank-2 tensor [M, K] is represented internally as
+    // BHWC(M, 1, 1, K).
+    attr.perm = BHWC(3, 1, 2, 0);
+  } else if (input_rank == 3 || input_rank == 4) {
+    // Rank-3 [B, M, K] and rank-4 [B, H, M, K] tensors map their
+    // matrix dimensions to WIDTH and CHANNELS.
+    attr.perm = BHWC(0, 1, 3, 2);
+  } else {
+    return absl::UnavailableError(
+        "Batched matmul adjoints require rank 2, 3, or 4 tensors.");
+  }
+
+  Node* transpose = graph->NewNode();
+  transpose->operation.type = ToString(OperationType::TRANSPOSE);
+  transpose->operation.attributes = attr;
+  RETURN_IF_ERROR(graph->AddConsumer(transpose->id, input->id));
+
+  Value* transposed = graph->NewValue();
+  transposed->tensor.type = input->tensor.type;
+  transposed->tensor.shape = CalculateOutputShape(input->tensor.shape, attr);
+  transposed->quant_params = input->quant_params;
+  RETURN_IF_ERROR(graph->SetProducer(transpose->id, transposed->id));
+  *output = transposed;
+  return absl::OkStatus();
+}
+
 class BatchedMatMulOperationParser : public TFLiteOperationParser {
  public:
   absl::Status IsSupported(const TfLiteContext* context,
                            const TfLiteNode* tflite_node,
                            const TfLiteRegistration* registration) final {
-    return CheckGpuDelegateCompatibility(context, tflite_node, registration);
+    RETURN_IF_ERROR(
+        CheckGpuDelegateCompatibility(context, tflite_node, registration));
+
+    const TfLiteBatchMatMulParams* tf_options;
+    RETURN_IF_ERROR(RetrieveBuiltinData(tflite_node, &tf_options));
+    if (tf_options->adj_x) {
+      return absl::UnavailableError(
+          "Batched matmul does not support adj_x on the GPU delegate.");
+    }
+
+    const TfLiteTensor& lhs =
+        context->tensors[tflite_node->inputs->data[0]];
+    const TfLiteTensor& rhs =
+        context->tensors[tflite_node->inputs->data[1]];
+    const TfLiteTensor& output =
+        context->tensors[tflite_node->outputs->data[0]];
+    const auto rank_is_supported = [](const TfLiteTensor& tensor) {
+      return tensor.dims->size >= 2 && tensor.dims->size <= 4;
+    };
+    if (!rank_is_supported(lhs) || !rank_is_supported(rhs) ||
+        !rank_is_supported(output)) {
+      return absl::UnavailableError(
+          "Batched matmul supports rank 2, 3, or 4 tensors.");
+    }
+    if (IsConstantTensor(&lhs)) {
+      return absl::UnavailableError(
+          "Batched matmul does not support a constant left-hand input.");
+    }
+    if (IsConstantTensor(&rhs) && rhs.dims->size != 2) {
+      return absl::UnavailableError(
+          "Batched matmul supports only rank-2 constant right-hand inputs.");
+    }
+    return absl::OkStatus();
   }
 
   absl::Status Parse(const TfLiteNode* tflite_node,
                      const TfLiteRegistration* registration,
                      GraphFloat32* graph, ObjectReader* reader) final {
+    const TfLiteBatchMatMulParams* tf_options;
+    RETURN_IF_ERROR(RetrieveBuiltinData(tflite_node, &tf_options));
+
     if (reader->GetNumberOfRuntimeInputs() == 2) {
+      Value* lhs;
+      Value* rhs;
+      RETURN_IF_ERROR(reader->ReadValue(0, &lhs));
+      RETURN_IF_ERROR(reader->ReadValue(1, &rhs));
+      if (tf_options->adj_y) {
+        RETURN_IF_ERROR(AddMatrixTransposeNode(
+            graph, rhs, reader->GetInputTensor(1)->dims->size, &rhs));
+      }
+
       Node* node = graph->NewNode();
       node->operation.type = ToString(OperationType::BATCHED_MATMUL);
-      RETURN_IF_ERROR(reader->AddInput(node, 0));
-      RETURN_IF_ERROR(reader->AddInput(node, 1));
+      RETURN_IF_ERROR(graph->AddConsumer(node->id, lhs->id));
+      RETURN_IF_ERROR(graph->AddConsumer(node->id, rhs->id));
       RETURN_IF_ERROR(reader->AddOutputs(node));
       return absl::OkStatus();
     } else if (reader->GetNumberOfRuntimeInputs() == 1) {
@@ -342,26 +416,39 @@ class BatchedMatMulOperationParser : public TFLiteOperationParser {
         // first input must be runtime and second is 2d constant tensor
         return absl::UnavailableError("Not supported batched mat mul case");
       }
+
+      Value* lhs;
+      RETURN_IF_ERROR(reader->ReadValue(0, &lhs));
+
       Node* node = graph->NewNode();
       node->operation.type = ToString(OperationType::CONVOLUTION_2D);
-      RETURN_IF_ERROR(reader->AddInput(node, 0));
+      RETURN_IF_ERROR(graph->AddConsumer(node->id, lhs->id));
       RETURN_IF_ERROR(reader->AddOutputs(node));
 
       Tensor<HW, DataType::FLOAT32> weights;
       RETURN_IF_ERROR(reader->ReadTensor(1, &weights));
       Convolution2DAttributes attr;
-      attr.weights.data.resize(weights.shape.w * weights.shape.h);
-      for (int i = 0; i < weights.shape.w; ++i) {
-        for (int j = 0; j < weights.shape.h; ++j) {
-          attr.weights.data[i * weights.shape.h + j] =
-              weights.data[j * weights.shape.w + i];
+      if (tf_options->adj_y) {
+        // rhs is [N, K]. Treat its rows directly as N convolution filters,
+        // which is equivalent to lhs * transpose(rhs).
+        attr.weights.data = std::move(weights.data);
+        attr.weights.shape.o = weights.shape.h;
+        attr.weights.shape.i = weights.shape.w;
+      } else {
+        // rhs is [K, N]. Convert its columns into N convolution filters.
+        attr.weights.data.resize(weights.shape.w * weights.shape.h);
+        for (int i = 0; i < weights.shape.w; ++i) {
+          for (int j = 0; j < weights.shape.h; ++j) {
+            attr.weights.data[i * weights.shape.h + j] =
+                weights.data[j * weights.shape.w + i];
+          }
         }
+        attr.weights.shape.o = weights.shape.w;
+        attr.weights.shape.i = weights.shape.h;
       }
       attr.weights.id = weights.id;
       attr.weights.shape.h = 1;
       attr.weights.shape.w = 1;
-      attr.weights.shape.o = weights.shape.w;
-      attr.weights.shape.i = weights.shape.h;
       attr.strides = HW(1, 1);
       attr.dilations = HW(1, 1);
       attr.padding.appended = HW(0, 0);

--- a/tflite/delegates/gpu/common/model_builder.cc
+++ b/tflite/delegates/gpu/common/model_builder.cc
@@ -317,9 +317,16 @@ bool IsLogicalOp(tflite::gpu::OperationType op_type) {
          op_type == tflite::gpu::OperationType::NOT_EQUAL;
 }
 
-absl::Status AddMatrixTransposeNode(GraphFloat32* graph, Value* input,
-                                    int input_rank, Value** output) {
+absl::Status ReadBatchedMatMulInput(ObjectReader* reader, int index,
+                                    bool adjoint, GraphFloat32* graph,
+                                    Value** output) {
+  RETURN_IF_ERROR(reader->ReadValue(index, output));
+  if (!adjoint) {
+    return absl::OkStatus();
+  }
+
   TransposeAttributes attr;
+  const int input_rank = reader->GetInputTensor(index)->dims->size;
   if (input_rank == 2) {
     // A rank-2 tensor [M, K] is represented internally as
     // BHWC(M, 1, 1, K).
@@ -336,12 +343,13 @@ absl::Status AddMatrixTransposeNode(GraphFloat32* graph, Value* input,
   Node* transpose = graph->NewNode();
   transpose->operation.type = ToString(OperationType::TRANSPOSE);
   transpose->operation.attributes = attr;
-  RETURN_IF_ERROR(graph->AddConsumer(transpose->id, input->id));
+  RETURN_IF_ERROR(graph->AddConsumer(transpose->id, (*output)->id));
 
   Value* transposed = graph->NewValue();
-  transposed->tensor.type = input->tensor.type;
-  transposed->tensor.shape = CalculateOutputShape(input->tensor.shape, attr);
-  transposed->quant_params = input->quant_params;
+  transposed->tensor.type = (*output)->tensor.type;
+  transposed->tensor.shape =
+      CalculateOutputShape((*output)->tensor.shape, attr);
+  transposed->quant_params = (*output)->quant_params;
   RETURN_IF_ERROR(graph->SetProducer(transpose->id, transposed->id));
   *output = transposed;
   return absl::OkStatus();
@@ -357,32 +365,19 @@ class BatchedMatMulOperationParser : public TFLiteOperationParser {
 
     const TfLiteBatchMatMulParams* tf_options;
     RETURN_IF_ERROR(RetrieveBuiltinData(tflite_node, &tf_options));
-    if (tf_options->adj_x) {
-      return absl::UnavailableError(
-          "Batched matmul does not support adj_x on the GPU delegate.");
-    }
-
     const TfLiteTensor& lhs =
         context->tensors[tflite_node->inputs->data[0]];
     const TfLiteTensor& rhs =
         context->tensors[tflite_node->inputs->data[1]];
-    const TfLiteTensor& output =
-        context->tensors[tflite_node->outputs->data[0]];
-    const auto rank_is_supported = [](const TfLiteTensor& tensor) {
-      return tensor.dims->size >= 2 && tensor.dims->size <= 4;
+    const auto adjoint_rank_is_supported = [](bool adjoint,
+                                              const TfLiteTensor& tensor) {
+      return !adjoint ||
+             (tensor.dims->size >= 2 && tensor.dims->size <= 4);
     };
-    if (!rank_is_supported(lhs) || !rank_is_supported(rhs) ||
-        !rank_is_supported(output)) {
+    if (!adjoint_rank_is_supported(tf_options->adj_x, lhs) ||
+        !adjoint_rank_is_supported(tf_options->adj_y, rhs)) {
       return absl::UnavailableError(
-          "Batched matmul supports rank 2, 3, or 4 tensors.");
-    }
-    if (IsConstantTensor(&lhs)) {
-      return absl::UnavailableError(
-          "Batched matmul does not support a constant left-hand input.");
-    }
-    if (IsConstantTensor(&rhs) && rhs.dims->size != 2) {
-      return absl::UnavailableError(
-          "Batched matmul supports only rank-2 constant right-hand inputs.");
+          "Batched matmul adjoints require rank 2, 3, or 4 inputs.");
     }
     return absl::OkStatus();
   }
@@ -396,12 +391,10 @@ class BatchedMatMulOperationParser : public TFLiteOperationParser {
     if (reader->GetNumberOfRuntimeInputs() == 2) {
       Value* lhs;
       Value* rhs;
-      RETURN_IF_ERROR(reader->ReadValue(0, &lhs));
-      RETURN_IF_ERROR(reader->ReadValue(1, &rhs));
-      if (tf_options->adj_y) {
-        RETURN_IF_ERROR(AddMatrixTransposeNode(
-            graph, rhs, reader->GetInputTensor(1)->dims->size, &rhs));
-      }
+      RETURN_IF_ERROR(ReadBatchedMatMulInput(
+          reader, 0, tf_options->adj_x, graph, &lhs));
+      RETURN_IF_ERROR(ReadBatchedMatMulInput(
+          reader, 1, tf_options->adj_y, graph, &rhs));
 
       Node* node = graph->NewNode();
       node->operation.type = ToString(OperationType::BATCHED_MATMUL);
@@ -418,8 +411,8 @@ class BatchedMatMulOperationParser : public TFLiteOperationParser {
       }
 
       Value* lhs;
-      RETURN_IF_ERROR(reader->ReadValue(0, &lhs));
-
+      RETURN_IF_ERROR(ReadBatchedMatMulInput(
+          reader, 0, tf_options->adj_x, graph, &lhs));
       Node* node = graph->NewNode();
       node->operation.type = ToString(OperationType::CONVOLUTION_2D);
       RETURN_IF_ERROR(graph->AddConsumer(node->id, lhs->id));
@@ -432,8 +425,6 @@ class BatchedMatMulOperationParser : public TFLiteOperationParser {
         // rhs is [N, K]. Treat its rows directly as N convolution filters,
         // which is equivalent to lhs * transpose(rhs).
         attr.weights.data = std::move(weights.data);
-        attr.weights.shape.o = weights.shape.h;
-        attr.weights.shape.i = weights.shape.w;
       } else {
         // rhs is [K, N]. Convert its columns into N convolution filters.
         attr.weights.data.resize(weights.shape.w * weights.shape.h);
@@ -443,12 +434,14 @@ class BatchedMatMulOperationParser : public TFLiteOperationParser {
                 weights.data[j * weights.shape.w + i];
           }
         }
-        attr.weights.shape.o = weights.shape.w;
-        attr.weights.shape.i = weights.shape.h;
       }
       attr.weights.id = weights.id;
       attr.weights.shape.h = 1;
       attr.weights.shape.w = 1;
+      attr.weights.shape.o =
+          tf_options->adj_y ? weights.shape.h : weights.shape.w;
+      attr.weights.shape.i =
+          tf_options->adj_y ? weights.shape.w : weights.shape.h;
       attr.strides = HW(1, 1);
       attr.dilations = HW(1, 1);
       attr.padding.appended = HW(0, 0);

--- a/tflite/delegates/gpu/common/model_builder_test.cc
+++ b/tflite/delegates/gpu/common/model_builder_test.cc
@@ -1515,6 +1515,26 @@ TEST(BatchMatMulOperationParserTest, TestIsSupported) {
       parser
           ->IsSupported(context.get(), context->node(), context->registration())
           .ok());
+
+  // adj_x is not lowered by the GPU parser.
+  TfLiteBatchMatMulParams* tf_options =
+      static_cast<TfLiteBatchMatMulParams*>(context->node()->builtin_data);
+  tf_options->adj_x = true;
+  ASSERT_FALSE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+
+  // Rank-1 matrix inputs are not supported.
+  tf_options->adj_x = false;
+  TfLiteTensor* lhs = context->tensor(context->node()->inputs->data[0]);
+  TfLiteIntArrayFree(lhs->dims);
+  lhs->dims = TfLiteIntArrayCreate(1);
+  lhs->dims->data[0] = 1;
+  ASSERT_FALSE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
 }
 
 TEST(CastOperationParserTest, TestIsSupported) {

--- a/tflite/delegates/gpu/common/model_builder_test.cc
+++ b/tflite/delegates/gpu/common/model_builder_test.cc
@@ -1516,21 +1516,32 @@ TEST(BatchMatMulOperationParserTest, TestIsSupported) {
           ->IsSupported(context.get(), context->node(), context->registration())
           .ok());
 
-  // adj_x is not lowered by the GPU parser.
   TfLiteBatchMatMulParams* tf_options =
       static_cast<TfLiteBatchMatMulParams*>(context->node()->builtin_data);
   tf_options->adj_x = true;
+  tf_options->adj_y = true;
+  ASSERT_TRUE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+
+  // Rank-1 adjoints cannot be represented as matrix transposes.
+  TfLiteTensor* lhs = context->tensor(context->node()->inputs->data[0]);
+  TfLiteIntArrayFree(lhs->dims);
+  lhs->dims = TfLiteIntArrayCreate(1);
+  lhs->dims->data[0] = 1;
   ASSERT_FALSE(
       parser
           ->IsSupported(context.get(), context->node(), context->registration())
           .ok());
 
-  // Rank-1 matrix inputs are not supported.
+  // The same validation applies independently to adj_y.
   tf_options->adj_x = false;
-  TfLiteTensor* lhs = context->tensor(context->node()->inputs->data[0]);
-  TfLiteIntArrayFree(lhs->dims);
-  lhs->dims = TfLiteIntArrayCreate(1);
-  lhs->dims->data[0] = 1;
+  tf_options->adj_y = true;
+  TfLiteTensor* rhs = context->tensor(context->node()->inputs->data[1]);
+  TfLiteIntArrayFree(rhs->dims);
+  rhs->dims = TfLiteIntArrayCreate(1);
+  rhs->dims->data[0] = 1;
   ASSERT_FALSE(
       parser
           ->IsSupported(context.get(), context->node(), context->registration())


### PR DESCRIPTION
While testing [Whisper Large V3 Turbo](https://huggingface.co/litert-community/whisper-large-v3-turbo) with the LiteRT GPU delegate, I found multiple sources of CPU/GPU output divergence. This PR fixes one of them: the GPU parser ignored the `adj_x` and `adj_y` options of `BATCH_MATMUL`, allowing the operation to run with the wrong matrix orientation.

## Changes

- Handle both `adj_x` and `adj_y` by adding internal GPU transpose operations.
- Support all four option combinations and rank-2, rank-3, and rank-4 tensors.
- Preserve tensor type, shape, and quantization information.
- Apply the same handling to constant right-hand inputs.
- Reject unsupported tensor ranks instead of silently producing incorrect results.