### PR TITLE
Qualcomm AI Engine Direct - Convert KV to UINT16.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -105,6 +105,7 @@ struct LrtQualcommOptionsT {
   std::optional<std::vector<std::int32_t>> dump_tensor_ids;
   std::optional<std::string> ir_json_dir;
   std::optional<std::string> dlc_dir;
+  std::optional<std::string> graph_transform;
   std::optional<std::uint32_t> vtcm_size;
   std::optional<std::uint32_t> num_hvx_threads;
   std::optional<LrtQualcommOptionsOptimizationLevel> optimization_level;
@@ -219,6 +220,9 @@ LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
         } else if (key == "dlc_dir") {
           status = LrtQualcommOptionsSetDlcDir(parsed_options,
                                                std::string(value).c_str());
+        } else if (key == "graph_transform") {
+          status = LrtQualcommOptionsSetGraphTransform(
+              parsed_options, std::string(value).c_str());
         } else if (key == "vtcm_size") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
@@ -361,6 +365,9 @@ LiteRtStatus LrtGetOpaqueQualcommOptionsData(LrtQualcommOptions options,
   }
   if (options->dlc_dir.has_value()) {
     toml << "dlc_dir = \"" << *options->dlc_dir << "\"\n";
+  }
+  if (options->graph_transform.has_value()) {
+    toml << "graph_transform = \"" << *options->graph_transform << "\"\n";
   }
   if (options->vtcm_size.has_value()) {
     toml << "vtcm_size = " << *options->vtcm_size << "\n";
@@ -926,6 +933,30 @@ LiteRtStatus LrtQualcommOptionsGetDlcDir(LrtQualcommOptions options,
   }
 
   *dlc_dir = options->dlc_dir.has_value() ? options->dlc_dir->c_str() : "";
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsSetGraphTransform(
+    LrtQualcommOptions options, const char* graph_transform) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->graph_transform = graph_transform;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsGetGraphTransform(
+    LrtQualcommOptions options, const char** graph_transform) {
+  if (options == nullptr || graph_transform == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *graph_transform = options->graph_transform.has_value()
+                         ? options->graph_transform->c_str()
+                         : "";
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -310,6 +310,12 @@ LiteRtStatus LrtQualcommOptionsSetDlcDir(LrtQualcommOptions options,
 LiteRtStatus LrtQualcommOptionsGetDlcDir(LrtQualcommOptions options,
                                          const char** dlc_dir);
 
+LiteRtStatus LrtQualcommOptionsSetGraphTransform(LrtQualcommOptions options,
+                                                 const char* graph_transform);
+
+LiteRtStatus LrtQualcommOptionsGetGraphTransform(LrtQualcommOptions options,
+                                                 const char** graph_transform);
+
 LiteRtStatus LrtQualcommOptionsSetVtcmSize(LrtQualcommOptions options,
                                            uint32_t vtcm_size);
 

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -237,6 +237,19 @@ TEST(LiteRtQualcommOptionsTest, DlcDir) {
   LrtDestroyQualcommOptions(qualcomm_options);
 }
 
+TEST(LiteRtQualcommOptionsTest, GraphTransform) {
+  LrtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
+
+  LITERT_ASSERT_OK(LrtQualcommOptionsSetGraphTransform(qualcomm_options,
+                                                       "option1,option2"));
+
+  auto parsed = SerializeAndParse(qualcomm_options);
+  EXPECT_EQ(parsed.GetGraphTransform(), "option1,option2");
+
+  LrtDestroyQualcommOptions(qualcomm_options);
+}
+
 TEST(LiteRtQualcommOptionsTest, VtcmSize) {
   LrtQualcommOptions qualcomm_options;
   LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
@@ -451,6 +464,10 @@ TEST(QualcommOptionsTest, CppWrapper) {
   EXPECT_EQ(options->GetDlcDir(), "");
   options->SetDlcDir("tmp");
   EXPECT_EQ(options->GetDlcDir(), "tmp");
+
+  EXPECT_EQ(options->GetGraphTransform(), "");
+  options->SetGraphTransform("option1,option2");
+  EXPECT_EQ(options->GetGraphTransform(), "option1,option2");
 
   EXPECT_EQ(options->GetVtcmSize(), 0);
   options->SetVtcmSize(4);

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -379,6 +379,18 @@ class QualcommOptions {
     return val;
   }
 
+  void SetGraphTransform(const std::string& graph_transform) {
+    LrtQualcommOptionsSetGraphTransform(options_, graph_transform.c_str());
+  }
+  StringView GetGraphTransform() {
+    const char* val;
+    auto status = LrtQualcommOptionsGetGraphTransform(options_, &val);
+    if (status == kLiteRtStatusErrorNotFound) {
+      return "";
+    }
+    return val;
+  }
+
   void SetVtcmSize(std::uint32_t vtcm_size) {
     LrtQualcommOptionsSetVtcmSize(options_, vtcm_size);
   }

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -433,6 +433,10 @@ ABSL_FLAG(
     std::string, qualcomm_dlc_dir, "",
     "DLC directory. If provided, you can obtain Qnn graphs in DLC format.");
 
+ABSL_FLAG(std::string, qualcomm_graph_transform, "",
+          "Comma-separated list of graph transform options to apply, e.g. "
+          "\"option1,option2\".");
+
 ABSL_FLAG(uint32_t, qualcomm_vtcm_size, 0,
           "The vtcm size of the target device. If this option is set to 0, the "
           "max size of vtcm size will be used.");
@@ -728,6 +732,10 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
 
   const std::string dlc_dir = absl::GetFlag(FLAGS_qualcomm_dlc_dir);
   opts.SetDlcDir(dlc_dir);
+
+  const std::string graph_transform =
+      absl::GetFlag(FLAGS_qualcomm_graph_transform);
+  opts.SetGraphTransform(graph_transform);
 
   const auto vtcm_size = absl::GetFlag(FLAGS_qualcomm_vtcm_size);
   opts.SetVtcmSize(vtcm_size);

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -82,6 +82,8 @@ ABSL_DECLARE_FLAG(std::string, qualcomm_ir_json_dir);
 
 ABSL_DECLARE_FLAG(std::string, qualcomm_dlc_dir);
 
+ABSL_DECLARE_FLAG(std::string, qualcomm_graph_transform);
+
 ABSL_DECLARE_FLAG(std::string, qualcomm_saver_output_dir);
 
 ABSL_DECLARE_FLAG(std::string, qualcomm_schematic_dir);

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -141,6 +141,7 @@ inline LiteRtStatus InitQnnOptions(
       qualcomm_options.GetDspPerfCtrlMode()));
   qnn_options.SetIrJsonDir(qualcomm_options.GetIrJsonDir());
   qnn_options.SetDlcDir(qualcomm_options.GetDlcDir());
+  qnn_options.SetGraphTransform(qualcomm_options.GetGraphTransform());
   qnn_options.SetVtcmSize(qualcomm_options.GetVtcmSize());
   qnn_options.SetNumHvxThreads(qualcomm_options.GetNumHvxThreads());
   qnn_options.SetOptimizationLevel(static_cast<::qnn::OptimizationLevel>(

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -1683,7 +1683,6 @@ LiteRtStatus AddTensorToQnn(
   if (created_tensors.count(&tensor)) {
     return kLiteRtStatusOk;
   }
-
   auto error =
       qnn_api->tensorCreateGraphTensor(graph_handle, &(tensor.GetQnnTensor()));
   if (QNN_SUCCESS == error) {
@@ -1728,8 +1727,8 @@ LiteRtStatus MapGraph(const LiteRtCompilerContext* ctx, QnnManager& qnn,
   auto dump_ids = options.GetDumpTensorIds();
   absl::flat_hash_set<std::int32_t> ids_to_dump(dump_ids.begin(),
                                                 dump_ids.end());
-
-  for (const auto& subgraph_input : graph_mapper.Graph().Inputs()) {
+  const auto subgraph_inputs = graph_mapper.Graph().Inputs();
+  for (const auto& subgraph_input : subgraph_inputs) {
     ::qnn::TensorWrapper* tensor_wrapper{nullptr};
     LITERT_RETURN_IF_ERROR(ConvertTensor(subgraph_input, tensor_pool,
                                          tensor_wrapper, ids_to_dump));
@@ -1738,11 +1737,6 @@ LiteRtStatus MapGraph(const LiteRtCompilerContext* ctx, QnnManager& qnn,
       tensor_wrapper->SetMemHandle(nullptr);
     }
     litert_tensor_to_wrapper.emplace(subgraph_input.Get(), tensor_wrapper);
-    LITERT_RETURN_IF_ERROR(AddTensorToQnn(qnn.Api(), graph_mapper.QnnGraph(),
-                                          *tensor_wrapper, created_tensors));
-    if (inputs != nullptr) {
-      inputs->push_back(*tensor_wrapper);
-    }
   }
 
   for (const auto& subgraph_output : graph_mapper.Graph().Outputs()) {
@@ -1822,6 +1816,27 @@ LiteRtStatus MapGraph(const LiteRtCompilerContext* ctx, QnnManager& qnn,
                           return qnn.ValidateOp(qnn_backend, op) ==
                                  kLiteRtStatusOk;
                         });
+
+  if (options.GetGraphTransform().find("kv_uint") != absl::string_view::npos) {
+    tensor_pool.ForEach([](::qnn::TensorWrapper& tensor_wrapper) {
+      if ((tensor_wrapper.IsSubgraphInput() ||
+           tensor_wrapper.IsSubgraphOutput()) &&
+          tensor_wrapper.GetName().find("kv") != std::string::npos) {
+        tensor_wrapper.ConvertFromQuantI16ToQuantU16();
+      }
+    });
+  }
+
+  // Create input tensors.
+  for (const auto& subgraph_input : subgraph_inputs) {
+    ::qnn::TensorWrapper* tensor_wrapper =
+        litert_tensor_to_wrapper[subgraph_input.Get()];
+    LITERT_RETURN_IF_ERROR(AddTensorToQnn(qnn.Api(), graph_mapper.QnnGraph(),
+                                          *tensor_wrapper, created_tensors));
+    if (inputs != nullptr) {
+      inputs->push_back(*tensor_wrapper);
+    }
+  }
 
   // Create ops and their corresponding tensors.
   for (auto& op_wrapper : graph_op_wrappers) {

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -478,6 +478,14 @@ absl::string_view Options::GetDlcDir() const { return dlc_dir_; }
 
 void Options::SetDlcDir(absl::string_view dlc_dir) { dlc_dir_ = dlc_dir; }
 
+absl::string_view Options::GetGraphTransform() const {
+  return graph_transform_;
+}
+
+void Options::SetGraphTransform(absl::string_view graph_transform) {
+  graph_transform_ = graph_transform;
+}
+
 std::uint32_t Options::GetVtcmSize() const { return vtcm_size_; }
 
 void Options::SetVtcmSize(std::uint32_t vtcm_size) { vtcm_size_ = vtcm_size; }
@@ -588,6 +596,7 @@ std::string Options::Dump() const {
   field(4, "compile_package_path", custom_op_package_.compile_package_path);
   field(4, "dispatch_package_path", custom_op_package_.dispatch_package_path);
   field(4, "target", custom_op_package_.target);
+  field(4, "GraphTransform", graph_transform_);
 
   // --- HTP ---
   absl::StrAppend(&out, "[HTP]\n");

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -177,6 +177,9 @@ class Options {
   absl::string_view GetDlcDir() const;
   void SetDlcDir(absl::string_view dlc_dir);
 
+  absl::string_view GetGraphTransform() const;
+  void SetGraphTransform(absl::string_view graph_transform);
+
   std::uint32_t GetVtcmSize() const;
   void SetVtcmSize(std::uint32_t vtcm_size);
 
@@ -232,6 +235,7 @@ class Options {
   std::vector<std::int32_t> dump_tensor_ids_;
   std::string ir_json_dir_;
   std::string dlc_dir_;
+  std::string graph_transform_;
   std::uint32_t vtcm_size_ = 0;
   std::uint32_t num_hvx_threads_ = 0;
   OptimizationLevel optimization_level_ =

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -250,6 +250,15 @@ TEST(QnnOptionTest, SetDlcDir) {
   EXPECT_TRUE(options.GetDlcDir().empty());
 }
 
+TEST(QnnOptionTest, SetGraphTransform) {
+  Options options;
+  options.SetGraphTransform("option1,option2");
+  EXPECT_FALSE(options.GetGraphTransform().empty());
+  EXPECT_EQ(options.GetGraphTransform(), "option1,option2");
+  options.SetGraphTransform("");
+  EXPECT_TRUE(options.GetGraphTransform().empty());
+}
+
 TEST(QnnOptionTest, SetVtcmSize) {
   Options options;
   options.SetVtcmSize(4);
@@ -357,6 +366,7 @@ TEST(QnnOptionTest, Default) {
   EXPECT_EQ(options.GetDspPerfCtrlMode(), DspPerfCtrlMode::kManual);
   EXPECT_TRUE(options.GetIrJsonDir().empty());
   EXPECT_TRUE(options.GetDlcDir().empty());
+  EXPECT_TRUE(options.GetGraphTransform().empty());
   EXPECT_EQ(options.GetVtcmSize(), 0);
   EXPECT_EQ(options.GetNumHvxThreads(), 0);
   EXPECT_EQ(options.GetOptimizationLevel(),

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -25,6 +25,9 @@
 #include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
 
 namespace qnn {
+namespace {
+constexpr int32_t kSUFixed16OffsetDiff = 32768;
+}  // namespace
 std::size_t GetDataTypeSize(const Qnn_DataType_t data_type) {
   std::size_t bytes = 0;
   switch (data_type) {
@@ -243,7 +246,6 @@ bool TensorWrapper::IsPerTensorQuantWithOffsetDiff(
               rhs.GetDataType() == QNN_DATATYPE_UFIXED_POINT_16) ||
              (GetDataType() == QNN_DATATYPE_UFIXED_POINT_16 &&
               rhs.GetDataType() == QNN_DATATYPE_SFIXED_POINT_16)) {
-    constexpr int kSUFixed16OffsetDiff = 32768;
     if (std::fabs(lhs_scale - rhs_scale) <
             std::numeric_limits<float>::epsilon() &&
         std::abs(lhs_offset - rhs_offset) == kSUFixed16OffsetDiff) {
@@ -363,6 +365,22 @@ void TensorWrapper::SetQuantBitwidth(std::uint32_t bitwidth) {
   }
 
   UpdateQnnQuantParams();
+}
+
+void TensorWrapper::ConvertFromQuantI16ToQuantU16() {
+  auto* p =
+      std::get_if<::qnn::ScaleOffsetQuantizeParamsWrapper>(&quantize_params_);
+  if (IsTensorStatic() || !IsQuantI16() || !p) {
+    QNN_LOG_WARNING("Cannot convert %s to UINT16.", GetName().data());
+    return;
+  }
+
+  // Signed and unsigned 16-bit differ only by where zero sits.
+  quantize_params_ = ::qnn::ScaleOffsetQuantizeParamsWrapper(
+      p->GetScale(), p->GetZeroPoint() + kSUFixed16OffsetDiff);
+  qnn_tensor_.v2.dataType = QNN_DATATYPE_UFIXED_POINT_16;
+  UpdateQnnQuantParams();
+  QNN_LOG_INFO("Convert %s to UINT16.", GetName().data());
 }
 
 std::string TensorWrapper::ToString() const {

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -179,6 +179,8 @@ class TensorWrapper final {
     qnn_tensor_.v2.memHandle = memory_handle;
   }
 
+  void ConvertFromQuantI16ToQuantU16();
+
  private:
   void SetDataBy(std::uint32_t bytes, const void* data, bool copy_data);
 

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -315,6 +315,47 @@ TEST(TensorWrapperTest, UpdateBitWidthOnUnsupportedQuantTypeTest) {
   EXPECT_FALSE(tensor_wrapper.IsQuantBitwidth(4));
 }
 
+TEST(TensorWrapperTest, ConvertFromQuantI16ToQuantU16Test) {
+  static constexpr float kScale = 0.0001f;
+  static constexpr std::int32_t kZeroPoint = -100;
+  TensorWrapper tensor_wrapper{
+      "",
+      QNN_TENSOR_TYPE_APP_WRITE,
+      QNN_DATATYPE_SFIXED_POINT_16,
+      ScaleOffsetQuantizeParamsWrapper{kScale, kZeroPoint},
+      {1, 1, 4}};
+  ASSERT_TRUE(tensor_wrapper.IsQuantI16());
+
+  tensor_wrapper.ConvertFromQuantI16ToQuantU16();
+
+  EXPECT_TRUE(tensor_wrapper.IsQuantU16());
+  EXPECT_FALSE(tensor_wrapper.IsQuantI16());
+  const auto& converted = std::get<ScaleOffsetQuantizeParamsWrapper>(
+      tensor_wrapper.GetQuantParams());
+  EXPECT_FLOAT_EQ(converted.GetScale(), kScale);
+  static constexpr std::int32_t kSUFixed16OffsetDiff = 32768;
+  EXPECT_EQ(converted.GetZeroPoint(), kZeroPoint + kSUFixed16OffsetDiff);
+}
+
+TEST(TensorWrapperTest, ConvertFromQuantI16ToQuantU16OnNonI16IsNoOp) {
+  static constexpr float kScale = 0.0001f;
+  static constexpr std::int32_t kZeroPoint = 0;
+  TensorWrapper tensor_wrapper{
+      "",
+      QNN_TENSOR_TYPE_APP_WRITE,
+      QNN_DATATYPE_SFIXED_POINT_8,
+      ScaleOffsetQuantizeParamsWrapper{kScale, kZeroPoint},
+      {1, 1, 4}};
+
+  tensor_wrapper.ConvertFromQuantI16ToQuantU16();
+
+  EXPECT_TRUE(tensor_wrapper.IsQuantI8());
+  EXPECT_FALSE(tensor_wrapper.IsQuantU16());
+  const auto& unchanged = std::get<ScaleOffsetQuantizeParamsWrapper>(
+      tensor_wrapper.GetQuantParams());
+  EXPECT_EQ(unchanged.GetZeroPoint(), 0);
+}
+
 TEST(TensorWrapperTest, QnnTensorPerTensorQuantConstructTest) {
   ScaleOffsetQuantizeParamsWrapper q_param(1, 0);
   TensorWrapper tensor_wrapper{"",


### PR DESCRIPTION
Summary:
- Add the `graph_transform` flag to pass a comma-separated list of graph transformation options to the LiteRT compiler.
- Add the `kv_uint16` option to convert INT16 KV cache tensors/slices to UINT16, reducing HTP latency. Runtimes (for example, LiteRT-LM) must enable the similar option for KV cache initialization to ensure compatibility.