### PR TITLE
Qualcomm AI Engine Direct - Support LSTM and UnidirectionalSequenceLS…

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -1688,6 +1688,12 @@ LiteRtStatus AddTensorToQnn(
   if (created_tensors.count(&tensor)) {
     return kLiteRtStatusOk;
   }
+
+  if (tensor.IsTensorNull()) {
+    created_tensors.emplace(&tensor);
+    return kLiteRtStatusOk;
+  }
+
   auto error =
       qnn_api->tensorCreateGraphTensor(graph_handle, &(tensor.GetQnnTensor()));
   if (QNN_SUCCESS == error) {

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -613,6 +613,21 @@ cc_library(
 )
 
 cc_library(
+    name = "lstm_op_builder",
+    srcs = ["lstm_op_builder.cc"],
+    hdrs = ["lstm_op_builder.h"],
+    deps = [
+        ":op_builder",
+        "//litert/vendors/qualcomm/core:op_code",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/utils:log",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+cc_library(
     name = "onehot_op_builder",
     srcs = ["onehot_op_builder.cc"],
     hdrs = ["onehot_op_builder.h"],

--- a/litert/vendors/qualcomm/core/builders/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/builders/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(qnn_builders
         l2_norm_op_builder.cc
         leaky_relu_op_builder.cc
         logistic_op_builder.cc
+        lstm_op_builder.cc
         onehot_op_builder.cc
         matmul_op_builder.cc
         op_builder.cc

--- a/litert/vendors/qualcomm/core/builders/lstm_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/lstm_op_builder.cc
@@ -1,0 +1,184 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/lstm_op_builder.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/op_code.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "QnnOpDef.h"  // from @qairt
+
+namespace qnn {
+namespace {
+
+constexpr size_t kInput = 0;
+constexpr size_t kInputToInputWeights = 1;
+constexpr size_t kInputToForgetWeights = 2;
+constexpr size_t kInputToCellWeights = 3;
+constexpr size_t kInputToOutputWeights = 4;
+constexpr size_t kRecurrentToInputWeights = 5;
+constexpr size_t kRecurrentToForgetWeights = 6;
+constexpr size_t kRecurrentToCellWeights = 7;
+constexpr size_t kRecurrentToOutputWeights = 8;
+constexpr size_t kCellToInputWeights = 9;
+constexpr size_t kCellToForgetWeights = 10;
+constexpr size_t kCellToOutputWeights = 11;
+constexpr size_t kInputGateBias = 12;
+constexpr size_t kForgetGateBias = 13;
+constexpr size_t kCellGateBias = 14;
+constexpr size_t kOutputGateBias = 15;
+constexpr size_t kProjectionWeights = 16;
+constexpr size_t kProjectionBias = 17;
+constexpr size_t kOutputState = 18;
+constexpr size_t kCellState = 19;
+constexpr size_t kInputLayerNormCoefficients = 20;
+constexpr size_t kForgetLayerNormCoefficients = 21;
+constexpr size_t kCellLayerNormCoefficients = 22;
+constexpr size_t kOutputLayerNormCoefficients = 23;
+
+constexpr size_t kNumInputsNoLayerNorm = 20;
+constexpr size_t kNumInputsWithLayerNorm = 24;
+
+constexpr size_t kOutput = 0;
+
+constexpr size_t kQnnInputLayerNormCoefficients = 12;
+constexpr size_t kQnnForgetLayerNormCoefficients = 13;
+constexpr size_t kQnnCellLayerNormCoefficients = 14;
+constexpr size_t kQnnOutputLayerNormCoefficients = 15;
+
+constexpr float kGateQScale = 1.0f / 4096;
+
+}  // namespace
+
+std::vector<OpWrapper> BuildLstmOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, float cell_clip,
+    float proj_clip, bool time_major) {
+  std::vector<OpWrapper> res;
+
+  // FULL LSTM has 20 canonical inputs, plus four optional LayerNorm inputs.
+  const bool has_layer_norm = inputs.size() == kNumInputsWithLayerNorm;
+  if ((!has_layer_norm && inputs.size() != kNumInputsNoLayerNorm) ||
+      outputs.empty()) {
+    QNN_LOG_ERROR(
+        "LiteRT Lstm lowering expects %zu or %zu canonical FULL input slots "
+        "and at least one TFLite output, got %zu inputs and %zu outputs.",
+        kNumInputsNoLayerNorm, kNumInputsWithLayerNorm, inputs.size(),
+        outputs.size());
+    return res;
+  }
+
+  TensorWrapper& output_tensor = outputs[kOutput].get();
+  const TensorWrapper& cell_state_tensor = inputs[kCellState].get();
+
+  // A 2D LSTM maps its TFLite output to QNN out[2]. A 3D sequence LSTM maps
+  // the full sequence to out[0], while out[2] remains the final 2D step.
+  const bool is_sequence = output_tensor.GetRank() == 3;
+  TensorWrapper& input_layer_norm =
+      has_layer_norm ? inputs[kInputLayerNormCoefficients].get()
+                     : tensor_pool.CreateNullTensor();
+  TensorWrapper& forget_layer_norm =
+      has_layer_norm ? inputs[kForgetLayerNormCoefficients].get()
+                     : tensor_pool.CreateNullTensor();
+  TensorWrapper& cell_layer_norm =
+      has_layer_norm ? inputs[kCellLayerNormCoefficients].get()
+                     : tensor_pool.CreateNullTensor();
+  TensorWrapper& output_layer_norm =
+      has_layer_norm ? inputs[kOutputLayerNormCoefficients].get()
+                     : tensor_pool.CreateNullTensor();
+
+  std::vector<ConstTensorWrapperRef> lstm_inputs{
+      inputs[kInput].get(),
+      inputs[kInputToForgetWeights].get(),
+      inputs[kInputToCellWeights].get(),
+      inputs[kInputToOutputWeights].get(),
+      inputs[kRecurrentToForgetWeights].get(),
+      inputs[kRecurrentToCellWeights].get(),
+      inputs[kRecurrentToOutputWeights].get(),
+      inputs[kForgetGateBias].get(),
+      inputs[kCellGateBias].get(),
+      inputs[kOutputGateBias].get(),
+      inputs[kOutputState].get(),
+      inputs[kCellState].get(),
+      input_layer_norm,
+      forget_layer_norm,
+      cell_layer_norm,
+      output_layer_norm,
+      inputs[kInputToInputWeights].get(),
+      inputs[kRecurrentToInputWeights].get(),
+      inputs[kCellToInputWeights].get(),
+      inputs[kCellToForgetWeights].get(),
+      inputs[kCellToOutputWeights].get(),
+      inputs[kInputGateBias].get(),
+      inputs[kProjectionWeights].get(),
+      inputs[kProjectionBias].get(),
+      tensor_pool.CreateNullTensor()};
+
+  const std::vector<std::uint32_t>& seq_dims = output_tensor.GetDimensions();
+  std::vector<std::uint32_t> step_dims;
+  if (is_sequence) {
+    // Extract [batch, output] from either [time, batch, output] or
+    // [batch, time, output].
+    step_dims = {seq_dims[time_major ? 1 : 0], seq_dims.back()};
+  }
+
+  // QNN requires out[0] output state, out[1] cell state, and out[2] output.
+  TensorWrapper& output_state_out =
+      is_sequence ? output_tensor
+                  : tensor_pool.CloneNativeTensorFrom(output_tensor);
+  TensorWrapper& cell_state_out =
+      tensor_pool.CloneNativeTensorFrom(cell_state_tensor);
+  TensorWrapper& final_step_out =
+      is_sequence ? tensor_pool.CloneNativeTensorFrom(output_tensor, step_dims)
+                  : output_tensor;
+
+  const std::vector<ConstTensorWrapperRef> lstm_outputs{
+      output_state_out, cell_state_out, final_step_out};
+
+  res.emplace_back(CreateLstmOp(lstm_inputs, lstm_outputs, cell_clip, proj_clip,
+                                time_major, QNN_OP_LSTM_DIRECTION_FORWARD));
+  return res;
+}
+
+OpWrapper CreateLstmOp(const std::vector<ConstTensorWrapperRef>& inputs,
+                       const std::vector<ConstTensorWrapperRef>& outputs,
+                       float cell_clip, float proj_clip, bool time_major,
+                       std::uint32_t direction) {
+  OpWrapper op(GetUniqueOpName(QNN_OP_LSTM), QNN_OP_LSTM, QnnOpCode::kLstm);
+  for (const auto& input : inputs) {
+    op.AddInputTensor(input);
+  }
+  for (const auto& output : outputs) {
+    op.AddOutputTensor(output);
+  }
+
+  op.AddScalarParam<std::uint32_t>(QNN_OP_LSTM_PARAM_DIRECTION, direction);
+  op.AddScalarParam<float>(QNN_OP_LSTM_PARAM_CELL_CLIP_THRESHOLD, cell_clip);
+  op.AddScalarParam<float>(QNN_OP_LSTM_PARAM_OUTPUT_CLIP_THRESHOLD, proj_clip);
+  op.AddScalarParam<bool>(QNN_OP_LSTM_PARAM_TIME_MAJOR, time_major);
+
+  // Quantized non-LayerNorm FULL uses a 2^-12 gate qscales. LayerNorm omits
+  // them to match qnn-delegate and QNN HTP requirements.
+  const bool has_layer_norm =
+      !inputs[kQnnInputLayerNormCoefficients].get().IsTensorNull() ||
+      !inputs[kQnnForgetLayerNormCoefficients].get().IsTensorNull() ||
+      !inputs[kQnnCellLayerNormCoefficients].get().IsTensorNull() ||
+      !inputs[kQnnOutputLayerNormCoefficients].get().IsTensorNull();
+  if (inputs.front().get().IsQuant() && !has_layer_norm) {
+    op.AddScalarParam<float>(QNN_OP_LSTM_PARAM_INPUT_GATE_QSCALE, kGateQScale);
+    op.AddScalarParam<float>(QNN_OP_LSTM_PARAM_FORGET_GATE_QSCALE, kGateQScale);
+    op.AddScalarParam<float>(QNN_OP_LSTM_PARAM_CELL_GATE_QSCALE, kGateQScale);
+    op.AddScalarParam<float>(QNN_OP_LSTM_PARAM_OUTPUT_GATE_QSCALE, kGateQScale);
+  }
+
+  return op;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/lstm_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/lstm_op_builder.h
@@ -1,0 +1,36 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_LSTM_OP_BUILDER_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_LSTM_OP_BUILDER_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/builders/op_builder.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+// Lowers TFLite LSTM and UnidirectionalSequenceLSTM to QNN_OP_LSTM.
+//
+// Supports the canonical FULL kernel with float or quantized 2D (single step)
+// or 3D (sequence) input. The 20-slot form omits layer-normalization
+// coefficients; the 24-slot form maps them to QNN inputs 12 through 15.
+// The BASIC kernel is not supported.
+
+std::vector<OpWrapper> BuildLstmOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs, float cell_clip,
+    float proj_clip, bool time_major);
+
+OpWrapper CreateLstmOp(const std::vector<ConstTensorWrapperRef>& inputs,
+                       const std::vector<ConstTensorWrapperRef>& outputs,
+                       float cell_clip, float proj_clip, bool time_major,
+                       std::uint32_t direction);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_LSTM_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/core/tensor_pool.cc
+++ b/litert/vendors/qualcomm/core/tensor_pool.cc
@@ -61,6 +61,14 @@ TensorWrapper& TensorPool::CreateNativeTensorWithSuffix(
                                        quant_params, dimensions);
 }
 
+TensorWrapper& TensorPool::CreateNullTensor() {
+  const auto id = tensor_wrappers_.size();
+  auto tensor_name = std::to_string(id) + kQnnSuffix;
+  return tensor_wrappers_.emplace_back(
+      std::move(tensor_name), QNN_TENSOR_TYPE_NULL, QNN_DATATYPE_UNDEFINED,
+      QuantizeParamsWrapperVariant{}, std::vector<std::uint32_t>{});
+}
+
 TensorWrapper& TensorPool::CreateStaticTensor(
     Qnn_DataType_t data_type, const QuantizeParamsWrapperVariant& quant_params,
     const std::vector<std::uint32_t>& dimensions, std::uint32_t bytes,

--- a/litert/vendors/qualcomm/core/tensor_pool.h
+++ b/litert/vendors/qualcomm/core/tensor_pool.h
@@ -49,6 +49,8 @@ class TensorPool {
       const QuantizeParamsWrapperVariant& quant_params,
       const std::vector<std::uint32_t>& dimensions, std::string_view suffix);
 
+  TensorWrapper& CreateNullTensor();
+
   TensorWrapper& CreateStaticTensor(
       Qnn_DataType_t data_type,
       const QuantizeParamsWrapperVariant& quant_params,

--- a/litert/vendors/qualcomm/core/utils/qnn_model.cc
+++ b/litert/vendors/qualcomm/core/utils/qnn_model.cc
@@ -77,6 +77,9 @@ bool QnnModel::Finalize() {
       context_handle_, "test", DefaultGraphConfigs().data(), &graph_handle_));
   for (auto& op_wrapper : op_wrappers_) {
     for (const auto& tensor_wrapper_ref : op_wrapper.GetAllTensors()) {
+      if (tensor_wrapper_ref.get().IsTensorNull()) {
+        continue;
+      }
       if (!created_tensors.count(&(tensor_wrapper_ref.get()))) {
         QNN_RETURN_STATUS_IF_NOT_OK(api_->tensorCreateGraphTensor(
             graph_handle_, &(tensor_wrapper_ref.get().GetQnnTensor())));

--- a/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
+++ b/litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h
@@ -146,6 +146,10 @@ class TensorWrapper final {
     return GetTensorType() == QNN_TENSOR_TYPE_STATIC;
   }
 
+  bool IsTensorNull() const {
+    return GetTensorType() == QNN_TENSOR_TYPE_NULL;
+  }
+
   bool IsMarkedDump() const {
     return absl::EndsWith(name_, kDumpSuffix) &&
            qnn_tensor_.v2.type == QNN_TENSOR_TYPE_APP_READ;

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -267,6 +267,42 @@ litert_test(
 )
 
 litert_test(
+    name = "lstm_test",
+    srcs = [
+        "lstm_test.cc",
+    ],
+    linkopts = select({
+        "//litert:android": [],
+        "//conditions:default": [
+            make_rpaths([
+                "//litert/c:litert_runtime_c_api_so",
+            ]),
+        ],
+    }),
+    linkstatic = True,
+    no_main = True,
+    tags = [
+        "noasan",
+        "nomsan",
+        "nosan",
+        "notsan",
+    ],
+    target_compatible_with = _COMPATIBLE_OS,
+    ungrte = True,
+    use_sys_malloc = True,
+    deps = [
+        "//litert/vendors/qualcomm/core:op_code",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/builders:lstm_op_builder",
+        "//litert/vendors/qualcomm/core/utils:test_main",
+        "//litert/vendors/qualcomm/core/wrappers:quantize_params_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "@qairt//:qnn_lib_headers",
+    ] + _QNN_DEPS,
+)
+
+litert_test(
     name = "splitv_test",
     srcs = [
         "splitv_test.cc",

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/lstm_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/lstm_test.cc
@@ -1,0 +1,516 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <cstdlib>
+#include <cstdint>
+#include <fstream>
+#include <vector>
+
+#include "QnnTypes.h"  // from @qairt
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "litert/vendors/qualcomm/core/builders/lstm_op_builder.h"
+#include "litert/vendors/qualcomm/core/op_code.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/quantize_params_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+
+namespace litert::qnn {
+namespace {
+using testing::FloatNear;
+using testing::Pointwise;
+
+INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
+                         QnnTestPrinter);
+
+// Builds canonical FULL LSTM inputs in TFLite slot order. Per-slot data types
+// follow the INT8 row of the HTP op-definition supplement.
+std::vector<::qnn::TensorWrapperRef> CreateLstmInputs(
+    ::qnn::TensorPool& tensor_pool, std::uint32_t n_batch,
+    std::uint32_t n_input, std::uint32_t n_cell, bool with_layer_norm = false) {
+  static constexpr Qnn_DataType_t kActType{QNN_DATATYPE_UFIXED_POINT_8};
+  static constexpr Qnn_DataType_t kWeightType{QNN_DATATYPE_UFIXED_POINT_8};
+  static constexpr Qnn_DataType_t kBiasType{QNN_DATATYPE_SFIXED_POINT_32};
+  static constexpr Qnn_DataType_t kPeepholeType{QNN_DATATYPE_SFIXED_POINT_16};
+  static constexpr Qnn_DataType_t kCellStateType{QNN_DATATYPE_SFIXED_POINT_16};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kActQuant{1.0f / 256, 0};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kWeightQuant{1.0f / 256, 0};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kBiasQuant{1.0f / 65536, 0};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kPeepholeQuant{1.0f / 32768, 0};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kCellStateQuant{1.0f / 32768,
+                                                                0};
+  const std::vector<std::uint32_t> kInputDims{n_batch, n_input};
+  const std::vector<std::uint32_t> kInputWeightDims{n_cell, n_input};
+  const std::vector<std::uint32_t> kRecurrentWeightDims{n_cell, n_cell};
+  const std::vector<std::uint32_t> kPeepholeDims{n_cell};
+  const std::vector<std::uint32_t> kBiasDims{n_cell};
+  const std::vector<std::uint32_t> kProjectionDims{n_cell, n_cell};
+  const std::vector<std::uint32_t> kStateDims{n_batch, n_cell};
+
+  std::vector<::qnn::TensorWrapperRef> inputs{
+      tensor_pool.CreateInputTensorWithName("input", kActType, kActQuant,
+                                            kInputDims),
+      tensor_pool.CreateInputTensorWithName("input_to_input", kWeightType,
+                                            kWeightQuant, kInputWeightDims),
+      tensor_pool.CreateInputTensorWithName("input_to_forget", kWeightType,
+                                            kWeightQuant, kInputWeightDims),
+      tensor_pool.CreateInputTensorWithName("input_to_cell", kWeightType,
+                                            kWeightQuant, kInputWeightDims),
+      tensor_pool.CreateInputTensorWithName("input_to_output", kWeightType,
+                                            kWeightQuant, kInputWeightDims),
+      tensor_pool.CreateInputTensorWithName("recurrent_to_input", kWeightType,
+                                            kWeightQuant, kRecurrentWeightDims),
+      tensor_pool.CreateInputTensorWithName("recurrent_to_forget", kWeightType,
+                                            kWeightQuant, kRecurrentWeightDims),
+      tensor_pool.CreateInputTensorWithName("recurrent_to_cell", kWeightType,
+                                            kWeightQuant, kRecurrentWeightDims),
+      tensor_pool.CreateInputTensorWithName("recurrent_to_output", kWeightType,
+                                            kWeightQuant, kRecurrentWeightDims),
+      tensor_pool.CreateInputTensorWithName("cell_to_input", kPeepholeType,
+                                            kPeepholeQuant, kPeepholeDims),
+      tensor_pool.CreateInputTensorWithName("cell_to_forget", kPeepholeType,
+                                            kPeepholeQuant, kPeepholeDims),
+      tensor_pool.CreateInputTensorWithName("cell_to_output", kPeepholeType,
+                                            kPeepholeQuant, kPeepholeDims),
+      tensor_pool.CreateInputTensorWithName("input_gate_bias", kBiasType,
+                                            kBiasQuant, kBiasDims),
+      tensor_pool.CreateInputTensorWithName("forget_gate_bias", kBiasType,
+                                            kBiasQuant, kBiasDims),
+      tensor_pool.CreateInputTensorWithName("cell_gate_bias", kBiasType,
+                                            kBiasQuant, kBiasDims),
+      tensor_pool.CreateInputTensorWithName("output_gate_bias", kBiasType,
+                                            kBiasQuant, kBiasDims),
+      tensor_pool.CreateInputTensorWithName("projection_weights", kWeightType,
+                                            kWeightQuant, kProjectionDims),
+      tensor_pool.CreateInputTensorWithName("projection_bias", kBiasType,
+                                            kBiasQuant, kBiasDims),
+      tensor_pool.CreateInputTensorWithName("output_state", kActType, kActQuant,
+                                            kStateDims),
+      tensor_pool.CreateInputTensorWithName("cell_state", kCellStateType,
+                                            kCellStateQuant, kStateDims),
+  };
+
+  if (with_layer_norm) {
+    inputs.emplace_back(tensor_pool.CreateInputTensorWithName(
+        "input_layer_norm", kPeepholeType, kPeepholeQuant, kPeepholeDims));
+    inputs.emplace_back(tensor_pool.CreateInputTensorWithName(
+        "forget_layer_norm", kPeepholeType, kPeepholeQuant, kPeepholeDims));
+    inputs.emplace_back(tensor_pool.CreateInputTensorWithName(
+        "cell_layer_norm", kPeepholeType, kPeepholeQuant, kPeepholeDims));
+    inputs.emplace_back(tensor_pool.CreateInputTensorWithName(
+        "output_layer_norm", kPeepholeType, kPeepholeQuant, kPeepholeDims));
+  }
+
+  return inputs;
+}
+
+// Static FP32 weights for the numeric check. The recurrent weights and the
+// peepholes are zero and the projection is the identity, so each step of a
+// 2-input, 2-cell LSTM depends only on the input-to-* weights and the biases.
+std::vector<::qnn::TensorWrapperRef> CreateExecuteLstmInputs(
+    ::qnn::TensorPool& tensor_pool, ::qnn::TensorWrapper& input,
+    ::qnn::TensorWrapper& output_state, ::qnn::TensorWrapper& cell_state) {
+  static constexpr Qnn_DataType_t kType{QNN_DATATYPE_FLOAT_32};
+  static constexpr std::array<float, 4> kInputToInput{0.1f, 0.2f, 0.3f, 0.4f};
+  static constexpr std::array<float, 4> kInputToForget{0.05f, 0.10f, 0.15f,
+                                                       0.20f};
+  static constexpr std::array<float, 4> kInputToCell{0.20f, 0.10f, 0.05f,
+                                                     0.30f};
+  static constexpr std::array<float, 4> kInputToOutput{0.10f, 0.10f, 0.20f,
+                                                       0.20f};
+  static constexpr std::array<float, 4> kRecurrentZeros{0.0f, 0.0f, 0.0f, 0.0f};
+  static constexpr std::array<float, 2> kPeepholes{0.0f, 0.0f};
+  static constexpr std::array<float, 2> kInputGateBias{0.1f, 0.1f};
+  static constexpr std::array<float, 2> kForgetGateBias{0.2f, 0.2f};
+  static constexpr std::array<float, 2> kCellGateBias{0.0f, 0.0f};
+  static constexpr std::array<float, 2> kOutputGateBias{0.1f, 0.1f};
+  static constexpr std::array<float, 4> kProjectionIdentity{1.0f, 0.0f, 0.0f,
+                                                            1.0f};
+  static constexpr std::array<float, 2> kProjectionBias{0.0f, 0.0f};
+  const std::vector<std::uint32_t> kMatrixDims{2, 2};
+  const std::vector<std::uint32_t> kVectorDims{2};
+
+  auto make_static = [&tensor_pool](const std::vector<std::uint32_t>& dims,
+                                    const auto& data) -> ::qnn::TensorWrapper& {
+    return tensor_pool.CreateStaticTensor(kType, {}, dims,
+                                          sizeof(float) * data.size(),
+                                          data.data());
+  };
+
+  return {
+      input,
+      make_static(kMatrixDims, kInputToInput),
+      make_static(kMatrixDims, kInputToForget),
+      make_static(kMatrixDims, kInputToCell),
+      make_static(kMatrixDims, kInputToOutput),
+      make_static(kMatrixDims, kRecurrentZeros),
+      make_static(kMatrixDims, kRecurrentZeros),
+      make_static(kMatrixDims, kRecurrentZeros),
+      make_static(kMatrixDims, kRecurrentZeros),
+      make_static(kVectorDims, kPeepholes),
+      make_static(kVectorDims, kPeepholes),
+      make_static(kVectorDims, kPeepholes),
+      make_static(kVectorDims, kInputGateBias),
+      make_static(kVectorDims, kForgetGateBias),
+      make_static(kVectorDims, kCellGateBias),
+      make_static(kVectorDims, kOutputGateBias),
+      make_static(kMatrixDims, kProjectionIdentity),
+      make_static(kVectorDims, kProjectionBias),
+      output_state,
+      cell_state,
+  };
+}
+
+// Static quantized CIFG tensors for LayerNorm offline preparation. Peephole
+// and projection slots remain canonical nulls, matching the HTP-supported
+// LayerNorm pattern while still exercising the 24-slot FULL kernel form.
+std::vector<::qnn::TensorWrapperRef> CreateLayerNormOfflinePrepareInputs(
+    ::qnn::TensorPool& tensor_pool, ::qnn::TensorWrapper& input,
+    ::qnn::TensorWrapper& output_state, ::qnn::TensorWrapper& cell_state) {
+  static constexpr std::array<std::int8_t, 4> kWeights{64, -32, 16, 48};
+  static constexpr std::array<std::int32_t, 2> kBiases{1024, -512};
+  static constexpr std::array<std::int16_t, 2> kLayerNormCoefficients{
+      16384, 8192};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kWeightQuant{1.0f / 128, 0};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kBiasQuant{1.0f / 16384, 0};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kPeepholeQuant{1.0f / 32768,
+                                                                0};
+  const std::vector<std::uint32_t> kMatrixDims{2, 2};
+  const std::vector<std::uint32_t> kVectorDims{2};
+
+  auto make_static = [&tensor_pool](Qnn_DataType_t type, const auto& quant,
+                                    const std::vector<std::uint32_t>& dims,
+                                    const auto& data) -> ::qnn::TensorWrapper& {
+    return tensor_pool.CreateStaticTensor(type, quant, dims,
+                                          sizeof(data[0]) * data.size(),
+                                          data.data());
+  };
+  auto make_weight = [&]() -> ::qnn::TensorWrapper& {
+    return make_static(QNN_DATATYPE_SFIXED_POINT_8, kWeightQuant, kMatrixDims,
+                       kWeights);
+  };
+  auto make_bias = [&]() -> ::qnn::TensorWrapper& {
+    return make_static(QNN_DATATYPE_SFIXED_POINT_32, kBiasQuant, kVectorDims,
+                       kBiases);
+  };
+  auto make_layer_norm = [&]() -> ::qnn::TensorWrapper& {
+    return make_static(QNN_DATATYPE_SFIXED_POINT_16, kPeepholeQuant,
+                       kVectorDims, kLayerNormCoefficients);
+  };
+
+  return {
+      input,                          tensor_pool.CreateNullTensor(),
+      make_weight(),                  make_weight(),
+      make_weight(),                  tensor_pool.CreateNullTensor(),
+      make_weight(),                  make_weight(),
+      make_weight(),                  tensor_pool.CreateNullTensor(),
+      tensor_pool.CreateNullTensor(), tensor_pool.CreateNullTensor(),
+      tensor_pool.CreateNullTensor(), make_bias(),
+      make_bias(),                    make_bias(),
+      tensor_pool.CreateNullTensor(), tensor_pool.CreateNullTensor(),
+      output_state,                   cell_state,
+      tensor_pool.CreateNullTensor(), make_layer_norm(),
+      make_layer_norm(),              make_layer_norm(),
+  };
+}
+
+// The TFLite slot order differs from the QNN Lstm signature, so verify the
+// remap puts each tensor in the QNN slot the master op definition expects.
+TEST_P(QnnModelTest, LstmRemapsCanonicalFullSlots) {
+  static constexpr std::uint32_t kNumBatch{2};
+  static constexpr std::uint32_t kNumInput{3};
+  static constexpr std::uint32_t kNumCell{4};
+  static constexpr std::uint32_t kNumTime{5};
+  static constexpr float kCellClip{8.0f};
+  static constexpr float kProjClip{0.0f};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kActQuant{1.0f / 256, 0};
+
+  auto inputs = CreateLstmInputs(tensor_pool_, kNumBatch, kNumInput, kNumCell);
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_UFIXED_POINT_8, kActQuant, {kNumBatch, kNumCell});
+
+  auto ops = ::qnn::BuildLstmOp(tensor_pool_, inputs, {output_tensor},
+                                kCellClip, kProjClip, /*time_major=*/false);
+  ASSERT_EQ(ops.size(), 1u);
+  EXPECT_EQ(ops[0].GetOpCode(), ::qnn::QnnOpCode::kLstm);
+  ASSERT_EQ(ops[0].GetInputCount(), 25u);
+
+  // QNN slots 0-9: input, the three input-to-* and three recurrent-to-* gates,
+  // then the three gate biases -- all with the input-gate group excluded.
+  EXPECT_EQ(ops[0].GetInputTensor(0).GetName(), "input");
+  EXPECT_EQ(ops[0].GetInputTensor(1).GetName(), "input_to_forget");
+  EXPECT_EQ(ops[0].GetInputTensor(2).GetName(), "input_to_cell");
+  EXPECT_EQ(ops[0].GetInputTensor(3).GetName(), "input_to_output");
+  EXPECT_EQ(ops[0].GetInputTensor(4).GetName(), "recurrent_to_forget");
+  EXPECT_EQ(ops[0].GetInputTensor(5).GetName(), "recurrent_to_cell");
+  EXPECT_EQ(ops[0].GetInputTensor(6).GetName(), "recurrent_to_output");
+  EXPECT_EQ(ops[0].GetInputTensor(7).GetName(), "forget_gate_bias");
+  EXPECT_EQ(ops[0].GetInputTensor(8).GetName(), "cell_gate_bias");
+  EXPECT_EQ(ops[0].GetInputTensor(9).GetName(), "output_gate_bias");
+
+  // QNN slots 10-11: the two state inputs.
+  EXPECT_EQ(ops[0].GetInputTensor(10).GetName(), "output_state");
+  EXPECT_EQ(ops[0].GetInputTensor(11).GetName(), "cell_state");
+
+  // QNN slots 12-15 are the layer-norm weights, which HTP does not support, so
+  // the builder leaves them unconnected.
+  for (std::uint32_t i = 12; i < 16; ++i) {
+    EXPECT_TRUE(ops[0].GetInputTensor(i).IsTensorNull());
+  }
+
+  // QNN slots 16-23: the input-gate group, peepholes and projection, which
+  // TFLite places before the state tensors.
+  EXPECT_EQ(ops[0].GetInputTensor(16).GetName(), "input_to_input");
+  EXPECT_EQ(ops[0].GetInputTensor(17).GetName(), "recurrent_to_input");
+  EXPECT_EQ(ops[0].GetInputTensor(18).GetName(), "cell_to_input");
+  EXPECT_EQ(ops[0].GetInputTensor(19).GetName(), "cell_to_forget");
+  EXPECT_EQ(ops[0].GetInputTensor(20).GetName(), "cell_to_output");
+  EXPECT_EQ(ops[0].GetInputTensor(21).GetName(), "input_gate_bias");
+  EXPECT_EQ(ops[0].GetInputTensor(22).GetName(), "projection_weights");
+  EXPECT_EQ(ops[0].GetInputTensor(23).GetName(), "projection_bias");
+
+  // QNN slot 24 is the reset signal, only meaningful for a 3D input.
+  EXPECT_TRUE(ops[0].GetInputTensor(24).IsTensorNull());
+
+  // TFLite exposes only the final output, so the builder must synthesize the
+  // two state outputs QNN requires; the TFLite output lands in slot 2.
+  EXPECT_EQ(ops[0].GetOutputTensor(2).GetName(), "output");
+
+  // For a 3D output the TFLite tensor moves to out[0] and out[2] becomes the
+  // synthesized final step, which is always [batch, output] however time_major
+  // orders out[0]. Check both orderings, since taking the trailing two
+  // dimensions happens to be right only for the time-major one.
+  const std::vector<std::uint32_t> kStepDims{kNumBatch, kNumCell};
+  for (const bool time_major : {false, true}) {
+    const std::vector<std::uint32_t> seq_dims =
+        time_major ? std::vector<std::uint32_t>{kNumTime, kNumBatch, kNumCell}
+                   : std::vector<std::uint32_t>{kNumBatch, kNumTime, kNumCell};
+    auto& seq_output = tensor_pool_.CreateOutputTensorWithName(
+        time_major ? "seq_time_major" : "seq_batch_major",
+        QNN_DATATYPE_UFIXED_POINT_8, kActQuant, seq_dims);
+    auto seq_ops = ::qnn::BuildLstmOp(tensor_pool_, inputs, {seq_output},
+                                      kCellClip, kProjClip, time_major);
+    ASSERT_EQ(seq_ops.size(), 1u);
+    EXPECT_EQ(seq_ops[0].GetOutputTensor(0).GetDimensions(), seq_dims);
+    EXPECT_EQ(seq_ops[0].GetOutputTensor(2).GetDimensions(), kStepDims);
+  }
+
+}
+
+TEST_P(QnnModelTest, LstmRemapsLayerNormFullSlots) {
+  static constexpr std::uint32_t kNumBatch{1};
+  static constexpr std::uint32_t kNumInput{3};
+  static constexpr std::uint32_t kNumCell{4};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kActQuant{1.0f / 256, 0};
+
+  auto inputs =
+      CreateLstmInputs(tensor_pool_, kNumBatch, kNumInput, kNumCell, true);
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_UFIXED_POINT_8, kActQuant, {kNumBatch, kNumCell});
+
+  auto ops = ::qnn::BuildLstmOp(tensor_pool_, inputs, {output_tensor},
+                                /*cell_clip=*/0.0f, /*proj_clip=*/0.0f,
+                                /*time_major=*/false);
+  ASSERT_EQ(ops.size(), 1u);
+  ASSERT_EQ(ops[0].GetInputCount(), 25u);
+  EXPECT_EQ(ops[0].GetInputTensor(12).GetName(), "input_layer_norm");
+  EXPECT_EQ(ops[0].GetInputTensor(13).GetName(), "forget_layer_norm");
+  EXPECT_EQ(ops[0].GetInputTensor(14).GetName(), "cell_layer_norm");
+  EXPECT_EQ(ops[0].GetInputTensor(15).GetName(), "output_layer_norm");
+}
+
+TEST_P(QnnModelTest, LstmPreservesCanonicalOptionalSlots) {
+  static constexpr std::uint32_t kNumBatch{1};
+  static constexpr std::uint32_t kNumInput{3};
+  static constexpr std::uint32_t kNumCell{4};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kActQuant{1.0f / 256, 0};
+
+  auto inputs = CreateLstmInputs(tensor_pool_, kNumBatch, kNumInput, kNumCell);
+  auto& null_tensor = tensor_pool_.CreateNullTensor();
+  inputs[1] = null_tensor;   // input_to_input_weights
+  inputs[5] = null_tensor;   // recurrent_to_input_weights
+  inputs[9] = null_tensor;   // cell_to_input_weights
+  inputs[10] = null_tensor;  // cell_to_forget_weights
+  inputs[11] = null_tensor;  // cell_to_output_weights
+  inputs[12] = null_tensor;  // input_gate_bias
+  inputs[16] = null_tensor;  // projection_weights
+  inputs[17] = null_tensor;  // projection_bias
+
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_UFIXED_POINT_8, kActQuant, {kNumBatch, kNumCell});
+  auto ops = ::qnn::BuildLstmOp(tensor_pool_, inputs, {output_tensor},
+                                /*cell_clip=*/0.0f, /*proj_clip=*/0.0f,
+                                /*time_major=*/false);
+
+  ASSERT_EQ(ops.size(), 1u);
+  EXPECT_TRUE(ops[0].GetInputTensor(16).IsTensorNull());
+  EXPECT_TRUE(ops[0].GetInputTensor(17).IsTensorNull());
+  EXPECT_TRUE(ops[0].GetInputTensor(18).IsTensorNull());
+  EXPECT_TRUE(ops[0].GetInputTensor(19).IsTensorNull());
+  EXPECT_TRUE(ops[0].GetInputTensor(20).IsTensorNull());
+  EXPECT_TRUE(ops[0].GetInputTensor(21).IsTensorNull());
+  EXPECT_TRUE(ops[0].GetInputTensor(22).IsTensorNull());
+  EXPECT_TRUE(ops[0].GetInputTensor(23).IsTensorNull());
+}
+
+// The remap above is checked in isolation. This drives the op through the QNN
+// backend so the HTP validator and the graph finalizer confirm the slot order
+// is the one QNN expects. Uses the quantized form, which additionally needs
+// the per-gate quantization scales a float Lstm does not.
+TEST_P(QnnModelTest, LstmQuantizedFinalizesOnQnnBackend) {
+  static constexpr std::uint32_t kNumBatch{1};
+  static constexpr std::uint32_t kNumInput{4};
+  static constexpr std::uint32_t kNumCell{4};
+  static constexpr float kCellClip{0.0f};
+  static constexpr float kProjClip{0.0f};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kActQuant{1.0f / 256, 0};
+
+  auto inputs = CreateLstmInputs(tensor_pool_, kNumBatch, kNumInput, kNumCell);
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_UFIXED_POINT_8, kActQuant, {kNumBatch, kNumCell});
+
+  auto ops = ::qnn::BuildLstmOp(tensor_pool_, inputs, {output_tensor},
+                                kCellClip, kProjClip, /*time_major=*/false);
+  ASSERT_FALSE(ops.empty());
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+}
+
+TEST_P(QnnModelTest, LstmQuantizedLayerNormPrepareAndExecute) {
+  static constexpr std::uint32_t kNumBatch{1};
+  static constexpr std::uint32_t kNumCell{2};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kActQuant{1.0f / 128, -128};
+  const ::qnn::ScaleOffsetQuantizeParamsWrapper kCellStateQuant{1.0f / 32768,
+                                                                0};
+
+  auto& input_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input", QNN_DATATYPE_UFIXED_POINT_8, kActQuant, {kNumBatch, kNumCell});
+  auto& output_state_tensor = tensor_pool_.CreateInputTensorWithName(
+      "output_state", QNN_DATATYPE_UFIXED_POINT_8, kActQuant,
+      {kNumBatch, kNumCell});
+  auto& cell_state_tensor = tensor_pool_.CreateInputTensorWithName(
+      "cell_state", QNN_DATATYPE_SFIXED_POINT_16, kCellStateQuant,
+      {kNumBatch, kNumCell});
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_UFIXED_POINT_8, kActQuant, {kNumBatch, kNumCell});
+
+#if defined(__ANDROID__)
+  auto input_idx = qnn_model_.AddInputTensor(input_tensor);
+  auto output_state_idx = qnn_model_.AddInputTensor(output_state_tensor);
+  auto cell_state_idx = qnn_model_.AddInputTensor(cell_state_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+#endif
+
+  auto inputs = CreateLayerNormOfflinePrepareInputs(
+      tensor_pool_, input_tensor, output_state_tensor, cell_state_tensor);
+  auto ops = ::qnn::BuildLstmOp(tensor_pool_, inputs, {output_tensor},
+                                /*cell_clip=*/0.0f, /*proj_clip=*/0.0f,
+                                /*time_major=*/false);
+  ASSERT_FALSE(ops.empty());
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if defined(__ANDROID__)
+  static constexpr std::array<std::uint8_t, 2> kZeroActivation{128, 128};
+  static constexpr std::array<std::int16_t, 2> kZeroCellState{0, 0};
+  ASSERT_TRUE(qnn_model_.SetInputData<std::uint8_t>(input_idx,
+                                                    kZeroActivation));
+  ASSERT_TRUE(qnn_model_.SetInputData<std::uint8_t>(output_state_idx,
+                                                    kZeroActivation));
+  ASSERT_TRUE(qnn_model_.SetInputData<std::int16_t>(cell_state_idx,
+                                                    kZeroCellState));
+                                                    
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<std::uint8_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  EXPECT_THAT(output_data.value(), testing::ElementsAre(0, 0));
+#endif
+
+  const char* context_binary_path =
+      std::getenv("LITERT_QNN_CONTEXT_BINARY_OUTPUT");
+  if (context_binary_path != nullptr) {
+    std::vector<char> context_binary;
+    ASSERT_EQ(qnn_manager_ptr_->GenerateContextBinary(context_handle_.Get(),
+                                                       context_binary),
+              kLiteRtStatusOk);
+    std::ofstream output(context_binary_path,
+                         std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(output.is_open());
+    output.write(context_binary.data(), context_binary.size());
+    ASSERT_TRUE(output.good());
+  }
+}
+
+// A 3D input is a time-major sequence: TFLite's UnidirectionalSequenceLSTM
+// emits the full [time, batch, output] sequence (the kernel resizes the output
+// to the input shape), which QNN exposes on out[0], not on the final-step
+// out[2]. So the builder must route the TFLite output to out[0] for a 3D
+// input; had it kept it on out[2] the shapes would not match and Finalize
+// would fail, which is what this covers when no device is present. On a real
+// HTP it also checks the values, pinning the output order rather than just the
+// shape. Two steps let the per-step values differ so a final-step-only bug
+// shows in the goldens.
+TEST_P(QnnModelTest, LstmExecutesTimeMajorSequence) {
+  static constexpr std::uint32_t kNumTime{2};
+  static constexpr std::uint32_t kNumBatch{1};
+  static constexpr std::uint32_t kNumInput{2};
+  static constexpr std::uint32_t kNumCell{2};
+  static constexpr float kCellClip{0.0f};
+  static constexpr float kProjClip{0.0f};
+  // Time-major [time, batch, input]: step 0 = {1, 2}, step 1 = {2, 1}.
+  static constexpr std::array<float, 4> kInputData{1.0f, 2.0f, 2.0f, 1.0f};
+  // Full [time, batch, output] sequence from zeroed state, computed from the
+  // reference LSTM equations.
+  static constexpr std::array<float, 4> kExpectedSequence{
+      0.1439910f, 0.2760279f, 0.2449168f, 0.3485698f};
+
+  auto& input_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input", QNN_DATATYPE_FLOAT_32, {}, {kNumTime, kNumBatch, kNumInput});
+  auto& output_state_tensor = tensor_pool_.CreateInputTensorWithName(
+      "output_state", QNN_DATATYPE_FLOAT_32, {}, {kNumBatch, kNumCell});
+  auto& cell_state_tensor = tensor_pool_.CreateInputTensorWithName(
+      "cell_state", QNN_DATATYPE_FLOAT_32, {}, {kNumBatch, kNumCell});
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_FLOAT_32, {}, {kNumTime, kNumBatch, kNumCell});
+
+  auto inputs = CreateExecuteLstmInputs(tensor_pool_, input_tensor,
+                                        output_state_tensor, cell_state_tensor);
+  auto ops = ::qnn::BuildLstmOp(tensor_pool_, inputs, {output_tensor},
+                                kCellClip, kProjClip, /*time_major=*/true);
+  ASSERT_FALSE(ops.empty());
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input_idx = qnn_model_.AddInputTensor(input_tensor);
+  auto output_state_idx = qnn_model_.AddInputTensor(output_state_tensor);
+  auto cell_state_idx = qnn_model_.AddInputTensor(cell_state_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+  qnn_model_.SetInputData<float>(input_idx, kInputData);
+  qnn_model_.SetInputData<float>(output_state_idx, {0.0f, 0.0f});
+  qnn_model_.SetInputData<float>(cell_state_idx, {0.0f, 0.0f});
+
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<float>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_THAT(output_data.value(),
+              Pointwise(FloatNear(1e-3), kExpectedSequence));
+}
+
+}  // namespace
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/tests/CMakeLists.txt
+++ b/litert/vendors/qualcomm/tests/CMakeLists.txt
@@ -113,6 +113,7 @@ target_sources(builder_test
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/elementwise_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/fully_connected_int2_test.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/lstm_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/pack_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/pad_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/relu_test.cc


### PR DESCRIPTION

# What
  - Add BuildLstmOp/CreateLstmOp in lstm_op_builder.cc/.h lowering the
    canonical FULL-kernel LSTM signature to QNN_OP_LSTM: remap TFLite's
    20/24-slot layout to QNN's fixed 25-slot signature (LayerNorm
    coefficients sit at QNN in[12..15], not the tail), and route 3D
    sequence output to QNN out[0] instead of out[2] per MasterOpDef.
  - Add QNN_TENSOR_TYPE_NULL support (TensorPool::CreateNullTensor,
    TensorWrapper::IsTensorNull) to fill unused optional/reset slots
    without shifting the signature; skip null tensors in
    qnn_model.cc::Finalize and qnn_compose_graph.cc::AddTensorToQnn.
  - Only support the FULL kernel; quantized non-LayerNorm paths add the
    TFLite-reference Q3.12 gate qscale (2^-12), while LayerNorm FULL
    omits it per qnn-delegate parity.
  - Add lstm_test.cc with 3 tests: canonical FULL slot remapping
    (including 2D/3D output routing), quantized CIFG LayerNorm
    prepare+execute, and a TFLite-reference-golden Cifg+peephole
    time-major sequence.


## Verification

- [ ] Developer-Verified

# Test

- Passed x86 unit test.
- Passed android unit test.
  - SM8850
  - SM8750
  - SM8650

- x86

======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:lstm_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:lstm_test        PASSED in 0.4s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 1.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 56.0s

- on device

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 25 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 25 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 18 tests from 12 test suites ran. (1 ms total)
[  PASSED  ] 18 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (28 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 36 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (3 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (4 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 29 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 29 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (32 ms total)
[  PASSED  ] 13 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (5 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (589 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (242 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (973 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (563 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1907 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1746 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (900 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1731 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:lstm_test
[==========] 3 tests from 1 test suite ran. (1090 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (5 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (48 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (615 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (5964 ms total)
[  PASSED  ] 26 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (42 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (19 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (777 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (608 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (528 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/c/options:litert_qualcomm_options_test
[==========] 25 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 25 tests.

SM8750: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 18 tests from 12 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8750: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (11 ms total)
[  PASSED  ] 16 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 36 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8750: //litert/vendors/qualcomm/core:common_test
[==========] 29 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 29 tests.

SM8750: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (23 ms total)
[  PASSED  ] 13 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (320 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (130 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (551 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (314 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1394 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1335 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (639 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1153 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:lstm_test
[==========] 3 tests from 1 test suite ran. (748 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (9 ms total)
[  PASSED  ] 9 tests.

SM8750: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (615 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (3991 ms total)
[  PASSED  ] 26 tests.

SM8750: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (13 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (7 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (500 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (405 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (387 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 25 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 25 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 18 tests from 12 test suites ran. (0 ms total)
[  PASSED  ] 18 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 36 tests from 3 test suites ran. (5 ms total)
[  PASSED  ] 36 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (0 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 29 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 29 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 13 tests from 5 test suites ran. (9 ms total)
[  PASSED  ] 13 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (334 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (152 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (551 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (301 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1277 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1255 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (708 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1303 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:lstm_test
[==========] 3 tests from 1 test suite ran. (794 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (17 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (602 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (4518 ms total)
[  PASSED  ] 26 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (9 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (10 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (596 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (462 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (423 ms total)
[  PASSED  ] 2 tests.