### PR TITLE
fix(litert): prevent signed integer overflow in reference Div op (fixes #9189)

### DIFF
--- a/tflite/kernels/div_test.cc
+++ b/tflite/kernels/div_test.cc
@@ -436,4 +436,22 @@ TEST(QuantizedDivOpTest, AsymmetricQuantizedDivisorZeroCheck) {
 }
 
 }  // namespace
+
+
+TEST(DivOpTest, Int32MinOverflowASan) {
+  BaseOpModel model(
+      {TensorType_INT32, {2}},
+      {TensorType_INT32, {2}},
+      {TensorType_INT32, {}},
+      BuiltinOperator_DIV);
+
+  model.SetInput1<int32_t>({std::numeric_limits<int32_t>::min(), 10});
+  model.SetInput2<int32_t>({-1, 2});
+  
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  
+  EXPECT_THAT(model.GetOutput<int32_t>(), 
+              ElementsAre(std::numeric_limits<int32_t>::max(), 5));
+}
+
 }  // namespace tflite

--- a/tflite/kernels/internal/reference/div.h
+++ b/tflite/kernels/internal/reference/div.h
@@ -1,3 +1,5 @@
+#include <limits>
+#include <type_traits>
 /* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +25,20 @@ limitations under the License.
 namespace tflite {
 
 namespace reference_ops {
+
+template <typename T>
+inline T SafeDiv(T input1, T input2) {
+  if (input2 == 0) {
+    return 0;
+  }
+  if constexpr (std::is_signed<T>::value) {
+    if (input1 == std::numeric_limits<T>::min() && input2 == static_cast<T>(-1)) {
+      return std::numeric_limits<T>::max();
+    }
+  }
+  return input1 / input2;
+}
+
 
 template <typename T>
 inline void DivCheckArithmeticParams(const ArithmeticParams& params) {
@@ -202,7 +218,7 @@ void BroadcastDivSlow(const ArithmeticParams& params,
   GetActivationParams(params, &output_activation_min, &output_activation_max);
 
   auto op = [output_activation_min, output_activation_max](T a, T b) {
-    return ActivationFunctionWithMinMax(a / b, output_activation_min,
+    return ActivationFunctionWithMinMax(SafeDiv(a, b), output_activation_min,
                                         output_activation_max);
   };
 
@@ -224,7 +240,7 @@ inline void Div(const ArithmeticParams& params,
       MatchingElementsSize(input1_shape, input2_shape, output_shape);
   for (int i = 0; i < flat_size; ++i) {
     output_data[i] = ActivationFunctionWithMinMax(
-        input1_data[i] / input2_data[i], output_activation_min,
+        SafeDiv(input1_data[i], input2_data[i]), output_activation_min,
         output_activation_max);
   }
 }


### PR DESCRIPTION
### Summary
Fixes an `int-overflow` crash / ASan abort occurring during WebNN / LiteRT execution when evaluating signed integer division with `INT_MIN` divided by `-1` (e.g. `INT32_MIN / -1`).

Fixes #9189

---

### Cause
In C++, dividing `std::numeric_limits<T>::min()` by `-1` on signed integer types causes signed integer overflow / undefined behavior. Under AddressSanitizer (ASan) or checked execution environments, this triggers an immediate runtime abort in `tflite::reference_ops::Div`.

---

### Solution
- Introduced `SafeDiv` template helper in `tflite/kernels/internal/reference/div.h` using `std::numeric_limits` and `std::is_signed`.
- Handled division-by-zero safely (returns `0`).
- Handled signed integer overflow by saturating `INT_MIN / -1` to `std::numeric_limits<T>::max()`.
- Updated both standard elementwise (`Div`) and broadcast (`BroadcastDivSlow`) evaluation loops to use `SafeDiv`.
- Added regression unit test `Int32MinOverflowASan` in `tflite/kernels/div_test.cc`.

---

