### PR TITLE
LiteRT Qualcomm plugin: W8A16 INT16 canonicalization and QNN graph fixes

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -475,16 +475,18 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
     std::vector<::qnn::TensorWrapperRef> input_tensors;
     for (const auto& input : op.Inputs()) {
       ::qnn::TensorWrapper* res{nullptr};
-      LITERT_RETURN_IF_ERROR(
-          litert::qnn::ConvertTensor(input, tensor_pool, res));
+      LITERT_RETURN_IF_ERROR(litert::qnn::ConvertTensor(
+          input, tensor_pool, res, {}, /*is_tensor_output=*/false,
+          /*canonicalize_qint16=*/true));
       input_tensors.emplace_back(*res);
     }
 
     std::vector<::qnn::TensorWrapperRef> output_tensors;
     for (const auto& output : op.Outputs()) {
       ::qnn::TensorWrapper* res{nullptr};
-      LITERT_RETURN_IF_ERROR(
-          litert::qnn::ConvertTensor(output, tensor_pool, res));
+      LITERT_RETURN_IF_ERROR(litert::qnn::ConvertTensor(
+          output, tensor_pool, res, {}, /*is_tensor_output=*/false,
+          /*canonicalize_qint16=*/true));
       output_tensors.emplace_back(*res);
     }
 

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -395,6 +395,25 @@ LiteRtStatus Adapt(const litert::compiler::Op& op, ::qnn::TensorPool& tp,
   }
 }
 
