### PR TITLE
Fix integer overflow to out-of-bounds in vendored safetensors.h (OOB read/write)

### DIFF
--- a/tensor/examples/gemma3/safetensors.h
+++ b/tensor/examples/gemma3/safetensors.h
@@ -4646,14 +4646,7 @@ std::string get_dtype_str(const safetensors::dtype dtype) {
 
 // Empty Tensor returns 0.
 // Zero-rank Tensor reuturns 1(scalar)
-//
-// `ok` (when non-null) is set to false when the shape product overflows or the
-// tensor has an invalid number of dimensions, and to true otherwise. On
-// overflow / invalid ndim the function returns 0 and the caller must treat the
-// tensor as invalid rather than as an empty tensor. Returning 0 here used to
-// be indistinguishable from a legitimately empty tensor, which let a wrapped
-// product (e.g. [2^32, 2^32] -> 0) or an out-of-range ndim skip every bounds
-// check below in validate_data_offsets().
+// `ok`=false on overflow or out-of-range ndim (a 0 return is then invalid, not empty).
 size_t get_shape_size(const tensor_t& t, bool* ok) {
   if (t.shape.empty()) {
     if (ok) *ok = true;
@@ -4710,10 +4703,6 @@ bool validate_data_offsets(const safetensors_t& st, std::string& err) {
     }
 
     // Compute the tensor size with overflow / invalid-ndim detection.
-    // A wrapped product (e.g. [2^32, 2^32] -> 0) or an out-of-range ndim used
-    // to silently produce tensor_size == 0 here, which the `continue` below
-    // treated as a benign empty tensor, skipping the offset/size bounds checks
-    // and leaving attacker-chosen data_offsets unvalidated.
     bool shape_ok = true;
     size_t shape_size = get_shape_size(tensor, &shape_ok);
     if (!shape_ok) {
@@ -4732,8 +4721,7 @@ bool validate_data_offsets(const safetensors_t& st, std::string& err) {
       continue;
     }
 
-    // Offset bounds and (for the last tensor) full-buffer coverage must hold
-    // even for a legitimately empty tensor, so do NOT skip them on size == 0.
+    // Bounds checks run for every tensor, including legitimately empty (size == 0) ones.
 
     // data_offsets are absolute offset from the databuffer(file)
     if (tensor.data_offsets[0] > databuffersize) {

--- a/tensor/examples/gemma3/safetensors.h
+++ b/tensor/examples/gemma3/safetensors.h
@@ -280,7 +280,8 @@ bool save_to_memory(const std::string& filename, std::vector<uint8_t>* data_out,
 // Returns shape[0] * shape[1] * ...
 // Empty Tensor(any shape[i] is 0) returns 0.
 // Zero-rank tensor([]) return 1.
-size_t get_shape_size(const tensor_t& t);
+// `ok` (non-null) reports overflow / invalid ndim; see definition below.
+size_t get_shape_size(const tensor_t& t, bool* ok = nullptr);
 
 // Returns dtype size in bytes.
 size_t get_dtype_bytes(const safetensors::dtype dtype);
@@ -4645,21 +4646,35 @@ std::string get_dtype_str(const safetensors::dtype dtype) {
 
 // Empty Tensor returns 0.
 // Zero-rank Tensor reuturns 1(scalar)
-size_t get_shape_size(const tensor_t& t) {
+//
+// `ok` (when non-null) is set to false when the shape product overflows or the
+// tensor has an invalid number of dimensions, and to true otherwise. On
+// overflow / invalid ndim the function returns 0 and the caller must treat the
+// tensor as invalid rather than as an empty tensor. Returning 0 here used to
+// be indistinguishable from a legitimately empty tensor, which let a wrapped
+// product (e.g. [2^32, 2^32] -> 0) or an out-of-range ndim skip every bounds
+// check below in validate_data_offsets().
+size_t get_shape_size(const tensor_t& t, bool* ok) {
   if (t.shape.empty()) {
+    if (ok) *ok = true;
     return 1;
   }
 
   if (t.shape.size() >= kMaxDim) {  // invalid ndim
+    if (ok) *ok = false;
     return 0;
   }
 
   size_t sz = 1;
 
   for (size_t i = 0; i < t.shape.size(); i++) {
-    sz *= t.shape[i];
+    if (__builtin_mul_overflow(sz, t.shape[i], &sz)) {
+      if (ok) *ok = false;
+      return 0;
+    }
   }
 
+  if (ok) *ok = true;
   return sz;
 }
 
@@ -4694,12 +4709,31 @@ bool validate_data_offsets(const safetensors_t& st, std::string& err) {
       valid = false;
     }
 
-    size_t tensor_size = get_dtype_bytes(tensor.dtype) * get_shape_size(tensor);
-
-    if (tensor_size == 0) {
-      // OK
+    // Compute the tensor size with overflow / invalid-ndim detection.
+    // A wrapped product (e.g. [2^32, 2^32] -> 0) or an out-of-range ndim used
+    // to silently produce tensor_size == 0 here, which the `continue` below
+    // treated as a benign empty tensor, skipping the offset/size bounds checks
+    // and leaving attacker-chosen data_offsets unvalidated.
+    bool shape_ok = true;
+    size_t shape_size = get_shape_size(tensor, &shape_ok);
+    if (!shape_ok) {
+      ss << "Tensor `" << key
+         << "` has an invalid shape (overflowed size or out-of-range ndim).\n";
+      valid = false;
       continue;
     }
+
+    size_t dtype_bytes = get_dtype_bytes(tensor.dtype);
+    size_t tensor_size;
+    if (__builtin_mul_overflow(dtype_bytes, shape_size, &tensor_size)) {
+      ss << "Tensor `" << key
+         << "` size (dtype_bytes * shape_size) overflows.\n";
+      valid = false;
+      continue;
+    }
+
+    // Offset bounds and (for the last tensor) full-buffer coverage must hold
+    // even for a legitimately empty tensor, so do NOT skip them on size == 0.
 
     // data_offsets are absolute offset from the databuffer(file)
     if (tensor.data_offsets[0] > databuffersize) {


### PR DESCRIPTION
## Summary

`tensor/examples/gemma3/safetensors.h` is a vendored copy of the [safetensors-cpp](https://github.com/syoyo/safetensors-cpp) header. Its `validate_data_offsets()` — the only bounds check on tensor `data_offsets` — can be bypassed with a crafted `.safetensors` file, leading to an **out-of-bounds heap read and write** with attacker-controlled offset and length.

The example loader `safetensor_loader.cc` follows the library's documented contract (`validate_data_offsets()` at `:361`, then use `data_offsets[0]`/`data_offsets[1]` as byte bounds at `:393-394`), so the bypass yields attacker-controlled out-of-bounds pointers into the data buffer.

## Root cause — the zero short-circuit

The shape product is computed with unchecked `size_t` multiplication. A product that wraps to *exactly 0* is read as "empty tensor, nothing to validate" and the offset/size bounds checks are skipped:

```cpp
size_t tensor_size = get_dtype_bytes(tensor.dtype) * get_shape_size(tensor);  // unchecked mul
if (tensor_size == 0) { /* OK */ continue; }                                  // <-- bypass
if (tensor.data_offsets[0] > databuffersize) { ... }                          // SKIPPED
if (tensor.data_offsets[1] > databuffersize) { ... }                          // SKIPPED
if (tensor_size != data_size) { ... }                                         // SKIPPED
```

Zero is the one overflow result no size guard rejects — every guard checks for values that are too *large*. Two routes to `tensor_size == 0`:

### HUNT-001 — 64-bit wrap of the shape product
`sz *= t.shape[i]` (`safetensors.h:4660`) and `dtype_bytes * shape_size` (`:4697`) are unchecked `size_t` multiplies. `shape = [4294967296, 4294967296]` → `2^32 · 2^32 = 2^64 ≡ 0`. Every dimension is non-zero, so the tensor is not classified as empty and `data_offsets` are honoured verbatim.

### HUNT-002 — `kMaxDim` off-by-one (no overflow needed)
`parse_shape` accepts 8 dims (`dst.size() >= kMaxDim` before push) but `get_shape_size` rejects 8 dims (`t.shape.size() >= kMaxDim` → `return 0;`). An 8-dim all-ones tensor is valid to the parser but "invalid ndim" to the size computation → size 0 → skip all bounds checks. Triggered by an ordinary 8-dim all-ones tensor — no overflow, no large numbers.

## Impact — ASAN-confirmed

Verified with AddressSanitizer (`-O1`) against this exact vendored copy. Real `heap-buffer-overflow`, with **both offset and length attacker-chosen**:

**OOB WRITE** — allocate by declared shape (0 bytes), fill from the file's byte range (4096 bytes). The bypass skips the `tensor_size != data_size` equality check, so the two disagree by an arbitrary attacker-chosen amount:
```
validate_data_offsets() returned TRUE
tensor[0]: alloc 0 bytes, copy 4096 bytes
==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000000151
WRITE of size 4096 ... 0 bytes after 1-byte region
```
4096 bytes of attacker-supplied file content written past a 1-byte heap allocation. Length and content fully controlled → heap-metadata / adjacent-object corruption, an RCE-class primitive, not a DoS.

**OOB READ** — controlled adjacent-heap disclosure (data_offsets beyond the databuffer).

### Reference implementation rejects every PoC
The official `safetensors` Rust crate rejects all PoCs (`TensorInvalidInfo` / `ValidationOverflow` / `InvalidOffset`). `Metadata::validate()` uses `try_fold(1usize, usize::checked_mul)` and `.checked_mul(dtype.bitsize())`, has **no** `tensor_size == 0` early-out, and enforces offset contiguity, with named regression tests for exactly this class. The C++ port this header was vendored from is missing that defense.

## The fix

1. Use `__builtin_mul_overflow` for both the shape product and the `dtype_bytes * shape_size` product, returning an explicit overflow / invalid-ndim status instead of a bare `0`.
2. Remove the `tensor_size == 0 → continue` skip so the offset bounds and full-buffer coverage checks run for every tensor, including legitimately empty ones (whose offsets are valid 0-length ranges and still pass). A wrapped product now fails validation with a clear error instead of bypassing it.
3. `get_shape_size` takes an optional `bool *ok` out-param so callers can distinguish "overflowed/invalid → 0" from "genuinely empty → 0".

## Verification

AddressSanitizer harnesses (`-O1`, the level at which the optimizer keeps the allocation live), built against this vendored header:
- 3 attack tensors (64-bit wrap OOB-write, 8-dim OOB-write, C++ heap OOB-read) now **rejected** with descriptive errors; no ASAN violation.
- Legitimate normal tensors still load — **no regression**.

Minimal repro harness and PoC tensors available on request.

## Note

This is the same vulnerability as in the upstream `safetensors-cpp` repo (syoyo/safetensors-cpp); this PR fixes the vendored copy in LiteRT. The upstream fix is pending submission.