### PR TITLE
Strided dma litert

### DIFF
--- a/litert/runtime/compiled_model.cc
+++ b/litert/runtime/compiled_model.cc
@@ -1593,6 +1593,49 @@ tflite::SignatureRunner* LiteRtCompiledModelT::GetSignatureRunner(
   return runner;
 }
 
+namespace {
+
+// Returns true when every dimension in `shape` is positive, i.e. the shape is
+// fully static with no dynamic (-1) or zero dims.
+bool AllPositive(absl::Span<const int> shape) {
+  for (int dim : shape) {
+    if (dim <= 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Returns true when `buffer_shape` has the same rank as `port_shape` and is
+// greater-or-equal on every dimension (i.e. the buffer fully contains the
+// port). Used to recognize a backend custom buffer that is intentionally
+// larger than a static graph port and will be bound as a sub-view by the
+// backend.
+bool ShapeContains(absl::Span<const int> buffer_shape,
+                   absl::Span<const int> port_shape) {
+  if (buffer_shape.size() != port_shape.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < buffer_shape.size(); ++i) {
+    if (buffer_shape[i] < port_shape[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+bool ShouldBindOversizedCustomBuffer(LiteRtTensorBufferType buffer_type,
+                                     absl::Span<const int> buffer_shape,
+                                     absl::Span<const int> port_shape) {
+  // Only user custom buffers provide their own backend binding, and the
+  // oversized path is only safe for fully-static ports: a dynamic (-1) port dim
+  // would spuriously satisfy ShapeContains and must instead be auto-resized.
+  return IsUserCustomBuffer(buffer_type) && AllPositive(port_shape) &&
+         buffer_shape != port_shape && ShapeContains(buffer_shape, port_shape);
+}
+
 Expected<void> LiteRtCompiledModelT::RegisterBuffer(
     tflite::SignatureRunner* runner, TfLiteTensor* tensor, int tensor_index,
     const char* tensor_name, LiteRtTensorBufferT* buffer, bool is_input,
@@ -1620,39 +1663,59 @@ Expected<void> LiteRtCompiledModelT::RegisterBuffer(
     absl::Span<const int> buffer_shape =
         absl::MakeConstSpan(layout.dimensions, layout.rank);
 
-    LITERT_ASSIGN_OR_RETURN(bool needs_auto_resize,
-                            InputTensorNeedsResize(tensor, buffer_shape));
-    if (needs_auto_resize) {
-      // When an input tensor is resized, output and intermediate tensors may
-      // also be resized. This can invalidate previously cached buffer
-      // requirements, so we clear the cache.
-      cpu_buffer_requirements_.clear();
-      // Shape change detected - perform automatic resize.
-      TfLiteStatus resize_status = kTfLiteOk;
-      if (runner) {
-        resize_status = runner->ResizeInputTensor(
-            tensor_name,
-            std::vector<int>(buffer_shape.begin(), buffer_shape.end()));
-      } else {
-        resize_status = interp_->ResizeInputTensor(
-            tensor_index,
-            std::vector<int>(buffer_shape.begin(), buffer_shape.end()));
-      }
-      if (resize_status == kTfLiteOk) {
-        LITERT_RETURN_IF_ERROR(MarkSignatureNeedsAllocation(runner));
-        LITERT_LOG(LITERT_INFO, "Automatically resized input tensor index %d",
-                   tensor_index);
-      } else {
-        LITERT_LOG(LITERT_WARNING,
-                   "Automatic resize failed for tensor index %d", tensor_index);
-      }
+    // Split-context KV cache: a backend custom buffer may be intentionally
+    // larger than a static graph port (one canonical max-length KV buffer is
+    // shared across signatures with different past-KV lengths). In that case
+    // the tensor is neither resized to the buffer nor required to match it;
+    // instead the backend binds a zero-copy sub-view sized to the port. Skip
+    // both the auto-resize and the equality check and let the buffer flow to
+    // the backend registration below. This only applies to user custom buffers
+    // (which provide their own binding) and only when the buffer fully contains
+    // the port on every dimension.
+    absl::Span<const int> port_shape =
+        absl::MakeConstSpan(tensor->dims->data, tensor->dims->size);
+    const bool bind_oversized_custom_buffer = ShouldBindOversizedCustomBuffer(
+        buffer->buffer_type(), buffer_shape, port_shape);
+
+    if (bind_oversized_custom_buffer) {
+      LITERT_LOG(LITERT_INFO,
+                 "Binding oversized custom buffer to input tensor index %d as "
+                 "a backend sub-view (buffer rank %zu)",
+                 tensor_index, buffer_shape.size());
     } else {
-      // Get current tensor shape.
-      absl::Span<const int> current_shape =
-          absl::MakeConstSpan(tensor->dims->data, tensor->dims->size);
-      LITERT_RETURN_IF_ERROR(current_shape == buffer_shape,
-                             Unexpected(kLiteRtStatusErrorInvalidArgument,
-                                        "Input tensor shape mismatch"));
+      LITERT_ASSIGN_OR_RETURN(bool needs_auto_resize,
+                              InputTensorNeedsResize(tensor, buffer_shape));
+      if (needs_auto_resize) {
+        // When an input tensor is resized, output and intermediate tensors may
+        // also be resized. This can invalidate previously cached buffer
+        // requirements, so we clear the cache.
+        cpu_buffer_requirements_.clear();
+        // Shape change detected - perform automatic resize.
+        TfLiteStatus resize_status = kTfLiteOk;
+        if (runner) {
+          resize_status = runner->ResizeInputTensor(
+              tensor_name,
+              std::vector<int>(buffer_shape.begin(), buffer_shape.end()));
+        } else {
+          resize_status = interp_->ResizeInputTensor(
+              tensor_index,
+              std::vector<int>(buffer_shape.begin(), buffer_shape.end()));
+        }
+        if (resize_status == kTfLiteOk) {
+          LITERT_RETURN_IF_ERROR(MarkSignatureNeedsAllocation(runner));
+          LITERT_LOG(LITERT_INFO, "Automatically resized input tensor index %d",
+                     tensor_index);
+        } else {
+          LITERT_LOG(LITERT_WARNING,
+                     "Automatic resize failed for tensor index %d",
+                     tensor_index);
+        }
+      } else {
+        // Shapes must match exactly (port_shape was computed above).
+        LITERT_RETURN_IF_ERROR(port_shape == buffer_shape,
+                               Unexpected(kLiteRtStatusErrorInvalidArgument,
+                                          "Input tensor shape mismatch"));
+      }
     }
   }
 

--- a/litert/runtime/compiled_model.h
+++ b/litert/runtime/compiled_model.h
@@ -33,6 +33,7 @@
 #include "litert/c/internal/litert_scheduling_info.h"
 #include "litert/c/litert_common.h"
 #include "litert/c/litert_layout.h"
+#include "litert/c/litert_tensor_buffer_types.h"
 #include "litert/cc/litert_buffer_ref.h"
 #include "litert/cc/litert_expected.h"
 #include "litert/cc/litert_macros.h"
@@ -588,5 +589,18 @@ class LiteRtCompiledModelT {
   // Owns dynamically created TfLiteRegistration objects for TfLiteOperator.
   std::vector<std::unique_ptr<TfLiteRegistration>> owned_tflite_registrations_;
 };
+
+// Decides whether a registered input buffer that is larger than its graph port
+// should be bound as-is (as a backend sub-view) instead of triggering
+// auto-resize or a shape-mismatch error. This is the split-context KV cache
+// case: one canonical max-length KV buffer is shared across signatures with
+// different past-KV lengths, and the backend binds a zero-copy sub-view sized to
+// each port. Returns true only when: the buffer is a user custom buffer (which
+// provides its own binding); the port is fully static (no dynamic dims); the
+// buffer differs from the port; and the buffer fully contains the port on every
+// dimension. Exposed at namespace scope so it can be unit-tested directly.
+bool ShouldBindOversizedCustomBuffer(LiteRtTensorBufferType buffer_type,
+                                     absl::Span<const int> buffer_shape,
+                                     absl::Span<const int> port_shape);
 
 #endif  // ODML_LITERT_LITERT_RUNTIME_COMPILED_MODEL_H_

--- a/litert/runtime/compiled_model_test.cc
+++ b/litert/runtime/compiled_model_test.cc
@@ -1541,6 +1541,66 @@ TEST(CompiledModelTest, CheckResizeFail) {
   LiteRtDestroyEnvironment(env_ptr);
 }
 
+// Unit tests for the split-context KV cache buffer-binding predicate. These are
+// pure-function tests (no compiled model needed) that pin the decision matrix
+// for whether an oversized registered input buffer is bound as a backend
+// sub-view vs. auto-resized vs. rejected.
+TEST(ShouldBindOversizedCustomBufferTest, OversizedCustomBufferBinds) {
+  // A user custom buffer larger than the port on one dim -> bind as sub-view.
+  const std::vector<int> buffer_shape = {1, 16383, 8, 256};
+  const std::vector<int> port_shape = {1, 16256, 8, 256};
+  EXPECT_TRUE(ShouldBindOversizedCustomBuffer(
+      kLiteRtTensorBufferTypeOpenVINOTensorBuffer,
+      absl::MakeConstSpan(buffer_shape), absl::MakeConstSpan(port_shape)));
+}
+
+TEST(ShouldBindOversizedCustomBufferTest, OversizedNonCustomBufferDoesNotBind) {
+  // Same oversized shapes but a host-memory (non-custom) buffer -> no bind;
+  // the caller falls through to the resize / shape-mismatch path.
+  const std::vector<int> buffer_shape = {1, 16383, 8, 256};
+  const std::vector<int> port_shape = {1, 16256, 8, 256};
+  EXPECT_FALSE(ShouldBindOversizedCustomBuffer(
+      kLiteRtTensorBufferTypeHostMemory, absl::MakeConstSpan(buffer_shape),
+      absl::MakeConstSpan(port_shape)));
+}
+
+TEST(ShouldBindOversizedCustomBufferTest, EqualShapesDoNotBind) {
+  // Buffer equal to the port is the ordinary matched case -> no oversized bind.
+  const std::vector<int> shape = {1, 16256, 8, 256};
+  EXPECT_FALSE(ShouldBindOversizedCustomBuffer(
+      kLiteRtTensorBufferTypeOpenVINOTensorBuffer, absl::MakeConstSpan(shape),
+      absl::MakeConstSpan(shape)));
+}
+
+TEST(ShouldBindOversizedCustomBufferTest, SmallerBufferDoesNotBind) {
+  // Buffer smaller than the port on a dim -> ShapeContains false -> no bind.
+  const std::vector<int> buffer_shape = {1, 1024, 8, 256};
+  const std::vector<int> port_shape = {1, 16256, 8, 256};
+  EXPECT_FALSE(ShouldBindOversizedCustomBuffer(
+      kLiteRtTensorBufferTypeOpenVINOTensorBuffer,
+      absl::MakeConstSpan(buffer_shape), absl::MakeConstSpan(port_shape)));
+}
+
+TEST(ShouldBindOversizedCustomBufferTest, DifferentRankDoesNotBind) {
+  // Rank mismatch -> ShapeContains false -> no bind.
+  const std::vector<int> buffer_shape = {1, 16383, 8, 256};
+  const std::vector<int> port_shape = {16256, 8, 256};
+  EXPECT_FALSE(ShouldBindOversizedCustomBuffer(
+      kLiteRtTensorBufferTypeOpenVINOTensorBuffer,
+      absl::MakeConstSpan(buffer_shape), absl::MakeConstSpan(port_shape)));
+}
+
+TEST(ShouldBindOversizedCustomBufferTest, DynamicPortDoesNotBind) {
+  // A dynamic (-1) port dim must auto-resize, not take the oversized path,
+  // even though a concrete buffer trivially "contains" a -1 dim. This is the
+  // AllPositive guard.
+  const std::vector<int> buffer_shape = {1, 16383, 8, 256};
+  const std::vector<int> port_shape = {1, -1, 8, 256};
+  EXPECT_FALSE(ShouldBindOversizedCustomBuffer(
+      kLiteRtTensorBufferTypeOpenVINOTensorBuffer,
+      absl::MakeConstSpan(buffer_shape), absl::MakeConstSpan(port_shape)));
+}
+
 TEST(CompiledModelTest, DynamicResizeWithCustomAllocationsSimple) {
   constexpr absl::string_view kSimpleAddDynamicShapeModel =
       "simple_add_dynamic_shape.tflite";

--- a/litert/vendors/intel_openvino/compiler/npu_optimizer.cc
+++ b/litert/vendors/intel_openvino/compiler/npu_optimizer.cc
@@ -472,7 +472,19 @@ void NpuOptimizer::Run(const std::shared_ptr<ov::Model>& model) const {
   if (eliminate_matmul_fq_) {
     pass_manager.register_pass<EliminateMatMulFakeQuantize>();
   }
+  if (fold_slice_indices_) {
+    // ConstantFolding turns the foldable Select/Broadcast subgraphs feeding
+    // Slice's start/stop/step/axes inputs into plain Constants, which is what
+    // Slice's shape inference needs to produce a static output shape.
+    pass_manager.register_pass<ov::pass::ConstantFolding>();
+  }
   pass_manager.run_passes(model);
+  if (fold_slice_indices_) {
+    // Folding makes each Slice static, but downstream ops keep the stale
+    // dynamic shapes they inferred earlier. Re-validate the whole graph so the
+    // static shapes propagate to the results.
+    model->validate_nodes_and_infer_types();
+  }
 }
 
 }  // namespace openvino

--- a/litert/vendors/intel_openvino/compiler/npu_optimizer.h
+++ b/litert/vendors/intel_openvino/compiler/npu_optimizer.h
@@ -122,6 +122,21 @@ class NpuOptimizer {
     return *this;
   }
 
+  // Toggles constant-folding of Slice index inputs (start/stop/step/axes).
+  //
+  // The TFLite frontend builds those inputs as small foldable subgraphs
+  // (e.g. Select / Broadcast over constants) rather than plain Constants. OV's
+  // Slice shape inference only produces a static output shape when it can read
+  // those inputs as constant data; otherwise it falls back to `[0..max]` on
+  // every sliced dimension. That makes ov::Model::is_dynamic() true, which in
+  // turn makes the NPU plugin reject NPU_ENABLE_STRIDES_FOR with "Dynamic
+  // batching is not supported with the dynamic strides feature". Enabled by
+  // default: without it the strided-ROI KV sharing cannot be compiled.
+  NpuOptimizer& SetFoldSliceIndices(bool enable) {
+    fold_slice_indices_ = enable;
+    return *this;
+  }
+
   // Runs all currently-enabled passes on |model|.
   void Run(const std::shared_ptr<ov::Model>& model) const;
 
@@ -131,6 +146,7 @@ class NpuOptimizer {
   bool cast_integer_sign_to_float_ = true;
   bool fuse_split_attention_to_sdpa_ = false;
   bool sdpa_pad_kv_to_alignment_ = true;
+  bool fold_slice_indices_ = true;
 };
 
 }  // namespace openvino

--- a/litert/vendors/intel_openvino/dispatch/BUILD
+++ b/litert/vendors/intel_openvino/dispatch/BUILD
@@ -73,6 +73,7 @@ litert_dynamic_lib(
     ],
     deps = [
         ":litert_dispatch_api",
+        ":roi_view",
         "//litert/c:litert_common",
         "//litert/c:litert_custom_tensor_buffer",
         "//litert/c:litert_environment_header",
@@ -133,6 +134,7 @@ litert_bin(
     visibility = ["//visibility:public"],  # Allows LiteRT-LM packaging.
     deps = [
         ":litert_dispatch_api",
+        ":roi_view",
         "//litert/c:litert_common",
         "//litert/c:litert_custom_tensor_buffer",
         "//litert/c:litert_environment_options_header",
@@ -203,7 +205,41 @@ litert_lib(
     ],
 )
 
+# Header-only helper: binds a graph port to a (possibly larger) backing tensor
+# as a zero-copy ROI sub-view. Extracted so it can be unit-tested on the host
+# CPU without a device (see roi_view_test).
+litert_lib(
+    name = "roi_view",
+    hdrs = ["roi_view.h"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
+    deps = [
+        "//litert/c:litert_common",
+        "//litert/c/internal:litert_logging",
+        "//litert/cc:litert_expected",
+        "@intel_openvino//:openvino",
+    ],
+)
+
 #Test targets for Openvino Dispatch
+
+# Host CPU unit test for MakePortView: fabricates plain host ov::Tensors (no
+# device) and checks the equal-shape passthrough, the sub-view shape/strides,
+# and the rank-mismatch and under-sized-buffer error paths.
+cc_test(
+    name = "roi_view_test",
+    srcs = ["roi_view_test.cc"],
+    copts = ["-fexceptions"],
+    features = ["-use_header_modules"],  # Incompatible with -fexceptions.
+    linkstatic = 1,
+    deps = [
+        ":roi_view",
+        "//litert/cc:litert_expected",
+        "@com_google_googletest//:gtest_main",
+        "@intel_openvino//:openvino",
+    ],
+)
+
 cc_test(
     name = "dispatch_api_openvino_test",
     srcs = [

--- a/litert/vendors/intel_openvino/dispatch/invocation_context.cc
+++ b/litert/vendors/intel_openvino/dispatch/invocation_context.cc
@@ -31,6 +31,8 @@
 #include <vector>
 
 #include "openvino/core/any.hpp"
+#include "openvino/core/coordinate.hpp"
+#include "openvino/core/shape.hpp"
 #include "openvino/runtime/compiled_model.hpp"
 #include "openvino/runtime/properties.hpp"
 #include "openvino/runtime/tensor.hpp"
@@ -48,6 +50,7 @@
 #include "litert/vendors/c/litert_dispatch.h"
 #include "litert/vendors/intel_openvino/bytecode_header.h"
 #include "litert/vendors/intel_openvino/compiler/global_graph.h"
+#include "litert/vendors/intel_openvino/dispatch/roi_view.h"
 #include "litert/vendors/intel_openvino/dispatch/weight_bank_runtime.h"
 
 namespace {
@@ -450,7 +453,14 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::AttachInput(
                           device_context_.getOVTensor(tensor_buffer_handle));
   // TODO: visit this if need to maintain graph indices for inputs and outputs
   // in dispatch_api
-  infer_request_.set_input_tensor(graph_input_index, ov_tensor);
+  // The bound buffer may be larger than the graph port (split-context KV
+  // cache: one max-length buffer shared by a shorter signature). Bind a
+  // zero-copy sub-view sized to the port when that is the case.
+  const ov::Shape port_shape =
+      infer_request_.get_input_tensor(graph_input_index).get_shape();
+  LITERT_ASSIGN_OR_RETURN(ov::Tensor bound_tensor,
+                          litert::openvino::MakePortView(ov_tensor, port_shape));
+  infer_request_.set_input_tensor(graph_input_index, bound_tensor);
   return {};
 }
 
@@ -460,7 +470,11 @@ litert::Expected<void> LiteRtDispatchInvocationContextT::AttachOutput(
                           device_context_.getOVTensor(tensor_buffer_handle));
   // TODO: visit this if need to maintain graph indices for inputs and outputs
   // in dispatch_api
-  infer_request_.set_output_tensor(graph_output_index, ov_tensor);
+  const ov::Shape port_shape =
+      infer_request_.get_output_tensor(graph_output_index).get_shape();
+  LITERT_ASSIGN_OR_RETURN(ov::Tensor bound_tensor,
+                          litert::openvino::MakePortView(ov_tensor, port_shape));
+  infer_request_.set_output_tensor(graph_output_index, bound_tensor);
   return {};
 }
 

--- a/litert/vendors/intel_openvino/dispatch/roi_view.h
+++ b/litert/vendors/intel_openvino/dispatch/roi_view.h
@@ -1,0 +1,127 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ODML_LITERT_LITERT_VENDORS_INTEL_OPENVINO_DISPATCH_ROI_VIEW_H_
+#define ODML_LITERT_LITERT_VENDORS_INTEL_OPENVINO_DISPATCH_ROI_VIEW_H_
+
+#include <cstddef>
+#include <exception>
+
+#include "openvino/core/coordinate.hpp"
+#include "openvino/core/shape.hpp"
+#include "openvino/core/strides.hpp"
+#include "openvino/runtime/tensor.hpp"
+#include "litert/c/internal/litert_logging.h"
+#include "litert/c/litert_common.h"
+#include "litert/cc/litert_expected.h"
+
+namespace litert::openvino {
+
+// Binds a graph port to a possibly-larger backing OpenVINO tensor by returning a
+// zero-copy view sized to the port.
+//
+// This is the split-context KV-cache primitive: one canonical max-length KV
+// buffer (e.g. decode seq 16383) is shared by signatures that declare a shorter
+// port (e.g. prefill seq 16256). When the buffer is larger than the port, a
+// region-of-interest sub-view is created that starts at offset 0 on every
+// dimension and extends to the port's extent. The ROI inherits the parent's
+// strides, which is exactly what the NPU/GPU plugin needs for strided access,
+// and it is layout-agnostic: it handles both the K layout ([1,H,S,D], seq at
+// dim 2) and the transposed-V layout ([1,H,D,S], seq at dim 3) uniformly, since
+// only the differing dimension is trimmed.
+//
+// Returns the buffer unchanged when the shapes are equal. Returns an error (not
+// a crash) on rank mismatch, an under-sized buffer, or a computed extent that
+// would fall outside the parent allocation. Never throws: any OpenVINO exception
+// is converted to a litert::Error.
+inline litert::Expected<ov::Tensor> MakePortView(const ov::Tensor& buffer_tensor,
+                                                 const ov::Shape& port_shape) {
+  try {
+    const ov::Shape& buffer_shape = buffer_tensor.get_shape();
+    if (buffer_shape == port_shape) {
+      return buffer_tensor;
+    }
+    if (buffer_shape.size() != port_shape.size()) {
+      return litert::Error(
+          kLiteRtStatusErrorRuntimeFailure,
+          "KV buffer rank does not match graph port rank; cannot create view");
+    }
+    // The buffer must be at least as large as the port on every dimension. The
+    // split-context design only ever trims a single (cache-length) dimension, so
+    // more than one differing dim signals an unexpected shape pairing; warn but
+    // still build the view (the bounds guard below remains authoritative).
+    size_t differing_dims = 0;
+    for (size_t i = 0; i < buffer_shape.size(); ++i) {
+      if (buffer_shape[i] < port_shape[i]) {
+        return litert::Error(
+            kLiteRtStatusErrorRuntimeFailure,
+            "KV buffer smaller than graph port; cannot create view");
+      }
+      if (buffer_shape[i] != port_shape[i]) {
+        ++differing_dims;
+      }
+    }
+    if (differing_dims > 1) {
+      LITERT_LOG(LITERT_WARNING,
+                 "Strided KV sub-view trims %zu dimensions; the split-context "
+                 "design expects exactly one",
+                 differing_dims);
+    }
+    ov::Coordinate begin(buffer_shape.size(), 0);
+    ov::Coordinate end(port_shape.begin(), port_shape.end());
+    // ov::Tensor(other, begin, end) is the ROI constructor: a zero-copy sub-view
+    // sharing the parent's memory and strides.
+    ov::Tensor view(buffer_tensor, begin, end);
+
+    // Bounds guard for the strided view. The ROI inherits the PARENT's byte
+    // strides, so the last element the driver may touch sits at
+    //   sum_i (port_shape[i] - 1) * parent_byte_stride[i]
+    // (the +1 element itself spans elem_size more bytes). If the parent buffer
+    // was under-allocated relative to its declared shape, that tail lands
+    // outside the allocation and the NPU driver walks off the end during graph
+    // execution (observed as a SIGSEGV inside libze_intel_npu after all binds
+    // succeed, never at bind time). Compute the extent explicitly and fail
+    // loudly here rather than letting the driver fault on stripped frames. Since
+    // every ROI starts at offset 0 and only trims dims, a full-size parent
+    // always covers the view; a triggered check means the parent allocation is
+    // short.
+    const ov::Strides& parent_strides = buffer_tensor.get_strides();  // bytes
+    const size_t elem_size = buffer_tensor.get_element_type().size();
+    size_t max_byte_offset = 0;
+    for (size_t i = 0; i < port_shape.size(); ++i) {
+      if (port_shape[i] == 0) continue;
+      max_byte_offset += (port_shape[i] - 1) * parent_strides[i];
+    }
+    const size_t roi_end_byte = max_byte_offset + elem_size;
+    const size_t parent_capacity = buffer_tensor.get_byte_size();
+    LITERT_LOG(LITERT_VERBOSE,
+               "Strided KV sub-view bind: parent data=%p parent_capacity=%zu "
+               "roi_end_byte=%zu elem_size=%zu",
+               buffer_tensor.data(), parent_capacity, roi_end_byte, elem_size);
+    if (roi_end_byte > parent_capacity) {
+      return litert::Error(
+          kLiteRtStatusErrorRuntimeFailure,
+          "Strided KV sub-view extends past the parent allocation; the parent "
+          "buffer was allocated smaller than its declared (max-length) shape");
+    }
+    return view;
+  } catch (const std::exception& e) {
+    return litert::Error(kLiteRtStatusErrorRuntimeFailure, e.what());
+  }
+}
+
+}  // namespace litert::openvino
+
+#endif  // ODML_LITERT_LITERT_VENDORS_INTEL_OPENVINO_DISPATCH_ROI_VIEW_H_

--- a/litert/vendors/intel_openvino/dispatch/roi_view_test.cc
+++ b/litert/vendors/intel_openvino/dispatch/roi_view_test.cc
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "litert/vendors/intel_openvino/dispatch/roi_view.h"
+
+#include <gtest/gtest.h>
+
+#include "openvino/core/shape.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/runtime/tensor.hpp"
+
+// These tests fabricate plain host ov::Tensors (self-allocating, no device) and
+// exercise MakePortView. The extent-overflow guard inside MakePortView is
+// deliberately not covered here: a well-formed ov::Tensor always reports a
+// byte size consistent with its shape and strides, so a zero-offset ROI can
+// never exceed it -- the guard only fires for an externally under-allocated
+// buffer, which the real strided device path exercises in roi_view_manual_test.
+
+namespace litert::openvino {
+namespace {
+
+TEST(MakePortViewTest, EqualShapeReturnsSameBuffer) {
+  ov::Tensor buffer(ov::element::f16, ov::Shape{1, 4, 8, 16});
+  auto result = MakePortView(buffer, ov::Shape{1, 4, 8, 16});
+  ASSERT_TRUE(static_cast<bool>(result));
+  EXPECT_EQ(result->get_shape(), (ov::Shape{1, 4, 8, 16}));
+  // Passthrough: same underlying allocation.
+  EXPECT_EQ(result->data(), buffer.data());
+}
+
+TEST(MakePortViewTest, LargerBufferReturnsZeroCopySubView) {
+  ov::Tensor buffer(ov::element::f16, ov::Shape{1, 4, 8, 16});
+  const ov::Shape port_shape{1, 4, 6, 16};  // trims the seq dim 8 -> 6
+  auto result = MakePortView(buffer, port_shape);
+  ASSERT_TRUE(static_cast<bool>(result));
+  EXPECT_EQ(result->get_shape(), port_shape);
+  // ROI starts at offset 0 on every dim: shares the parent's memory...
+  EXPECT_EQ(result->data(), buffer.data());
+  // ...and inherits the parent's (byte) strides for strided access.
+  EXPECT_EQ(result->get_strides(), buffer.get_strides());
+}
+
+TEST(MakePortViewTest, RankMismatchIsError) {
+  ov::Tensor buffer(ov::element::f16, ov::Shape{1, 4, 8, 16});
+  auto result = MakePortView(buffer, ov::Shape{4, 8, 16});
+  EXPECT_FALSE(static_cast<bool>(result));
+}
+
+TEST(MakePortViewTest, BufferSmallerThanPortIsError) {
+  ov::Tensor buffer(ov::element::f16, ov::Shape{1, 4, 6, 16});
+  auto result = MakePortView(buffer, ov::Shape{1, 4, 8, 16});
+  EXPECT_FALSE(static_cast<bool>(result));
+}
+
+}  // namespace
+}  // namespace litert::openvino


### PR DESCRIPTION
Allow for prefill and decode to have shared KV cache with prefill mapping to a subset of the decodes cache. 

With Strided DMA capability, even with the transposed V tensors we can have optimal performance when the cache is not exactly matched. 