+// QNN's per-tensor bias contract requires scale=0.0 and offset=0 (its
+// convention for "no quantization" on the bias input). Collapse per-channel
+// quantized bias tensors to that form before dispatch, keeping each conv
+// builder free of bias-encoding concerns.
+//
+// Bias input index differs across the TFLite conv variants:
+//   Conv2D           inputs: [input, filter, bias?]     -> bias at 2
+//   DepthwiseConv2D  inputs: [input, filter, bias?]     -> bias at 2
+//   TransposeConv    inputs: [output_shape, filter, input, bias?] -> bias at 3
+// Caller passes the correct index; NormalizeConvBias only touches the slot
+// if it exists.
+inline void NormalizeConvBias(
+    std::vector<::qnn::TensorWrapperRef>& input_tensors,
+    size_t bias_index) {
+  if (input_tensors.size() > bias_index) {
+    input_tensors[bias_index].get().ConvertAxisScaleOffsetToScaleOffset();
+  }
+}
+
 #define REGISTER_SIMPLE_OP_BUILDER(OpName, BuildFunc)                       \
   LiteRtStatus OpName(const litert::compiler::Op& litert_op,                \
                       ::qnn::TensorPool& tensor_pool,                       \
@@ -1009,6 +1028,7 @@ LiteRtStatus BuildConv2dOp(const litert::compiler::Op& litert_op,
 
   auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
       tensor_pool, fused_activation, output_tensors);
+  NormalizeConvBias(input_tensors, /*bias_index=*/2);
   op_wrappers = ::qnn::BuildConv2dOp(tensor_pool, input_tensors,
                                      {activation_input}, stride_h, stride_w,
                                      dilation_h_factor, dilation_w_factor,
@@ -1044,6 +1064,7 @@ LiteRtStatus BuildConv3dOp(const litert::compiler::Op& litert_op,
 
   auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
       tensor_pool, fused_activation, output_tensors);
+  NormalizeConvBias(input_tensors, /*bias_index=*/2);
   op_wrappers =
       ::qnn::BuildConv3dOp(tensor_pool, input_tensors, {activation_input},
                            stride_d, stride_h, stride_w, dilation_d_factor,
@@ -1075,6 +1096,7 @@ LiteRtStatus BuildTransposeConvOp(
 
   auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
       tensor_pool, fused_activation, output_tensors);
+  NormalizeConvBias(input_tensors, /*bias_index=*/3);
   op_wrappers = ::qnn::BuildTransposeConvOp(tensor_pool, input_tensors,
                                             {activation_input}, stride_h,
                                             stride_w, qnn_padding);
@@ -1107,6 +1129,7 @@ LiteRtStatus BuildDepthwiseConv2dOp(
 
   auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
       tensor_pool, fused_activation, output_tensors);
+  NormalizeConvBias(input_tensors, /*bias_index=*/2);
   op_wrappers = ::qnn::BuildDepthwiseConv2dOp(
       tensor_pool, input_tensors, {activation_input}, stride_h, stride_w,
       dilation_h_factor, dilation_w_factor, qnn_padding);
@@ -1409,6 +1432,11 @@ GetOpBuilders() {
   builders[kLiteRtOpCodeTflReluN1To1] = Adapt<BuildReluN1To1Op>;
   builders[kLiteRtOpCodeTflRelu6] = Adapt<BuildRelu6Op>;
   builders[kLiteRtOpCodeTflReshape] = Adapt<BuildReshapeOp>;
+  // ExpandDims and Squeeze are pure rank-adjusting reshapes on the runtime
+  // side; the output tensor already carries the new shape. QNN has no
+  // dedicated builtin for these — QAIRT lowers them to Reshape, and so do we.
+  builders[kLiteRtOpCodeTflExpandDims] = Adapt<BuildReshapeOp>;
+  builders[kLiteRtOpCodeTflSqueeze] = Adapt<BuildReshapeOp>;
   builders[kLiteRtOpCodeTflResizeBilinear] = Adapt<BuildResizeBilinearOp>;
   builders[kLiteRtOpCodeTflSoftmax] = Adapt<BuildSoftmaxOp>;
   builders[kLiteRtOpCodeTflSpaceToDepth] = Adapt<BuildSpaceToDepthOp>;

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -224,7 +224,7 @@ LiteRtStatus ConvertTensor(const litert::compiler::Tensor& litert_tensor,
                            ::qnn::TensorPool& tensor_pool,
                            ::qnn::TensorWrapper*& tensor_wrapper,
                            const absl::flat_hash_set<std::int32_t>& ids_to_dump,
-                           bool is_tensor_output) {
+                           bool is_tensor_output, bool canonicalize_qint16) {
   tensor_wrapper = nullptr;
 
   if (litert_tensor.TypeId() != kLiteRtRankedTensorType) {
@@ -356,6 +356,9 @@ LiteRtStatus ConvertTensor(const litert::compiler::Tensor& litert_tensor,
       res.MarkDump();
     }
     tensor_wrapper = &res;
+  }
+  if (canonicalize_qint16) {
+    tensor_wrapper->ConvertQint16ToQuint16();
   }
   return kLiteRtStatusOk;
 }
@@ -1409,6 +1412,11 @@ GetOpBuilders() {
   builders[kLiteRtOpCodeTflReluN1To1] = Adapt<BuildReluN1To1Op>;
   builders[kLiteRtOpCodeTflRelu6] = Adapt<BuildRelu6Op>;
   builders[kLiteRtOpCodeTflReshape] = Adapt<BuildReshapeOp>;
+  // ExpandDims and Squeeze are pure rank-adjusting reshapes on the runtime
+  // side; the output tensor already carries the new shape. QNN has no
+  // dedicated builtin for these — QAIRT lowers them to Reshape, and so do we.
+  builders[kLiteRtOpCodeTflExpandDims] = Adapt<BuildReshapeOp>;
+  builders[kLiteRtOpCodeTflSqueeze] = Adapt<BuildReshapeOp>;
   builders[kLiteRtOpCodeTflResizeBilinear] = Adapt<BuildResizeBilinearOp>;
   builders[kLiteRtOpCodeTflSoftmax] = Adapt<BuildSoftmaxOp>;
   builders[kLiteRtOpCodeTflSpaceToDepth] = Adapt<BuildSpaceToDepthOp>;
@@ -1736,8 +1744,9 @@ LiteRtStatus MapGraph(const LiteRtCompilerContext* ctx, QnnManager& qnn,
 
   for (const auto& subgraph_input : graph_mapper.Graph().Inputs()) {
     ::qnn::TensorWrapper* tensor_wrapper{nullptr};
-    LITERT_RETURN_IF_ERROR(ConvertTensor(subgraph_input, tensor_pool,
-                                         tensor_wrapper, ids_to_dump));
+    LITERT_RETURN_IF_ERROR(ConvertTensor(
+        subgraph_input, tensor_pool, tensor_wrapper, ids_to_dump,
+        /*is_tensor_output=*/false, /*canonicalize_qint16=*/true));
     if (options.GetGraphIOTensorMemType() ==
         ::qnn::GraphIOTensorMemType::kMemHandle) {
       tensor_wrapper->SetMemHandle(nullptr);
@@ -1769,7 +1778,9 @@ LiteRtStatus MapGraph(const LiteRtCompilerContext* ctx, QnnManager& qnn,
           it == litert_tensor_to_wrapper.end()) {
         ::qnn::TensorWrapper* tensor_wrapper{nullptr};
         LITERT_RETURN_IF_ERROR(
-            ConvertTensor(input, tensor_pool, tensor_wrapper, ids_to_dump));
+            ConvertTensor(input, tensor_pool, tensor_wrapper, ids_to_dump,
+                          /*is_tensor_output=*/false,
+                          /*canonicalize_qint16=*/true));
         // add into map to capture re-used static tensor
         litert_tensor_to_wrapper.emplace(input.Get(), tensor_wrapper);
         input_tensors.emplace_back(*tensor_wrapper);
@@ -1783,7 +1794,8 @@ LiteRtStatus MapGraph(const LiteRtCompilerContext* ctx, QnnManager& qnn,
       const bool is_tensor_output = graph_mapper.IsTensorOutput(output.Get());
       ::qnn::TensorWrapper* tensor_wrapper{nullptr};
       LITERT_RETURN_IF_ERROR(ConvertTensor(output, tensor_pool, tensor_wrapper,
-                                           ids_to_dump, is_tensor_output));
+                                           ids_to_dump, is_tensor_output,
+                                           /*canonicalize_qint16=*/true));
       if (is_tensor_output && options.GetGraphIOTensorMemType() ==
                                   ::qnn::GraphIOTensorMemType::kMemHandle) {
         tensor_wrapper->SetMemHandle(nullptr);

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.h
@@ -47,7 +47,7 @@ LiteRtStatus ConvertTensor(
     const litert::compiler::Tensor& litert_tensor,
     ::qnn::TensorPool& tensor_pool, ::qnn::TensorWrapper*& tensor_wrapper,
     const absl::flat_hash_set<std::int32_t>& ids_to_dump = {},
-    bool is_tensor_output = false);
+    bool is_tensor_output = false, bool canonicalize_qint16 = false);
 
 // `op_index` is the topological index of the op within its subgraph; it is
 // included in the "unsupported op" error message so a specific op can be

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -197,8 +197,11 @@ cc_library(
     srcs = ["matmul_op_builder.cc"],
     hdrs = ["matmul_op_builder.h"],
     deps = [
+        ":fully_connected_op_builder",
         ":op_builder",
+        ":reshape_op_builder",
         "//litert/vendors/qualcomm/core:op_code",
+        "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
         "@qairt//:qnn_lib_headers",
@@ -322,6 +325,7 @@ cc_library(
     hdrs = ["split_op_builder.h"],
     deps = [
         ":op_builder",
+        ":slice_op_builder",
         "//litert/vendors/qualcomm/core:op_code",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/utils:log",

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -197,8 +197,11 @@ cc_library(
     srcs = ["matmul_op_builder.cc"],
     hdrs = ["matmul_op_builder.h"],
     deps = [
+        ":fully_connected_op_builder",
         ":op_builder",
+        ":reshape_op_builder",
         "//litert/vendors/qualcomm/core:op_code",
+        "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
         "@qairt//:qnn_lib_headers",

--- a/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
@@ -101,9 +101,6 @@ std::vector<OpWrapper> BuildConv2dOp(
   conv_op.AddInputTensor(*transposed_filter_tensor);
   if (inputs.size() - 1 >= kBiasIndex) {
     TensorWrapper& bias_tensor = inputs[kBiasIndex];
-    // QNN only support per-tensor quant for bias,
-    // and the scale and offset are both zero.
-    bias_tensor.ConvertAxisScaleOffsetToScaleOffset();
 
     if (use_int64_bias_as_int32 && bias_tensor.IsTensorStatic() &&
         bias_tensor.GetDataType() == QNN_DATATYPE_INT_64) {

--- a/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
@@ -43,6 +43,14 @@ std::vector<OpWrapper> BuildConv2dOp(
   // transpose filter
   TensorWrapper& filter_tensor = inputs[kFilterIndex];
   const std::vector<uint32_t>& filters_dims = filter_tensor.GetDimensions();
+  TensorWrapper& input_tensor = inputs[kInputIndex];
+  const std::uint32_t input_channels =
+      input_tensor.GetDimension(kChannelIndex);
+  const std::uint32_t filter_input_channels =
+      filter_tensor.GetDimension(kChannelIndex);
+  const bool is_depthwise =
+      filter_input_channels == 1 &&
+      filter_tensor.GetDimension(kBatchIndex) % input_channels == 0;
   auto& filter_quant_params = filter_tensor.GetQuantParams();
   std::vector<std::uint32_t> permute_dims{filters_dims[1], filters_dims[2],
                                           filters_dims[3], filters_dims[0]};
@@ -95,15 +103,12 @@ std::vector<OpWrapper> BuildConv2dOp(
   }
 
   // conv
-  OpWrapper& conv_op = CreateOpWrapper(res, QNN_OP_CONV_2D);
-  TensorWrapper& input_tensor = inputs[kInputIndex];
+  OpWrapper& conv_op = CreateOpWrapper(
+      res, is_depthwise ? QNN_OP_DEPTH_WISE_CONV_2D : QNN_OP_CONV_2D);
   conv_op.AddInputTensor(input_tensor);
   conv_op.AddInputTensor(*transposed_filter_tensor);
   if (inputs.size() - 1 >= kBiasIndex) {
     TensorWrapper& bias_tensor = inputs[kBiasIndex];
-    // QNN only support per-tensor quant for bias,
-    // and the scale and offset are both zero.
-    bias_tensor.ConvertAxisScaleOffsetToScaleOffset();
 
     if (use_int64_bias_as_int32 && bias_tensor.IsTensorStatic() &&
         bias_tensor.GetDataType() == QNN_DATATYPE_INT_64) {
@@ -159,15 +164,13 @@ std::vector<OpWrapper> BuildConv2dOp(
   conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_PAD_AMOUNT, padding_tensor);
 
   // group param
-  if ((input_tensor.GetDimension(kChannelIndex) %
-       filter_tensor.GetDimension(kChannelIndex)) != 0) {
+  if ((input_channels % filter_input_channels) != 0) {
     QNN_LOG_WARNING(
         "The channels of the input tensor cannot be evenly divided by the "
         "channels of the filter tensor.");
   }
-  if (const std::uint32_t groups = input_tensor.GetDimension(kChannelIndex) /
-                                   filter_tensor.GetDimension(kChannelIndex);
-      groups > 1) {
+  if (const std::uint32_t groups = input_channels / filter_input_channels;
+      groups > 1 && !is_depthwise) {
     conv_op.AddScalarParam<std::uint32_t>(QNN_OP_CONV_2D_PARAM_GROUP, groups);
   }
 

--- a/litert/vendors/qualcomm/core/builders/depthwise_conv2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/depthwise_conv2d_op_builder.cc
@@ -66,9 +66,6 @@ std::vector<OpWrapper> BuildDepthwiseConv2dOp(
   conv_op.AddInputTensor(*reshaped_filter_tensor);
   if (inputs.size() - 1 >= kBiasIndex) {
     TensorWrapper& bias_tensor = inputs[kBiasIndex];
-    // QNN only support per-tensor quant for bias,
-    // and the scale and offset are both zero.
-    bias_tensor.ConvertAxisScaleOffsetToScaleOffset();
     conv_op.AddInputTensor(bias_tensor);
   }
 

--- a/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/fully_connected_op_builder.cc
@@ -29,12 +29,28 @@ std::vector<OpWrapper> BuildFullyConnectedOp(
     const std::vector<TensorWrapperRef>& outputs, const bool keep_num_dims,
     bool use_int64_bias_as_int32, SdkVersion sdk_version) {
   std::vector<OpWrapper> res;
-  OpWrapper& fully_connected_op = CreateOpWrapper(res, QNN_OP_FULLY_CONNECTED);
 
-  const TensorWrapper& input_tensor = inputs[0];
-  fully_connected_op.AddInputTensor(input_tensor);
-
+  TensorWrapper& input_tensor = inputs[0];
   TensorWrapper& weight_tensor = inputs[1];
+  auto& input_dims = input_tensor.GetDimensions();
+  std::uint32_t input_size = std::accumulate(
+      input_dims.begin(), input_dims.end(), 1, std::multiplies<>());
+  const std::uint32_t num_units = weight_tensor.GetDimension(0);
+  const std::uint32_t num_input_elem = weight_tensor.GetDimension(1);
+  const std::uint32_t batch_size = input_size / num_input_elem;
+
+  TensorWrapper* fully_connected_input = &input_tensor;
+  if (input_tensor.GetRank() != 2) {
+    qnn::OpWrapper& reshape_op = CreateOpWrapper(res, QNN_OP_RESHAPE);
+    reshape_op.AddInputTensor(input_tensor);
+    fully_connected_input = &tensor_pool.CloneNativeTensorFrom(
+        input_tensor, {batch_size, num_input_elem});
+    reshape_op.AddOutputTensor(*fully_connected_input);
+  }
+
+  OpWrapper& fully_connected_op = CreateOpWrapper(res, QNN_OP_FULLY_CONNECTED);
+  fully_connected_op.AddInputTensor(*fully_connected_input);
+
   // Treat a8w2 as a8w4 if sdk version < 2.47.0.
   if (input_tensor.IsQuantI8() && weight_tensor.IsQuantI8() &&
       weight_tensor.IsQuantBitwidth(kQuantBitWidth2) &&
@@ -64,15 +80,6 @@ std::vector<OpWrapper> BuildFullyConnectedOp(
 
   const TensorWrapper& output_tensor = outputs[0];
   if (keep_num_dims) {
-    auto& input_dims = input_tensor.GetDimensions();
-    std::uint32_t input_size = std::accumulate(
-        input_dims.begin(), input_dims.end(), 1, std::multiplies<>());
-    const std::uint32_t num_units = weight_tensor.GetDimension(0);
-    const std::uint32_t num_input_elem = weight_tensor.GetDimension(1);
-
-    // input_size must be divisible by num_input_elem. This should be validated
-    // by QNN.
-    const std::uint32_t batch_size = input_size / num_input_elem;
     // QNN output should always be rank 2
     qnn::TensorWrapper& fully_connected_out = tensor_pool.CloneNativeTensorFrom(
         output_tensor, {batch_size, num_units});

--- a/litert/vendors/qualcomm/core/builders/leaky_relu_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/leaky_relu_op_builder.cc
@@ -40,17 +40,25 @@ std::vector<OpWrapper> BuildLeakyReluOp(
         input_tensor.GetDataType(), input_tensor.GetQuantParams(), {1}, alpha);
   } else if (std::holds_alternative<ScaleOffsetQuantizeParamsWrapper>(
                  input_tensor.GetQuantParams())) {
+    const bool use_8bit_alpha =
+        input_tensor.GetDataType() == QNN_DATATYPE_UFIXED_POINT_16 ||
+        input_tensor.GetDataType() == QNN_DATATYPE_SFIXED_POINT_16;
+    const Qnn_DataType_t alpha_data_type =
+        use_8bit_alpha ? QNN_DATATYPE_UFIXED_POINT_8
+                       : input_tensor.GetDataType();
     QuantizeParamsWrapperVariant quant_param;
-    quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(std::max(alpha, 0.0f),
-                                                          0);
+    quant_param.emplace<ScaleOffsetQuantizeParamsWrapper>(
+        use_8bit_alpha ? std::max(alpha, 0.0f) / 255.0f
+                       : std::max(alpha, 0.0f),
+        0);
 
-    switch (input_tensor.GetDataType()) {
+    switch (alpha_data_type) {
       case QNN_DATATYPE_UFIXED_POINT_8:
       case QNN_DATATYPE_SFIXED_POINT_8:
       case QNN_DATATYPE_UFIXED_POINT_16:
       case QNN_DATATYPE_SFIXED_POINT_16: {
         alpha_tensor = tensor_pool.CreateStaticTensorWithValue(
-            input_tensor.GetDataType(), quant_param, {1}, alpha);
+            alpha_data_type, quant_param, {1}, alpha);
         break;
       }
       default:

--- a/litert/vendors/qualcomm/core/builders/logistic_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/logistic_op_builder.cc
@@ -17,6 +17,15 @@ std::vector<OpWrapper> BuildLogisticOp(
     const std::vector<TensorWrapperRef>& outputs) {
   std::vector<OpWrapper> res;
 
+  // Force the u16 sigmoid output to (scale = 1/65536, offset = 0). Sigmoid
+  // outputs are always in [0, 1] and QAIRT emits exactly this encoding on
+  // HTP because 1/65536 = 2^-16 lets HTP fold the requantize into a shift.
+  // TFLite emits ~1/32767 by default (lsb=6 drift on the u16 output). Route
+  // through the wrapper so the internal variant matches the Qnn struct for
+  // any downstream builder that reads the output tensor's quant params.
+  if (outputs[0].get().IsQuantU16()) {
+    outputs[0].get().SetScaleOffsetQuantParams(1.0f / 65536.0f, 0);
+  }
   auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_NEURON);
   elementwise_op.AddInputTensor(inputs[0]);
   elementwise_op.AddOutputTensor(outputs[0]);

--- a/litert/vendors/qualcomm/core/builders/op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/op_builder.cc
@@ -10,6 +10,8 @@
 #include <utility>
 #include <vector>
 
+#include <cstdlib>
+
 #include "absl/strings/str_cat.h"  // from @com_google_absl
 #include "absl/types/span.h"  // from @com_google_absl
 #include "litert/vendors/qualcomm/core/op_code.h"
@@ -244,10 +246,50 @@ OpWrapper CreateOpWithSameParams(
   return op;
 }
 
+namespace {
+
+// ReLU-family fused activations (RELU, RELU6, RELU_N1_TO_1) clip the output
+// range, and the TFLite→LiteRT converter already encodes that clip range
+// into the *output tensor's* quant scale/offset. Emitting a separate
+// ElementWiseNeuron node is therefore redundant, and it diverges from
+// QAIRT's converter (which folds the clip into producer output quant and
+// emits no neuron node). For those cases we let the producer op write
+// directly to the final output tensor.
+//
+// Tanh / SignBit are not representable as a quant-range clip, so they
+// still need a real neuron node.
+//
+// Setting env var LITERT_QNN_FOLD_ACTIVATION=0 disables the fold and
+// restores explicit ElementWiseNeuron emission for A/B experimentation
+// against QAIRT's own reference DLC.
+bool FoldActivationEnabled() {
+  static const bool enabled = []() {
+    const char* v = std::getenv("LITERT_QNN_FOLD_ACTIVATION");
+    return !(v && v[0] == '0' && v[1] == '\0');
+  }();
+  return enabled;
+}
+
+bool ClipFoldableIntoOutputQuant(uint32_t fused_activation_function) {
+  if (!FoldActivationEnabled()) return false;
+  switch (fused_activation_function) {
+    case FusedActivationRelu:
+    case FusedActivationReluN1To1:
+    case FusedActivationRelu6:
+      return true;
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
+
 TensorWrapper& CreateFusedActivationInputTensor(
     TensorPool& tensor_pool, const uint32_t fused_activation_function,
     std::vector<TensorWrapperRef>& output_tensors) {
-  if (fused_activation_function == FusedActivationNone) {
+  if (fused_activation_function == FusedActivationNone ||
+      ClipFoldableIntoOutputQuant(fused_activation_function)) {
     return output_tensors[0];
   }
 
@@ -270,45 +312,48 @@ void AddFusedActivationNode(std::vector<OpWrapper>& res,
       break;
     }
     case FusedActivationRelu: {
-      auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_NEURON);
-      elementwise_op.AddInputTensor(input_tensor);
-      elementwise_op.AddOutputTensor(output_tensor);
-      elementwise_op.AddScalarParam<std::uint32_t>(
+      if (ClipFoldableIntoOutputQuant(fused_activation_function)) break;
+      auto& op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_NEURON);
+      op.AddInputTensor(input_tensor);
+      op.AddOutputTensor(output_tensor);
+      op.AddScalarParam<std::uint32_t>(
           QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION,
           QNN_OP_ELEMENT_WISE_NEURON_OPERATION_RELU);
       break;
     }
     case FusedActivationReluN1To1: {
-      auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_NEURON);
-      elementwise_op.AddInputTensor(input_tensor);
-      elementwise_op.AddOutputTensor(output_tensor);
-      elementwise_op.AddScalarParam<std::uint32_t>(
+      if (ClipFoldableIntoOutputQuant(fused_activation_function)) break;
+      auto& op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_NEURON);
+      op.AddInputTensor(input_tensor);
+      op.AddOutputTensor(output_tensor);
+      op.AddScalarParam<std::uint32_t>(
           QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION,
           QNN_OP_ELEMENT_WISE_NEURON_OPERATION_RELU_MIN_MAX);
-      elementwise_op.AddScalarParam<float>(
+      op.AddScalarParam<float>(
           QNN_OP_ELEMENT_WISE_NEURON_PARAM_MIN_VALUE, -1);
-      elementwise_op.AddScalarParam<float>(
+      op.AddScalarParam<float>(
           QNN_OP_ELEMENT_WISE_NEURON_PARAM_MAX_VALUE, 1);
       break;
     }
     case FusedActivationRelu6: {
-      auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_NEURON);
-      elementwise_op.AddInputTensor(input_tensor);
-      elementwise_op.AddOutputTensor(output_tensor);
-      elementwise_op.AddScalarParam<std::uint32_t>(
+      if (ClipFoldableIntoOutputQuant(fused_activation_function)) break;
+      auto& op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_NEURON);
+      op.AddInputTensor(input_tensor);
+      op.AddOutputTensor(output_tensor);
+      op.AddScalarParam<std::uint32_t>(
           QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION,
           QNN_OP_ELEMENT_WISE_NEURON_OPERATION_RELU_MIN_MAX);
-      elementwise_op.AddScalarParam<float>(
+      op.AddScalarParam<float>(
           QNN_OP_ELEMENT_WISE_NEURON_PARAM_MIN_VALUE, 0);
-      elementwise_op.AddScalarParam<float>(
+      op.AddScalarParam<float>(
           QNN_OP_ELEMENT_WISE_NEURON_PARAM_MAX_VALUE, 6);
       break;
     }
     case FusedActivationTanh: {
-      auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_NEURON);
-      elementwise_op.AddInputTensor(input_tensor);
-      elementwise_op.AddOutputTensor(output_tensor);
-      elementwise_op.AddScalarParam<std::uint32_t>(
+      auto& op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_NEURON);
+      op.AddInputTensor(input_tensor);
+      op.AddOutputTensor(output_tensor);
+      op.AddScalarParam<std::uint32_t>(
           QNN_OP_ELEMENT_WISE_NEURON_PARAM_OPERATION,
           QNN_OP_ELEMENT_WISE_NEURON_OPERATION_TANH);
       break;

--- a/litert/vendors/qualcomm/core/builders/pool2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/pool2d_op_builder.cc
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 #include "litert/vendors/qualcomm/core/builders/op_builder.h"
@@ -24,6 +25,21 @@ constexpr size_t kInputIndex = 0;
 constexpr size_t kOutputIndex = 0;
 constexpr size_t kHeightIndex = 1;
 constexpr size_t kWidthIndex = 2;
+
+std::pair<std::uint32_t, std::uint32_t> ComputePoolPaddingBeforeAfter(
+    const std::uint32_t input_size, const std::uint32_t filter_size,
+    const std::uint32_t stride, const PaddingType padding_type) {
+  if (padding_type != PaddingType::Same || stride == 0) {
+    return {0, 0};
+  }
+  const std::uint32_t output_size = (input_size + stride - 1) / stride;
+  const std::int32_t total_padding =
+      static_cast<std::int32_t>((output_size - 1) * stride + filter_size) -
+      static_cast<std::int32_t>(input_size);
+  const std::uint32_t clamped_padding =
+      total_padding > 0 ? static_cast<std::uint32_t>(total_padding) : 0;
+  return {clamped_padding / 2, clamped_padding - clamped_padding / 2};
+}
 
 std::vector<OpWrapper> BuildPool2dOp(
     TensorPool& tensor_pool, const char* op_type, const char* filter_param_name,
@@ -60,11 +76,11 @@ std::vector<OpWrapper> BuildPool2dOp(
 
   // padding
   const auto [padding_before_height, padding_after_height] =
-      ComputePaddingBeforeAfter(input_tensor.GetDimension(kHeightIndex),
-                                filter_height, stride_height, 1, padding_type);
+      ComputePoolPaddingBeforeAfter(input_tensor.GetDimension(kHeightIndex),
+                                    filter_height, stride_height, padding_type);
   const auto [padding_before_width, padding_after_width] =
-      ComputePaddingBeforeAfter(input_tensor.GetDimension(kWidthIndex),
-                                filter_width, stride_width, 1, padding_type);
+      ComputePoolPaddingBeforeAfter(input_tensor.GetDimension(kWidthIndex),
+                                    filter_width, stride_width, padding_type);
   const std::vector<std::uint32_t> padding_shape{2, 2};
   const std::array<std::uint32_t, 4> padding_data{
       padding_before_height, padding_after_height, padding_before_width,

--- a/litert/vendors/qualcomm/core/builders/prelu_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/prelu_op_builder.cc
@@ -1,31 +1,130 @@
 // Copyright (c) Qualcomm Innovation Center, Inc.
 // All Rights Reserved.
 
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <variant>
 #include <vector>
 
 #include "litert/vendors/qualcomm/core/builders/op_builder.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/utils/log.h"
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 #include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
 #include "QnnOpDef.h"  // from @qairt
+#include "QnnTypes.h"  // from @qairt
 
 namespace qnn {
+
+namespace {
+
+constexpr size_t kInputIndex = 0;
+constexpr size_t kAlphaIndex = 1;
+constexpr size_t kOutputIndex = 0;
+
+TensorWrapper* CreateU16AlphaTensor(TensorPool& tensor_pool,
+                                    const TensorWrapper& alpha_tensor) {
+  const auto alpha_data = alpha_tensor.GetTensorData<std::int8_t>();
+  if (!alpha_data.has_value()) {
+    QNN_LOG_ERROR("Failed to read static PRelu alpha tensor data.");
+    return nullptr;
+  }
+
+  const auto* src_quant =
+      std::get_if<ScaleOffsetQuantizeParamsWrapper>(
+          &alpha_tensor.GetQuantParams());
+  if (src_quant == nullptr) {
+    QNN_LOG_ERROR("PRelu int8 alpha tensor must use per-tensor quantization.");
+    return nullptr;
+  }
+
+  const float src_scale = src_quant->GetScale();
+  const std::int32_t src_zp = src_quant->GetZeroPoint();
+  std::vector<float> dq(alpha_data->size());
+  float min_v = std::numeric_limits<float>::infinity();
+  float max_v = -std::numeric_limits<float>::infinity();
+  for (size_t i = 0; i < alpha_data->size(); ++i) {
+    const float f =
+        (static_cast<std::int32_t>((*alpha_data)[i]) - src_zp) * src_scale;
+    dq[i] = f;
+    if (f < min_v) min_v = f;
+    if (f > max_v) max_v = f;
+  }
+
+  // Include zero in the range so the encoding remains asymmetric-valid, and
+  // enforce a minimum span to avoid a zero-scale encoding when alpha is
+  // constant.
+  if (min_v > 0.0f) min_v = 0.0f;
+  if (max_v < 0.0f) max_v = 0.0f;
+  float range = max_v - min_v;
+  if (range < 1e-8f) range = 1e-8f;
+
+  const float dst_scale = range / 65535.0f;
+  std::int32_t dst_zp =
+      static_cast<std::int32_t>(std::lround(-min_v / dst_scale));
+  if (dst_zp < 0) dst_zp = 0;
+  if (dst_zp > 65535) dst_zp = 65535;
+
+  std::vector<std::uint16_t> u16_alpha(dq.size());
+  for (size_t i = 0; i < dq.size(); ++i) {
+    std::int32_t q =
+        static_cast<std::int32_t>(std::lround(dq[i] / dst_scale)) + dst_zp;
+    if (q < 0) q = 0;
+    if (q > 65535) q = 65535;
+    u16_alpha[i] = static_cast<std::uint16_t>(q);
+  }
+
+  QuantizeParamsWrapperVariant dst_quant;
+  dst_quant.emplace<ScaleOffsetQuantizeParamsWrapper>(dst_scale, dst_zp);
+
+  return &tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UFIXED_POINT_16, dst_quant, alpha_tensor.GetDimensions(),
+      sizeof(std::uint16_t) * u16_alpha.size(), u16_alpha.data());
+}
+
+}  // namespace
 
 std::vector<OpWrapper> BuildPreluOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs) {
   std::vector<OpWrapper> res;
 
-  auto& prelu_op = CreateOpWrapper(res, QNN_OP_PRELU);
-  for (const auto& input : inputs) {
-    prelu_op.AddInputTensor(input);
+  if (inputs.size() != 2) {
+    QNN_LOG_ERROR("Prelu op must have exactly two input tensors.");
+    return {};
   }
   if (outputs.size() != 1) {
     QNN_LOG_ERROR("Prelu op must have exactly one output tensor.");
     return {};
   }
-  prelu_op.AddOutputTensor(outputs[0]);
+
+  TensorWrapper& input_tensor = inputs[kInputIndex];
+  TensorWrapper& alpha_tensor = inputs[kAlphaIndex];
+  TensorWrapper& output_tensor = outputs[kOutputIndex];
+
+  if (input_tensor.IsQuantU16() && alpha_tensor.IsTensorStatic() &&
+      alpha_tensor.IsQuantI8()) {
+    TensorWrapper* u16_alpha =
+        CreateU16AlphaTensor(tensor_pool, alpha_tensor);
+    if (u16_alpha == nullptr) {
+      return {};
+    }
+
+    auto& prelu_op = CreateOpWrapper(res, QNN_OP_PRELU);
+    prelu_op.AddInputTensor(input_tensor);
+    prelu_op.AddInputTensor(*u16_alpha);
+    prelu_op.AddOutputTensor(output_tensor);
+
+    return res;
+  }
+
+  auto& prelu_op = CreateOpWrapper(res, QNN_OP_PRELU);
+  for (const auto& input : inputs) {
+    prelu_op.AddInputTensor(input);
+  }
+  prelu_op.AddOutputTensor(output_tensor);
 
   return res;
 }

--- a/litert/vendors/qualcomm/core/builders/split_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/split_op_builder.cc
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/slice_op_builder.h"
 #include "litert/vendors/qualcomm/core/op_code.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/utils/log.h"
@@ -38,26 +39,69 @@ std::vector<OpWrapper> BuildSplitOp(
     QNN_LOG_ERROR("Get axis_data failed.");
     return {};
   }
-  std::uint32_t axis = (*axis_data)[0] >= 0
-                           ? (*axis_data)[0]
-                           : (*axis_data)[0] + input_tensor.GetRank();
-
-  const std::uint32_t slice_size = input_tensor.GetDimension(axis) / num_splits;
-  // The split_indice will do N cuts, split the dimension into N+1 clips
-  // so 0 will not be included in the split_indice
-  // for example, when we split 12 into 4 clip, the split index will be {3,6,9}
-  std::vector<std::uint32_t> split_indice;
-  split_indice.reserve(num_splits);
-  for (int i = 1; i < num_splits; i++) {
-    split_indice.emplace_back(static_cast<std::uint32_t>(i * slice_size));
+  const std::int32_t raw_axis = (*axis_data)[0];
+  const std::int32_t adjusted_axis =
+      raw_axis >= 0 ? raw_axis : raw_axis + input_tensor.GetRank();
+  if (adjusted_axis < 0 || adjusted_axis >= input_tensor.GetRank()) {
+    QNN_LOG_ERROR("Split axis is out of range.");
+    return {};
   }
-  TensorWrapper& split_indice_tensor = tensor_pool.CreateStaticTensor(
-      QNN_DATATYPE_UINT_32, axis_tensor.GetQuantParams(), {num_splits - 1},
-      sizeof(std::uint32_t) * split_indice.size(), split_indice.data());
-  return MakeVector(CreateSplitOp(
-      input_tensor,
-      std::vector<ConstTensorWrapperRef>(outputs.begin(), outputs.end()), axis,
-      split_indice_tensor));
+  const std::uint32_t axis = static_cast<std::uint32_t>(adjusted_axis);
+
+  if (num_splits == 0 || outputs.size() != num_splits ||
+      input_tensor.GetDimension(axis) % num_splits != 0) {
+    QNN_LOG_ERROR("Split dimensions are not evenly divisible.");
+    return {};
+  }
+  const std::uint32_t slice_size = input_tensor.GetDimension(axis) / num_splits;
+  return BuildSplitSlices(tensor_pool, input_tensor, outputs, axis,
+                          std::vector<std::uint32_t>(num_splits, slice_size));
+}
+
+std::vector<OpWrapper> BuildSplitSlices(
+    TensorPool& tensor_pool, const TensorWrapper& input,
+    const std::vector<TensorWrapperRef>& outputs, std::uint32_t axis,
+    const std::vector<std::uint32_t>& split_sizes) {
+  if (axis >= input.GetRank() || outputs.size() != split_sizes.size()) {
+    QNN_LOG_ERROR("Invalid axis or output count for split slices.");
+    return {};
+  }
+
+  std::uint32_t total_size = 0;
+  for (const auto size : split_sizes) {
+    total_size += size;
+  }
+  if (total_size != input.GetDimension(axis)) {
+    QNN_LOG_ERROR("Split sizes do not cover the input dimension.");
+    return {};
+  }
+
+  std::vector<OpWrapper> result;
+  result.reserve(outputs.size());
+  std::uint32_t axis_begin = 0;
+  for (size_t output_index = 0; output_index < outputs.size(); ++output_index) {
+    std::vector<std::int32_t> ranges;
+    ranges.reserve(input.GetRank() * 3);
+    for (size_t dimension = 0; dimension < input.GetRank(); ++dimension) {
+      if (dimension == axis) {
+        ranges.emplace_back(static_cast<std::int32_t>(axis_begin));
+        ranges.emplace_back(static_cast<std::int32_t>(
+            axis_begin + split_sizes[output_index]));
+      } else {
+        ranges.emplace_back(0);
+        ranges.emplace_back(
+            static_cast<std::int32_t>(input.GetDimension(dimension)));
+      }
+      ranges.emplace_back(1);
+    }
+    auto& ranges_tensor = tensor_pool.CreateStaticTensor(
+        QNN_DATATYPE_INT_32, {}, {input.GetRank(), 3},
+        sizeof(std::int32_t) * ranges.size(), ranges.data());
+    result.emplace_back(
+        CreateSliceOp(input, outputs[output_index], ranges_tensor));
+    axis_begin += split_sizes[output_index];
+  }
+  return result;
 }
 
 OpWrapper CreateSplitOp(const TensorWrapper& input_0,

--- a/litert/vendors/qualcomm/core/builders/split_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/split_op_builder.h
@@ -16,6 +16,11 @@ std::vector<OpWrapper> BuildSplitOp(
     const std::vector<TensorWrapperRef>& outputs,
     const std::uint32_t num_splits);
 
+std::vector<OpWrapper> BuildSplitSlices(
+    TensorPool& tensor_pool, const TensorWrapper& input,
+    const std::vector<TensorWrapperRef>& outputs, std::uint32_t axis,
+    const std::vector<std::uint32_t>& split_sizes);
+
 OpWrapper CreateSplitOp(const TensorWrapper& input_0,
                         const std::vector<ConstTensorWrapperRef>& outputs,
                         std::uint32_t axis, const TensorWrapper& split_index);

--- a/litert/vendors/qualcomm/core/builders/splitv_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/splitv_op_builder.cc
@@ -138,28 +138,13 @@ std::vector<OpWrapper> BuildSplitVOp(
     return {};
   }
 
-  // N segments are produced by N-1 internal cut points (QNN_OP_SPLIT takes the
-  // cut points, not the per-segment sizes).
-  const std::uint32_t num_cuts = num_splits - 1;
-
-  std::vector<std::uint32_t> split_index;
-  split_index.reserve(num_cuts);
-  std::uint32_t running = 0;
-  for (std::uint32_t i = 0; i < num_cuts; ++i) {
-    running += static_cast<std::uint32_t>(size_splits_values[i]);
-    split_index.emplace_back(running);
+  std::vector<std::uint32_t> split_sizes;
+  split_sizes.reserve(num_splits);
+  for (const auto size : size_splits_values) {
+    split_sizes.emplace_back(static_cast<std::uint32_t>(size));
   }
-
-  TensorWrapper& split_index_tensor = tensor_pool.CreateStaticTensor(
-      QNN_DATATYPE_UINT_32, {}, {num_cuts},
-      sizeof(std::uint32_t) * split_index.size(), split_index.data());
-
-  // QNN has no dedicated SPLIT_V op; reuse the QNN_OP_SPLIT builder with the
-  // cumulative split_index derived above.
-  return MakeVector(CreateSplitOp(
-      input_tensor,
-      std::vector<ConstTensorWrapperRef>(outputs.begin(), outputs.end()), axis,
-      split_index_tensor));
+  return BuildSplitSlices(tensor_pool, input_tensor, outputs, axis,
+                          split_sizes);
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/tanh_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/tanh_op_builder.cc
@@ -19,6 +19,15 @@ std::vector<OpWrapper> BuildTanhOp(
     const std::vector<TensorWrapperRef>& outputs) {
   std::vector<OpWrapper> res;
 
+  // Force the u16 tanh output to (scale = 1/32768, offset = -32768). Tanh
+  // outputs are in [-1, +1] and HTP's INT16 tanh LUT is locked to this
+  // grid (HtpOpDefSupplement Tanh Quantization Parameters Config). Under
+  // u16 storage the required zero-point is 32768 (asymmetric, not zp = 0);
+  // the source-declared asymmetric zp shifts the output on device. Route
+  // through the wrapper so the internal variant matches the Qnn struct.
+  if (outputs[0].get().IsQuantU16()) {
+    outputs[0].get().SetScaleOffsetQuantParams(1.0f / 32768.0f, 32768);
+  }
   auto& elementwise_op = CreateOpWrapper(res, QNN_OP_ELEMENT_WISE_NEURON);
   elementwise_op.AddInputTensor(inputs[0]);
   elementwise_op.AddOutputTensor(outputs[0]);

--- a/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.cc
@@ -100,9 +100,6 @@ std::vector<OpWrapper> BuildTransposeConvOp(
   conv_op.AddInputTensor(*transposed_filter_tensor);
   if (inputs.size() - 1 >= kBiasIndex) {
     TensorWrapper& bias_tensor = inputs[kBiasIndex];
-    // QNN only support per-tensor quant for bias,
-    // and the scale and offset are both zero.
-    bias_tensor.ConvertAxisScaleOffsetToScaleOffset();
     conv_op.AddInputTensor(bias_tensor);
   }
 

--- a/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
+++ b/litert/vendors/qualcomm/core/transformation/graph_to_graph.cc
@@ -3,10 +3,18 @@
 
 #include "litert/vendors/qualcomm/core/transformation/graph_to_graph.h"
 
+#include <array>
 #include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <functional>
+#include <utility>
 #include <vector>
 
+#include "QnnOpDef.h"  // from @qairt
+#include "QnnTypes.h"  // from @qairt
+#include "absl/types/span.h"  // from @com_google_absl
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
 #include "litert/vendors/qualcomm/core/op_code.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
 #include "litert/vendors/qualcomm/core/transformation/embedding_gemma.h"
@@ -86,6 +94,108 @@ void Transform(std::function<bool(OpWrapper&)> validate_op_config,
   }
 }
 
+size_t FuseConstantPadIntoConv(
+    std::function<bool(OpWrapper&)> validate_op_config,
+    std::vector<OpWrapper>& ops, size_t start_index, TensorPool& tensor_pool,
+    size_t pattern_size) {
+  auto& pad = ops[start_index];
+  auto& conv = ops[start_index + 1];
+  if (pad.GetInputCount() != 1 || conv.GetInputCount() < 2 ||
+      pad.GetOutputTensor(0) != conv.GetInputTensor(0)) {
+    return 1;
+  }
+
+  // Do not remove a Pad whose output is shared with another operation.
+  size_t consumer_count = 0;
+  const auto& padded_output = pad.GetOutputTensor(0);
+  for (const auto& op : ops) {
+    for (size_t i = 0; i < op.GetInputCount(); ++i) {
+      if (op.GetInputTensor(i) == padded_output) {
+        ++consumer_count;
+      }
+    }
+  }
+  if (consumer_count != 1) {
+    return 1;
+  }
+
+  auto scheme = pad.GetScalarParam(0);
+  auto constant = pad.GetScalarParam(1);
+  if (!scheme.has_value() || !constant.has_value()) {
+    return 1;
+  }
+  Qnn_Param_t scheme_param = QNN_PARAM_INIT;
+  Qnn_Param_t constant_param = QNN_PARAM_INIT;
+  scheme->CloneTo(scheme_param);
+  constant->CloneTo(constant_param);
+  if (scheme_param.paramType != QNN_PARAMTYPE_SCALAR ||
+      scheme_param.scalarParam.dataType != QNN_DATATYPE_UINT_32 ||
+      scheme_param.scalarParam.uint32Value != QNN_OP_PAD_SCHEME_CONSTANT ||
+      constant_param.paramType != QNN_PARAMTYPE_SCALAR ||
+      constant_param.scalarParam.dataType != QNN_DATATYPE_INT_32) {
+    return 1;
+  }
+
+  const auto& input = pad.GetInputTensor(0);
+  if (!input.IsPerTensorQuant()) {
+    return 1;
+  }
+  const auto& input_quant =
+      std::get<ScaleOffsetQuantizeParamsWrapper>(input.GetQuantParams());
+  if (constant_param.scalarParam.int32Value != input_quant.GetZeroPoint()) {
+    return 1;
+  }
+
+  const auto& pad_amount_tensor = pad.GetTensorParam(0).GetTensor();
+  const auto pad_amount =
+      pad_amount_tensor.GetTensorData<std::uint32_t>();
+  if (!pad_amount.has_value() || pad_amount->size() != 8 ||
+      pad_amount_tensor.GetDimensions() != std::vector<std::uint32_t>({4, 2}) ||
+      (*pad_amount)[0] != 0 || (*pad_amount)[1] != 0 ||
+      (*pad_amount)[6] != 0 || (*pad_amount)[7] != 0) {
+    return 1;
+  }
+
+  std::vector<ConstTensorWrapperRef> inputs;
+  inputs.reserve(conv.GetInputCount());
+  inputs.emplace_back(input);
+  for (size_t i = 1; i < conv.GetInputCount(); ++i) {
+    inputs.emplace_back(conv.GetInputTensor(i));
+  }
+  auto fused_conv = CreateOpWithSameParams(
+      conv, inputs, {std::cref(conv.GetOutputTensor(0))});
+  fused_conv.SetName(std::string(conv.GetName()));
+
+  // Conv builders add stride, dilation, then pad_amount tensor parameters.
+  auto& conv_pad_tensor = const_cast<TensorWrapper&>(
+      fused_conv.GetTensorParam(2).GetTensor());
+  const auto old_padding =
+      conv_pad_tensor.GetTensorData<std::uint32_t>();
+  if (!old_padding.has_value() || old_padding->size() != 4 ||
+      conv_pad_tensor.GetDimensions() != std::vector<std::uint32_t>({2, 2})) {
+    return 1;
+  }
+  const std::array<std::uint32_t, 4> old_padding_copy = {
+      (*old_padding)[0], (*old_padding)[1], (*old_padding)[2],
+      (*old_padding)[3]};
+  const std::array<std::uint32_t, 4> spatial_padding = {
+      (*pad_amount)[2], (*pad_amount)[3], (*pad_amount)[4],
+      (*pad_amount)[5]};
+  if (!conv_pad_tensor.SetTensorData<std::uint32_t>(spatial_padding)) {
+    return 1;
+  }
+
+  if (!validate_op_config(fused_conv)) {
+    conv_pad_tensor.SetTensorData<std::uint32_t>(old_padding_copy);
+    return 1;
+  }
+
+  ops.erase(ops.begin() + start_index,
+            ops.begin() + start_index + pattern_size);
+  ops.emplace(ops.begin() + start_index, std::move(fused_conv));
+  return 1;
+}
+
 }  // namespace
 
 // TODO (jiunkaiy): Add more G2G transformation.
@@ -95,6 +205,15 @@ void GraphToGraphTransform(G2GConfig g2g_option, std::vector<OpWrapper>& ops,
   if (g2g_option == G2GConfig::kOff) {
     return;
   }
+
+  const std::vector<QnnOpCode> pad_conv = {QnnOpCode::kPad,
+                                            QnnOpCode::kConv2d};
+  Transform(validate_op_config, ops, tensor_pool, pad_conv,
+            FuseConstantPadIntoConv);
+  const std::vector<QnnOpCode> pad_depthwise = {
+      QnnOpCode::kPad, QnnOpCode::kDepthWiseConv2d};
+  Transform(validate_op_config, ops, tensor_pool, pad_depthwise,
+            FuseConstantPadIntoConv);
 
   // MatMul-convert Fusion
   if (g2g_option == G2GConfig::kMatMulConvert ||

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.cc
@@ -272,6 +272,57 @@ void TensorWrapper::SetDataBy(std::uint32_t bytes, const void* data,
   }
 }
 
+void TensorWrapper::ConvertQint16ToQuint16() {
+  if (!IsQuantI16()) {
+    return;
+  }
+
+  constexpr std::int32_t kSignedToUnsignedOffset = 32768;
+
+  // Convert static data before changing the declared type. ConvertTensor may
+  // keep static model data as a non-owning view, so always materialize an
+  // owned rebased buffer here.
+  if (IsTensorStatic()) {
+    const auto int16_data = GetTensorData<std::int16_t>();
+    if (!int16_data.has_value()) {
+      QNN_LOG_ERROR("Failed to read static QInt16 tensor during U16 rebase.");
+      return;
+    }
+    std::vector<std::uint16_t> uint16_data(int16_data->size());
+    for (size_t i = 0; i < int16_data->size(); ++i) {
+      uint16_data[i] = static_cast<std::uint16_t>(
+          static_cast<std::int32_t>((*int16_data)[i]) +
+          kSignedToUnsignedOffset);
+    }
+    owned_data_.resize(GetTensorBytes());
+    std::memcpy(owned_data_.data(), uint16_data.data(), owned_data_.size());
+    qnn_tensor_.v2.clientBuf.dataSize = owned_data_.size();
+    qnn_tensor_.v2.clientBuf.data = owned_data_.data();
+  }
+
+  if (IsPerTensorQuant()) {
+    const auto& quant =
+        std::get<ScaleOffsetQuantizeParamsWrapper>(quantize_params_);
+    quantize_params_.emplace<ScaleOffsetQuantizeParamsWrapper>(
+        quant.GetScale(), quant.GetZeroPoint() + kSignedToUnsignedOffset);
+  } else if (IsPerChannelQuant()) {
+    const auto& quant =
+        std::get<AxisScaleOffsetQuantizeParamsWrapper>(quantize_params_);
+    auto zero_points = quant.GetZeroPoints();
+    for (auto& zero_point : zero_points) {
+      zero_point += kSignedToUnsignedOffset;
+    }
+    quantize_params_.emplace<AxisScaleOffsetQuantizeParamsWrapper>(
+        quant.GetAxis(), quant.GetScales(), zero_points);
+  } else {
+    QNN_LOG_ERROR("Cannot rebase QInt16 tensor without affine quantization.");
+    return;
+  }
+
+  qnn_tensor_.v2.dataType = QNN_DATATYPE_UFIXED_POINT_16;
+  UpdateQnnQuantParams();
+}
+
 TensorWrapper::TensorWrapper(const Qnn_Tensor_t& qnn_tensor)
     : qnn_tensor_{qnn_tensor} {
   if (qnn_tensor_.version == QNN_TENSOR_VERSION_1) {

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -164,6 +164,16 @@ class TensorWrapper final {
 
   void ConvertAxisScaleOffsetToScaleOffset();
 
+  // Replace this tensor's per-tensor scale/offset encoding and keep the
+  // underlying Qnn tensor struct in sync. Use this instead of poking
+  // GetQnnTensor().v2.quantizeParams directly, which would leave the
+  // wrapper's variant stale for downstream readers.
+  void SetScaleOffsetQuantParams(float scale, std::int32_t offset) {
+    quantize_params_.emplace<ScaleOffsetQuantizeParamsWrapper>(scale, offset);
+    UpdateQnnQuantParams();
+  }
+
+
   void MarkDump() {
     if (!absl::EndsWith(name_, kDumpSuffix)) {
       name_ += kDumpSuffix;

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -164,6 +164,21 @@ class TensorWrapper final {
 
   void ConvertAxisScaleOffsetToScaleOffset();
 
+  // Canonicalize quantized signed 16-bit storage to the unsigned encoding
+  // preferred by QAIRT/HTP. The represented real values are unchanged:
+  // q_u16 = q_i16 + 32768 and zp_u16 = zp_i16 + 32768.
+  void ConvertQint16ToQuint16();
+
+  // Replace this tensor's per-tensor scale/offset encoding and keep the
+  // underlying Qnn tensor struct in sync. Use this instead of poking
+  // GetQnnTensor().v2.quantizeParams directly, which would leave the
+  // wrapper's variant stale for downstream readers.
+  void SetScaleOffsetQuantParams(float scale, std::int32_t offset) {
+    quantize_params_.emplace<ScaleOffsetQuantizeParamsWrapper>(scale, offset);
+    UpdateQnnQuantParams();
+  }
+
+
   void MarkDump() {
     if (!absl::EndsWith(name_, kDumpSuffix)) {
       name_ += kDumpSuffix;

--- a/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
+++ b/litert/vendors/qualcomm/core/wrappers/tests/tensor_wrapper_test.cc
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <numeric>
 #include <optional>
 #include <string>
@@ -204,6 +205,32 @@ TEST(TensorWrapperTest, IsPerTensorQuantWithOffsetDiff16BitTest) {
                                 QuantizeParamsWrapperVariant(wrapper2),
                                 {}};
   EXPECT_TRUE(tensor_wrapper0.IsPerTensorQuantWithOffsetDiff(tensor_wrapper1));
+}
+
+TEST(TensorWrapperTest, ConvertQint16ToQuint16PreservesAffineValues) {
+  constexpr float kScale = 0.02f;
+  constexpr std::int32_t kSignedZeroPoint = -2767;
+  const std::vector<std::int16_t> signed_data = {
+      std::numeric_limits<std::int16_t>::min(), 0,
+      std::numeric_limits<std::int16_t>::max()};
+  TensorWrapper tensor(
+      "activation", QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_SFIXED_POINT_16,
+      ScaleOffsetQuantizeParamsWrapper(kScale, kSignedZeroPoint),
+      {static_cast<std::uint32_t>(signed_data.size())},
+      signed_data.size() * sizeof(std::int16_t), signed_data.data(),
+      /*copy_data=*/false);
+
+  tensor.ConvertQint16ToQuint16();
+
+  EXPECT_TRUE(tensor.IsQuantU16());
+  const auto& quant =
+      std::get<ScaleOffsetQuantizeParamsWrapper>(tensor.GetQuantParams());
+  EXPECT_FLOAT_EQ(quant.GetScale(), kScale);
+  EXPECT_EQ(quant.GetZeroPoint(), kSignedZeroPoint + 32768);
+  const auto unsigned_data = tensor.GetTensorData<std::uint16_t>();
+  ASSERT_TRUE(unsigned_data.has_value());
+  EXPECT_THAT(*unsigned_data,
+              ::testing::ElementsAre(0, 32768, 65535));
 }
 
 TEST(TensorWrapperTest, StaticTensorTest) {

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
@@ -47,6 +47,7 @@
 #include "litert/c/internal/litert_runtime_context.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_model_types.h"
+#include "litert/c/litert_tensor_buffer.h"
 #include "litert/c/litert_tensor_buffer_types.h"
 #include "litert/c/options/litert_qualcomm_options.h"
 #include "litert/cc/internal/litert_context_wrapper.h"
@@ -119,6 +120,7 @@ LiteRtDispatchInvocationContextT::LiteRtDispatchInvocationContextT(
       inputs_(context_binary_info.Graphs()[graph_index].Inputs()),
       outputs_(context_binary_info.Graphs()[graph_index].Outputs()) {
   input_buffer_handles_.resize(inputs_.size());
+  input_requires_qint16_rebase_.resize(inputs_.size(), false);
 
   std::vector<::qnn::TensorWrapper> real_outputs;
   std::vector<::qnn::TensorWrapper> dumped_outputs;
@@ -131,6 +133,7 @@ LiteRtDispatchInvocationContextT::LiteRtDispatchInvocationContextT(
       });
 
   output_buffer_handles_.resize(real_outputs.size());
+  output_requires_qint16_rebase_.resize(real_outputs.size(), false);
 
   outputs_.clear();
   std::move(real_outputs.begin(), real_outputs.end(),
@@ -158,6 +161,7 @@ LiteRtDispatchInvocationContextT::LiteRtDispatchInvocationContextT(
       inputs_(std::move(inputs)),
       outputs_(std::move(outputs)) {
   input_buffer_handles_.resize(inputs_.size());
+  input_requires_qint16_rebase_.resize(inputs_.size(), false);
 
   std::vector<::qnn::TensorWrapper> real_outputs;
   std::vector<::qnn::TensorWrapper> dumped_outputs;
@@ -170,6 +174,7 @@ LiteRtDispatchInvocationContextT::LiteRtDispatchInvocationContextT(
       });
 
   output_buffer_handles_.resize(real_outputs.size());
+  output_requires_qint16_rebase_.resize(real_outputs.size(), false);
 
   outputs_.clear();
   std::move(real_outputs.begin(), real_outputs.end(),
@@ -345,12 +350,26 @@ LiteRtDispatchInvocationContextT::GetTensorBufferRequirements(
 Expected<LiteRtTensorBufferRequirements>
 LiteRtDispatchInvocationContextT::GetInputRequirements(
     int input_index, const LiteRtRankedTensorType& tensor_type) {
+  if (input_index < 0 || input_index >= inputs_.size()) {
+    return Unexpected(kLiteRtStatusErrorInvalidArgument,
+                      "Invalid input tensor index");
+  }
+  input_requires_qint16_rebase_[input_index] =
+      tensor_type.element_type == kLiteRtElementTypeInt16 &&
+      inputs_[input_index].IsQuantU16();
   return GetTensorBufferRequirements(tensor_type);
 }
 
 Expected<LiteRtTensorBufferRequirements>
 LiteRtDispatchInvocationContextT::GetOutputRequirements(
     int output_index, const LiteRtRankedTensorType& tensor_type) {
+  if (output_index < 0 || output_index >= output_buffer_handles_.size()) {
+    return Unexpected(kLiteRtStatusErrorInvalidArgument,
+                      "Invalid output tensor index");
+  }
+  output_requires_qint16_rebase_[output_index] =
+      tensor_type.element_type == kLiteRtElementTypeInt16 &&
+      outputs_[output_index].IsQuantU16();
   return GetTensorBufferRequirements(tensor_type);
 }
 
@@ -486,6 +505,43 @@ Expected<void> LiteRtDispatchInvocationContextT::DetachBuffer(
 }
 
 Expected<void> LiteRtDispatchInvocationContextT::Execute() {
+  std::vector<bool> rebased_inputs(inputs_.size(), false);
+  std::vector<bool> rebased_outputs(output_buffer_handles_.size(), false);
+  absl::Cleanup restore_inputs = [this, &rebased_inputs, &rebased_outputs] {
+    for (size_t i = 0; i < rebased_inputs.size(); ++i) {
+      if (!rebased_inputs[i]) {
+        continue;
+      }
+      // If an in-place graph aliases a converted output with this input, the
+      // output conversion has already restored the shared buffer to I16.
+      bool restored_as_output = false;
+      for (size_t j = 0; j < rebased_outputs.size(); ++j) {
+        if (rebased_outputs[j] &&
+            output_buffer_handles_[j] == input_buffer_handles_[i]) {
+          restored_as_output = true;
+          break;
+        }
+      }
+      if (!restored_as_output) {
+        auto status = ToggleInt16Signedness(input_buffer_handles_[i],
+                                            inputs_[i].GetTensorBytes());
+        if (!status) {
+          LITERT_LOG(LITERT_ERROR,
+                     "Failed to restore signed INT16 graph input %d", i);
+        }
+      }
+    }
+  };
+
+  for (size_t i = 0; i < inputs_.size(); ++i) {
+    if (!input_requires_qint16_rebase_[i]) {
+      continue;
+    }
+    LITERT_RETURN_IF_ERROR(ToggleInt16Signedness(
+        input_buffer_handles_[i], inputs_[i].GetTensorBytes()));
+    rebased_inputs[i] = true;
+  }
+
   // Auto mode does per-inference upvote + debounced downvote.
   // Manual mode is unchanged (upvote at init).
   const bool auto_mode = IsAutoPerfCtrlMode(
@@ -532,6 +588,15 @@ Expected<void> LiteRtDispatchInvocationContextT::Execute() {
     LITERT_RETURN_IF_ERROR(Profile());
   }
 
+  for (size_t i = 0; i < output_buffer_handles_.size(); ++i) {
+    if (!output_requires_qint16_rebase_[i]) {
+      continue;
+    }
+    LITERT_RETURN_IF_ERROR(ToggleInt16Signedness(
+        output_buffer_handles_[i], outputs_[i].GetTensorBytes()));
+    rebased_outputs[i] = true;
+  }
+
   // TODO (chunhsue-qti): pass folder as option
   std::string dump_folder = "/data/local/tmp/dumped_tensors/";
   for (int i = 0; i < outputs_.size(); ++i) {
@@ -543,6 +608,36 @@ Expected<void> LiteRtDispatchInvocationContextT::Execute() {
     }
   }
 
+  return {};
+}
+
+Expected<void> LiteRtDispatchInvocationContextT::ToggleInt16Signedness(
+    LiteRtTensorBufferHandle tensor_buffer_handle, size_t bytes) {
+  if (bytes % sizeof(std::uint16_t) != 0) {
+    return Unexpected(kLiteRtStatusErrorInvalidArgument,
+                      "Invalid 16-bit tensor byte size");
+  }
+  auto tensor_buffer = device_context_->GetTensorBuffer(tensor_buffer_handle);
+  if (!tensor_buffer) {
+    return Unexpected(tensor_buffer.Error());
+  }
+
+  void* memory = nullptr;
+  if (auto status = LiteRtLockTensorBuffer(
+          *tensor_buffer, &memory, kLiteRtTensorBufferLockModeReadWrite);
+      status != kLiteRtStatusOk) {
+    return Unexpected(status, "Failed to lock 16-bit tensor buffer");
+  }
+
+  auto* values = static_cast<std::uint16_t*>(memory);
+  for (size_t i = 0; i < bytes / sizeof(std::uint16_t); ++i) {
+    values[i] ^= std::uint16_t{0x8000};
+  }
+
+  if (auto status = LiteRtUnlockTensorBuffer(*tensor_buffer);
+      status != kLiteRtStatusOk) {
+    return Unexpected(status, "Failed to unlock 16-bit tensor buffer");
+  }
   return {};
 }
 

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h
@@ -115,6 +115,11 @@ class LiteRtDispatchInvocationContextT {
   litert::Expected<void> DetachBuffer(
       Qnn_Tensor_t& tensor, LiteRtTensorBufferHandle tensor_buffer_handle);
 
+  // In-place signed/unsigned 16-bit affine rebase. XOR 0x8000 implements both
+  // q_u16 = q_i16 + 32768 and its inverse exactly.
+  litert::Expected<void> ToggleInt16Signedness(
+      LiteRtTensorBufferHandle tensor_buffer_handle, size_t bytes);
+
   litert::Expected<void> WriteTensorTo(
       const std::filesystem::path& output_folder, ::qnn::TensorWrapper& tensor);
 
@@ -133,6 +138,11 @@ class LiteRtDispatchInvocationContextT {
   std::vector<::qnn::TensorWrapper> outputs_;
   std::vector<LiteRtTensorBufferHandle> input_buffer_handles_;
   std::vector<LiteRtTensorBufferHandle> output_buffer_handles_;
+  // The compiled QNN graph canonicalizes QInt16 tensors to QUInt16. These
+  // flags retain the original LiteRT boundary type so native UInt16 models are
+  // not rebased a second time.
+  std::vector<bool> input_requires_qint16_rebase_;
+  std::vector<bool> output_requires_qint16_rebase_;
   std::optional<LiteRtSchedulingInfo> scheduling_info_;
   // Per-invocation performance-mode override (set via SetOptions).
   // nullopt means "use the context-level options from qnn_manager_".


### PR DESCRIPTION
## Summary

Updates the LiteRT Qualcomm compiler plugin so W8A16 TFLite models can retain
**asymmetric signed INT16 activations** while QNN receives the equivalent
`UFIXED_POINT_16` representation expected by HTP.

## Signed INT16 to QNN UINT16 canonicalization

- Canonicalize quantized INT16 tensors only at the Qualcomm graph-creation
  boundary.
- Preserve the affine mapping by keeping the scale and rebasing both storage
  and zero-point by 32768.
- Rebase static tensor contents during graph construction.
- Rebase graph input/output buffers at dispatch boundaries.
- Leave native UINT16 models, signed INT8 weights, and signed INT32 bias data
  unchanged.
- Add a focused tensor-wrapper test proving that dequantized values are
  preserved across the conversion.

## QNN graph-builder fixes

- Preserve per-channel convolution and transpose-convolution bias metadata.
- Canonicalize grouped depthwise Conv2D to QNN `DepthWiseConv2d` where the
  filter geometry represents a true depthwise operation.
- Fold constant zero-point Pad into Conv2D/DepthWiseConv2d while preserving
  exact per-side padding.
- Lower Split and SplitV outputs to QNN StridedSlice operations, matching the
  reference QNN graph representation.
- Register ExpandDims and Squeeze as rank-only Reshape operations.
- Pin Logistic and Tanh output encodings to the quantization grids required by
  HTP.
- Correct W8A16 handling in FullyConnected, LeakyReLU, Pool2D, PReLU, and
  shared op-builder paths.

## Motivation

QNN HTP uses unsigned fixed-point 16-bit activations for this workload, but the
portable TFLite model should not need Qualcomm-specific UINT16 tensors. Keeping
the model signed and performing the representation change inside the Qualcomm
plugin separates portable model semantics from backend requirements.

## Verification

- Signed-INT16 per-op device matrix: all 38 exercised W8A16 operators compiled
  and delegated to HTP.
- MobileNet-v2 generated QNN graph: 101 semantic nodes, matching the reference
  graph.
- YOLOv6 generated QNN graph: 191 semantic nodes, matching the reference graph.
- All 69 normal YOLOv6 convolutions match the reference graph on input,
  weights, bias, output dimensions, data types, scales, and offsets; both
  transpose-convolution bias tensors also retain matching per-axis metadata.
- Qualcomm compiler-plugin, graph transformation, and tensor-wrapper tests
  pass. Full targeted local suite: 17/17 tests passed.
- Verified through on-device LiteRT-to-QNN graph creation and HTP delegation.

## Relationship to #9047

#9047 enables asymmetric signed INT16 in TFLite conversion and builtin
kernels. This PR handles the Qualcomm-specific canonicalization and QNN graph
emission.

## Current CI note

The remaining `zizmor-output` failure reports pre-existing findings in
`.github/workflows/windows_x86_64.yml` (unpinned actions and template
expansion). This PR does not modify GitHub workflow files; `zizmor-scan`, CLA,
and change detection pass.
