### PR TITLE
[MLDrift] Support the BroadcastTo op

### DIFF
--- a/ml_drift_delegate/tflite/model_builder.cc
+++ b/ml_drift_delegate/tflite/model_builder.cc
@@ -549,6 +549,7 @@ bool IsBoolSupportedCompositeOp(
 bool SupportAllPrecisionOp(int32_t builtin_code) {
   return builtin_code == kTfLiteBuiltinStablehloBroadcastInDim ||
          builtin_code == kTfLiteBuiltinBitcast ||
+         builtin_code == kTfLiteBuiltinBroadcastTo ||
          builtin_code == kTfLiteBuiltinCast ||
          builtin_code == kTfLiteBuiltinConcatenation ||
          builtin_code == kTfLiteBuiltinDynamicUpdateSlice ||
@@ -1055,6 +1056,81 @@ class BroadcastInDimOperationParser : public TFLiteOperationParser {
       return absl::InvalidArgumentError("Index values must be unique");
     }
     return absl::OkStatus();
+  }
+};
+
+class BroadcastToOperationParser : public TFLiteOperationParser {
+ public:
+  absl::Status IsSupported(const TfLiteContext* context,
+                           const TfLiteNode* tflite_node,
+                           const TfLiteRegistration* registration) final {
+    ABSL_RETURN_IF_ERROR(tflite::CheckGpuDelegateCompatibility(
+        context, tflite_node, registration));
+    ABSL_RETURN_IF_ERROR(PreCheckReadValue(context, tflite_node, 0));
+    ABSL_RETURN_IF_ERROR(PreCheckOutputs(context, tflite_node));
+    return absl::OkStatus();
+  }
+
+  void Parse(const TfLiteNode* tflite_node,
+             const TfLiteRegistration* registration,
+             ::ml_drift::GraphFloat32* graph, ObjectReader* reader) final {
+    const TfLiteTensor* input_tensor = reader->GetInputTensor(0);
+    const TfLiteTensor* output_tensor = reader->GetOutputTensor(0);
+    const int input_rank = input_tensor->dims->size;
+    const int output_rank = output_tensor->dims->size;
+
+    const ::ml_drift::BHWC output_shape = ExtractTensorShape(output_tensor);
+    const ::ml_drift::BHWC input_shape = ExtractTensorShape(input_tensor);
+
+    // Right-align the input shape to the output rank by left-padding with 1s.
+    std::vector<int> padded(output_rank, 1);
+    for (int i = 0; i < input_rank; ++i) {
+      padded[output_rank - input_rank + i] = input_tensor->dims->data[i];
+    }
+    const ::ml_drift::BHWC padded_shape = ExtractTensorShape(padded);
+
+    const bool need_reshape = input_shape != padded_shape;
+    const bool need_tile = padded_shape != output_shape;
+
+    if (!need_reshape && !need_tile) {
+      ::ml_drift::Node* node = graph->NewNode();
+      node->operation.type = ToString(::ml_drift::OperationType::RESHAPE);
+      ::ml_drift::ReshapeAttributes attr;
+      attr.new_shape = output_shape;
+      node->operation.attributes = std::move(attr);
+      reader->AddInput(node, 0);
+      reader->AddOutputs(node);
+      return;
+    }
+
+    ::ml_drift::Value* reshaped_value = nullptr;
+    if (need_reshape) {
+      ::ml_drift::Node* reshape_node = graph->NewNode();
+      reshape_node->operation.type =
+          ToString(::ml_drift::OperationType::RESHAPE);
+      ::ml_drift::ReshapeAttributes attr;
+      attr.new_shape = padded_shape;
+      reshape_node->operation.attributes = std::move(attr);
+      reader->AddInput(reshape_node, 0);
+      if (!need_tile) {
+        reader->AddOutputs(reshape_node);
+        return;
+      }
+      const ::ml_drift::Value* input_value = reader->ReadValue(0);
+      reshaped_value = graph->NewValue();
+      reshaped_value->tensor.type = input_value->tensor.type;
+      reshaped_value->tensor.shape = padded_shape;
+      graph->SetProducer(reshape_node->id, reshaped_value->id);
+    }
+
+    ::ml_drift::Node* tile_node = graph->NewNode();
+    tile_node->operation.type = ToString(::ml_drift::OperationType::TILE);
+    if (need_reshape) {
+      graph->AddConsumer(tile_node->id, reshaped_value->id);
+    } else {
+      reader->AddInput(tile_node, 0);
+    }
+    reader->AddOutputs(tile_node);
   }
 };
 
@@ -6799,6 +6875,8 @@ std::unique_ptr<TFLiteOperationParser> NewOperationParser(
           ::ml_drift::OperationType::LOGICAL_XOR);
     case kTfLiteBuiltinStablehloBroadcastInDim:
       return std::make_unique<BroadcastInDimOperationParser>();
