### PR TITLE
[Intel OV] Add MoEGatherRewrite pass for Gemma4 MoE on Intel NPU

### DIFF
--- a/litert/vendors/intel_openvino/compiler/npu_optimizer.cc
+++ b/litert/vendors/intel_openvino/compiler/npu_optimizer.cc
@@ -14,12 +14,22 @@
 
 #include "litert/vendors/intel_openvino/compiler/npu_optimizer.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <functional>
+#include <map>
 #include <memory>
+#include <numeric>
+#include <optional>
+#include <set>
+#include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "litert/c/internal/litert_logging.h"
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/core/node.hpp"
@@ -32,15 +42,24 @@
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
+#include "openvino/op/equal.hpp"
 #include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/gelu.hpp"
 #include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
 #include "openvino/op/pad.hpp"
+#include "openvino/op/reduce_sum.hpp"
+#include "openvino/op/reshape.hpp"
 #include "openvino/op/scaled_dot_product_attention.hpp"
 #include "openvino/op/sign.hpp"
 #include "openvino/op/slice.hpp"
 #include "openvino/op/softmax.hpp"
+#include "openvino/op/squeeze.hpp"
 #include "openvino/op/strided_slice.hpp"
+#include "openvino/op/topk.hpp"
 #include "openvino/op/transpose.hpp"
+#include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/util/attr_types.hpp"
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
@@ -49,7 +68,6 @@
 #include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
