### PR TITLE
Qualcomm AI Engine Direct - Fix manual perf mode down-vote to default.

### DIFF
--- a/litert/vendors/qualcomm/core/backends/dsp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/dsp_backend.cc
@@ -93,12 +93,15 @@ class DspBackend::DspPerfControl {
 
   // Debounce the downvote only for burst/sustained modes to avoid thrashing
   // the high-perf vote between back-to-back inferences.
-  void ScheduleDownVote() {
+  void ScheduleDownVote(bool is_manual = false) {
     EnsureVotingThread();
     const bool debounce =
         current_mode_ == DspPerformanceMode::kBurst ||
         current_mode_ == DspPerformanceMode::kSustainedHighPerformance;
     voting_thread_->Enqueue(VotingThread::VoteType::kDownVote, debounce);
+    if (is_manual) {
+      current_mode_ = DspPerformanceMode::kDefault;
+    }
   }
 
   bool ReinitIfNeeded(DspPerformanceMode new_mode) {
@@ -317,11 +320,13 @@ bool DspBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
 }
 
 bool DspBackend::SetPerformanceMode(const Options& options) {
-  DspPerformanceMode performance_mode = options.GetDspPerformanceMode();
+  const DspPerformanceMode performance_mode = options.GetDspPerformanceMode();
+  const bool is_manual =
+      options.GetDspPerfCtrlMode() == DspPerfCtrlMode::kManual;
 
   if (performance_mode == DspPerformanceMode::kDefault) {
     if (dsp_perf_control_) {
-      dsp_perf_control_->ScheduleDownVote();
+      dsp_perf_control_->ScheduleDownVote(is_manual);
     }
     return true;
   }

--- a/litert/vendors/qualcomm/core/backends/dsp_backend_test.cc
+++ b/litert/vendors/qualcomm/core/backends/dsp_backend_test.cc
@@ -296,6 +296,26 @@ TEST_F(DspBackendPerfTest, DefaultModeSchedulesDownvote) {
   EXPECT_GT(set_power_config_call_count.load(), calls_after_init);
 }
 
+TEST_F(DspBackendPerfTest, ManualBurstDefaultBurstRevotes) {
+  Options options;
+  options.SetDspPerformanceMode(DspPerformanceMode::kBurst);
+  options.SetDspPerfCtrlMode(DspPerfCtrlMode::kManual);
+  DspBackend backend(&qnn_api_copy_);
+
+  ASSERT_TRUE(backend.Init(options, std::nullopt));
+
+  Options default_options;
+  default_options.SetDspPerfCtrlMode(DspPerfCtrlMode::kManual);
+  EXPECT_TRUE(backend.SetPerformanceMode(default_options));
+  std::this_thread::sleep_for(std::chrono::milliseconds(400));
+  const int calls_after_downvote = set_power_config_call_count.load();
+
+  options.SetDspPerformanceMode(DspPerformanceMode::kBurst);
+  EXPECT_TRUE(backend.SetPerformanceMode(options));
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_GT(set_power_config_call_count.load(), calls_after_downvote);
+}
+
 TEST_F(DspBackendPerfTest, AutoModeChangesAcrossExecutes) {
   Options options;
   options.SetDspPerformanceMode(DspPerformanceMode::kPowerSaver);

--- a/litert/vendors/qualcomm/core/backends/htp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.cc
@@ -163,12 +163,15 @@ class HtpBackend::HtpPerfControl {
 
   // Debounce the downvote only for burst/sustained modes to avoid thrashing
   // the high-perf vote between back-to-back inferences.
-  void ScheduleDownVote() {
+  void ScheduleDownVote(bool is_manual = false) {
     EnsureVotingThread();
     const bool debounce =
         current_mode_ == HtpPerformanceMode::kBurst ||
         current_mode_ == HtpPerformanceMode::kSustainedHighPerformance;
     voting_thread_->Enqueue(VotingThread::VoteType::kDownVote, debounce);
+    if (is_manual) {
+      current_mode_ = HtpPerformanceMode::kDefault;
+    }
   }
 
   bool ReinitIfNeeded(HtpPerformanceMode new_mode) {
@@ -606,11 +609,13 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
 }
 
 bool HtpBackend::SetPerformanceMode(const Options& options) {
-  HtpPerformanceMode performance_mode = options.GetHtpPerformanceMode();
+  const HtpPerformanceMode performance_mode = options.GetHtpPerformanceMode();
+  const bool is_manual =
+      options.GetHtpPerfCtrlMode() == HtpPerfCtrlMode::kManual;
 
   if (performance_mode == HtpPerformanceMode::kDefault) {
     if (htp_perf_control_) {
-      htp_perf_control_->ScheduleDownVote();
+      htp_perf_control_->ScheduleDownVote(is_manual);
     }
     return true;
   }

--- a/litert/vendors/qualcomm/core/backends/htp_backend_test.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend_test.cc
@@ -413,6 +413,30 @@ TEST_F(HtpBackendPerfBaseTest, DefaultModeSchedulesDownvote) {
   EXPECT_GT(captured_configs->size(), configs_after_init);
 }
 
+TEST_F(HtpBackendPerfBaseTest, ManualBurstDefaultBurstRevotes) {
+  Options options;
+  options.SetHtpPerformanceMode(HtpPerformanceMode::kBurst);
+  options.SetHtpPerfCtrlMode(HtpPerfCtrlMode::kManual);
+  HtpBackend backend(&qnn_api_copy_);
+
+#if defined(__x86_64__) || defined(_M_X64)
+  ASSERT_TRUE(backend.Init(options, kSocInfos[8]));
+#else
+  ASSERT_TRUE(backend.Init(options, std::nullopt));
+#endif
+
+  Options default_options;
+  default_options.SetHtpPerfCtrlMode(HtpPerfCtrlMode::kManual);
+  EXPECT_TRUE(backend.SetPerformanceMode(default_options));
+  std::this_thread::sleep_for(std::chrono::milliseconds(400));
+  const size_t configs_after_downvote = captured_configs->size();
+
+  options.SetHtpPerformanceMode(HtpPerformanceMode::kBurst);
+  EXPECT_TRUE(backend.SetPerformanceMode(options));
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_GT(captured_configs->size(), configs_after_downvote);
+}
+
 TEST_F(HtpBackendPerfBaseTest, AutoModeChangesAcrossExecutes) {
   Options options;
   options.SetHtpPerformanceMode(HtpPerformanceMode::kPowerSaver);

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
@@ -686,14 +686,10 @@ Expected<void> LiteRtDispatchInvocationContextT::SetOptions(
   switch (qnn_manager_.GetOptions().GetBackendType()) {
     case ::qnn::BackendType::kHtpBackend:
       manual =
-          qnn_options.GetHtpPerformanceMode() !=
-              ::qnn::HtpPerformanceMode::kDefault &&
           qnn_options.GetHtpPerfCtrlMode() == ::qnn::HtpPerfCtrlMode::kManual;
       break;
     case ::qnn::BackendType::kDspBackend:
       manual =
-          qnn_options.GetDspPerformanceMode() !=
-              ::qnn::DspPerformanceMode::kDefault &&
           qnn_options.GetDspPerfCtrlMode() == ::qnn::DspPerfCtrlMode::kManual;
       break;
     default:


### PR DESCRIPTION
# What
- Fix manual ctrl mode with default performance mode.
- Add related tests.

# Verification

- [x] Developer-Verified
- Pass 300+ real tests for voting behavior in HTP device
- Pass some real tests for voting behavior in DSP device

# Test

- Passed x86 unit test. 
- Passed android unit test.
  - HTP
  - DSP
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 1.4s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 29.0s

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 25 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 25 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 18 tests from 12 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (30 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 36 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (5 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 29 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 29 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (24 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (568 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (214 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (556 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1877 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1536 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (49 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (613 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 27 tests from 6 test suites ran. (5793 ms total)
[  PASSED  ] 27 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (58 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 30 tests from 3 test suites ran. (19 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (4 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (568 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (503 ms total)
[  PASSED  ] 2 tests.

======================== Test Summary ========================
SM8250: //litert/c/options:litert_qualcomm_options_test
[==========] 25 tests from 2 test suites ran. (6 ms total)
[  PASSED  ] 25 tests.

SM8250: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 18 tests from 12 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8250: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 15 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 36 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (10 ms total)
[  PASSED  ] 31 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 66 tests.

SM8250: //litert/vendors/qualcomm/core:common_test
[==========] 29 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 29 tests.

SM8250: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8250: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8250: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (18 ms total)
[  PASSED  ] 13 tests.

SM8250: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

SM8250: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8250: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (24 ms total)
[  PASSED  ] 9 tests.

SM8250: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (619 ms total)
[  PASSED  ] 5 tests.

SM8250: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 27 tests from 6 test suites ran. (8 ms total)
[  PASSED  ] 6 tests.

SM8250: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (36 ms total)
[  PASSED  ] 3 tests.

SM8250: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 30 tests from 3 test suites ran. (20579 ms total)
[  PASSED  ] 30 tests.

SM8250: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.