### PR TITLE
Qualcomm AI Engine Direct - Add DLC test.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
@@ -613,5 +613,39 @@ TEST(TestQnnPlugin, CompileWithSchematicDir) {
   LiteRtDestroyCompiledResult(compiled);
 }
 
+TEST(TestQnnPlugin, CompileWithDlcDir) {
+  auto opts = Options::Create();
+  ASSERT_TRUE(opts);
+
+  auto qnn_opts = opts->GetQualcommOptions();
+  ASSERT_TRUE(qnn_opts);
+
+  // Create a temporary directory for the emitted DLC.
+  std::filesystem::path temp_dir =
+      std::filesystem::temp_directory_path() / "litert_qnn_test_dlc";
+  std::filesystem::create_directories(temp_dir);
+
+  qnn_opts->SetDlcDir(temp_dir.string());
+
+  LITERT_ASSERT_OK_AND_ASSIGN(auto env, Environment::Create({}));
+  LITERT_ASSERT_OK_AND_ASSIGN(
+      auto litert_opts,
+      internal::LiteRtOptionsPtrBuilder::Build(*opts, env.GetHolder()));
+  auto plugin =
+      CreatePlugin(LrtGetCompilerContext(), /*env=*/nullptr, litert_opts.get());
+  auto model = testing::LoadTestFileModel("one_mul.tflite");
+
+  LiteRtCompiledResult compiled;
+  LITERT_ASSERT_OK(LiteRtCompilerPluginCompile(plugin.get(), "SM8650",
+                                               model.Get(), &compiled));
+
+  std::filesystem::path expected_dlc = temp_dir / "qnn_partition_0.dlc";
+  EXPECT_TRUE(std::filesystem::exists(expected_dlc));
+
+  // Clean up
+  std::filesystem::remove_all(temp_dir);
+  LiteRtDestroyCompiledResult(compiled);
+}
+
 }  // namespace
 }  // namespace litert


### PR DESCRIPTION
# Test
```
[       OK ] TestQnnPlugin.CompileWithDlcDir (11 ms)
[----------] 1 test from TestQnnPlugin (11 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (11 ms total)
[  PASSED  ] 1 test.
================================================================================
INFO: Found 1 test target...
Target //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test up-to-date:
  bazel-bin/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test
INFO: Elapsed time: 5.808s, Critical Path: 4.99s
INFO: 4 processes: 1 internal, 3 local.
INFO: Build completed successfully, 4 total actions
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 0.1s
```