### PR TITLE
Fixes an issue where `CompiledModel::CreateOutputBuffers` returns 4-byte host buffers for CPU output tensors when models contain custom ops (such as `TFLite_Detection_PostProcess`).

### DIFF
--- a/litert/runtime/compiled_model.cc
+++ b/litert/runtime/compiled_model.cc
@@ -1432,11 +1432,23 @@ LiteRtCompiledModelT::GetTensorBufferRequirements(const TfLiteTensor* tensor) {
   if (cached_req != cpu_buffer_requirements_.end()) {
     return cached_req->second.get();
   }
+  size_t buffer_bytes = tensor->bytes;
+  if (tensor->dims != nullptr && tensor->dims->size > 0) {
+    size_t num_elements = 1;
+    for (int i = 0; i < tensor->dims->size; ++i) {
+      num_elements *= tensor->dims->data[i];
+    }
+    size_t computed_bytes = num_elements * TfLiteTypeGetSize(tensor->type);
+    if (computed_bytes > buffer_bytes) {
+      buffer_bytes = computed_bytes;
+    }
+  }
+
   LiteRtTensorBufferRequirements litert_cpu_buffer_requirements;
   LiteRtTensorBufferType cpu_buffer_type[] = {
       kLiteRtTensorBufferTypeHostMemory};
   LITERT_RETURN_IF_ERROR(LiteRtCreateTensorBufferRequirements(
-      /*num_supported_tensor_buffer_types=*/1, cpu_buffer_type, tensor->bytes,
+      /*num_supported_tensor_buffer_types=*/1, cpu_buffer_type, buffer_bytes,
       /*num_strides=*/0, /*strides=*/nullptr, &litert_cpu_buffer_requirements));
   cpu_buffer_requirements_[tensor_id] =
       LiteRtTensorBufferRequirementsPtr(litert_cpu_buffer_requirements);


### PR DESCRIPTION
### Summary
Fixes #9518

Fixes an issue where `CompiledModel::CreateOutputBuffers` returns 4-byte host buffers for CPU output tensors when models contain custom ops (such as `TFLite_Detection_PostProcess`).

### Cause
`LiteRtCompiledModelT::GetTensorBufferRequirements` relied directly on `tensor->bytes` for host CPU tensors. For dynamic/custom op output tensors whose allocations have not executed yet, `tensor->bytes` reports unit/dummy byte size (`4` bytes for a scalar `float32`).

### Solution
Calculate the expected tensor byte requirement from `tensor->dims` and `TfLiteTypeGetSize(tensor->type)`. If the computed size exceeds `tensor->bytes`, use the computed size for creating host buffer requirements.