### PR TITLE
mediatek: exclude int32 Reshape from NPU partition selection

### DIFF
--- a/litert/vendors/mediatek/compiler/compiler_plugin.cc
+++ b/litert/vendors/mediatek/compiler/compiler_plugin.cc
@@ -38,6 +38,7 @@
 #include "litert/cc/internal/litert_handle.h"
 #include "litert/cc/internal/litert_opaque_options_wrapper.h"
 #include "litert/cc/internal/litert_options_wrapper.h"
+#include "litert/cc/litert_element_type.h"
 #include "litert/cc/litert_expected.h"
 #include "litert/cc/litert_macros.h"
 #include "litert/compiler/cc/litert_model.h"
@@ -429,6 +430,22 @@ bool IsOpSupported(const litert::compiler::Op& op) {
   return false;
 }
 
+bool IsInt32ReshapeUnsupportedByMdla(const litert::compiler::Op& op) {
+  if (op.Code() != kLiteRtOpCodeTflReshape) {
+    return false;
+  }
+  auto is_int32 = [](const litert::compiler::Tensor& t) {
+    return t.ElementType() == litert::ElementType::Int32;
+  };
+  for (const auto& t : op.Inputs()) {
+    if (is_int32(t)) return true;
+  }
+  for (const auto& t : op.Outputs()) {
+    if (is_int32(t)) return true;
+  }
+  return false;
+}
+
 }  // namespace
 
 LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
@@ -467,7 +484,7 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
   if (!neuron_adapter_api->IsFeatureEnabled(
           litert::mediatek::NeuronFeatureType::NEURON_FEATURE_UNKNOWN_OP)) {
     for (const auto& op : ops) {
-      if (!IsOpSupported(op)) {
+      if (!IsOpSupported(op) || IsInt32ReshapeUnsupportedByMdla(op)) {
         continue;
       }
       LITERT_RETURN_IF_ERROR(op.ctx()->push_op(selected_ops, op.Get(), 0));
@@ -481,7 +498,7 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
   std::unordered_set<int> unknown_op_indices;
   for (int op_idx = 0; op_idx < num_ops; ++op_idx) {
     const auto& op = ops[op_idx];
-    if (!IsOpSupported(op)) {
+    if (!IsOpSupported(op) || IsInt32ReshapeUnsupportedByMdla(op)) {
       unknown_op_indices.insert(op_idx);
     }
   }
@@ -509,7 +526,8 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
     return status.Error().Status();
   }
   for (int op_idx = 0; op_idx < num_ops; ++op_idx) {
-    if (support_flags[op_idx]) {
+    if (support_flags[op_idx] &&
+        !IsInt32ReshapeUnsupportedByMdla(ops[op_idx])) {
       LITERT_RETURN_IF_ERROR(
           ops[op_idx].ctx()->push_op(selected_ops, ops[op_idx].Get(), 0));
     }


### PR DESCRIPTION
`LiteRtCompilerPluginPartition` selects ops for the MediaTek NPU partition based on `GetSupportedOperations` (which calls `NeuronCompilation_getSupportedOperations` in
  the vendor's `libneuron_adapter.so`). For a `RESHAPE` op with an INT32 input or output tensor, this query reports the op as **supported** — but the same vendor
  library's actual compile step (`NeuronCompilation_finish`, reached via `CompilePartition`) **rejects** it:
                                                                                      
  ERROR: Compile error: NoExecPlan                                                    
  ERROR: NIR[2]: ReshapeLayer<2>{RESHAPE}                                             
   ├ MDLA: Cannot support Int32 input                                                 
   ├ MDLA: Cannot support Int32 output                                                
  INFO: [compile_model.cc:170] NeuronCompilation_finish failed with error 6           
                                                                                      
  The vendor library's own partition-time query and compile-time validation disagree with each other — a bug in `libneuron_adapter.so` itself, not in this file. Since
  there's no way to fix the closed-source adapter, this patches the open-source partitioner to correctly exclude this pattern from NPU selection, matching what the
  adapter's *compile* phase actually enforces rather than trusting the *query* phase's incorrect answer.
                                                                                      
  ## Where this shows up in practice                                                  
                                                                                      
  Reproduced on `SocModel.MT6878` compiling a full LLM decode graph (Gemma-3-270M) exported via `litert-torch`. The specific op is the token-ID tensor squeeze immediately
  before embedding lookup — `RESHAPE(decode_tokens: [1,1] INT32 → [1] INT32)` feeding `EMBEDDING_LOOKUP` — a pattern that's structural to essentially any transformer
  decode step, not specific to this one model.                                        
                                                                                      
  ## Fix                                                                              
                                                                                      
  Added `IsInt32ReshapeUnsupportedByMdla()`, which checks an op's code and its input/output tensor element types via the existing `litert::compiler::Op`/`Tensor` API, and
  applied it alongside the existing `IsOpSupported()` check at all three places `LiteRtCompilerPluginPartition` selects ops for the partition:
  1. The `NEURON_FEATURE_UNKNOWN_OP`-disabled fast path (direct `IsOpSupported` loop).
  2. The `unknown_op_indices` marking step (used to build the "get supported graph" model passed to the vendor query).
  3. The final `support_flags`-based selection loop (after the vendor's `GetSupportedOperations` call returns).
                                                                                      
  Applying it at all three keeps behavior consistent regardless of which code path a given environment/feature-flag combination takes.
                                                                                      
  ## Testing                                                                          
                                                                                      
  Verified with `google/gemma-3-270m-it` (converted via `litert-torch`, float32, `transpose_kv_cache=True`): before this fix, `aot_compile(...,
  target=Target(SocModel.MT6878))` fails with the `NoExecPlan` error above. After this fix, the same model compiles successfully with substantial real NPU offload:
                                                                                      
  RESULT: CompilationResult(models_with_backend=[(MediaTekBackend, Model)], failed_backends=[])
                                                                                      
  `prefill_128`: 246/531 ops offloaded to the NPU (`DISPATCH_OP`); `decode`: 150/353 ops offloaded. Confirmed genuine NPU dispatch bytecode (not a silent CPU fallback) by
  checking the compiled output fails to load in a plain CPU-only interp Jump to bottom (ctrl+End) ↓ olved custom op: DISPATCH_OP` — the expected signature of real compiled NPU bytecode.