### PR TITLE
Qualcomm AI Engine Direct - Support ADD_N Op.

### DIFF
--- a/litert/vendors/qualcomm/compiler/BUILD
+++ b/litert/vendors/qualcomm/compiler/BUILD
@@ -265,6 +265,7 @@ litert_lib(
         "//litert/vendors/qualcomm/core:op_code",
         "//litert/vendors/qualcomm/core:tensor_pool",
         "//litert/vendors/qualcomm/core/backends:qnn_backend",
+        "//litert/vendors/qualcomm/core/builders:addn_op_builder",
         "//litert/vendors/qualcomm/core/builders:arg_min_max_op_builder",
         "//litert/vendors/qualcomm/core/builders:broadcast_to_op_builder",
         "//litert/vendors/qualcomm/core/builders:cast_op_builder",

--- a/litert/vendors/qualcomm/compiler/Qualcomm_QNN_Compiler.md
+++ b/litert/vendors/qualcomm/compiler/Qualcomm_QNN_Compiler.md
@@ -43,6 +43,7 @@ provides the corresponding QNN operation it is legalized to.
 | :--- | :--- |
 | `kLiteRtOpCodeTflAbs` | Legalized to `QNN_OP_ELEMENT_WISE_UNARY` (ABS). |
 | `kLiteRtOpCodeTflAdd` | Legalized to `QNN_OP_ELEMENT_WISE_BINARY` (ADD). Supports fused activation. |
+| `kLiteRtOpCodeTflAddN` | Legalized to a chain of N-1 `QNN_OP_ELEMENT_WISE_BINARY` (ADD). FLOAT32 and INT32 only. |
 | `kLiteRtOpCodeTflArgMax` | Legalized to `QNN_OP_ARGMAX`. |
 | `kLiteRtOpCodeTflArgMin` | Legalized to `QNN_OP_ARGMIN`. |
 | `kLiteRtOpCodeTflAveragePool2d` | Legalized to `QNN_OP_POOL_AVG_2D`. Supports fused activation. |

--- a/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compose_graph.cc
@@ -53,6 +53,7 @@
 #include "litert/vendors/qualcomm/common.h"
 #include "litert/vendors/qualcomm/compiler/graph_mapper.h"
 #include "litert/vendors/qualcomm/core/backends/qnn_backend.h"
+#include "litert/vendors/qualcomm/core/builders/addn_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/arg_min_max_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/broadcast_to_op_builder.h"
 #include "litert/vendors/qualcomm/core/builders/cast_op_builder.h"
@@ -556,6 +557,7 @@ REGISTER_SIMPLE_OP_BUILDER(BuildSignOp, BuildElementwiseSignOp)
 REGISTER_SIMPLE_OP_BUILDER(BuildScatterNdOp, BuildScatterNdOp)
 REGISTER_SIMPLE_OP_BUILDER(BuildBatchToSpaceNdOp, BuildBatchToSpaceNdOp)
 REGISTER_SIMPLE_OP_BUILDER(BuildSpaceToBatchNdOp, BuildSpaceToBatchNdOp)
+REGISTER_SIMPLE_OP_BUILDER(BuildAddNOp, BuildAddNOp)
 
 #undef REGISTER_SIMPLE_OP_BUILDER
 
@@ -1506,6 +1508,7 @@ constexpr std::array<OpBuilder, kLiteRtOpCodeShloComposite + 1>
 GetOpBuilders() {
   std::array<OpBuilder, kLiteRtOpCodeShloComposite + 1> builders{};
   builders[kLiteRtOpCodeTflAdd] = Adapt<BuildAddOp>;
+  builders[kLiteRtOpCodeTflAddN] = Adapt<BuildAddNOp>;
   builders[kLiteRtOpCodeTflAveragePool2d] = Adapt<BuildAveragePool2dOp>;
   builders[kLiteRtOpCodeTflConcatenation] = Adapt<BuildConcatenationOp>;
   builders[kLiteRtOpCodeTflConv2d] = Adapt<BuildConv2dOp>;

--- a/litert/vendors/qualcomm/core/builders/BUILD
+++ b/litert/vendors/qualcomm/core/builders/BUILD
@@ -27,6 +27,20 @@ cc_library(
 )
 
 cc_library(
+    name = "addn_op_builder",
+    srcs = ["addn_op_builder.cc"],
+    hdrs = ["addn_op_builder.h"],
+    deps = [
+        ":elementwise_op_builder",
+        "//litert/vendors/qualcomm/core:tensor_pool",
+        "//litert/vendors/qualcomm/core/utils:log",
+        "//litert/vendors/qualcomm/core/wrappers:op_wrapper",
+        "//litert/vendors/qualcomm/core/wrappers:tensor_wrapper",
+        "@qairt//:qnn_lib_headers",
+    ],
+)
+
+cc_library(
     name = "elementwise_op_builder",
     srcs = ["elementwise_op_builder.cc"],
     hdrs = ["elementwise_op_builder.h"],

--- a/litert/vendors/qualcomm/core/builders/CMakeLists.txt
+++ b/litert/vendors/qualcomm/core/builders/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(qnn_builders STATIC)
 
 target_sources(qnn_builders
     PRIVATE
+        addn_op_builder.cc
         arg_min_max_op_builder.cc
         broadcast_to_op_builder.cc
         cast_op_builder.cc

--- a/litert/vendors/qualcomm/core/builders/addn_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/addn_op_builder.cc
@@ -1,0 +1,62 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "litert/vendors/qualcomm/core/builders/addn_op_builder.h"
+
+#include <cstddef>
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/builders/elementwise_op_builder.h"
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/utils/log.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildAddNOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs) {
+  std::vector<OpWrapper> res;
+
+  constexpr size_t kMinNumInputs = 2;
+  if (inputs.size() < kMinNumInputs || outputs.size() != 1) {
+    QNN_LOG_ERROR("AddN op expects at least 2 inputs and only 1 output.");
+    return res;
+  }
+
+  for (const TensorWrapper& input : inputs) {
+    if (input.IsQuant()) {
+      QNN_LOG_ERROR("AddN op does not support quantized inputs.");
+      return res;
+    }
+  }
+
+  TensorWrapper& output_tensor = outputs[0];
+  if (output_tensor.IsQuant()) {
+    QNN_LOG_ERROR("AddN op does not support quantized outputs.");
+    return res;
+  }
+
+  if (inputs.size() == kMinNumInputs) {
+    res.emplace_back(
+        CreateElementWiseAddOp(inputs[0], inputs[1], output_tensor));
+    return res;
+  }
+
+  TensorWrapperRef accumulator = tensor_pool.CloneNativeTensorFrom(inputs[0]);
+  res.emplace_back(CreateElementWiseAddOp(inputs[0], inputs[1], accumulator));
+
+  for (size_t i = kMinNumInputs; i < inputs.size(); ++i) {
+    const bool is_last = (i == inputs.size() - 1);
+    TensorWrapper& add_output =
+        is_last ? output_tensor : tensor_pool.CloneNativeTensorFrom(inputs[0]);
+    res.emplace_back(
+        CreateElementWiseAddOp(accumulator, inputs[i], add_output));
+    accumulator = add_output;
+  }
+
+  return res;
+}
+
+}  // namespace qnn

--- a/litert/vendors/qualcomm/core/builders/addn_op_builder.h
+++ b/litert/vendors/qualcomm/core/builders/addn_op_builder.h
@@ -1,0 +1,21 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_ADDN_OP_BUILDER_H_
+#define ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_ADDN_OP_BUILDER_H_
+
+#include <vector>
+
+#include "litert/vendors/qualcomm/core/tensor_pool.h"
+#include "litert/vendors/qualcomm/core/wrappers/op_wrapper.h"
+#include "litert/vendors/qualcomm/core/wrappers/tensor_wrapper.h"
+
+namespace qnn {
+
+std::vector<OpWrapper> BuildAddNOp(
+    TensorPool& tensor_pool, const std::vector<TensorWrapperRef>& inputs,
+    const std::vector<TensorWrapperRef>& outputs);
+
+}  // namespace qnn
+
+#endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_BUILDERS_ADDN_OP_BUILDER_H_

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/BUILD
@@ -578,3 +578,36 @@ litert_test(
         "@qairt//:qnn_lib_headers",
     ] + _QNN_DEPS,
 )
+
+litert_test(
+    name = "addn_test",
+    srcs = [
+        "addn_test.cc",
+    ],
+    linkopts = select({
+        "//litert:android": [],
+        "//conditions:default": [
+            make_rpaths([
+                "//litert/c:litert_runtime_c_api_so",
+            ]),
+        ],
+    }),
+    linkstatic = True,
+    no_main = True,
+    tags = [
+        "noasan",
+        "nomsan",
+        "nosan",
+        "notsan",
+    ],
+    target_compatible_with = _COMPATIBLE_OS,
+    ungrte = True,
+    use_sys_malloc = True,
+    deps = [
+        "//litert/vendors/qualcomm/core:op_code",
+        "//litert/vendors/qualcomm/core/builders:addn_op_builder",
+        "//litert/vendors/qualcomm/core/utils:test_main",
+        "//litert/vendors/qualcomm/qnn_backend_test:test_utils",
+        "@qairt//:qnn_lib_headers",
+    ] + _QNN_DEPS,
+)

--- a/litert/vendors/qualcomm/qnn_backend_test/builder_test/addn_test.cc
+++ b/litert/vendors/qualcomm/qnn_backend_test/builder_test/addn_test.cc
@@ -1,0 +1,151 @@
+// Copyright (c) Qualcomm Innovation Center, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "QnnTypes.h"  // from @qairt
+#include "litert/vendors/qualcomm/core/builders/addn_op_builder.h"
+#include "litert/vendors/qualcomm/core/op_code.h"
+#include "litert/vendors/qualcomm/qnn_backend_test/test_utils.h"
+
+namespace litert::qnn {
+namespace {
+using testing::FloatNear;
+using testing::Pointwise;
+
+INSTANTIATE_TEST_SUITE_P(, QnnModelTest, GetDefaultQnnModelParams(),
+                         QnnTestPrinter);
+
+TEST_P(QnnModelTest, AddNThreeInputs) {
+  const std::vector<std::uint32_t> kDims{1, 2, 2, 1};
+
+  auto& input0_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input0", QNN_DATATYPE_FLOAT_32, {}, kDims);
+  auto& input1_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input1", QNN_DATATYPE_FLOAT_32, {}, kDims);
+  auto& input2_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input2", QNN_DATATYPE_FLOAT_32, {}, kDims);
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_FLOAT_32, {}, kDims);
+
+  auto ops = ::qnn::BuildAddNOp(tensor_pool_,
+                                {input0_tensor, input1_tensor, input2_tensor},
+                                {output_tensor});
+  ASSERT_EQ(ops.size(), 2u);
+  EXPECT_EQ(ops[0].GetOpCode(), ::qnn::QnnOpCode::kElementWiseBinary);
+  EXPECT_EQ(ops[1].GetOpCode(), ::qnn::QnnOpCode::kElementWiseBinary);
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input0_idx = qnn_model_.AddInputTensor(input0_tensor);
+  auto input1_idx = qnn_model_.AddInputTensor(input1_tensor);
+  auto input2_idx = qnn_model_.AddInputTensor(input2_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+  qnn_model_.SetInputData<float>(input0_idx, {-2.0f, 0.2f, 0.7f, 0.8f});
+  qnn_model_.SetInputData<float>(input1_idx, {0.1f, 0.2f, 0.3f, 0.5f});
+  qnn_model_.SetInputData<float>(input2_idx, {0.5f, 0.1f, 0.1f, 0.2f});
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<float>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_THAT(output_data.value(),
+              Pointwise(FloatNear(1e-3), {-1.4f, 0.5f, 1.1f, 1.5f}));
+}
+
+TEST_P(QnnModelTest, AddNTwoInputsEmitsSingleAdd) {
+  const std::vector<std::uint32_t> kDims{1, 2, 2, 1};
+
+  auto& input0_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input0", QNN_DATATYPE_FLOAT_32, {}, kDims);
+  auto& input1_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input1", QNN_DATATYPE_FLOAT_32, {}, kDims);
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_FLOAT_32, {}, kDims);
+
+  auto ops = ::qnn::BuildAddNOp(tensor_pool_, {input0_tensor, input1_tensor},
+                                {output_tensor});
+  ASSERT_EQ(ops.size(), 1u);
+  EXPECT_EQ(ops[0].GetOpCode(), ::qnn::QnnOpCode::kElementWiseBinary);
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input0_idx = qnn_model_.AddInputTensor(input0_tensor);
+  auto input1_idx = qnn_model_.AddInputTensor(input1_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+  qnn_model_.SetInputData<float>(input0_idx, {-2.0f, 0.2f, 0.7f, 0.8f});
+  qnn_model_.SetInputData<float>(input1_idx, {0.1f, 0.2f, 0.3f, 0.5f});
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<float>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_THAT(output_data.value(),
+              Pointwise(FloatNear(1e-3), {-1.9f, 0.4f, 1.0f, 1.3f}));
+}
+
+TEST_P(QnnModelTest, AddNThreeInputsInt32) {
+  const std::vector<std::uint32_t> kDims{1, 2, 2, 1};
+
+  auto& input0_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input0", QNN_DATATYPE_INT_32, {}, kDims);
+  auto& input1_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input1", QNN_DATATYPE_INT_32, {}, kDims);
+  auto& input2_tensor = tensor_pool_.CreateInputTensorWithName(
+      "input2", QNN_DATATYPE_INT_32, {}, kDims);
+  auto& output_tensor = tensor_pool_.CreateOutputTensorWithName(
+      "output", QNN_DATATYPE_INT_32, {}, kDims);
+
+  auto ops = ::qnn::BuildAddNOp(tensor_pool_,
+                                {input0_tensor, input1_tensor, input2_tensor},
+                                {output_tensor});
+  ASSERT_EQ(ops.size(), 2u);
+
+  qnn_model_.MoveOpsToGraph(std::move(ops));
+
+  ASSERT_TRUE(qnn_model_.ValidateOpConfig());
+  ASSERT_TRUE(qnn_model_.Finalize());
+
+#if !defined(__ANDROID__)
+  GTEST_SKIP() << "The rest of this test is specific to Android devices with a "
+                  "Qualcomm HTP";
+#endif
+
+  auto input0_idx = qnn_model_.AddInputTensor(input0_tensor);
+  auto input1_idx = qnn_model_.AddInputTensor(input1_tensor);
+  auto input2_idx = qnn_model_.AddInputTensor(input2_tensor);
+  auto output_idx = qnn_model_.AddOutputTensor(output_tensor);
+  qnn_model_.SetInputData<std::int32_t>(input0_idx, {-20, 2, 7, 8});
+  qnn_model_.SetInputData<std::int32_t>(input1_idx, {1, 2, 3, 5});
+  qnn_model_.SetInputData<std::int32_t>(input2_idx, {10, -5, 1, -2});
+
+  ASSERT_TRUE(qnn_model_.Execute());
+
+  auto output_data = qnn_model_.GetOutputData<std::int32_t>(output_idx);
+  ASSERT_TRUE(output_data);
+  ASSERT_THAT(output_data.value(), testing::ElementsAre(-9, -1, 11, 11));
+}
+
+}  // namespace
+}  // namespace litert::qnn

--- a/litert/vendors/qualcomm/tests/CMakeLists.txt
+++ b/litert/vendors/qualcomm/tests/CMakeLists.txt
@@ -111,6 +111,7 @@ add_executable(builder_test)
 
 target_sources(builder_test
     PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/addn_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/depthwise_conv2d_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/elementwise_test.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/../qnn_backend_test/builder_test/fully_connected_test.cc


### PR DESCRIPTION
 # What
  - Add ADD_N (op code 106) op builder for the Qualcomm QNN backend.
  - QNN has no n-ary AddN op, so ADD_N is legalized into a chain of N-1 `QNN_OP_ELEMENT_WISE_BINARY` (ADD) nodes: `in[0]+in[1] -> tmp0`, `tmp0+in[2] -> tmp1`, ..., with the last add
  writing directly to the graph output.
  - N == 2 emits a single add and allocates no intermediate tensor. Intermediates are only cloned when a further add consumes them.
  - FLOAT32 and INT32 only, matching the TFLite kernel. Quantized inputs and outputs are not supported and are rejected with an error log.

  ## Verification

  - [x] Developer-Verified
  - Ran x86 and on-device unit tests locally on SM8650, SM8750 and SM8850.

  # Test

  - Passed x86 unit test.
  - Passed android unit test.
    - SM8850
    - SM8750
    - SM8650

======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.1s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:addn_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:addn_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 1.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 53.7s

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 27 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 27 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 24 tests from 15 test suites ran. (1 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (28 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 38 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 38 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (3 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (3 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 31 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 17 tests from 6 test suites ran. (38 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (5 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (557 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (191 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (769 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (551 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1538 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1789 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (1003 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1590 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:addn_test
[==========] 3 tests from 1 test suite ran. (1097 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (49 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (610 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (6033 ms total)
[  PASSED  ] 26 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (51 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (15 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (818 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (596 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (549 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/c/options:litert_qualcomm_options_test
[==========] 27 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 27 tests.

SM8750: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 24 tests from 15 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8750: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (12 ms total)
[  PASSED  ] 16 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 38 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 38 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8750: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8750: //litert/vendors/qualcomm/core:common_test
[==========] 31 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8750: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 17 tests from 6 test suites ran. (20 ms total)
[  PASSED  ] 17 tests.

SM8750: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (320 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (137 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (628 ms total)
[  PASSED  ] 2 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (353 ms total)
[  PASSED  ] 1 test.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1180 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1227 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (648 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1202 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:addn_test
[==========] 3 tests from 1 test suite ran. (854 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (5 ms total)
[  PASSED  ] 9 tests.

SM8750: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (612 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (4020 ms total)
[  PASSED  ] 26 tests.

SM8750: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (16 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (5 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8750: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (464 ms total)
[  PASSED  ] 3 tests.

SM8750: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (412 ms total)
[  PASSED  ] 5 tests.

SM8750: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (383 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 27 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 27 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 24 tests from 15 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (11 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 38 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 38 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (2 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 31 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 17 tests from 6 test suites ran. (9 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (279 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (168 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (590 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (336 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1309 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1269 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (700 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1253 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:addn_test
[==========] 3 tests from 1 test suite ran. (838 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (15 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (602 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (4563 ms total)
[  PASSED  ] 26 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (16 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (609 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (464 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (415 ms total)
[  PASSED  ] 2 tests.