-#include "litert/c/internal/litert_logging.h"
 
 namespace litert {
 namespace openvino {
@@ -456,6 +474,663 @@ FuseSplitAttentionToSDPA::FuseSplitAttentionToSDPA(bool pad_kv_to_alignment) {
   register_matcher(m, callback);
 }
 
+namespace {
+
+// One expert's GEGLU branch:
+//   hidden -> up/gate MatMul(W_up) -> Slice/Gelu/Mul (GEGLU) ->
+//   down MatMul(W_down) -> Multiply(x router score) -> Add (into accum chain)
+struct ExpertBranch {
+  int64_t expert_id = -1;                           // read from the Equal const
+  std::shared_ptr<ov::op::v0::MatMul> up_matmul;    // gate/up projection
+  std::shared_ptr<ov::op::v0::MatMul> down_matmul;  // down projection
+  ov::Output<ov::Node> w_up_src;  // weight source to stack (post i4 dequant)
+  ov::Output<ov::Node> w_down_src;
+  // Raw pre-dequant source, when the up/down weight matches the
+  // Multiply(Convert(Constant<u4/i4>), scale) pattern: the packed Constant,
+  // its dequant scale, and the Convert's target type. Populated by
+  // FindDequantSource(); w_up_has_dequant/w_down_has_dequant are set to
+  // false when the pattern is not found.
+  ov::Output<ov::Node> w_up_packed;
+  ov::Output<ov::Node> w_up_scale;
+  ov::element::Type w_up_dequant_type;
+  bool w_up_has_dequant = false;
+  ov::Output<ov::Node> w_down_packed;
+  ov::Output<ov::Node> w_down_scale;
+  ov::element::Type w_down_dequant_type;
+  bool w_down_has_dequant = false;
+  ov::Output<ov::Node> score;           // per-expert router score (mask input)
+  ov::Output<ov::Node> router_weights;  // shared [1,K] routing-weight vector
+  ov::Output<ov::Node> branch_output;   // masked output feeding the Add chain
+  std::shared_ptr<ov::Node> chain_add;  // this branch's link in the Add chain
+};
+
+struct MoELayer {
+  std::shared_ptr<ov::op::v11::TopK> topk;
+  ov::Output<ov::Node> topk_indices;  // TopK output(1)
+  int64_t k = 0;                      // active experts (top-K)
+  size_t num_experts = 0;             // total experts (=128 for Gemma4-26B)
+  std::vector<ExpertBranch> experts;  // filled + sorted by expert_id
+  // The router's per-position routing-weight vector [1,K] that dense multiplies
+  // each expert by (shared across all experts). Gemma4's router is
+  // SoftMax(128) -> TopK -> divide-by-sum renormalize; the vector fed to each
+  // expert's Equal-masked ReduceSum is that fully-normalized result, NOT the
+  // raw TopK value. Captured in CollectExpertBranch.
+  ov::Output<ov::Node> router_weights;
+};
+
+// Reads the constant expert-id an Equal(topk_indices, const) compares against.
+// Returns nullopt if input(1) is not a 1-element Constant.
+std::optional<int64_t> ExtractExpertIdFromEqual(
+    const std::shared_ptr<ov::Node>& equal) {
+  for (size_t i = 0; i < 2; ++i) {
+    if (auto c = std::dynamic_pointer_cast<ov::op::v0::Constant>(
+            equal->input_value(i).get_node_shared_ptr())) {
+      if (ov::shape_size(c->get_shape()) == 1) {
+        return c->cast_vector<int64_t>().front();
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+// Walks forward from |out| through single-consumer nodes (max |max_depth|
+// hops) looking for the first node matching |pred|. Returns nullptr if the
+// chain forks (a consumer count != 1) or |pred| isn't matched in time.
+std::shared_ptr<ov::Node> FindDescendant(
+    const ov::Output<ov::Node>& out,
+    const std::function<bool(const std::shared_ptr<ov::Node>&)>& pred,
+    int max_depth) {
+  ov::Output<ov::Node> cur = out;
+  for (int i = 0; i < max_depth; ++i) {
+    if (cur.get_target_inputs().size() != 1) return nullptr;
+    auto n = cur.get_target_inputs().begin()->get_node()->shared_from_this();
+    if (pred(n)) return n;
+    cur = n->output(0);
+  }
+  return nullptr;
+}
+
+// Walks backward from |out| along input(0) (max |max_depth| hops) looking for
+// the first ov::op::v0::MatMul. This follows the §0.1 GEGLU chain (Multiply
+// -> Gelu -> Slice -> MatMul, or MatMul -> ... -> MatMul) since each of those
+// ops keeps the "main" data path on input(0).
+std::shared_ptr<ov::op::v0::MatMul> FindAncestorMatmul(
+    const ov::Output<ov::Node>& out, int max_depth) {
+  std::shared_ptr<ov::Node> n = out.get_node_shared_ptr();
+  for (int i = 0; i < max_depth; ++i) {
+    if (auto mm = std::dynamic_pointer_cast<ov::op::v0::MatMul>(n)) return mm;
+    if (n->get_input_size() == 0) return nullptr;
+    n = n->input_value(0).get_node_shared_ptr();
+  }
+  return nullptr;
+}
+
+// Detects the weight-compression pattern feeding a MatMul weight input:
+//   Multiply(Convert(Constant<u4/i4>), scale)
+// (operand order may be either way). On match, returns the raw packed
+// Constant, the dequant scale, and the Convert's target element type;
+// returns false if |weight_src| isn't that exact shape (e.g. weights are
+// stored uncompressed), in which case the caller must stack/gather
+// |weight_src| directly instead.
+bool FindDequantSource(const ov::Output<ov::Node>& weight_src,
+                       ov::Output<ov::Node>& packed_out,
+                       ov::Output<ov::Node>& scale_out,
+                       ov::element::Type& dequant_type_out) {
+  auto mul = std::dynamic_pointer_cast<ov::op::v1::Multiply>(
+      weight_src.get_node_shared_ptr());
+  if (!mul) return false;
+  for (size_t i = 0; i < 2; ++i) {
+    auto convert = std::dynamic_pointer_cast<ov::op::v0::Convert>(
+        mul->input_value(i).get_node_shared_ptr());
+    if (!convert) continue;
+    auto packed = std::dynamic_pointer_cast<ov::op::v0::Constant>(
+        convert->input_value(0).get_node_shared_ptr());
+    if (!packed) continue;
+    const auto& packed_type = packed->get_element_type();
+    if (packed_type != ov::element::u4 && packed_type != ov::element::i4)
+      continue;
+    packed_out = convert->input_value(0);
+    scale_out = mul->input_value(1 - i);
+    dequant_type_out = convert->get_element_type();
+    return true;
+  }
+  return false;
+}
+
+// Matches one expert's GEGLU branch starting from its Equal mask node
+//   Equal(indices==expert_id) -> ReduceSum(score) -> Multiply(mask) -> Add
+// and, from the Multiply's non-score input, backs up through
+//   down_matmul <- GEGLU (Multiply/Gelu/Slice) <- up_matmul
+// Returns false (leaving the graph untouched) if any step doesn't match —
+// callers must treat that expert as "not found" rather than guessing.
+bool CollectExpertBranch(const std::shared_ptr<ov::Node>& equal_node,
+                         ExpertBranch& out) {
+  auto id = ExtractExpertIdFromEqual(equal_node);
+  if (!id) return false;
+  out.expert_id = *id;
+
+  auto reduce = FindDescendant(
+      equal_node->output(0),
+      [](const std::shared_ptr<ov::Node>& n) {
+        return ov::is_type<ov::op::v1::ReduceSum>(n);
+      },
+      /*max_depth=*/3);
+  if (!reduce) return false;
+  out.score = reduce->output(0);
+
+  // Capture the router's per-position routing-weight vector.
+  auto premul = std::dynamic_pointer_cast<ov::op::v1::Multiply>(
+      reduce->input_value(0).get_node_shared_ptr());
+  if (!premul) return false;
+  auto traces_to_equal = [&](const ov::Output<ov::Node>& o) {
+    ov::Node* n = o.get_node();
+    for (int i = 0; i < 4 && n; ++i) {
+      if (n == equal_node.get()) return true;
+      if (n->get_input_size() == 0) break;
+      n = n->input_value(0).get_node();
+    }
+    return false;
+  };
+  const bool in0_is_mask = traces_to_equal(premul->input_value(0));
+  const bool in1_is_mask = traces_to_equal(premul->input_value(1));
+  if (in0_is_mask == in1_is_mask) return false;  // can't disambiguate -> bail
+  out.router_weights =
+      in0_is_mask ? premul->input_value(1) : premul->input_value(0);
+
+  auto mult = FindDescendant(
+      reduce->output(0),
+      [](const std::shared_ptr<ov::Node>& n) {
+        return ov::is_type<ov::op::v1::Multiply>(n);
+      },
+      /*max_depth=*/2);
+  if (!mult) return false;
+
+  auto add = FindDescendant(
+      mult->output(0),
+      [](const std::shared_ptr<ov::Node>& n) {
+        return ov::is_type<ov::op::v1::Add>(n);
+      },
+      /*max_depth=*/2);
+  if (!add) return false;
+  out.branch_output = mult->output(0);
+  out.chain_add = add;
+
+  // The Multiply's other input is the pre-mask branch (down-proj) output.
+  const bool score_is_input0 = mult->input_value(0) == reduce->output(0);
+  ov::Output<ov::Node> branch_val =
+      score_is_input0 ? mult->input_value(1) : mult->input_value(0);
+
+  auto down_mm = FindAncestorMatmul(branch_val, /*max_depth=*/4);
+  if (!down_mm) return false;
+  out.down_matmul = down_mm;
+  out.w_down_src = down_mm->input_value(1);
+  out.w_down_has_dequant =
+      FindDequantSource(out.w_down_src, out.w_down_packed, out.w_down_scale,
+                        out.w_down_dequant_type);
+
+  auto up_mm = FindAncestorMatmul(down_mm->input_value(0), /*max_depth=*/4);
+  if (!up_mm || up_mm == down_mm) return false;
+  out.up_matmul = up_mm;
+  out.w_up_src = up_mm->input_value(1);
+  out.w_up_has_dequant = FindDequantSource(
+      out.w_up_src, out.w_up_packed, out.w_up_scale, out.w_up_dequant_type);
+
+  return true;
+}
+
+// Stacks per-expert raw Constants (sorted by expert_id) into one grouped
+// [N, ...] Constant by directly concatenating their raw byte buffers,
+// bypassing the generic Concat/Unsqueeze ops entirely.
+//
+// This exists specifically for sub-byte packed weight types (u4/i4): OV's
+// Concat/Unsqueeze constant-folding evaluate() decompresses such types to a
+// wider element type when it materializes the folded result (observed:
+// u4/i4 -> a wider type), which would silently multiply the grouped weight
+// constant's on-disk size by 2-8x. Building the merged Constant's data
+// buffer ourselves guarantees the packed representation survives unchanged.
+std::shared_ptr<ov::op::v0::Constant> StackConstantsRaw(
+    const ov::OutputVector& per_expert /*sorted*/) {
+  if (per_expert.empty()) return nullptr;
+
+  std::vector<std::shared_ptr<ov::op::v0::Constant>> consts;
+  consts.reserve(per_expert.size());
+  for (const auto& o : per_expert) {
+    auto c = std::dynamic_pointer_cast<ov::op::v0::Constant>(
+        o.get_node_shared_ptr());
+    if (!c) return nullptr;
+    consts.push_back(c);
+  }
+
+  const ov::element::Type type = consts.front()->get_element_type();
+  const ov::Shape per_shape = consts.front()->get_shape();
+  const size_t per_elems = ov::shape_size(per_shape);
+
+  // Verify that all constants have the exact same data type and identical
+  // shape. Using shape inequality (c->get_shape() != per_shape) is safer than
+  // just checking total elements, avoiding silent corruption if dimensions are
+  // swapped.
+  for (const auto& c : consts) {
+    if (c->get_element_type() != type || c->get_shape() != per_shape) {
+      return nullptr;
+    }
+  }
+
+  // Ensure byte-alignment. Sub-byte types (like i4/u4) must perfectly fit into
+  // complete bytes to allow safe memcpy operations.
+  const size_t bits = type.bitwidth();
+  if ((per_elems * bits) % 8 != 0) return nullptr;
+  const size_t per_bytes = (per_elems * bits) / 8;
+
+  ov::Shape new_shape;
+  new_shape.reserve(per_shape.size() + 1);
+  new_shape.push_back(consts.size());
+  new_shape.insert(new_shape.end(), per_shape.begin(), per_shape.end());
+
+  std::vector<uint8_t> buffer(per_bytes * consts.size());
+  for (size_t i = 0; i < consts.size(); ++i) {
+    std::memcpy(buffer.data() + i * per_bytes, consts[i]->get_data_ptr(),
+                per_bytes);
+  }
+
+  // The ov::op::v0::Constant constructor taking a void* data pointer
+  // will internally copy the data from the buffer.
+  return std::make_shared<ov::op::v0::Constant>(type, new_shape, buffer.data());
+}
+
+// Expands per-expert scalar indices |idx| ([K], i64/i32) into flat row
+// indices selecting whole rows out of a [N*rows, cols] flattened table
+// (expert e's rows land at [e*rows, (e+1)*rows)).
+ov::Output<ov::Node> ExpandExpertRowIndices(const ov::Output<ov::Node>& idx,
+                                            int64_t k, int64_t rows) {
+  auto col_shape = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2},
+                                                std::vector<int64_t>{k, 1});
+  auto idx_col = std::make_shared<ov::op::v1::Reshape>(idx, col_shape, false);
+  // TopK indices are i32; match idx's type so Multiply/Add don't mismatch.
+  const auto idx_type = idx.get_element_type();
+  auto rows_const = ov::op::v0::Constant::create(idx_type, ov::Shape{1, 1},
+                                                 std::vector<int64_t>{rows});
+  auto base = std::make_shared<ov::op::v1::Multiply>(idx_col, rows_const);
+  std::vector<int64_t> row_iota(rows);
+  std::iota(row_iota.begin(), row_iota.end(), 0);
+  auto offsets = ov::op::v0::Constant::create(
+      idx_type, ov::Shape{1, static_cast<size_t>(rows)}, row_iota);
+  auto expanded = std::make_shared<ov::op::v1::Add>(base, offsets);
+  auto flat_shape =
+      ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {k * rows});
+  return std::make_shared<ov::op::v1::Reshape>(expanded, flat_shape, false)
+      ->output(0);
+}
+
+// Reshapes a per-expert 3-D packed weight Constant [N, rows, cols] to 2-D
+// [N*rows, cols], Gathers whole rows for the K selected experts, then
+// reshapes the result back to [K, rows, cols]. The NPU backend's Gather
+// kernel is better optimized for 2-D row-gather than for 3-D batched gather
+// on sub-byte (i4/u4) tensors, so flattening gets better hardware utilization.
+// The (already f32) scale Gathers directly in 3-D and needs none of this.
+// Falls back to a direct 3-D Gather if grouped_packed isn't 3-D (shouldn't
+// happen in practice, since StackConstantsRaw always produces a 3-D
+// constant).
+ov::Output<ov::Node> GatherPackedRowsViaFlatten(
+    const std::shared_ptr<ov::op::v0::Constant>& grouped_packed,
+    const ov::Output<ov::Node>& idx, int64_t k) {
+  const ov::Shape& shape = grouped_packed->get_shape();
+  auto axis0 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0});
+  if (shape.size() != 3) {
+    LITERT_LOG(
+        LITERT_DEBUG,
+        "GatherPackedRowsViaFlatten: grouped_packed shape is not 3-D got %zuD"
+        ", falling back to direct Gather",
+        shape.size());
+    return std::make_shared<ov::op::v8::Gather>(grouped_packed, idx, axis0)
+        ->output(0);
+  }
+  const int64_t rows = static_cast<int64_t>(shape[1]);
+  const int64_t cols = static_cast<int64_t>(shape[2]);
+  auto flat2d_shape = ov::op::v0::Constant::create(
+      ov::element::i64, ov::Shape{2}, std::vector<int64_t>{-1, cols});
+  auto flat2d = std::make_shared<ov::op::v1::Reshape>(grouped_packed,
+                                                      flat2d_shape, false);
+  auto flat_idx = ExpandExpertRowIndices(idx, k, rows);
+  auto gathered2d =
+      std::make_shared<ov::op::v8::Gather>(flat2d, flat_idx, axis0);
+  auto out3d_shape = ov::op::v0::Constant::create(
+      ov::element::i64, ov::Shape{3}, std::vector<int64_t>{k, rows, cols});
+  return std::make_shared<ov::op::v1::Reshape>(gathered2d, out3d_shape, false)
+      ->output(0);
+}
+
+// Rewrites one MoE layer into gather-K form:
+//   1. Validate that ALL experts strictly share uniform quantization patterns
+//      and byte-aligned plain Constant weights/scales.
+//   2. Stack per-expert weights (sorted by expert_id) into grouped [N,...]
+//      constants and Gather the K selected by the router.
+//   3. Recompute the up-proj with the gathered weights (batched MatMul of
+//      hidden [1,H] against gathered_up_weights [K,gate_up,H] -> [K,1,gate_up]
+//      -> [K,gate_up]), then rebuild the GEGLU EXPLICITLY (feature-axis slices
+//      + Gelu-TANH) and the down-proj as a batched MatMul. The GEGLU is
+//      rebuilt rather than cloned because the model's GEGLU Slice carries a
+//      batch-1-baked size that would truncate the K experts back to 1.
+//   4. Weight each of the K down-proj outputs by layer.router_weights (the
+//      dense graph's actual per-position routing weight [1,K], divide-by-sum
+//      renormalized -- NOT the raw TopK value) and ReduceSum over the K axis.
+//   5. Replace the final node of the 128-way Add accumulation chain with that
+//   sum.
+// Returns false (leaving the graph untouched) if any expert lacks valid packed
+// weights, shapes/types are non-uniform, or the accumulation chain shape fails.
+bool RegroupAndRewrite(const MoELayer& layer) {
+  const std::string name = layer.topk->get_friendly_name();
+  if (layer.experts.size() != layer.num_experts || layer.k <= 0) {
+    LITERT_LOG(LITERT_INFO,
+               "[MoEGather] rewrite[%s]: abort: experts.size()=%zu "
+               "num_experts=%zu k=%lld",
+               name.c_str(), layer.experts.size(), layer.num_experts,
+               static_cast<long long>(layer.k));
+    return false;
+  }
+  if (!layer.router_weights.get_node_shared_ptr()) {
+    LITERT_LOG(LITERT_INFO,
+               "[MoEGather] rewrite[%s]: abort: router weight vector not "
+               "captured (unexpected router topology)",
+               name.c_str());
+    return false;
+  }
+  // Gather indexes the grouped weight table by expert_id value while rows are
+  // stacked in sorted-expert_id order; only correct when the sorted expert_ids
+  // are exactly 0..N-1 (contiguous). Confirmed for Gemma4 (branch p tests
+  // topk==p and uses weight_p); bail to dense otherwise.
+  for (size_t i = 0; i < layer.experts.size(); ++i) {
+    if (layer.experts[i].expert_id != static_cast<int64_t>(i)) {
+      LITERT_LOG(LITERT_INFO,
+                 "[MoEGather] rewrite[%s]: abort: expert_ids not contiguous "
+                 "0..N-1 (experts[%zu].expert_id=%lld)",
+                 name.c_str(), i,
+                 static_cast<long long>(layer.experts[i].expert_id));
+      return false;
+    }
+  }
+  // The fused gate+up projection width must be statically known and even (it is
+  // sliced in half: gate | up) to reproduce the original two-Slice GEGLU.
+  const auto up_ps =
+      layer.experts.front().up_matmul->get_output_partial_shape(0);
+  const int64_t up_rank =
+      up_ps.rank().is_static() ? up_ps.rank().get_length() : 0;
+  if (up_rank < 1 || !up_ps[up_rank - 1].is_static() ||
+      up_ps[up_rank - 1].get_length() % 2 != 0) {
+    LITERT_LOG(LITERT_INFO,
+               "[MoEGather] rewrite[%s]: abort: gate+up width not static/even",
+               name.c_str());
+    return false;
+  }
+  const int64_t half = up_ps[up_rank - 1].get_length() / 2;
+
+  std::set<ov::Node*> chain_adds;
+  for (auto& e : layer.experts) {
+    chain_adds.insert(e.chain_add.get());
+  }
+  std::shared_ptr<ov::Node> final_add;
+  int root_count = 0;
+  for (auto& e : layer.experts) {
+    bool feeds_another_chain_add = false;
+    for (const auto& ti : e.chain_add->output(0).get_target_inputs()) {
+      if (chain_adds.count(ti.get_node())) {
+        // This expert's Add feeds another expert's Add, so it is not a root.
+        feeds_another_chain_add = true;
+        break;
+      }
+    }
+    if (!feeds_another_chain_add) {
+      ++root_count;
+      final_add = e.chain_add;
+    }
+  }
+  if (root_count != 1) {
+    LITERT_LOG(LITERT_INFO,
+               "[MoEGather] rewrite[%s]: abort: found %d chain roots "
+               "(expected exactly 1)",
+               name.c_str(), root_count);
+    return false;
+  }
+
+  auto k_shape =
+      ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {layer.k});
+  auto idx =
+      std::make_shared<ov::op::v1::Reshape>(layer.topk_indices, k_shape, false);
+  auto axis0 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0});
+
+  // Ensure ALL experts share the exact same quantization standard.
+  auto& ref = layer.experts.front();
+  for (const auto& e : layer.experts) {
+    if (!e.w_up_has_dequant || !e.w_down_has_dequant) {
+      LITERT_LOG(LITERT_INFO,
+                 "[MoEGather] rewrite[%s]: abort: missing i4/u4 packed "
+                 "pattern for some experts.",
+                 name.c_str());
+      return false;
+    }
+    if (e.w_up_dequant_type != ref.w_up_dequant_type ||
+        e.w_down_dequant_type != ref.w_down_dequant_type) {
+      LITERT_LOG(
+          LITERT_INFO,
+          "[MoEGather] rewrite[%s]: abort: mixed dequant types among experts.",
+          name.c_str());
+      return false;
+    }
+  }
+
+  // Helper lambda: Extracts constants, stacks them, and builds the Gather
+  // subgraph. Returns an empty Output if strict stacking fails.
+  auto build_gathered_weights = [&](bool is_up_proj) -> ov::Output<ov::Node> {
+    ov::OutputVector packed, scales;
+    packed.reserve(layer.experts.size());
+    scales.reserve(layer.experts.size());
+
+    for (const auto& e : layer.experts) {
+      packed.push_back(is_up_proj ? e.w_up_packed : e.w_down_packed);
+      scales.push_back(is_up_proj ? e.w_up_scale : e.w_down_scale);
+    }
+    auto grouped_packed = StackConstantsRaw(packed);
+    auto grouped_scale = StackConstantsRaw(scales);
+
+    // Strict Stacking check: abort if not uniform constants or byte-aligned.
+    if (!grouped_packed || !grouped_scale) {
+      LITERT_LOG(LITERT_INFO,
+                 "[MoEGather] rewrite[%s]: abort: %s weights or scales are not "
+                 "uniform plain constants or not byte-aligned.",
+                 name.c_str(), is_up_proj ? "up" : "down");
+      return ov::Output<ov::Node>();  // Return empty output to signal failure
+    }
+    auto dequant_type =
+        is_up_proj ? ref.w_up_dequant_type : ref.w_down_dequant_type;
+    // Flattening to 2-D before Gather gets better hardware utilization on the
+    // NPU backend than a direct 3-D batched gather (see
+    // GatherPackedRowsViaFlatten). The (already f32) scale Gathers directly in
+    // 3-D either way.
+    ov::Output<ov::Node> g_packed =
+        GatherPackedRowsViaFlatten(grouped_packed, idx, layer.k);
+    auto g_scale =
+        std::make_shared<ov::op::v8::Gather>(grouped_scale, idx, axis0);
+    auto g_dequant =
+        std::make_shared<ov::op::v0::Convert>(g_packed, dequant_type);
+
+    return std::make_shared<ov::op::v1::Multiply>(g_dequant, g_scale);
+  };
+
+  // Build the strict gather subgraphs
+  ov::Output<ov::Node> gathered_up_weights = build_gathered_weights(true);
+  if (!gathered_up_weights.get_node_shared_ptr()) return false;
+  ov::Output<ov::Node> gathered_down_weights = build_gathered_weights(false);
+  if (!gathered_down_weights.get_node_shared_ptr()) return false;
+
+  // Batched up/gate projection. Keep hidden as [1,H] (do NOT squeeze to 1-D --
+  // 1-D MatMul lowers poorly on the NPU). MatMul([1,H],
+  // gathered_up_weights[K,gate_up,H], transpose_b) broadcasts to [K,1,gate_up];
+  // squeeze the size-1 middle dim.
+  auto new_up_bcast = ref.up_matmul->clone_with_new_inputs(
+      {ref.up_matmul->input_value(0), gathered_up_weights});
+  auto sq_axis1 =
+      ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+  auto up_2d = std::make_shared<ov::op::v0::Squeeze>(new_up_bcast, sq_axis1);
+
+  // Reproduce the original GEGLU faithfully: two Slice ops (one per consumer
+  // chain -- gate half and up half), a Gelu, and a Multiply. The ONLY deviation
+  // forced by the weights-gather is the slice axis: the original Slice carries
+  // a batch-1-baked size ([1,half]) that would truncate our K experts (axis 0)
+  // back to 1, so we slice only the feature axis (axes=[1]) and leave axis 0
+  // (the K experts) untouched. gate=[:,0:half] (Gelu-TANH), up=[:,half:2*half].
+  auto slice_step =
+      ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+  auto slice_axis =
+      ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+  auto gate_start =
+      ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+  auto gate_stop =
+      ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {half});
+  auto gate = std::make_shared<ov::op::v8::Slice>(up_2d, gate_start, gate_stop,
+                                                  slice_step, slice_axis);
+  auto up_start =
+      ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {half});
+  auto up_stop =
+      ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {2 * half});
+  auto up_half = std::make_shared<ov::op::v8::Slice>(up_2d, up_start, up_stop,
+                                                     slice_step, slice_axis);
+  auto gate_act = std::make_shared<ov::op::v7::Gelu>(
+      gate, ov::op::GeluApproximationMode::TANH);
+  auto geglu = std::make_shared<ov::op::v1::Multiply>(gate_act, up_half);
+
+  // Batched down projection: [K,half] -> [K,1,half] to batch-matmul against
+  // gathered_down_weights[K,H,half] (transpose_b) -> [K,1,H].
+  auto un_axis1 =
+      ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+  auto geglu_3d = std::make_shared<ov::op::v0::Unsqueeze>(geglu, un_axis1);
+  auto new_down =
+      ref.down_matmul->clone_with_new_inputs({geglu_3d, gathered_down_weights});
+
+  // Weight each expert by the dense graph's actual routing-weight vector
+  // (renormalized [1,K], captured as layer.router_weights) -- NOT
+  // TopK.output(0) which lacks Gemma4's divide-by-sum renormalization -- then
+  // sum over K.
+  auto weights = std::make_shared<ov::op::v1::Reshape>(layer.router_weights,
+                                                       k_shape, false);
+  auto weights_bshape = ov::op::v0::Constant::create(
+      ov::element::i64, ov::Shape{3}, std::vector<int64_t>{layer.k, 1, 1});
+  auto weights_b =
+      std::make_shared<ov::op::v1::Reshape>(weights, weights_bshape, false);
+  auto weighted = std::make_shared<ov::op::v1::Multiply>(new_down, weights_b);
+  auto reduce_axis =
+      ov::op::v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
+  auto summed =
+      std::make_shared<ov::op::v1::ReduceSum>(weighted, reduce_axis, false);
+
+  summed->set_friendly_name(final_add->get_friendly_name());
+  ov::copy_runtime_info(
+      final_add, {new_up_bcast, up_2d, gate, up_half, gate_act, geglu, geglu_3d,
+                  new_down, gathered_up_weights.get_node_shared_ptr(),
+                  gathered_down_weights.get_node_shared_ptr(), weights,
+                  weights_b, weighted, summed});
+  ov::replace_node(final_add, summed);
+  LITERT_LOG(LITERT_INFO,
+             "[MoEGather] rewrite[%s]: OK, replaced chain root '%s' with "
+             "gather-K subgraph",
+             name.c_str(), summed->get_friendly_name().c_str());
+  return true;
+}
+
+// Discovers all MoE layers: each router TopK, its expert branches (via the
+// Equal consumers of TopK.output(1)), and K.
+std::vector<MoELayer> FindMoeLayers(const std::shared_ptr<ov::Model>& model) {
+  std::vector<MoELayer> layers;
+  for (const auto& node : model->get_ordered_ops()) {
+    auto topk = std::dynamic_pointer_cast<ov::op::v11::TopK>(node);
+    if (!topk) continue;
+
+    MoELayer layer;
+    layer.topk = topk;
+    layer.topk_indices = topk->output(1);
+
+    if (auto kc = std::dynamic_pointer_cast<ov::op::v0::Constant>(
+            topk->input_value(1).get_node_shared_ptr())) {
+      if (ov::shape_size(kc->get_shape()) >= 1)
+        layer.k = kc->cast_vector<int64_t>().front();
+    }
+    if (layer.k <= 0) {
+      continue;
+    }
+
+    // The indices (output 1) drive one per-expert Equal mask each.
+    std::vector<std::shared_ptr<ov::Node>> equals;
+    for (const auto& ti : layer.topk_indices.get_target_inputs()) {
+      auto n = ti.get_node()->shared_from_this();
+      if (std::dynamic_pointer_cast<ov::op::v1::Equal>(n)) equals.push_back(n);
+    }
+    if (equals.size() < 2) continue;  // not a router-style TopK
+
+    for (const auto& eq : equals) {
+      ExpertBranch br;
+      if (CollectExpertBranch(eq, br)) layer.experts.push_back(std::move(br));
+    }
+    if (layer.experts.size() != equals.size()) {
+      LITERT_LOG(LITERT_DEBUG,
+                 "[MoE] layer TopK='%s' K=%lld experts=%zu: some experts "
+                 "failed to match GEGLU branch",
+                 layer.topk->get_friendly_name().c_str(),
+                 static_cast<long long>(layer.k), layer.experts.size());
+      continue;
+    }
+    layer.num_experts = layer.experts.size();
+
+    // Decode/generate only: the gather form assumes a single token. At this
+    // point (right after the TFLite frontend, before shape resolution) the
+    // batch dim may still be dynamic, so only reject when it is STATICALLY not
+    // 1 — matching NPUW's DeviceRoutedMoETransform guard. The concrete K used
+    // for the gather comes from the TopK 'k' constant, not from this shape.
+    const auto ishape = layer.topk_indices.get_partial_shape();
+    bool decode_ok = true;
+    if (ishape.rank().is_static() && ishape.rank().get_length() >= 1) {
+      if (ishape[0].is_static() && ishape[0].get_length() != 1) {
+        decode_ok = false;
+      }
+    }
+    std::ostringstream shp;
+    shp << ishape;
+    LITERT_LOG(LITERT_DEBUG,
+               "[MoE] layer TopK='%s' K=%lld experts=%zu indices=%s%s",
+               layer.topk->get_friendly_name().c_str(),
+               static_cast<long long>(layer.k), layer.experts.size(),
+               shp.str().c_str(), decode_ok ? "" : " [skip: batch != 1]");
+    if (!decode_ok) continue;
+
+    std::sort(layer.experts.begin(), layer.experts.end(),
+              [](const ExpertBranch& a, const ExpertBranch& b) {
+                return a.expert_id < b.expert_id;
+              });
+    // The routing-weight vector is shared across all experts; lift it to layer.
+    if (!layer.experts.empty()) {
+      layer.router_weights = layer.experts.front().router_weights;
+    }
+    layers.push_back(std::move(layer));
+  }
+  return layers;
+}
+
+}  // namespace
+
+bool MoEGatherRewrite::run_on_model(const std::shared_ptr<ov::Model>& model) {
+  // 1. Find all TopK nodes that look like MoE routers.
+  auto layers = FindMoeLayers(model);
+  LITERT_LOG(LITERT_INFO, "[MoEGather] discovered %zu candidate MoE layer(s)",
+             layers.size());
+
+  // 2. For each candidate, attempt to rewrite it into gather-K form.
+  bool changed = false;
+  for (auto& layer : layers) {
+    if (RegroupAndRewrite(layer)) {
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
 void NpuOptimizer::Run(const std::shared_ptr<ov::Model>& model) const {
   ov::pass::Manager pass_manager;
   // First: fold constants (removes dynamic shapes) before the passes below.
@@ -471,6 +1146,9 @@ void NpuOptimizer::Run(const std::shared_ptr<ov::Model>& model) const {
   }
   if (eliminate_matmul_fq_) {
     pass_manager.register_pass<EliminateMatMulFakeQuantize>();
+  }
+  if (enable_moe_gather_) {
+    pass_manager.register_pass<MoEGatherRewrite>();
   }
   pass_manager.run_passes(model);
 }

--- a/litert/vendors/intel_openvino/compiler/npu_optimizer.h
+++ b/litert/vendors/intel_openvino/compiler/npu_optimizer.h
@@ -19,6 +19,7 @@
 
 #include "openvino/core/model.hpp"
 #include "openvino/pass/graph_rewrite.hpp"
+#include "openvino/pass/pass.hpp"
 
 namespace litert {
 namespace openvino {
@@ -83,6 +84,31 @@ class FuseSplitAttentionToSDPA : public ov::pass::MatcherPass {
   explicit FuseSplitAttentionToSDPA(bool pad_kv_to_alignment);
 };
 
+// Rewrites Gemma4's dense Mixture-of-Experts block — where all N experts are
+// computed and non-selected ones are masked to zero — into selective
+// computation of only the K experts chosen by the router's TopK.
+//
+// Gemma4 (decode) exports each expert as an independent GEGLU branch with its
+// own weights (there is NO batched expert dimension to gather over), the
+// branches accumulated via a chain of Add and masked by per-expert router
+// scores (Equal(topk_indices, expert_id) -> score, 0 when not selected). Per
+// MoE layer this pass:
+//   1. Locates the router TopK and its N (=128) expert branches; the expert_id
+//      of each branch is read from that branch's Equal constant.
+//   2. Stacks the per-expert weights into grouped constants [N, ...] ordered by
+//      expert_id (i4 dequant scales stacked in the same order).
+//   3. Inserts Gather(grouped_w, topk_indices, axis=0) so only K experts are
+//      computed on-device.
+//   4. Replaces the N-way masked Add chain with a K-way score-weighted sum.
+//
+// Decode/generate only (requires TopK indices batch == 1). Disabled by default;
+// enable via config key "enable_moe_gather" = "true".
+class MoEGatherRewrite : public ov::pass::ModelPass {
+ public:
+  OPENVINO_RTTI("MoEGatherRewrite");
+  bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
+};
+
 // Configurable runner for NPU-specific optimization passes.
 // Use the setter APIs to toggle individual optimizations, then call Run() to
 // apply the enabled passes to a model.
@@ -122,6 +148,14 @@ class NpuOptimizer {
     return *this;
   }
 
+  // Toggles the MoEGatherRewrite pass. Disabled by default; enable via config
+  // key "enable_moe_gather" = "true" to turn Gemma4's dense masked MoE into
+  // gather-based selective (K-of-N) expert computation.
+  NpuOptimizer& SetEnableMoeGather(bool enable) {
+    enable_moe_gather_ = enable;
+    return *this;
+  }
+
   // Runs all currently-enabled passes on |model|.
   void Run(const std::shared_ptr<ov::Model>& model) const;
 
@@ -131,6 +165,7 @@ class NpuOptimizer {
   bool cast_integer_sign_to_float_ = true;
   bool fuse_split_attention_to_sdpa_ = false;
   bool sdpa_pad_kv_to_alignment_ = true;
+  bool enable_moe_gather_ = false;
 };
 
 }  // namespace openvino

--- a/litert/vendors/intel_openvino/compiler/npu_optimizer_test.cc
+++ b/litert/vendors/intel_openvino/compiler/npu_optimizer_test.cc
@@ -14,11 +14,15 @@
 
 #include "litert/vendors/intel_openvino/compiler/npu_optimizer.h"
 
+#include <gtest/gtest.h>
+
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
+#include <numeric>
 #include <vector>
 
 #include "openvino/core/model.hpp"
@@ -26,17 +30,24 @@
 #include "openvino/op/add.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/divide.hpp"
+#include "openvino/op/equal.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/gelu.hpp"
 #include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
 #include "openvino/op/parameter.hpp"
+#include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/result.hpp"
 #include "openvino/op/scaled_dot_product_attention.hpp"
 #include "openvino/op/slice.hpp"
 #include "openvino/op/softmax.hpp"
+#include "openvino/op/topk.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/runtime/core.hpp"
 #include "openvino/runtime/infer_request.hpp"
 #include "openvino/runtime/tensor.hpp"
-#include <gtest/gtest.h>
 
 namespace litert {
 namespace openvino {
@@ -248,6 +259,362 @@ TEST(FuseSplitAttentionToSDPATest, NumericallyMatchesSplitCache) {
   }
   EXPECT_LT(max_abs_diff, 1e-4f)
       << "fused output diverges from split-cache reference";
+}
+
+// Fixed per-expert weight shapes used by BuildDenseMoeGraph: a fused gate+up
+// projection of width kMoeGateUp (split evenly into gate | up for GEGLU) and
+// a down projection back to kMoeHiddenDim.
+constexpr int64_t kMoeHiddenDim = 4;
+constexpr int64_t kMoeHalf = 2;
+constexpr int64_t kMoeGateUp = 2 * kMoeHalf;
+
+// Builds one expert's i4/u4-packed dequantized weight:
+//   Multiply(Convert(Constant<u4>(shape)), Constant<f32>(scale_shape))
+// matching the pattern find_dequant_source() looks for. |fill| seeds the
+// packed values (0-15, wrapped) so each expert's weights are numerically
+// distinguishable.
+ov::Output<ov::Node> MakeDequantWeight(const ov::Shape& shape,
+                                       const ov::Shape& scale_shape,
+                                       uint8_t fill, float scale_value) {
+  std::vector<uint8_t> packed_values(ov::shape_size(shape), fill % 16);
+  auto packed =
+      ov::op::v0::Constant::create(ov::element::u4, shape, packed_values);
+  auto scale = ov::op::v0::Constant::create(
+      ov::element::f32, scale_shape,
+      std::vector<float>(ov::shape_size(scale_shape), scale_value));
+  auto convert =
+      std::make_shared<ov::op::v0::Convert>(packed, ov::element::f32);
+  return std::make_shared<ov::op::v1::Multiply>(convert, scale)->output(0);
+}
+
+// Builds a Gemma4-style dense MoE block: one independent GEGLU branch per
+// entry in |expert_ids|, each masked by Equal(router_topk_indices, expert_id)
+// and summed via a chain of Add — the pattern MoEGatherRewrite looks for (see
+// find_moe_layers / collect_expert_branch in npu_optimizer.cc). |expert_ids|
+// need not be contiguous/sorted; the rewrite requires sorted 0..N-1 and will
+// reject graphs that aren't (see DoesNotRewriteWhenExpertIdsNotContiguous).
+// Inputs, in order, are {hidden [batch,H], router_logits [batch,N]}.
+std::shared_ptr<ov::Model> BuildDenseMoeGraph(
+    int64_t k, const std::vector<int64_t>& expert_ids, int64_t batch = 1) {
+  using ov::op::v0::Constant;
+  using ov::op::v0::Convert;
+  using ov::op::v0::MatMul;
+  using ov::op::v0::Parameter;
+  using ov::op::v1::Add;
+  using ov::op::v1::Divide;
+  using ov::op::v1::Equal;
+  using ov::op::v1::Multiply;
+  using ov::op::v1::ReduceSum;
+  using ov::op::v7::Gelu;
+  using ov::op::v8::Slice;
+
+  const auto f32 = ov::element::f32;
+  const int64_t num_experts = static_cast<int64_t>(expert_ids.size());
+  auto hidden = std::make_shared<Parameter>(
+      f32, ov::Shape{static_cast<size_t>(batch),
+                     static_cast<size_t>(kMoeHiddenDim)});
+  auto logits = std::make_shared<Parameter>(
+      f32,
+      ov::Shape{static_cast<size_t>(batch), static_cast<size_t>(num_experts)});
+
+  auto k_const = Constant::create(ov::element::i64, ov::Shape{}, {k});
+  auto topk = std::make_shared<ov::op::v11::TopK>(logits, k_const, /*axis=*/1,
+                                                  "max", "value");
+  ov::Output<ov::Node> values = topk->output(0);
+  ov::Output<ov::Node> indices = topk->output(1);
+
+  auto sum_axis = Constant::create(ov::element::i64, ov::Shape{1}, {1});
+  auto weight_sum =
+      std::make_shared<ReduceSum>(values, sum_axis, /*keep_dims=*/true);
+  ov::Output<ov::Node> router_weights =
+      std::make_shared<Divide>(values, weight_sum)->output(0);
+
+  ov::Output<ov::Node> accum;
+  for (int64_t i = 0; i < num_experts; ++i) {
+    auto expert_id = Constant::create(indices.get_element_type(), ov::Shape{},
+                                      {expert_ids[i]});
+    auto eq = std::make_shared<Equal>(indices, expert_id);
+    auto conv = std::make_shared<Convert>(eq, f32);
+    auto premul = std::make_shared<Multiply>(conv, router_weights);
+    auto reduce_axis = Constant::create(ov::element::i64, ov::Shape{1}, {1});
+    auto score = std::make_shared<ReduceSum>(premul, reduce_axis,
+                                             /*keep_dims=*/true);
+
+    auto w_up = MakeDequantWeight(ov::Shape{static_cast<size_t>(kMoeGateUp),
+                                            static_cast<size_t>(kMoeHiddenDim)},
+                                  ov::Shape{static_cast<size_t>(kMoeGateUp), 1},
+                                  static_cast<uint8_t>(i + 1), 0.1f * (i + 1));
+    auto up_mm = std::make_shared<MatMul>(hidden, w_up, /*transpose_a=*/false,
+                                          /*transpose_b=*/true);
+
+    auto slice_step = Constant::create(ov::element::i64, ov::Shape{1}, {1});
+    auto slice_axis = Constant::create(ov::element::i64, ov::Shape{1}, {1});
+    auto gate_start = Constant::create(ov::element::i64, ov::Shape{1}, {0});
+    auto gate_stop =
+        Constant::create(ov::element::i64, ov::Shape{1}, {kMoeHalf});
+    auto gate = std::make_shared<Slice>(up_mm, gate_start, gate_stop,
+                                        slice_step, slice_axis);
+    auto up_start =
+        Constant::create(ov::element::i64, ov::Shape{1}, {kMoeHalf});
+    auto up_stop =
+        Constant::create(ov::element::i64, ov::Shape{1}, {2 * kMoeHalf});
+    auto up_half = std::make_shared<Slice>(up_mm, up_start, up_stop, slice_step,
+                                           slice_axis);
+    auto gate_act =
+        std::make_shared<Gelu>(gate, ov::op::GeluApproximationMode::TANH);
+    auto geglu = std::make_shared<Multiply>(gate_act, up_half);
+
+    auto w_down =
+        MakeDequantWeight(ov::Shape{static_cast<size_t>(kMoeHiddenDim),
+                                    static_cast<size_t>(kMoeHalf)},
+                          ov::Shape{static_cast<size_t>(kMoeHiddenDim), 1},
+                          static_cast<uint8_t>(i + 2), 0.05f * (i + 1));
+    auto down_mm = std::make_shared<MatMul>(geglu, w_down,
+                                            /*transpose_a=*/false,
+                                            /*transpose_b=*/true);
+
+    auto branch = std::make_shared<Multiply>(score, down_mm);
+    if (i == 0) {
+      accum = branch->output(0);
+    } else {
+      accum = std::make_shared<Add>(accum, branch)->output(0);
+    }
+  }
+
+  auto result = std::make_shared<ov::op::v0::Result>(accum);
+  return std::make_shared<ov::Model>(ov::ResultVector{result},
+                                     ov::ParameterVector{hidden, logits},
+                                     "dense_moe");
+}
+
+std::vector<int64_t> SequentialExpertIds(int64_t num_experts) {
+  std::vector<int64_t> ids(num_experts);
+  std::iota(ids.begin(), ids.end(), 0);
+  return ids;
+}
+
+TEST(MoEGatherRewriteTest, RewritesDenseMoeIntoGatherForm) {
+  auto model = BuildDenseMoeGraph(/*k=*/2, SequentialExpertIds(4));
+
+  EXPECT_EQ(CountOps<ov::op::v1::Equal>(model), 4u);
+  EXPECT_EQ(CountOps<ov::op::v1::Add>(model), 3u);
+  EXPECT_EQ(CountOps<ov::op::v1::ReduceSum>(model), 5u);
+  EXPECT_EQ(CountOps<ov::op::v8::Gather>(model), 0u);
+
+  NpuOptimizer().SetCastIntegerSignToFloat(false).SetEnableMoeGather(true).Run(
+      model);
+
+  // Postcondition: the masked dense chain (Equal/Add) is gone, replaced by
+  // Gather-K weight selection (2 Gathers per weight: flattened packed rows +
+  // scale) and a single weighted ReduceSum over the K selected experts. The
+  // router's weight-sum ReduceSum survives (it still feeds the K-weighting).
+  EXPECT_EQ(CountOps<ov::op::v1::Equal>(model), 0u);
+  // ExpandExpertRowIndices emits one row-offset Add per gathered weight (up +
+  // down)
+  EXPECT_EQ(CountOps<ov::op::v1::Add>(model), 2u);
+  EXPECT_EQ(CountOps<ov::op::v8::Gather>(model), 4u);
+  EXPECT_EQ(CountOps<ov::op::v1::ReduceSum>(model), 2u);
+  EXPECT_EQ(CountOps<ov::op::v0::MatMul>(model), 2u);
+}
+
+// Negative: MoEGatherRewrite requires sorted expert_ids to be exactly
+// contiguous 0..N-1 (the grouped weight table is indexed by expert_id, and
+// rows are stacked in sorted-expert_id order). A gap must abort the rewrite
+// and leave the graph untouched.
+TEST(MoEGatherRewriteTest, DoesNotRewriteWhenExpertIdsNotContiguous) {
+  auto model = BuildDenseMoeGraph(/*k=*/2, /*expert_ids=*/{0, 1, 3});
+
+  NpuOptimizer().SetCastIntegerSignToFloat(false).SetEnableMoeGather(true).Run(
+      model);
+
+  EXPECT_EQ(CountOps<ov::op::v1::Equal>(model), 3u);
+  EXPECT_EQ(CountOps<ov::op::v8::Gather>(model), 0u);
+}
+
+// Negative: the gather form assumes a single token (decode/generate). When
+// the router's TopK indices have a statically-known batch dim != 1 (a
+// prefill-shaped call), the rewrite must skip the layer rather than
+// mis-compile it.
+TEST(MoEGatherRewriteTest, DoesNotRewritePrefillShapedRouter) {
+  auto model = BuildDenseMoeGraph(/*k=*/2, SequentialExpertIds(4), /*batch=*/2);
+
+  NpuOptimizer().SetCastIntegerSignToFloat(false).SetEnableMoeGather(true).Run(
+      model);
+
+  EXPECT_EQ(CountOps<ov::op::v1::Equal>(model), 4u);
+  EXPECT_EQ(CountOps<ov::op::v8::Gather>(model), 0u);
+}
+
+// Negative/edge case: a degenerate batch=0 call (zero tokens). The TopK
+// indices' batch dim is statically 0, which is != 1, so this must hit the
+// same "not decode-shaped" guard as batch=2 rather than e.g. dividing by zero
+// or otherwise misbehaving on an empty tensor.
+TEST(MoEGatherRewriteTest, DoesNotRewriteWhenBatchIsZero) {
+  auto model = BuildDenseMoeGraph(/*k=*/2, SequentialExpertIds(4), /*batch=*/0);
+
+  NpuOptimizer().SetCastIntegerSignToFloat(false).SetEnableMoeGather(true).Run(
+      model);
+
+  EXPECT_EQ(CountOps<ov::op::v1::Equal>(model), 4u);
+  EXPECT_EQ(CountOps<ov::op::v8::Gather>(model), 0u);
+}
+
+// Runs |reference| and its MoEGatherRewrite-rewritten clone on identical
+// {hidden, logits} inputs and returns the max abs difference between their
+// outputs. Asserts the rewrite actually fired (Gather count == 4) so a silent
+// no-op rewrite can't masquerade as "numerically matches".
+float MaxAbsDiffAfterRewrite(const std::shared_ptr<ov::Model>& reference,
+                             const ov::Tensor& hidden,
+                             const ov::Tensor& logits) {
+  auto rewritten = reference->clone();
+  NpuOptimizer().SetCastIntegerSignToFloat(false).SetEnableMoeGather(true).Run(
+      rewritten);
+  EXPECT_EQ(CountOps<ov::op::v8::Gather>(rewritten), 4u)
+      << "rewrite did not fire";
+
+  ov::Core core;
+  auto ref_compiled = core.compile_model(reference, "CPU");
+  auto rew_compiled = core.compile_model(rewritten, "CPU");
+  auto ref_req = ref_compiled.create_infer_request();
+  auto rew_req = rew_compiled.create_infer_request();
+  for (auto& req : {std::ref(ref_req), std::ref(rew_req)}) {
+    req.get().set_input_tensor(0, hidden);
+    req.get().set_input_tensor(1, logits);
+  }
+  ref_req.infer();
+  rew_req.infer();
+
+  auto ref_out = ref_req.get_output_tensor(0);
+  auto rew_out = rew_req.get_output_tensor(0);
+  EXPECT_EQ(ref_out.get_size(), rew_out.get_size());
+  const auto* a = ref_out.data<float>();
+  const auto* b = rew_out.data<float>();
+  float max_abs_diff = 0.0f;
+  for (size_t i = 0; i < ref_out.get_size(); ++i) {
+    max_abs_diff = std::max(max_abs_diff, std::abs(a[i] - b[i]));
+  }
+  return max_abs_diff;
+}
+
+ov::Tensor MakeFilledTensor(const ov::Shape& shape, float value) {
+  ov::Tensor t(ov::element::f32, shape);
+  std::fill_n(t.data<float>(), t.get_size(), value);
+  return t;
+}
+
+TEST(MoEGatherRewriteTest, NumericallyMatchesDenseComputation) {
+  auto reference = BuildDenseMoeGraph(/*k=*/2, SequentialExpertIds(6));
+
+  ov::Tensor hidden(ov::element::f32, ov::Shape{1, kMoeHiddenDim});
+  FillRandom(hidden, /*seed=*/1);
+  ov::Tensor logits(ov::element::f32, ov::Shape{1, 6});
+  FillRandom(logits, /*seed=*/2);
+
+  EXPECT_LT(MaxAbsDiffAfterRewrite(reference, hidden, logits), 1e-3f)
+      << "gather-K rewrite diverges from dense masked-experts reference";
+}
+
+TEST(MoEGatherRewriteTest, NumericallyMatchesWithAllZeroInputs) {
+  auto reference = BuildDenseMoeGraph(/*k=*/2, SequentialExpertIds(6));
+  auto hidden = MakeFilledTensor(ov::Shape{1, kMoeHiddenDim}, 0.0f);
+  auto logits = MakeFilledTensor(ov::Shape{1, 6}, 0.0f);
+
+  float max_abs_diff = MaxAbsDiffAfterRewrite(reference, hidden, logits);
+  // With all-zero logits, weight_sum == 0 and router_weights is 0/0 (NaN) in
+  // *both* the reference and rewritten graphs identically, so this only
+  // checks that both sides agree (both NaN or both equal), not that the
+  // result is finite.
+  if (!std::isnan(max_abs_diff)) {
+    EXPECT_LT(max_abs_diff, 1e-3f);
+  }
+}
+
+TEST(MoEGatherRewriteTest, NumericallyMatchesWithAllOnesInputs) {
+  auto reference = BuildDenseMoeGraph(/*k=*/2, SequentialExpertIds(6));
+  auto hidden = MakeFilledTensor(ov::Shape{1, kMoeHiddenDim}, 1.0f);
+  auto logits = MakeFilledTensor(ov::Shape{1, 6}, 1.0f);
+
+  EXPECT_LT(MaxAbsDiffAfterRewrite(reference, hidden, logits), 1e-3f);
+}
+
+TEST(MoEGatherRewriteTest, NumericallyMatchesWithExtremeValueInputs) {
+  auto reference = BuildDenseMoeGraph(/*k=*/2, SequentialExpertIds(6));
+  auto hidden = MakeFilledTensor(ov::Shape{1, kMoeHiddenDim}, 1.0e4f);
+  ov::Tensor logits(ov::element::f32, ov::Shape{1, 6});
+  // Large, distinct-magnitude logits so TopK's chosen experts are unambiguous
+  // even at this scale.
+  const float kLogitValues[] = {1.0e3f,  -1.0e4f, 1.0e5f,
+                                -1.0e2f, 1.0e4f,  -1.0e5f};
+  std::copy(std::begin(kLogitValues), std::end(kLogitValues),
+            logits.data<float>());
+
+  EXPECT_LT(MaxAbsDiffAfterRewrite(reference, hidden, logits), 5.0f)
+      << "absolute tolerance widened for the extreme-magnitude inputs "
+         "case above; a growing gap here would indicate the rewrite's "
+         "arithmetic (e.g. gather order) diverges at scale, not just noise";
+}
+
+// Tanh-approximation Gelu, matching ov::op::GeluApproximationMode::TANH, used
+// to independently hand-compute the expected per-expert contribution below
+// without relying on the (dense) reference OpenVINO graph at all.
+float ReferenceGeluTanh(float x) {
+  constexpr float kSqrt2OverPi = 0.7978845608f;
+  const float inner = kSqrt2OverPi * (x + 0.044715f * x * x * x);
+  return 0.5f * x * (1.0f + std::tanh(inner));
+}
+
+TEST(MoEGatherRewriteTest, GatherSelectsCorrectExpertRows) {
+  constexpr int64_t kNumExperts = 4;
+  constexpr int64_t kK = 2;
+  auto model = BuildDenseMoeGraph(kK, SequentialExpertIds(kNumExperts));
+
+  NpuOptimizer().SetCastIntegerSignToFloat(false).SetEnableMoeGather(true).Run(
+      model);
+  ASSERT_EQ(CountOps<ov::op::v8::Gather>(model), 4u) << "rewrite did not fire";
+
+  // logits chosen so experts 1 and 3 (values 5.0, 8.0) are the clear top-2;
+  // experts 0 and 2 must be excluded from the result.
+  const float kLogitValues[kNumExperts] = {0.1f, 5.0f, 0.2f, 8.0f};
+  const std::vector<int64_t> kSelected = {1, 3};
+
+  ov::Tensor hidden = MakeFilledTensor(ov::Shape{1, kMoeHiddenDim}, 1.0f);
+  ov::Tensor logits(ov::element::f32, ov::Shape{1, kNumExperts});
+  std::copy(std::begin(kLogitValues), std::end(kLogitValues),
+            logits.data<float>());
+
+  ov::Core core;
+  auto compiled = core.compile_model(model, "CPU");
+  auto req = compiled.create_infer_request();
+  req.set_input_tensor(0, hidden);
+  req.set_input_tensor(1, logits);
+  req.infer();
+
+  // Independently recompute BuildDenseMoeGraph's math for exactly the
+  // selected experts (all-ones hidden + a uniform per-row weight fill means
+  // every one of the H output columns collapses to the same scalar).
+  float weight_sum = 0.0f;
+  for (int64_t e : kSelected) weight_sum += kLogitValues[e];
+  float expected = 0.0f;
+  for (int64_t e : kSelected) {
+    const float router_weight = kLogitValues[e] / weight_sum;
+    const float v_up = static_cast<float>((e + 1) % 16) * 0.1f * (e + 1);
+    const float up_val = static_cast<float>(kMoeHiddenDim) * v_up;
+    const float geglu_val = ReferenceGeluTanh(up_val) * up_val;
+    const float v_down = static_cast<float>((e + 2) % 16) * 0.05f * (e + 1);
+    const float down_val = static_cast<float>(kMoeHalf) * geglu_val * v_down;
+    expected += router_weight * down_val;
+  }
+
+  auto out = req.get_output_tensor(0);
+  ASSERT_EQ(out.get_size(), static_cast<size_t>(kMoeHiddenDim));
+  const auto* out_data = out.data<float>();
+  for (size_t i = 0; i < out.get_size(); ++i) {
+    EXPECT_NEAR(out_data[i], expected, std::abs(expected) * 1e-3f + 1e-4f)
+        << "output[" << i
+        << "] does not match the hand-computed "
+           "contribution of experts {1,3} — the gather may be selecting "
+           "the wrong expert rows";
+  }
 }
 
 }  // namespace

--- a/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
+++ b/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
@@ -102,6 +102,12 @@ OpenVinoCompileContext::OpenVinoCompileContext() {
         context.sdpa_pad_kv_to_alignment_ = (value == "true");
         continue;
       }
+      if (key == "enable_moe_gather") {
+        LITERT_LOG(LITERT_INFO, "Custom config: enable_moe_gather = %s",
+                   value.c_str());
+        context.enable_moe_gather_ = (value == "true");
+        continue;
+      }
       context.configs_map_[key] = value;
       LITERT_LOG(LITERT_INFO, "Custom config: %s = %s", key.c_str(),
                  value.c_str());
@@ -184,6 +190,7 @@ void OpenVinoCompileContext::OptimizeModel(
         .SetEliminateMatMulFakeQuantize(eliminate_fq_after_matmul_)
         .SetFuseSplitAttentionToSDPA(fuse_split_attention_to_sdpa_)
         .SetSdpaPadKvToAlignment(sdpa_pad_kv_to_alignment_)
+        .SetEnableMoeGather(enable_moe_gather_)
         .Run(model);
   }
 }

--- a/litert/vendors/intel_openvino/compiler/openvino_compile_context.h
+++ b/litert/vendors/intel_openvino/compiler/openvino_compile_context.h
@@ -69,6 +69,9 @@ class OpenVinoCompileContext {
   ov::AnyMap configs_map_;
   bool eliminate_fq_after_matmul_ = false;
   bool fuse_split_attention_to_sdpa_ = false;
+  // Enables MoEGatherRewrite: turns Gemma4's dense masked MoE into gather-based
+  // selective (K-of-N) expert computation. Set via config "enable_moe_gather".
+  bool enable_moe_gather_ = false;
   // `sdpa_pad_kv_to_alignment_` is only meaningful when
   // `fuse_split_attention_to_sdpa_` is true and enabled by default. It controls
   // whether the `FuseSplitAttentionToSDPA` pass pads KV sequences up to the NPU


### PR DESCRIPTION
Rewrites Gemma4's dense MoE (128 experts) into selective K-of-N expert
computation via Gather operations, reducing NPU compute and memory
bandwidth. Stacks per-expert i4/u4 weights into grouped constants and
inserts Gather to select only K active experts. Rebuilds GEGLU as batched
operations over K experts, replacing 128-way masked Add chain.
    
Usage: Enable via config
--intel_openvino_configs_map="enable_moe_gather=true,NPU_COMPILER_DYNAMIC_QUANTIZATION=YES".