### PR TITLE
Qualcomm AI Engine Direct - Fix manual and auto perf ctrl mode.

### DIFF
--- a/litert/vendors/qualcomm/core/backends/dsp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/dsp_backend.cc
@@ -101,25 +101,29 @@ class DspBackend::DspPerfControl {
     voting_thread_->Enqueue(VotingThread::VoteType::kDownVote, debounce);
   }
 
-  bool ReinitIfNeeded(DspPerformanceMode new_mode) {
-    const bool needs_init =
-        dsp_perf_infra_ == nullptr || new_mode != current_mode_;
-    if (needs_init && !Init(new_mode)) {
-      QNN_LOG_ERROR("DSP backend failed to re-init for performance mode %d.",
-                    new_mode);
-      return false;
-    }
-    ScheduleUpVote();
-    return true;
-  }
-
-  // Applies new_mode for one inference. Manual skips a same-mode re-vote
-  // when init already upvoted, auto always re-votes.
-  bool ApplyPerfMode(DspPerformanceMode new_mode, DspPerfCtrlMode ctrl_mode) {
-    if (new_mode == current_mode_ && ctrl_mode == DspPerfCtrlMode::kManual) {
+  bool SetPerfModeAndApplyIfManual(const Options& options) {
+    const auto new_mode = options.GetDspPerformanceMode();
+    const bool mode_changed = new_mode != current_mode_;
+    if (new_mode == DspPerformanceMode::kDefault) {
+      if (mode_changed) {
+        ScheduleDownVote();
+        current_mode_ = DspPerformanceMode::kDefault;
+      }
       return true;
     }
-    return ReinitIfNeeded(new_mode);
+    if (!mode_changed) {
+      QNN_LOG_DEBUG("SetPerfModeAndApplyIfManual: Perf mode doesn't change.");
+      return true;
+    }
+    QNN_LOG_DEBUG("SetPerfModeAndApplyIfManual: Init new mode.");
+    if (!Init(new_mode)) return false;
+    if (options.GetDspPerfCtrlMode() == DspPerfCtrlMode::kManual) {
+      QNN_LOG_DEBUG("SetPerfModeAndApplyIfManual: Work for kManual.");
+      UpVote();
+    } else {
+      QNN_LOG_DEBUG("SetPerfModeAndApplyIfManual: Ignore due to kAuto.");
+    }
+    return true;
   }
 
  private:
@@ -317,28 +321,26 @@ bool DspBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
 }
 
 bool DspBackend::SetPerformanceMode(const Options& options) {
-  DspPerformanceMode performance_mode = options.GetDspPerformanceMode();
-
-  if (performance_mode == DspPerformanceMode::kDefault) {
-    if (dsp_perf_control_) {
-      dsp_perf_control_->ScheduleDownVote();
+  const auto perf_mode = options.GetDspPerformanceMode();
+  if (perf_mode != DspPerformanceMode::kDefault) {
+    if (!dsp_perf_control_) {
+      dsp_perf_control_ = std::make_unique<DspPerfControl>(QnnApi());
     }
-    return true;
   }
-
-  if (!dsp_perf_control_) {
-    QNN_LOG_ERROR(
-        "DSP performance control is not initialized in SetPerformanceMode.");
-    return false;
-  }
-
-  if (!dsp_perf_control_->ApplyPerfMode(performance_mode,
-                                        options.GetDspPerfCtrlMode())) {
+  if (dsp_perf_control_ &&
+      !dsp_perf_control_->SetPerfModeAndApplyIfManual(options)) {
     QNN_LOG_ERROR("Failed to set DSP performance mode in SetPerformanceMode");
     return false;
   }
-
   return true;
+}
+
+void DspBackend::ScheduleUpVote() {
+  if (dsp_perf_control_) dsp_perf_control_->ScheduleUpVote();
+}
+
+void DspBackend::ScheduleDownVote() {
+  if (dsp_perf_control_) dsp_perf_control_->ScheduleDownVote();
 }
 
 }  // namespace qnn

--- a/litert/vendors/qualcomm/core/backends/dsp_backend.h
+++ b/litert/vendors/qualcomm/core/backends/dsp_backend.h
@@ -48,7 +48,10 @@ class DspBackend : public QnnBackend {
   DspBackend& operator=(DspBackend&&) = delete;
 
   bool Init(const Options& options, std::optional<SocInfo> soc_info) override;
+
   bool SetPerformanceMode(const Options& options) override;
+  void ScheduleUpVote() override;
+  void ScheduleDownVote() override;
 
   // TODO: DSP does not build any graph configs yet; returns an empty builder.
   GraphConfigBuilder BuildGraphConfigs(

--- a/litert/vendors/qualcomm/core/backends/dsp_backend_test.cc
+++ b/litert/vendors/qualcomm/core/backends/dsp_backend_test.cc
@@ -74,6 +74,41 @@ struct DspPerfParams {
   QnnDspPerfInfrastructure_VoltageCorner_t expected_max_voltage;
 };
 
+bool LastVoteIsUpVoteTo(QnnDspPerfInfrastructure_VoltageCorner_t corner) {
+  const auto& configs = *captured_configs;
+  bool power_mode_ok = false;
+  bool target_ok = false;
+  for (const auto& cfg : configs) {
+    const bool is_power_mode =
+        cfg.config ==
+        QNN_DSP_PERF_INFRASTRUCTURE_POWER_CONFIGOPTION_DCVS_POWER_MODE;
+    const bool is_corner =
+        cfg.config ==
+        QNN_DSP_PERF_INFRASTRUCTURE_POWER_CONFIGOPTION_DCVS_VOLTAGE_CORNER;
+    if (is_power_mode) {
+      power_mode_ok = cfg.dcvsPowerModeConfig ==
+                      QNN_DSP_PERF_INFRASTRUCTURE_POWERMODE_PERFORMANCE_MODE;
+    }
+    if (is_corner && cfg.dcvsVoltageCornerTargetConfig == corner) {
+      target_ok = true;
+    }
+  }
+  return power_mode_ok && target_ok;
+}
+
+bool LastVoteIsDownVote() {
+  const auto& configs = *captured_configs;
+  for (const auto& cfg : configs) {
+    if (cfg.config ==
+            QNN_DSP_PERF_INFRASTRUCTURE_POWER_CONFIGOPTION_DCVS_POWER_MODE &&
+        cfg.dcvsPowerModeConfig ==
+            QNN_DSP_PERF_INFRASTRUCTURE_POWERMODE_POWER_SAVER_MODE) {
+      return true;
+    }
+  }
+  return false;
+}
+
 class DspBackendPerfParamTest : public testing::TestWithParam<DspPerfParams> {
  public:
   void SetUp() override {
@@ -227,7 +262,7 @@ TEST_P(DspBackendPerfParamTest, ManualSameModeSkipsRevote) {
   EXPECT_EQ(set_power_config_call_count.load(), calls_after_init);
 }
 
-TEST_P(DspBackendPerfParamTest, AutoSameModeRevotes) {
+TEST_P(DspBackendPerfParamTest, AutoSchedulesVotePerInference) {
   const auto& params = GetParam();
   Options options;
   options.SetDspPerformanceMode(params.mode);
@@ -235,11 +270,16 @@ TEST_P(DspBackendPerfParamTest, AutoSameModeRevotes) {
   DspBackend backend(&qnn_api_copy_);
 
   ASSERT_TRUE(backend.Init(options, std::nullopt));
-  const int calls_after_init = set_power_config_call_count.load();
 
+  const int calls_after_init = set_power_config_call_count.load();
   EXPECT_TRUE(backend.SetPerformanceMode(options));
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_EQ(set_power_config_call_count.load(), calls_after_init);
+
+  backend.ScheduleUpVote();
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
   EXPECT_EQ(set_power_config_call_count.load(), calls_after_init + 1);
+  EXPECT_TRUE(LastVoteIsUpVoteTo(params.expected_target_voltage));
 }
 
 class DspBackendPerfTest : public testing::Test {
@@ -279,6 +319,7 @@ TEST_F(DspBackendPerfTest, ManualModeChangeRevotes) {
   EXPECT_TRUE(backend.SetPerformanceMode(options));
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
   EXPECT_GT(set_power_config_call_count.load(), calls_after_init);
+  EXPECT_TRUE(LastVoteIsUpVoteTo(DCVS_VOLTAGE_VCORNER_MAX_VOLTAGE_CORNER));
 }
 
 TEST_F(DspBackendPerfTest, DefaultModeSchedulesDownvote) {
@@ -294,9 +335,50 @@ TEST_F(DspBackendPerfTest, DefaultModeSchedulesDownvote) {
   EXPECT_TRUE(backend.SetPerformanceMode(default_options));
   std::this_thread::sleep_for(std::chrono::milliseconds(400));
   EXPECT_GT(set_power_config_call_count.load(), calls_after_init);
+  EXPECT_TRUE(LastVoteIsDownVote());
 }
 
-TEST_F(DspBackendPerfTest, AutoModeChangesAcrossExecutes) {
+TEST_F(DspBackendPerfTest, AutoDefaultModeSchedulesDownvote) {
+  Options options;
+  options.SetDspPerformanceMode(DspPerformanceMode::kBurst);
+  options.SetDspPerfCtrlMode(DspPerfCtrlMode::kAuto);
+  DspBackend backend(&qnn_api_copy_);
+
+  ASSERT_TRUE(backend.Init(options, std::nullopt));
+  backend.ScheduleUpVote();
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  const int calls_after_upvote = set_power_config_call_count.load();
+
+  Options default_options;
+  default_options.SetDspPerfCtrlMode(DspPerfCtrlMode::kAuto);
+  EXPECT_TRUE(backend.SetPerformanceMode(default_options));
+  std::this_thread::sleep_for(std::chrono::milliseconds(400));
+  EXPECT_GT(set_power_config_call_count.load(), calls_after_upvote);
+  EXPECT_TRUE(LastVoteIsDownVote());
+}
+
+TEST_F(DspBackendPerfTest, ManualBurstDefaultBurstRevotes) {
+  Options options;
+  options.SetDspPerformanceMode(DspPerformanceMode::kBurst);
+  options.SetDspPerfCtrlMode(DspPerfCtrlMode::kManual);
+  DspBackend backend(&qnn_api_copy_);
+
+  ASSERT_TRUE(backend.Init(options, std::nullopt));
+
+  Options default_options;
+  default_options.SetDspPerfCtrlMode(DspPerfCtrlMode::kManual);
+  EXPECT_TRUE(backend.SetPerformanceMode(default_options));
+  std::this_thread::sleep_for(std::chrono::milliseconds(400));
+  const int calls_after_downvote = set_power_config_call_count.load();
+  EXPECT_TRUE(LastVoteIsDownVote());
+
+  EXPECT_TRUE(backend.SetPerformanceMode(options));
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_GT(set_power_config_call_count.load(), calls_after_downvote);
+  EXPECT_TRUE(LastVoteIsUpVoteTo(DCVS_VOLTAGE_VCORNER_MAX_VOLTAGE_CORNER));
+}
+
+TEST_F(DspBackendPerfTest, AutoSchedulesUpAndDownVotes) {
   Options options;
   options.SetDspPerformanceMode(DspPerformanceMode::kPowerSaver);
   options.SetDspPerfCtrlMode(DspPerfCtrlMode::kAuto);
@@ -305,20 +387,16 @@ TEST_F(DspBackendPerfTest, AutoModeChangesAcrossExecutes) {
   ASSERT_TRUE(backend.Init(options, std::nullopt));
   const int calls_after_init = set_power_config_call_count.load();
 
-  EXPECT_TRUE(backend.SetPerformanceMode(options));
+  backend.ScheduleUpVote();
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  const int calls_after_same = set_power_config_call_count.load();
-  EXPECT_GT(calls_after_same, calls_after_init);
+  const int calls_after_upvote = set_power_config_call_count.load();
+  EXPECT_GT(calls_after_upvote, calls_after_init);
+  EXPECT_TRUE(LastVoteIsUpVoteTo(DCVS_VOLTAGE_VCORNER_SVS));
 
-  Options default_options;
-  EXPECT_TRUE(backend.SetPerformanceMode(default_options));
-
-  Options burst_options;
-  burst_options.SetDspPerformanceMode(DspPerformanceMode::kBurst);
-  burst_options.SetDspPerfCtrlMode(DspPerfCtrlMode::kAuto);
-  EXPECT_TRUE(backend.SetPerformanceMode(burst_options));
+  backend.ScheduleDownVote();
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  EXPECT_GT(set_power_config_call_count.load(), calls_after_same);
+  EXPECT_GT(set_power_config_call_count.load(), calls_after_upvote);
+  EXPECT_TRUE(LastVoteIsDownVote());
 }
 
 }  // namespace

--- a/litert/vendors/qualcomm/core/backends/htp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.cc
@@ -171,32 +171,34 @@ class HtpBackend::HtpPerfControl {
     voting_thread_->Enqueue(VotingThread::VoteType::kDownVote, debounce);
   }
 
-  bool ReinitIfNeeded(HtpPerformanceMode new_mode) {
-    const bool needs_init =
-        htp_perf_infra_ == nullptr || new_mode != current_mode_;
-    if (needs_init && !Init(new_mode)) {
-      QNN_LOG_ERROR("HTP backend failed to re-init for performance mode %d.",
-                    new_mode);
-      return false;
-    }
-    ScheduleUpVote();
-    return true;
-  }
-
-  // Applies new_mode for one inference. Manual skips a same-mode re-vote
-  // when init already upvoted, auto always re-votes.
-  bool ApplyPerfMode(HtpPerformanceMode new_mode, HtpPerfCtrlMode ctrl_mode,
-                     bool supports_rpc_polling) {
+  bool SetPerfModeAndApplyIfManual(const Options& options) {
+    const auto new_mode = options.GetHtpPerformanceMode();
     const bool mode_changed = new_mode != current_mode_;
-    if (!mode_changed && ctrl_mode == HtpPerfCtrlMode::kManual) {
+    if (new_mode == HtpPerformanceMode::kDefault) {
+      if (mode_changed) {
+        ScheduleDownVote();
+        current_mode_ = HtpPerformanceMode::kDefault;
+      }
       return true;
     }
-    if (!ReinitIfNeeded(new_mode)) {
+    if (!mode_changed) {
+      QNN_LOG_DEBUG("SetPerfModeAndApplyIfManual: Perf mode doesn't change.");
+      return true;
+    }
+    QNN_LOG_DEBUG("SetPerfModeAndApplyIfManual: Init new mode.");
+    if (!Init(new_mode)) return false;
+    // TODO(jiunkaiy): Enable RPC polling only on SoCs v69 and later. For now,
+    // rely on the QAIRT SDK to disable it on unsupported platforms.
+    if (!SetRpcPolling(new_mode)) {
+      QNN_LOG_ERROR(
+          "Failed to set RPC polling in SetPerfModeAndApplyIfManual.");
       return false;
     }
-    if (mode_changed && supports_rpc_polling && !SetRpcPolling(new_mode)) {
-      QNN_LOG_ERROR("Failed to set RPC Polling in ApplyPerfMode.");
-      return false;
+    if (options.GetHtpPerfCtrlMode() == HtpPerfCtrlMode::kManual) {
+      QNN_LOG_DEBUG("SetPerfModeAndApplyIfManual: Work for kManual.");
+      UpVote();
+    } else {
+      QNN_LOG_DEBUG("SetPerfModeAndApplyIfManual: Ignore due to kAuto.");
     }
     return true;
   }
@@ -606,30 +608,26 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
 }
 
 bool HtpBackend::SetPerformanceMode(const Options& options) {
-  HtpPerformanceMode performance_mode = options.GetHtpPerformanceMode();
-
-  if (performance_mode == HtpPerformanceMode::kDefault) {
-    if (htp_perf_control_) {
-      htp_perf_control_->ScheduleDownVote();
+  const auto perf_mode = options.GetHtpPerformanceMode();
+  if (perf_mode != HtpPerformanceMode::kDefault) {
+    if (!htp_perf_control_) {
+      htp_perf_control_ = std::make_unique<HtpPerfControl>(QnnApi());
     }
-    return true;
   }
-
-  if (!htp_perf_control_) {
-    QNN_LOG_ERROR(
-        "HTP performance control is not initialized in SetPerformanceMode.");
-    return false;
-  }
-
-  // TODO(jiunkaiy): Enable RPC polling only on SoCs v69 and later. For now,
-  // rely on the QAIRT SDK to disable it on unsupported platforms.
-  if (!htp_perf_control_->ApplyPerfMode(performance_mode,
-                                        options.GetHtpPerfCtrlMode(), true)) {
+  if (htp_perf_control_ &&
+      !htp_perf_control_->SetPerfModeAndApplyIfManual(options)) {
     QNN_LOG_ERROR("Failed to set HTP performance mode in SetPerformanceMode");
     return false;
   }
-
   return true;
+}
+
+void HtpBackend::ScheduleUpVote() {
+  if (htp_perf_control_) htp_perf_control_->ScheduleUpVote();
+}
+
+void HtpBackend::ScheduleDownVote() {
+  if (htp_perf_control_) htp_perf_control_->ScheduleDownVote();
 }
 
 GraphConfigBuilder HtpBackend::BuildGraphConfigs(

--- a/litert/vendors/qualcomm/core/backends/htp_backend.h
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.h
@@ -64,6 +64,8 @@ class HtpBackend : public QnnBackend {
   bool Init(const Options& options, std::optional<SocInfo> soc_info) override;
 
   bool SetPerformanceMode(const Options& options) override;
+  void ScheduleUpVote() override;
+  void ScheduleDownVote() override;
 
   GraphConfigBuilder BuildGraphConfigs(
       const Options& options, absl::string_view qnn_graph_name) override;

--- a/litert/vendors/qualcomm/core/backends/htp_backend_test.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend_test.cc
@@ -113,6 +113,28 @@ struct HtpPerfParams {
   QnnHtpPerfInfrastructure_VoltageCorner_t voltage_corner;
 };
 
+const QnnHtpPerfInfrastructure_DcvsV3_t* LastDcvsConfig() {
+  if (captured_configs->empty()) return nullptr;
+  for (const auto& cfg : captured_configs->back()) {
+    if (cfg.option == QNN_HTP_PERF_INFRASTRUCTURE_POWER_CONFIGOPTION_DCVS_V3) {
+      return &cfg.dcvsV3Config;
+    }
+  }
+  return nullptr;
+}
+
+bool LastVoteIsUpVoteTo(QnnHtpPerfInfrastructure_VoltageCorner_t corner) {
+  const auto* dcvs = LastDcvsConfig();
+  return dcvs != nullptr &&
+         dcvs->sleepLatency != PowerConfig::kSleepMaxLatency &&
+         dcvs->busVoltageCornerTarget == corner;
+}
+
+bool LastVoteIsDownVote() {
+  const auto* dcvs = LastDcvsConfig();
+  return dcvs != nullptr && dcvs->sleepLatency == PowerConfig::kSleepMaxLatency;
+}
+
 class HtpBackendPerfBaseTest : public testing::TestWithParam<HtpPerfParams> {
  public:
   void SetUp() override {
@@ -356,7 +378,7 @@ TEST_P(HtpBackendRPCPollingPerfParamTest, ManualSameModeSkipsRevote) {
   EXPECT_EQ(captured_configs->size(), configs_after_init);
 }
 
-TEST_P(HtpBackendRPCPollingPerfParamTest, AutoSameModeRevotes) {
+TEST_P(HtpBackendRPCPollingPerfParamTest, AutoSchedulesVotePerInference) {
   const auto& params = GetParam();
   Options options;
   options.SetHtpPerformanceMode(params.mode);
@@ -372,7 +394,12 @@ TEST_P(HtpBackendRPCPollingPerfParamTest, AutoSameModeRevotes) {
   const size_t configs_after_init = captured_configs->size();
   EXPECT_TRUE(backend.SetPerformanceMode(options));
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_EQ(captured_configs->size(), configs_after_init);
+
+  backend.ScheduleUpVote();
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
   EXPECT_EQ(captured_configs->size(), configs_after_init + 1);
+  EXPECT_TRUE(LastVoteIsUpVoteTo(params.voltage_corner));
 }
 
 TEST_F(HtpBackendPerfBaseTest, ManualModeChangeRevotes) {
@@ -392,6 +419,7 @@ TEST_F(HtpBackendPerfBaseTest, ManualModeChangeRevotes) {
   EXPECT_TRUE(backend.SetPerformanceMode(options));
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
   EXPECT_GT(captured_configs->size(), configs_after_init);
+  EXPECT_TRUE(LastVoteIsUpVoteTo(DCVS_VOLTAGE_VCORNER_MAX_VOLTAGE_CORNER));
 }
 
 TEST_F(HtpBackendPerfBaseTest, DefaultModeSchedulesDownvote) {
@@ -411,9 +439,58 @@ TEST_F(HtpBackendPerfBaseTest, DefaultModeSchedulesDownvote) {
   EXPECT_TRUE(backend.SetPerformanceMode(default_options));
   std::this_thread::sleep_for(std::chrono::milliseconds(400));
   EXPECT_GT(captured_configs->size(), configs_after_init);
+  EXPECT_TRUE(LastVoteIsDownVote());
 }
 
-TEST_F(HtpBackendPerfBaseTest, AutoModeChangesAcrossExecutes) {
+TEST_F(HtpBackendPerfBaseTest, AutoDefaultModeSchedulesDownvote) {
+  Options options;
+  options.SetHtpPerformanceMode(HtpPerformanceMode::kBurst);
+  options.SetHtpPerfCtrlMode(HtpPerfCtrlMode::kAuto);
+  HtpBackend backend(&qnn_api_copy_);
+
+#if defined(__x86_64__) || defined(_M_X64)
+  ASSERT_TRUE(backend.Init(options, kSocInfos[8]));
+#else
+  ASSERT_TRUE(backend.Init(options, std::nullopt));
+#endif
+  backend.ScheduleUpVote();
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  const size_t configs_after_upvote = captured_configs->size();
+
+  Options default_options;
+  default_options.SetHtpPerfCtrlMode(HtpPerfCtrlMode::kAuto);
+  EXPECT_TRUE(backend.SetPerformanceMode(default_options));
+  std::this_thread::sleep_for(std::chrono::milliseconds(400));
+  EXPECT_GT(captured_configs->size(), configs_after_upvote);
+  EXPECT_TRUE(LastVoteIsDownVote());
+}
+
+TEST_F(HtpBackendPerfBaseTest, ManualBurstDefaultBurstRevotes) {
+  Options options;
+  options.SetHtpPerformanceMode(HtpPerformanceMode::kBurst);
+  options.SetHtpPerfCtrlMode(HtpPerfCtrlMode::kManual);
+  HtpBackend backend(&qnn_api_copy_);
+
+#if defined(__x86_64__) || defined(_M_X64)
+  ASSERT_TRUE(backend.Init(options, kSocInfos[8]));
+#else
+  ASSERT_TRUE(backend.Init(options, std::nullopt));
+#endif
+
+  Options default_options;
+  default_options.SetHtpPerfCtrlMode(HtpPerfCtrlMode::kManual);
+  EXPECT_TRUE(backend.SetPerformanceMode(default_options));
+  std::this_thread::sleep_for(std::chrono::milliseconds(400));
+  const size_t configs_after_downvote = captured_configs->size();
+  EXPECT_TRUE(LastVoteIsDownVote());
+
+  EXPECT_TRUE(backend.SetPerformanceMode(options));
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_GT(captured_configs->size(), configs_after_downvote);
+  EXPECT_TRUE(LastVoteIsUpVoteTo(DCVS_VOLTAGE_VCORNER_MAX_VOLTAGE_CORNER));
+}
+
+TEST_F(HtpBackendPerfBaseTest, AutoSchedulesUpAndDownVotes) {
   Options options;
   options.SetHtpPerformanceMode(HtpPerformanceMode::kPowerSaver);
   options.SetHtpPerfCtrlMode(HtpPerfCtrlMode::kAuto);
@@ -426,20 +503,16 @@ TEST_F(HtpBackendPerfBaseTest, AutoModeChangesAcrossExecutes) {
 #endif
   const size_t configs_after_init = captured_configs->size();
 
-  EXPECT_TRUE(backend.SetPerformanceMode(options));
+  backend.ScheduleUpVote();
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  const size_t configs_after_same = captured_configs->size();
-  EXPECT_GT(configs_after_same, configs_after_init);
+  const size_t configs_after_upvote = captured_configs->size();
+  EXPECT_GT(configs_after_upvote, configs_after_init);
+  EXPECT_TRUE(LastVoteIsUpVoteTo(DCVS_VOLTAGE_VCORNER_SVS));
 
-  Options default_options;
-  EXPECT_TRUE(backend.SetPerformanceMode(default_options));
-
-  Options burst_options;
-  burst_options.SetHtpPerformanceMode(HtpPerformanceMode::kBurst);
-  burst_options.SetHtpPerfCtrlMode(HtpPerfCtrlMode::kAuto);
-  EXPECT_TRUE(backend.SetPerformanceMode(burst_options));
+  backend.ScheduleDownVote();
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  EXPECT_GT(captured_configs->size(), configs_after_same);
+  EXPECT_GT(captured_configs->size(), configs_after_upvote);
+  EXPECT_TRUE(LastVoteIsDownVote());
 }
 
 // GRAPH CONFIG CHARACTERIZATION ///////////////////////////////////////////////

--- a/litert/vendors/qualcomm/core/backends/qnn_backend.h
+++ b/litert/vendors/qualcomm/core/backends/qnn_backend.h
@@ -51,10 +51,11 @@ class QnnBackend {
   virtual bool Init(const Options& options,
                     std::optional<::qnn::SocInfo> soc_info) = 0;
 
-  // Update the HTP/DSP performance mode and re-apply upvote with the new
-  // config. Passing options with kDefault resets to the default (low-power)
-  // state.
   virtual bool SetPerformanceMode(const Options& options) { return true; }
+
+  // In auto mode, the update is deferred until before and after inference.
+  virtual void ScheduleUpVote() { return; }
+  virtual void ScheduleDownVote() { return; }
 
   const SocInfo& GetSocInfo() const { return soc_info_; }
 

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.cc
@@ -27,7 +27,6 @@
 #include <ios>
 #include <iterator>
 #include <limits>
-#include <optional>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -41,7 +40,6 @@
 #include "QnnProfile.h"  // from @qairt
 #include "QnnTypes.h"  // from @qairt
 #include "absl/base/no_destructor.h"  // from @com_google_absl
-#include "absl/cleanup/cleanup.h"  // from @com_google_absl
 #include "absl/strings/string_view.h"  // from @com_google_absl
 #include "litert/c/internal/litert_logging.h"
 #include "litert/c/internal/litert_runtime_context.h"
@@ -87,14 +85,28 @@ std::string_view inline GetEventUnit(QnnProfile_EventUnit_t unit) {
 }
 
 namespace {
-bool IsAutoPerfCtrlMode(const std::optional<::qnn::Options>& run_options,
-                        ::qnn::BackendType backend_type) {
-  if (!run_options.has_value()) return false;
+bool IsPerformanceModeSet(const ::qnn::Options& options,
+                          ::qnn::BackendType backend_type) {
   switch (backend_type) {
     case ::qnn::BackendType::kHtpBackend:
-      return run_options->GetHtpPerfCtrlMode() == ::qnn::HtpPerfCtrlMode::kAuto;
+      return options.GetHtpPerformanceMode() !=
+             ::qnn::HtpPerformanceMode::kDefault;
     case ::qnn::BackendType::kDspBackend:
-      return run_options->GetDspPerfCtrlMode() == ::qnn::DspPerfCtrlMode::kAuto;
+      return options.GetDspPerformanceMode() !=
+             ::qnn::DspPerformanceMode::kDefault;
+    default:
+      return false;
+  }
+}
+
+bool IsAutoPerfCtrlMode(const ::qnn::Options& options,
+                        ::qnn::BackendType backend_type) {
+  if (!IsPerformanceModeSet(options, backend_type)) return false;
+  switch (backend_type) {
+    case ::qnn::BackendType::kHtpBackend:
+      return options.GetHtpPerfCtrlMode() == ::qnn::HtpPerfCtrlMode::kAuto;
+    case ::qnn::BackendType::kDspBackend:
+      return options.GetDspPerfCtrlMode() == ::qnn::DspPerfCtrlMode::kAuto;
     default:
       return false;
   }
@@ -179,12 +191,10 @@ LiteRtDispatchInvocationContextT::LiteRtDispatchInvocationContextT(
 }
 
 LiteRtDispatchInvocationContextT::~LiteRtDispatchInvocationContextT() {
-  // Manual: sync downvote handled by backend dtor.
-  // Auto: schedule a final downvote here.
-  if (IsAutoPerfCtrlMode(run_options_,
-                         qnn_manager_.GetOptions().GetBackendType())) {
-    ::qnn::Options default_options;
-    (void)qnn_backend_.SetPerformanceMode(default_options);
+  const ::qnn::Options& options =
+      run_options_.has_value() ? *run_options_ : qnn_manager_.GetOptions();
+  if (IsAutoPerfCtrlMode(options, qnn_manager_.GetOptions().GetBackendType())) {
+    qnn_backend_.ScheduleDownVote();
   }
 }
 
@@ -492,23 +502,6 @@ Expected<void> LiteRtDispatchInvocationContextT::DetachBuffer(
 }
 
 Expected<void> LiteRtDispatchInvocationContextT::Execute() {
-  // Auto mode does per-inference upvote + debounced downvote.
-  // Manual mode is unchanged (upvote at init).
-  const bool auto_mode = IsAutoPerfCtrlMode(
-      run_options_, qnn_manager_.GetOptions().GetBackendType());
-  if (auto_mode) {
-    if (!qnn_backend_.SetPerformanceMode(*run_options_)) {
-      return Unexpected(kLiteRtStatusErrorRuntimeFailure,
-                        "Failed to set performance mode");
-    }
-  }
-
-  absl::Cleanup downvote = [this, auto_mode] {
-    if (!auto_mode) return;
-    ::qnn::Options default_options;
-    qnn_backend_.SetPerformanceMode(default_options);
-  };
-
   const size_t num_ins = inputs_.size();
   LITERT_STACK_ARRAY(Qnn_Tensor_t, inputs, num_ins, QNN_TENSOR_INIT);
   for (size_t i = 0; i < num_ins; ++i) {
@@ -525,15 +518,26 @@ Expected<void> LiteRtDispatchInvocationContextT::Execute() {
     }
     *(outputs + i) = outputs_.at(i).GetQnnTensor();
   }
+  const ::qnn::Options& options =
+      run_options_.has_value() ? *run_options_ : qnn_manager_.GetOptions();
 
-  if (auto status = qnn_manager_.Api()->graphExecute(
-          graph_handle_, inputs, num_ins, outputs, num_outs, profile_handle_,
-          /*signalHandle=*/nullptr);
-      status != QNN_SUCCESS) {
+  // Auto mode does per-inference upvote + debounced downvote. Manual mode
+  // upvotes when its options are applied in SetOptions().
+  const bool auto_mode =
+      IsAutoPerfCtrlMode(options, qnn_manager_.GetOptions().GetBackendType());
+  if (auto_mode) {
+    qnn_backend_.ScheduleUpVote();
+  }
+  const auto status = qnn_manager_.Api()->graphExecute(
+      graph_handle_, inputs, num_ins, outputs, num_outs, profile_handle_,
+      /*signalHandle=*/nullptr);
+  if (auto_mode) {
+    qnn_backend_.ScheduleDownVote();
+  }
+  if (status != QNN_SUCCESS) {
     return Unexpected(kLiteRtStatusErrorRuntimeFailure,
                       "Failed to execute graph");
   }
-
   if (profile_handle_ != nullptr) {
     LITERT_RETURN_IF_ERROR(Profile());
   }
@@ -572,12 +576,11 @@ Expected<void> LiteRtDispatchInvocationContextT::Profile() {
   QnnProfile_EventData_t event_data;
   if (events_ptr != nullptr) {
     for (std::uint32_t i = 0; i < num_events; ++i) {
-      if (auto status = qnn_manager_.Api()->profileGetEventData(
-              events_ptr[i], &event_data);
+      if (auto status = qnn_manager_.Api()->profileGetEventData(events_ptr[i],
+                                                                &event_data);
           status != QNN_SUCCESS) {
-        return Unexpected(
-            kLiteRtStatusErrorRuntimeFailure,
-            "Failed to get the event data from profiling result");
+        return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                          "Failed to get the event data from profiling result");
       }
       data_ss << "    " << event_data.identifier << ": " << event_data.value
               << " " << GetEventUnit(event_data.unit) << std::endl;
@@ -657,9 +660,12 @@ Expected<void> LiteRtDispatchInvocationContextT::SetOptions(
     LiteRtOptions options) {
   if (options == nullptr) {
     run_options_ = std::nullopt;
+    if (!qnn_backend_.SetPerformanceMode(qnn_manager_.GetOptions())) {
+      return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                        "Failed to reset performance mode.");
+    }
     return {};
   }
-
   // Parse LiteRtOptions into qnn::Options (same path as dispatch_api.cc).
   auto* runtime_context = device_context_->runtime_context();
   litert::internal::OptionsWrapper internal_options(
@@ -689,31 +695,10 @@ Expected<void> LiteRtDispatchInvocationContextT::SetOptions(
   ::qnn::Options qnn_options;
   litert::qualcomm::QualcommOptions qualcomm_options(options_handle);
   LITERT_RETURN_IF_ERROR(InitQnnOptions(qnn_options, qualcomm_options));
-
-  run_options_ = qnn_options;
-
-  // Manual mode: forward to the backend so a runtime mode change re-votes
-  // (same-mode is skipped there). Auto defers voting to Execute().
-  bool manual = false;
-  switch (qnn_manager_.GetOptions().GetBackendType()) {
-    case ::qnn::BackendType::kHtpBackend:
-      manual =
-          qnn_options.GetHtpPerformanceMode() !=
-              ::qnn::HtpPerformanceMode::kDefault &&
-          qnn_options.GetHtpPerfCtrlMode() == ::qnn::HtpPerfCtrlMode::kManual;
-      break;
-    case ::qnn::BackendType::kDspBackend:
-      manual =
-          qnn_options.GetDspPerformanceMode() !=
-              ::qnn::DspPerformanceMode::kDefault &&
-          qnn_options.GetDspPerfCtrlMode() == ::qnn::DspPerfCtrlMode::kManual;
-      break;
-    default:
-      break;
+  if (!qnn_backend_.SetPerformanceMode(qnn_options)) {
+    return Unexpected(kLiteRtStatusErrorRuntimeFailure,
+                      "Failed to set performance mode.");
   }
-  if (manual) {
-    (void)qnn_backend_.SetPerformanceMode(qnn_options);
-  }
-
+  run_options_ = std::move(qnn_options);
   return {};
 }

--- a/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h
+++ b/litert/vendors/qualcomm/dispatch/litert_dispatch_invocation_context.h
@@ -43,7 +43,7 @@ class LiteRtDispatchInvocationContextT {
  public:
   using Ptr = std::unique_ptr<LiteRtDispatchInvocationContextT>;
 
-  // Downvotes the current performance mode on destruction.
+  // Schedules a final downvote when this context used auto mode.
   ~LiteRtDispatchInvocationContextT();
 
   static litert::Expected<Ptr> Create(
@@ -134,8 +134,8 @@ class LiteRtDispatchInvocationContextT {
   std::vector<LiteRtTensorBufferHandle> input_buffer_handles_;
   std::vector<LiteRtTensorBufferHandle> output_buffer_handles_;
   std::optional<LiteRtSchedulingInfo> scheduling_info_;
-  // Per-invocation performance-mode override (set via SetOptions).
-  // nullopt means "use the context-level options from qnn_manager_".
+  // Per-invocation performance-mode override (set via SetOptions). nullopt
+  // means to use the device-context options from qnn_manager_.
   std::optional<::qnn::Options> run_options_;
 };
 


### PR DESCRIPTION
# What
- Fix manual ctrl mode with default performance mode.
- Separate manual mode and auto mode.
- Add related tests.

# Verification

- [x] Developer-Verified
- Pass 300+ real tests for voting behavior in HTP device
- Pass some real tests for voting behavior in DSP device

# Test

- Passed x86 unit test. 
- Passed android unit test.
  - HTP
  - DSP


======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                          PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test            PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test        PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test         PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                               PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                          PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test       PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test        PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test       PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.4s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test        PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test      PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test                      PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.2s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test                 PASSED in 1.7s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test                  PASSED in 0.0s

//litert/tools:tensor_utils_test
//litert/tools:tensor_utils_test                                         PASSED in 0.2s

//litert/vendors/qualcomm/core/schema:soc_table_test
//litert/vendors/qualcomm/core/schema:soc_table_test            (cached) PASSED in 0.1s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                                        PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 71.1s

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 27 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 27 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (548 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 24 tests from 15 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (56 ms total)
[  PASSED  ] 10 tests.

SM8850: //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
[==========] 268 tests from 4 test suites ran. (79621 ms total)
[  PASSED  ] 252 tests.

SM8850: //litert/vendors/qualcomm/compiler:qnn_compose_graph_test
[==========] 7 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 7 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 31 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (676 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (617 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 30 tests from 3 test suites ran. (16 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:graph_config_builder_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 27 tests from 6 test suites ran. (5762 ms total)
[  PASSED  ] 27 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (45 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:lpai_backend_test
[==========] 6 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 6 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (4 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/schema:soc_table_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (3 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 17 tests from 6 test suites ran. (19 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test
[==========] 21 tests from 3 test suites ran. (3 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (26 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (3 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 38 tests from 3 test suites ran. (4 ms total)
[  PASSED  ] 38 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (666 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (595 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1699 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
[==========] 2 tests from 1 test suite ran. (737 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1367 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:hadamard_transform_test
[==========] 1 test from 1 test suite ran. (456 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:onehot_test
[==========] 1 test from 1 test suite ran. (467 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (784 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pad_test
[==========] 7 tests from 2 test suites ran. (998 ms total)
[  PASSED  ] 7 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (164 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (814 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test
[==========] 2 tests from 1 test suite ran. (778 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1425 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (469 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:transpose_conv_test
[==========] 5 tests from 1 test suite ran. (1251 ms total)
[  PASSED  ] 5 tests.

======================== Test Summary ========================
SM8250: //litert/c/options:litert_qualcomm_options_test
[==========] 27 tests from 2 test suites ran. (6 ms total)
[  PASSED  ] 27 tests.

SM8250: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 24 tests from 15 test suites ran. (6 ms total)
[  PASSED  ] 24 tests.

SM8250: //litert/vendors/qualcomm:qnn_manager_test
[==========] 10 tests from 2 test suites ran. (28 ms total)
[  PASSED  ] 10 tests.

SM8250: //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test


SM8250: //litert/vendors/qualcomm/compiler:qnn_compose_graph_test
[==========] 7 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 7 tests.

SM8250: //litert/vendors/qualcomm/core:common_test
[==========] 31 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8250: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (5 ms total)
[  PASSED  ] 19 tests.

SM8250: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (1770 ms total)
[  PASSED  ] 3 tests.

SM8250: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (610 ms total)
[  PASSED  ] 5 tests.

SM8250: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 30 tests from 3 test suites ran. (20967 ms total)
[  PASSED  ] 30 tests.

SM8250: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/core/backends:graph_config_builder_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8250: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 27 tests from 6 test suites ran. (20 ms total)
[  PASSED  ] 6 tests.

SM8250: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (37 ms total)
[  PASSED  ] 3 tests.

SM8250: //litert/vendors/qualcomm/core/backends:lpai_backend_test
[==========] 6 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 6 tests.

SM8250: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8250: //litert/vendors/qualcomm/core/schema:soc_table_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.

SM8250: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8250: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 17 tests from 6 test suites ran. (21 ms total)
[  PASSED  ] 17 tests.

SM8250: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8250: //litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test
[==========] 21 tests from 3 test suites ran. (0 ms total)
[  PASSED  ] 21 tests.

SM8250: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (8 ms total)
[  PASSED  ] 15 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (6 ms total)
[  PASSED  ] 24 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (7 ms total)
[  PASSED  ] 31 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8250: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 38 tests from 3 test suites ran. (11 ms total)
[  PASSED  ] 38 tests.

SM8250: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:hadamard_transform_test
[==========] 1 test from 1 test suite ran. (17 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:onehot_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pad_test
[==========] 7 tests from 2 test suites ran. (30 ms total)
[  PASSED  ] 3 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8250: //litert/vendors/qualcomm/qnn_backend_test/builder_test:transpose_conv_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.