### PR TITLE
Fix run_model GPU latency measurement

### DIFF
--- a/litert/tools/run_model.cc
+++ b/litert/tools/run_model.cc
@@ -233,22 +233,22 @@ Expected<Options> GetOptions() {
   options.SetHardwareAccelerators(accelerators);
 
   if (accelerators & litert::HwAccelerators::kGpu) {
+    LITERT_ASSIGN_OR_RETURN(auto& gpu_opts, options.GetGpuOptions());
+    // Enable benchmark mode to run clFinish() after each inference.
+    LITERT_RETURN_IF_ERROR(gpu_opts.EnableBenchmarkMode(/*enabled=*/true));
+
     int kernel_batch_size = absl::GetFlag(FLAGS_kernel_batch_size);
     if (kernel_batch_size > 0) {
-      LITERT_ASSIGN_OR_RETURN(auto& gpu_opts, options.GetGpuOptions());
       LITERT_RETURN_IF_ERROR(gpu_opts.SetKernelBatchSize(kernel_batch_size));
     }
     std::string gpu_precision = absl::GetFlag(FLAGS_gpu_precision);
     if (gpu_precision == "fp32") {
-      LITERT_ASSIGN_OR_RETURN(auto& gpu_opts, options.GetGpuOptions());
       LITERT_RETURN_IF_ERROR(
           gpu_opts.SetPrecision(GpuOptions::Precision::kFp32));
     } else if (gpu_precision == "fp16") {
-      LITERT_ASSIGN_OR_RETURN(auto& gpu_opts, options.GetGpuOptions());
       LITERT_RETURN_IF_ERROR(
           gpu_opts.SetPrecision(GpuOptions::Precision::kFp16));
     } else if (gpu_precision == "auto") {
-      LITERT_ASSIGN_OR_RETURN(auto& gpu_opts, options.GetGpuOptions());
       LITERT_RETURN_IF_ERROR(
           gpu_opts.SetPrecision(GpuOptions::Precision::kDefault));
     } else {


### PR DESCRIPTION
## Summary

- enable GPU benchmark mode when `run_model` selects the GPU
- propagate failure to configure benchmark mode
- reuse the selected `GpuOptions` instance for the existing kernel-batch and precision configuration

## Problem

[`CompiledModel::Run()`](https://github.com/google-ai-edge/LiteRT/blob/9e377c6/litert/cc/litert_compiled_model.h#L721-L728) is documented as running synchronously and, through RunHelper() and RunCApiHelper(), dispatches to the synchronous [`LiteRtRunCompiledModel`](https://github.com/google-ai-edge/LiteRT/blob/9e377c6/litert/c/litert_compiled_model.h#L126-L141) C API has the same synchronous contract.

`run_model` times each `Run()` call with host-side timestamps and reports the result as inference latency. However, GPU benchmark mode defaults to false. In the observed OpenCL path, the call returned after command submission rather than completed GPU execution, so a fully delegated 366-node pose model was reported as taking 274 microseconds even though completed inference took approximately 17 milliseconds.

The dedicated benchmark already [enables benchmark mode to run `clFinish()` after each inference](https://github.com/google-ai-edge/LiteRT/blob/9e377c6/litert/tools/benchmark_litert_model.cc#L165-L167).

## Fix

Enable `GpuOptions::EnableBenchmarkMode(true)` before constructing the compiled model. This makes the OpenCL backend finish queued work before the timed synchronous `Run()` call returns, so `run_model` reports completed inference latency rather than enqueue latency.

## Verification

Android ARM64 build:

```text
Target //litert/tools:run_model up-to-date
Build completed successfully
```

Samsung SM-A7050, Android 11, Qualcomm GPU, 366/366 nodes delegated to `LITERT_CL`:

```text
run_model average:       328.297 ms (5 runs)
benchmark_model average: 327.580 ms (5 runs)
difference:              approximately 0.22%
```

Samsung SM-F9460, Android 16, Qualcomm GPU, 366/366 nodes delegated to `LITERT_CL`:

```text
run_model average:       18.538 ms (3 runs)
benchmark_model average: 17.210 ms (5 runs)
```

Both patched runs logged `Benchmark mode is enabled.` and completed successfully.

Fixes #9453

## Submission attribution

This issue was diagnosed and this PR was implemented, built, tested on the reporter's devices, and submitted by **OpenAI Codex (`openai-codex/gpt-5.6-sol`)** in @Jacfger's development environment. @Jacfger supplied the original reproduction, model, and devices and authorized submission.