### PR TITLE
Qualcomm AI Engine Direct - Support int64 bias as int32 in TransposeConv2D.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -1153,7 +1153,7 @@ LiteRtStatus BuildTransposeConvOp(
     const litert::compiler::Op& litert_op, ::qnn::TensorPool& tensor_pool,
     std::vector<::qnn::TensorWrapperRef>& input_tensors,
     std::vector<::qnn::TensorWrapperRef>& output_tensors,
-    std::vector<::qnn::OpWrapper>& op_wrappers) {
+    std::vector<::qnn::OpWrapper>& op_wrappers, bool use_int64_bias_as_int32) {
   auto options =
       litert::compiler::GetOptionsAs<litert::compiler::TransposeConvOptions>(
           litert_op.ctx(), litert_op.Get());
@@ -1171,9 +1171,9 @@ LiteRtStatus BuildTransposeConvOp(
 
   auto& activation_input = ::qnn::CreateFusedActivationInputTensor(
       tensor_pool, fused_activation, output_tensors);
-  op_wrappers = ::qnn::BuildTransposeConvOp(tensor_pool, input_tensors,
-                                            {activation_input}, stride_h,
-                                            stride_w, qnn_padding);
+  op_wrappers = ::qnn::BuildTransposeConvOp(
+      tensor_pool, input_tensors, {activation_input}, stride_h, stride_w,
+      qnn_padding, use_int64_bias_as_int32);
   ::qnn::AddFusedActivationNode(op_wrappers, fused_activation, activation_input,
                                 output_tensors[0]);
   return kLiteRtStatusOk;

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -676,6 +676,7 @@ cc_library(
     deps = [
         ":op_builder",
         "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/utils:log",
         "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
         "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",

--- a/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.cc
@@ -11,6 +11,7 @@
 
 #include "litert/vendors/qualcomm/core/builders/op_builder.h"
 #include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
 #include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
 #include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
 #include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
@@ -35,7 +36,8 @@ constexpr size_t kFilterChannelInIndex = 3;
 std::vector<OpWrapper> BuildTransposeConvOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs, const std::uint32_t stride_h,
-    const std::uint32_t stride_w, const PaddingType padding_type) {
+    const std::uint32_t stride_w, const PaddingType padding_type,
+    bool use_int64_bias_as_int32) {
   std::vector<OpWrapper> res;
 
   // reshape filter
@@ -103,7 +105,19 @@ std::vector<OpWrapper> BuildTransposeConvOp(
     // QNN only support per-tensor quant for bias,
     // and the scale and offset are both zero.
     bias_tensor.ConvertAxisScaleOffsetToScaleOffset();
-    conv_op.AddInputTensor(bias_tensor);
+    if (use_int64_bias_as_int32 && bias_tensor.IsTensorStatic() &&
+        bias_tensor.GetDataType() == QNN_DATATYPE_INT_64) {
+      auto* converted_bias_tensor =
+          tensor_pool.ConvertStaticTensorFrom<std::int32_t>(bias_tensor);
+      if (converted_bias_tensor == nullptr) {
+        return {};
+      }
+      conv_op.AddInputTensor(*converted_bias_tensor);
+      QNN_LOG_WARNING(
+          "Convert bias tensor in transpose conv op from int64 to int32.");
+    } else {
+      conv_op.AddInputTensor(bias_tensor);
+    }
   }
 
   TensorWrapper& output_tensor = outputs[kOutputIndex];

--- a/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.h
@@ -17,7 +17,8 @@ namespace qnn {
 std::vector<OpWrapper> BuildTransposeConvOp(
     TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
     const std::vector<TensorWrapperRef>& outputs, const std::uint32_t stride_h,
-    const std::uint32_t stride_w, const PaddingType padding_type);
+    const std::uint32_t stride_w, const PaddingType padding_type,
+    bool use_int64_bias_as_int32);
 
 }  // namespace qnn
 

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -435,3 +435,41 @@ litert_test(
         "@qairt//:qnn_lib_headers",
     ] + _QNN_DEPS,
 )
+
+litert_test(
+    name = "transpose_conv_test",
+    srcs = [
+        "transpose_conv_test.cc",
+    ],
+    linkopts = select({
+        "//litert:android": [],
+        "//conditions:default": [
+            make_rpaths([
+                "//litert/c:litert_runtime_c_api_so",
+            ]),
+        ],
+    }),
+    linkstatic = True,
+    no_main = True,
+    tags = [
+        "noasan",
+        "nomsan",
+        "nosan",
+        "notsan",
+    ],
+    target_compatible_with = _COMPATIBLE_OS,
+    ungrte = True,
+    use_sys_malloc = True,
+    deps = [
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:op_builder",
+        "//litert/vendors/qualcomm/core/builders:transpose_conv_op_builder",
+        "//litert/vendors/qualcomm/core/utils:miscs",
+        "//litert/vendors/qualcomm/core/utils:test_main",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "@com_google_absl//absl/types:span",
+        "@qairt//:qnn_lib_headers",
+    ] + _QNN_DEPS,
+)

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/transpose_conv_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/transpose_conv_test.cc
@@ -1,0 +1,165 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/builders/transpose_conv_op_builder.h"
+#include "litert/vendors/qualcomm/core/utils/miscs.h"
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+#include "QnnTypes.h"  // from @qairt
+
+namespace litert::qnn {
+namespace {
+
+INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
+                         QnnTestPrinter);
+
+constexpr float kActScale = 0.01f;
+constexpr float kFilterScale = 0.5f;
+constexpr float kBiasScale = kActScale * kFilterScale;
+
+constexpr size_t kOpBiasIndex = 2;
+
+std::vector<::qnn::OpWrapper> BuildTransposeConvWithInt64Bias(
+    ::qnn::TensorPool& tensor_pool, const std::vector<std::int64_t>& bias_data,
+    bool use_int64_bias_as_int32,
+    ::qnn::TensorWrapper** input_tensor = nullptr,
+    ::qnn::TensorWrapper** output_tensor = nullptr) {
+  const std::vector<std::uint32_t> kInOutDims{1, 2, 2, 1};
+  const std::vector<std::uint32_t> kFilterDims{1, 1, 1, 1};  // OHWI
+  const std::vector<std::uint32_t> kBiasDims{1};
+  const std::vector<std::uint32_t> kShapeDims{4};
+
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kActQuant{kActScale, 0};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kFilterQuant{kFilterScale, 0};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kBiasQuant{kBiasScale, 0};
+
+  // TFLite TransposeConv operand order: output_shape, filter, input, bias.
+  const std::vector<std::int32_t> kShapeData{1, 2, 2, 1};
+  auto& output_shape = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_32, ::qnn::QuantizeParamsWrapperVariant{}, kShapeDims,
+      sizeof(std::int32_t) * kShapeData.size(), kShapeData.data());
+
+  const std::vector<std::int8_t> kFilterData{1};
+  auto& filter = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_SFIXED_POINT_8, kFilterQuant, kFilterDims,
+      sizeof(std::int8_t) * kFilterData.size(), kFilterData.data());
+
+  auto& input = tensor_pool.CreateInputTensorWithName(
+      "in_0", QNN_DATATYPE_SFIXED_POINT_8, kActQuant, kInOutDims);
+
+  auto& bias = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_INT_64, kBiasQuant, kBiasDims,
+      sizeof(std::int64_t) * bias_data.size(), bias_data.data());
+
+  auto& output = tensor_pool.CreateOutputTensorWithName(
+      "out_0", QNN_DATATYPE_SFIXED_POINT_8, kActQuant, kInOutDims);
+
+  if (input_tensor != nullptr) {
+    *input_tensor = &input;
+  }
+  if (output_tensor != nullptr) {
+    *output_tensor = &output;
+  }
+
+  return ::qnn::BuildTransposeConvOp(
+      tensor_pool, {output_shape, filter, input, bias}, {output},
+      /*stride_h=*/1, /*stride_w=*/1, ::qnn::PaddingType::Valid,
+      use_int64_bias_as_int32);
+}
+
+TEST_P(QnnModelTest, TransposeConvInt64BiasConvertedToInt32) {
+  auto ops = BuildTransposeConvWithInt64Bias(tensor_pool_, /*bias_data=*/{100},
+                                             /*use_int64_bias_as_int32=*/true);
+
+  ASSERT_EQ(ops.size(), 1);
+  ASSERT_GT(ops[0].GetInputCount(), kOpBiasIndex);
+  EXPECT_EQ(ops[0].GetInputTensor(kOpBiasIndex).GetDataType(),
+            QNN_DATATYPE_SFIXED_POINT_32);
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  EXPECT_TRUE(qnn_model_.ValidateOpConfig());
+}
+
+TEST_P(QnnModelTest, TransposeConvInt64BiasKeptWhenFlagDisabled) {
+  auto ops = BuildTransposeConvWithInt64Bias(tensor_pool_, /*bias_data=*/{100},
+                                             /*use_int64_bias_as_int32=*/false);
+
+  ASSERT_EQ(ops.size(), 1);
+  ASSERT_GT(ops[0].GetInputCount(), kOpBiasIndex);
+  EXPECT_EQ(ops[0].GetInputTensor(kOpBiasIndex).GetDataType(),
+            QNN_DATATYPE_INT_64);
+}
+
+TEST_P(QnnModelTest, TransposeConvInt64BiasOutOfInt32RangeFails) {
+  constexpr std::int64_t kBiasOverInt32Max =
+      static_cast<std::int64_t>(std::numeric_limits<std::int32_t>::max()) + 1;
+  auto ops = BuildTransposeConvWithInt64Bias(
+      tensor_pool_, /*bias_data=*/{kBiasOverInt32Max},
+      /*use_int64_bias_as_int32=*/true);
+
+  EXPECT_TRUE(ops.empty());
+}
+
+TEST_P(QnnModelTest, TransposeConvInt64BiasBelowInt32RangeFails) {
+  constexpr std::int64_t kBiasBelowInt32Min =
+      static_cast<std::int64_t>(std::numeric_limits<std::int32_t>::lowest()) -
+      1;
+  auto ops = BuildTransposeConvWithInt64Bias(
+      tensor_pool_, /*bias_data=*/{kBiasBelowInt32Min},
+      /*use_int64_bias_as_int32=*/true);
+
+  EXPECT_TRUE(ops.empty());
+}
+
+TEST_P(QnnModelTest, TransposeConvInt64BiasConvertedIsNumericallyCorrect) {
+  ::qnn::TensorWrapper* input = nullptr;
+  ::qnn::TensorWrapper* output = nullptr;
+
+  auto ops = BuildTransposeConvWithInt64Bias(
+      tensor_pool_, /*bias_data=*/{100}, /*use_int64_bias_as_int32=*/true,
+      &input, &output);
+  ASSERT_EQ(ops.size(), 1);
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "Execution requires an Android device with a Qualcomm HTP.";
+#else
+  const auto input_idx = qnn_model_.AddInputTensor(*input);
+  const auto output_idx = qnn_model_.AddOutputTensor(*output);
+
+  // Real inputs {0.02, 0, 0.04, 0}.
+  // out = in * filter + bias.
+  // With filter real value {0.5} and bias real value {0.5},
+  // real outputs are {0.51, 0.5, 0.52, 0.5}.
+  const std::vector<std::int8_t> in_data{2, 0, 4, 0};
+  qnn_model_.SetInputData<std::int8_t>(
+      input_idx, absl::MakeConstSpan(in_data.data(), in_data.size()));
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  const auto output_data = qnn_model_.GetOutputData<std::int8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_EQ(output_data->size(), 4);
+
+  const std::vector<float> kExpected{0.51f, 0.50f, 0.52f, 0.50f};
+  for (size_t i = 0; i < kExpected.size(); ++i) {
+    const float f_out =
+        ::qnn::Dequantize<std::int8_t>(output_data.value()[i], kActScale, 0);
+    EXPECT_NEAR(f_out, kExpected[i], kActScale / 2);
+  }
+#endif
+}
+
+}  // namespace
+}  // namespace litert::qnn


### PR DESCRIPTION
# What

- Honor use_int64_bias_as_int32 in the transpose conv op builder, converting a static INT_64 bias to a 32-bit bias the same way BuildFullyConnectedOp does.
- Add transpose_conv_test covering the three branches the flag introduces: conversion when enabled (and that the op then passes ValidateOpConfig), passthrough when disabled, and the failure path when a bias value exceeds the int32 range.

# Test
```
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 25 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 25 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 18 tests from 12 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (15 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 36 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (3 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 29 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 29 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (15 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (339 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (218 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (365 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (2525 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1449 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (657 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (3072 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:transpose_conv_test
[==========] 4 tests from 1 test suite ran. (677 ms total)
[  PASSED  ] 4 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (23 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (618 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:graph_config_builder_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (8190 ms total)
[  PASSED  ] 26 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (35 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (8 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (601 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (462 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (484 ms total)
[  PASSED  ] 2 tests.
```

```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test       PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test        PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test      PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:transpose_conv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:transpose_conv_test PASSED in 0.5s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test               PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:graph_config_builder_test
//litert/vendors/qualcomm/core/backends:graph_config_builder_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test                 PASSED in 1.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test                  PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 59.6s
```