### PR TITLE
fix(litert): skip BATCH coord for TEXTURE_2D in GPU elementwise shader generation  (fixes #9481 ) 

### DIFF
--- a/tflite/delegates/gpu/common/task/gpu_operation.cc
+++ b/tflite/delegates/gpu/common/task/gpu_operation.cc
@@ -621,7 +621,8 @@ GPUOperation CreateGpuOperation(const OperationDef& definition,
       const std::string y_coord = second_shape.h == 1 ? "0" : "Y_COORD";
       const std::string s_coord = second_shape.c == 1 ? "0" : "S_COORD";
       std::string coords = absl::StrCat(x_coord, ", ", y_coord, ", ", s_coord);
-      if (second_tensor_def.HasAxis(Axis::BATCH)) {
+      if (second_tensor_def.HasAxis(Axis::BATCH) &&
+          second_tensor_def.storage_type != TensorStorageType::TEXTURE_2D) {
         const std::string b_coord = second_shape.b == 1 ? "0" : "B_COORD";
         coords += ", " + b_coord;
       }


### PR DESCRIPTION
### Summary
Fixes a WebGPU delegate initialization failure (`INVALID_ARGUMENT: Unable to parse bc coord for BATCH axis`) occurring when executing elementwise operations on 4D tensors using `TEXTURE_2D` layout.

Fixes of #9481 
---

### Cause
In `tflite/delegates/gpu/common/task/gpu_operation.cc`, elementwise shader generation constructs coordinate parameters for reading secondary input tensors (`src_tensor_1.Read(coords)`). 

For `TensorStorageType::TEXTURE_2D`, the `.Read()` signature expects 3 spatial coordinates `(X_COORD, Y_COORD, S_COORD)`. However, the generator checked `HasAxis(Axis::BATCH)` without checking `storage_type`, unconditionally appending `, B_COORD` (or `, 0`). This resulted in a 4-argument call signature `(X_COORD, Y_COORD, S_COORD, 0)` that the `TEXTURE_2D` descriptor parser failed to process.

---

### Solution
- Updated `gpu_operation.cc` to ensure `B_COORD` is only appended when `second_tensor_def.storage_type != TensorStorageType::TEXTURE_2D`.
- Preserves 3-coordinate signatures for 2D textures while retaining 4-coordinate indexing for 3D textures and buffer storage types.

---

