### PR TITLE
fix null-pointer crash serializing subgraphs with zero operators

### DIFF
--- a/litert/core/model/model_serialize.cc
+++ b/litert/core/model/model_serialize.cc
@@ -428,6 +428,13 @@ Expected<OwningBufferRef<uint8_t>> SerializeWithAppendedBuffers(
        ++sg_ind) {
     auto* sg = tfl_model->mutable_subgraphs()->GetMutableObject(sg_ind);
 
+    // A subgraph with zero operators serializes its `operators` field as a
+    // null offset rather than an offset to an empty vector, so
+    // mutable_operators() can return null here.
+    if (sg->mutable_operators() == nullptr) {
+      continue;
+    }
+
     for (auto op_ind = 0; op_ind < sg->mutable_operators()->size(); ++op_ind) {
       SerializationContext::TflOpInd ind = {sg_ind, op_ind};
 


### PR DESCRIPTION
If a subgraph has zero operators, the FlatBuffer serializer writes the `operators` field as a null offset rather than an offset to an empty vector.
  `sg->mutable_operators()` then returns `nullptr`, and calling `->size()` on it segfaults.
                                                                                      
  ## Where this shows up in practice                                                  
                                                                                      
  Reproduced by AOT-compiling `litert-torch`'s own `ToyModelWithKVCache` test fixture (`litert_torch/generative/examples/test_models/toy_model_with_kv_cache.py`),
  converted with a non-transposed KV cache (`kv_layout=KV_LAYOUT_DEFAULT`), for a MediaTek NPU target — reproduces at both 2 and 18 transformer layers. Not
  vendor-specific: any backend whose compiled output includes an empty subgraph would hit the same crash, since the bug is in generic post-compile serialization, not
  vendor glue code.                                                                   
                                                                                      
  Crash backtrace (built `apply_plugin_main` with `-c dbg` for symbols):              
                                                                                      
  ```                                                                                 
  #0  flatbuffers::Vector<flatbuffers::Offset<tflite::Operator>, unsigned int>::size (this=0x0)
      at bazel-out/k8-dbg/bin/external/flatbuffers/_virtual_includes/runtime_cc/flatbuffers/vector.h:177
  #1  litert::internal::(anonymous namespace)::SerializeWithAppendedBuffers (...)     
      at litert/core/model/model_serialize.cc:431                                     
  #2  litert::internal::SerializeModel (...) at litert/core/model/model_serialize.cc:564
  #3  litert::tools::(anonymous namespace)::Apply (...) at litert/tools/apply_plugin.cc:461
  #4  litert::tools::ApplyPlugin (...) at litert/tools/apply_plugin.cc:525            
  #5  main (...) at litert/tools/apply_plugin_main.cc:174                             
  ```                                                                                 
                                                                                      
  ## Fix                                                                              
                                                                                      
  Skip subgraphs with no operators — they can't contain a dispatch op needing an external-buffer offset patched in, so there's nothing to do for them:
                                                                                      
  ```cpp                                                                              
  if (sg->mutable_operators() == nullptr) {                                           
    continue;                                                                         
  }                                                                                   

  ## Testing                                                                          
                                                                                      
  Rebuilt `apply_plugin_main` with the patch and reran the previously-crashing repro model — compiles and serializes successfully end-to-end (`Serialized a model of size
  2232528 bytes`), flatbuffer verification passes, real vendor `DISPATCH_OP` bytecode confirmed present in the output (24/87 ops in the `prefill` signature, 19/79 in
  `decode`).