+    case kTfLiteBuiltinBroadcastTo:
+      return std::make_unique<BroadcastToOperationParser>();
     case kTfLiteBuiltinCast:
       return std::make_unique<CastOperationParser>();
     case kTfLiteBuiltinStablehloCbrt:

--- a/ml_drift_delegate/tflite/model_builder_helper.cc
+++ b/ml_drift_delegate/tflite/model_builder_helper.cc
@@ -70,6 +70,14 @@ std::string GetTensorDebugString(const TfLiteTensor* tensor) {
   return passthru_node;
 }
 
+::ml_drift::BHWC ExtractTensorShapeImpl(const int32_t* data, int size) {
+  if (size == 0) return ::ml_drift::BHWC(1, 1, 1, 1);
+  if (size == 1) return ::ml_drift::BHWC(data[0], 1, 1, 1);
+  if (size == 2) return ::ml_drift::BHWC(data[0], 1, 1, data[1]);
+  if (size == 3) return ::ml_drift::BHWC(data[0], 1, data[1], data[2]);
+  return ::ml_drift::BHWC(data[0], data[1], data[2], data[3]);
+}
+
 }  // namespace
 
 absl::Status GetNodeAndRegistration(TfLiteContext* context, int node_id,
@@ -113,18 +121,15 @@ absl::Status GetNodeAndRegistration(TfLiteContext* context, int node_id,
 }
 
 ::ml_drift::BHWC ExtractTensorShape(const TfLiteIntArray* dims) {
-  const int size = dims->size;
-  if (size == 0) return ::ml_drift::BHWC(1, 1, 1, 1);
-  if (size == 1) return ::ml_drift::BHWC(dims->data[0], 1, 1, 1);
-  if (size == 2) return ::ml_drift::BHWC(dims->data[0], 1, 1, dims->data[1]);
-  if (size == 3)
-    return ::ml_drift::BHWC(dims->data[0], 1, dims->data[1], dims->data[2]);
-  return ::ml_drift::BHWC(dims->data[0], dims->data[1], dims->data[2],
-                          dims->data[3]);
+  return ExtractTensorShapeImpl(dims->data, dims->size);
 }
 
 ::ml_drift::BHWC ExtractTensorShape(const TfLiteTensor* tflite_tensor) {
   return ExtractTensorShape(tflite_tensor->dims);
+}
+
+::ml_drift::BHWC ExtractTensorShape(const std::vector<int>& dims) {
+  return ExtractTensorShapeImpl(dims.data(), static_cast<int>(dims.size()));
 }
 
 ::ml_drift::Axis ExtractAxisFromIndex(const TfLiteTensor& tflite_tensor,

--- a/ml_drift_delegate/tflite/model_builder_helper.h
+++ b/ml_drift_delegate/tflite/model_builder_helper.h
@@ -44,6 +44,8 @@ absl::Status GetNodeAndRegistration(TfLiteContext* context, int node_id,
 
 ::ml_drift::BHWC ExtractTensorShape(const TfLiteTensor* tflite_tensor);
 
+::ml_drift::BHWC ExtractTensorShape(const std::vector<int> &dims);
+
 // Must check PreCheckAxisFromIndex.
 ::ml_drift::Axis ExtractAxisFromIndex(const TfLiteTensor& tflite_tensor,
                                       int index);

--- a/ml_drift_delegate/tflite/model_builder_test.cc
+++ b/ml_drift_delegate/tflite/model_builder_test.cc
@@ -2019,6 +2019,97 @@ TEST(BroadcastInDimOperationParserTest, TestIsSupported) {
   context->node()->inputs->data[0] = 0;
 }
 
+TEST(BroadcastToOperationParserTest, TestIsSupported) {
+  // BroadcastTo needs one runtime input (data) and one const input (shape).
+  // A single input fails the const-input requirement.
+  auto context = std::make_unique<StubTfLiteContext>(
+      kTfLiteBuiltinBroadcastTo,
+      /*op_version=*/1,
+      /*num_inputs=*/1,
+      /*shape=*/std::vector<int>({1, 1, 1, 4}));
+  auto parser = NewOperationParser(context->node(), context->registration());
+  EXPECT_FALSE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+
+  // Valid: runtime f32 data broadcast to an identical output shape, with a
+  // constant int32 shape input (tensor 2).
+  context = std::make_unique<StubTfLiteContext>(
+      kTfLiteBuiltinBroadcastTo,
+      /*op_version=*/1,
+      /*num_inputs=*/2,
+      /*shape=*/std::vector<int>({1, 1, 1, 4}));
+  parser = NewOperationParser(context->node(), context->registration());
+  context->SetTensorType(2, kTfLiteInt32, kTfLiteMmapRo);
+  EXPECT_TRUE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+
+  // Valid: right-aligned broadcast that requires tiling (dim 1 -> N).
+  context->ChangeTensorShape(3, {2, 1, 1, 4});
+  EXPECT_TRUE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+
+  // Valid: input rank < output rank (left-padded with 1s), compatible.
+  context->ChangeTensorShape(1, {4});
+  context->ChangeTensorShape(3, {2, 4});
+  EXPECT_TRUE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+
+  // Invalid: trailing-aligned dims are not broadcast-compatible (3 vs 2).
+  context->ChangeTensorShape(1, {3, 4});
+  context->ChangeTensorShape(3, {2, 4});
+  EXPECT_FALSE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+
+  // Invalid: input rank exceeds output rank.
+  context->ChangeTensorShape(1, {2, 4});
+  context->ChangeTensorShape(3, {4});
+  EXPECT_FALSE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+
+  // Invalid: rank > 4 is unsupported.
+  context->ChangeTensorShape(1, {2, 2, 2, 2, 2});
+  context->ChangeTensorShape(3, {2, 2, 2, 2, 2});
+  EXPECT_FALSE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+
+  // Restore a valid identity broadcast before the remaining checks.
+  context->ChangeTensorShape(1, {1, 1, 1, 4});
+  context->ChangeTensorShape(3, {1, 1, 1, 4});
+  EXPECT_TRUE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+
+  // Invalid: input and output data types differ.
+  context->SetTensorType(3, kTfLiteInt32, kTfLiteArenaRw);
+  EXPECT_FALSE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+  context->SetTensorType(3, kTfLiteFloat32, kTfLiteArenaRw);
+
+  // Invalid: the shape input is not constant.
+  context->SetTensorType(2, kTfLiteInt32, kTfLiteArenaRw);
+  EXPECT_FALSE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+}
+
 TEST(CastOperationParserTest, TestIsSupported) {
   // Invalid num_inputs
   auto context = std::make_unique<StubTfLiteContext>(

--- a/tflite/tools/versioning/gpu_compatibility.cc
+++ b/tflite/tools/versioning/gpu_compatibility.cc
@@ -630,6 +630,39 @@ absl::Status CheckGpuDelegateCompatibility(const OpSignature& op_sig,
       return absl::OkStatus();
     }
 
+    case kTfLiteBuiltinBroadcastTo: {
+      RETURN_IF_ERROR(CheckInputsConstsOutputs(op_sig,
+                                               /*required_runtime_inputs=*/1,
+                                               /*required_const_inputs=*/1,
+                                               /*required_outputs=*/1));
+      const auto &bcast_input = op_sig.inputs[0];
+      const auto &bcast_output = op_sig.outputs[0];
+      if (bcast_input.dims.empty() || bcast_input.dims.size() > 4 ||
+          bcast_output.dims.empty() || bcast_output.dims.size() > 4) {
+        return absl::UnimplementedError(
+            "BroadcastTo only supports 1D-4D tensors.");
+      }
+      if (bcast_input.dims.size() > bcast_output.dims.size()) {
+        return absl::InvalidArgumentError(
+            "BroadcastTo input rank must not exceed output rank.");
+      }
+      // Numpy-style right-aligned broadcast compatibility: pairing dims from the
+      // trailing end, each input dim must be 1 or equal to the output dim.
+      for (int i = 0; i < static_cast<int>(bcast_input.dims.size()); ++i) {
+        const int in_dim = bcast_input.dims[bcast_input.dims.size() - 1 - i];
+        const int out_dim = bcast_output.dims[bcast_output.dims.size() - 1 - i];
+        if (in_dim != 1 && in_dim != out_dim) {
+          return absl::InvalidArgumentError(
+              "BroadcastTo dimensions are not broadcast-compatible.");
+        }
+      }
+      if (bcast_input.type != bcast_output.type) {
+        return absl::InvalidArgumentError(
+            "BroadcastTo input and output must have the same data type.");
+      }
+      return absl::OkStatus();
+    }
+
     case kTfLiteBuiltinCast:
       RETURN_IF_ERROR(CheckInputsOutputs(op_sig,
                                          /*required_runtime_inputs=*/1,

--- a/tflite/tools/versioning/gpu_compatibility_test.cc
+++ b/tflite/tools/versioning/gpu_compatibility_test.cc
@@ -56,6 +56,29 @@ absl::Status CheckGpuDelegateCompatibility(const tflite::Model* model) {
   return absl::OkStatus();
 }
 
+// Builds a BroadcastTo OpSignature: runtime data input[0], const shape
+// input[1], and one output.
+static OpSignature MakeBroadcastToOpSig(const std::vector<int32_t> &input_dims,
+                                        const std::vector<int32_t> &output_dims,
+                                        TfLiteType input_type = kTfLiteFloat32,
+                                        TfLiteType output_type = kTfLiteFloat32) {
+  OpSignature op_sig = OpSignature();
+  op_sig.op = BuiltinOperator_BROADCAST_TO;
+  op_sig.inputs = std::vector<OpSignatureTensorSpec>(2);
+  op_sig.inputs[0] = OpSignatureTensorSpec();
+  op_sig.inputs[0].dims = input_dims;
+  op_sig.inputs[0].type = input_type;
+  op_sig.inputs[1] = OpSignatureTensorSpec(); // shape tensor
+  op_sig.inputs[1].is_const = true;
+  op_sig.inputs[1].dims = {static_cast<int32_t>(output_dims.size())};
+  op_sig.inputs[1].type = kTfLiteInt32;
+  op_sig.outputs = std::vector<OpSignatureTensorSpec>(1);
+  op_sig.outputs[0] = OpSignatureTensorSpec();
+  op_sig.outputs[0].dims = output_dims;
+  op_sig.outputs[0].type = output_type;
+  return op_sig;
+}
+
 }  // namespace
 
 // FYI, CheckGpuDelegateCompatibility() will be validated by
@@ -190,6 +213,48 @@ TEST(CheckGpuDelegateCompatibility, Add2Dto4DBroadcastSuccess2) {
   op_sig.inputs[1].dims = {1, 1};
 
   EXPECT_TRUE(CheckGpuDelegateCompatibility(op_sig).message().empty());
+}
+
+TEST(CheckGpuDelegateCompatibility, BroadcastToTileSuccess) {
+  OpSignature op_sig = MakeBroadcastToOpSig({1, 1, 1, 4}, {2, 1, 1, 4});
+  EXPECT_TRUE(CheckGpuDelegateCompatibility(op_sig).message().empty());
+}
+
+TEST(CheckGpuDelegateCompatibility, BroadcastToLowerRankSuccess) {
+  OpSignature op_sig = MakeBroadcastToOpSig({4}, {2, 4});
+  EXPECT_TRUE(CheckGpuDelegateCompatibility(op_sig).message().empty());
+}
+
+TEST(CheckGpuDelegateCompatibility, BroadcastToRankExceedsFail) {
+  OpSignature op_sig = MakeBroadcastToOpSig({2, 4}, {4});
+  EXPECT_EQ(CheckGpuDelegateCompatibility(op_sig).message(),
+            "BroadcastTo input rank must not exceed output rank.");
+}
+
+TEST(CheckGpuDelegateCompatibility, BroadcastToIncompatibleDimsFail) {
+  OpSignature op_sig = MakeBroadcastToOpSig({3, 4}, {2, 4});
+  EXPECT_EQ(CheckGpuDelegateCompatibility(op_sig).message(),
+            "BroadcastTo dimensions are not broadcast-compatible.");
+}
+
+TEST(CheckGpuDelegateCompatibility, BroadcastToTypeMismatchFail) {
+  OpSignature op_sig =
+      MakeBroadcastToOpSig({1, 4}, {2, 4}, kTfLiteFloat32, kTfLiteInt32);
+  EXPECT_EQ(CheckGpuDelegateCompatibility(op_sig).message(),
+            "BroadcastTo input and output must have the same data type.");
+}
+
+TEST(CheckGpuDelegateCompatibility, BroadcastToTooManyDimsFail) {
+  OpSignature op_sig =
+      MakeBroadcastToOpSig({2, 2, 2, 2, 2}, {2, 2, 2, 2, 2});
+  EXPECT_EQ(CheckGpuDelegateCompatibility(op_sig).message(),
+            "BroadcastTo only supports 1D-4D tensors.");
+}
+
+TEST(CheckGpuDelegateCompatibility, BroadcastToNonConstShapeFail) {
+  OpSignature op_sig = MakeBroadcastToOpSig({1, 4}, {2, 4});
+  op_sig.inputs[1].is_const = false;  // shape must be constant
+  EXPECT_FALSE(CheckGpuDelegateCompatibility(op_sig).message().empty());
 }
 
 TEST(CheckGpuDelegateCompatibility, Add2Dto4DBroadcastSuccess3) {


### PR DESCRIPTION
This PR supports the BroadcastTo op for ml-drift, which is used by Whisper demo. `BroadcastTo` uses NumPy right-aligned broadcasting, while ml-drift's BHWC layout is left-aligned. It's lowered to RESHAPE + TILE: the input is left-padded with 1s and reshaped into the right BHWC slots, then tiled up to the output shape (TILE infers repeats from the shapes). Identity / reshape-only / tile-only cases skip the unneeded node.

see chromium issue: https://issues.chromium.org/issues/534893138