### PR TITLE
[MLDrift] Fix FULLY_CONNECTED shared-bias handling with runtime weights

### DIFF
--- a/ml_drift_delegate/tflite/model_builder.cc
+++ b/ml_drift_delegate/tflite/model_builder.cc
@@ -3222,13 +3222,17 @@ class FullyConnectedOperationParser : public TFLiteOperationParser {
       ConfigSharedBiasFullyConnectedNode(bias_share.IsShared(),
                                          tflite_node->inputs, kInputBiasId,
                                          reader, graph, node);
-      if (weights_share.IsShared()) {
+      // Register weights and bias independently so a shared bias keeps
+      // Layout::LINEAR even when weights are runtime tensors.
+      {
         auto node_inputs = graph->FindInputs(node->id);
-        reader->SetSharedTensor(node_inputs[1]->id, weights_share.PreferredId(),
-                                tflite_node->inputs->data[kInputWeightsId],
-                                /*dequant_forced=*/false,
-                                /*layout=*/std::nullopt);
-        if (bias_share.IsShared()) {
+        if (weights_share.IsShared() && node_inputs.size() > 1) {
+          reader->SetSharedTensor(
+              node_inputs[1]->id, weights_share.PreferredId(),
+              tflite_node->inputs->data[kInputWeightsId],
+              /*dequant_forced=*/false, /*layout=*/std::nullopt);
+        }
+        if (bias_share.IsShared() && node_inputs.size() > 2) {
           reader->SetSharedTensor(node_inputs[2]->id, bias_share.PreferredId(),
                                   tflite_node->inputs->data[kInputBiasId],
                                   /*dequant_forced=*/false,


### PR DESCRIPTION
Register the shared bias independently from shared weights so runtime-weight fully connected nodes still get the required LINEAR bias layout. This avoids the GPU delegate compile failure seen on EfficientNet-Lite4 in the WebNN path.

Fix Chromium issue: https://issues.chromium.org/issues/534394048