### PR TITLE
Qualcomm AI Engine Direct - Enable HTP device id option.

### DIFF
--- a/litert/c/options/litert_qualcomm_options.cc
+++ b/litert/c/options/litert_qualcomm_options.cc
@@ -107,6 +107,7 @@ struct LrtQualcommOptionsT {
   std::optional<std::string> dlc_dir;
   std::optional<std::string> graph_transform;
   std::optional<std::uint32_t> vtcm_size;
+  std::optional<std::uint32_t> htp_device_id;
   std::optional<std::uint32_t> num_hvx_threads;
   std::optional<LrtQualcommOptionsOptimizationLevel> optimization_level;
   std::optional<LrtQualcommOptionsGraphPriority> graph_priority;
@@ -234,6 +235,11 @@ LiteRtStatus LrtCreateQualcommOptionsFromToml(const char* toml_payload,
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
           status = LrtQualcommOptionsSetVtcmSize(parsed_options,
                                                  static_cast<uint32_t>(*v));
+        } else if (key == "htp_device_id") {
+          auto v = litert::internal::ParseTomlInt(value);
+          if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
+          status = LrtQualcommOptionsSetHtpDeviceId(parsed_options,
+                                                    static_cast<uint32_t>(*v));
         } else if (key == "num_hvx_threads") {
           auto v = litert::internal::ParseTomlInt(value);
           if (!v) return litert::ToLiteRtStatus(v.Error().StatusCC());
@@ -409,6 +415,9 @@ LiteRtStatus LrtGetOpaqueQualcommOptionsData(LrtQualcommOptions options,
   }
   if (options->vtcm_size.has_value()) {
     toml << "vtcm_size = " << *options->vtcm_size << "\n";
+  }
+  if (options->htp_device_id.has_value()) {
+    toml << "htp_device_id = " << *options->htp_device_id << "\n";
   }
   if (options->num_hvx_threads.has_value()) {
     toml << "num_hvx_threads = " << *options->num_hvx_threads << "\n";
@@ -1036,6 +1045,28 @@ LiteRtStatus LrtQualcommOptionsGetVtcmSize(LrtQualcommOptions options,
   }
 
   *vtcm_size = options->vtcm_size.value_or(0);
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsSetHtpDeviceId(LrtQualcommOptions options,
+                                              std::uint32_t htp_device_id) {
+  if (options == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  options->htp_device_id = htp_device_id;
+
+  return kLiteRtStatusOk;
+}
+
+LiteRtStatus LrtQualcommOptionsGetHtpDeviceId(LrtQualcommOptions options,
+                                              std::uint32_t* htp_device_id) {
+  if (options == nullptr || htp_device_id == nullptr) {
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  *htp_device_id = options->htp_device_id.value_or(0);
 
   return kLiteRtStatusOk;
 }

--- a/litert/c/options/litert_qualcomm_options.h
+++ b/litert/c/options/litert_qualcomm_options.h
@@ -322,6 +322,12 @@ LiteRtStatus LrtQualcommOptionsSetVtcmSize(LrtQualcommOptions options,
 LiteRtStatus LrtQualcommOptionsGetVtcmSize(LrtQualcommOptions options,
                                            uint32_t* vtcm_size);
 
+LiteRtStatus LrtQualcommOptionsSetHtpDeviceId(LrtQualcommOptions options,
+                                              uint32_t htp_device_id);
+
+LiteRtStatus LrtQualcommOptionsGetHtpDeviceId(LrtQualcommOptions options,
+                                              uint32_t* htp_device_id);
+
 LiteRtStatus LrtQualcommOptionsSetNumHvxThreads(LrtQualcommOptions options,
                                                 uint32_t num_hvx_threads);
 

--- a/litert/c/options/litert_qualcomm_options_test.cc
+++ b/litert/c/options/litert_qualcomm_options_test.cc
@@ -260,6 +260,18 @@ TEST(LiteRtQualcommOptionsTest, VtcmSize) {
   LrtDestroyQualcommOptions(qualcomm_options);
 }
 
+TEST(LiteRtQualcommOptionsTest, HtpDeviceId) {
+  LrtQualcommOptions qualcomm_options;
+  LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
+
+  LITERT_ASSERT_OK(LrtQualcommOptionsSetHtpDeviceId(qualcomm_options, 1));
+
+  auto parsed = SerializeAndParse(qualcomm_options);
+  EXPECT_EQ(parsed.GetHtpDeviceId(), 1);
+
+  LrtDestroyQualcommOptions(qualcomm_options);
+}
+
 TEST(LiteRtQualcommOptionsTest, NumHvxThreads) {
   LrtQualcommOptions qualcomm_options;
   LITERT_ASSERT_OK(LrtCreateQualcommOptions(&qualcomm_options));
@@ -469,6 +481,10 @@ TEST(QualcommOptionsTest, CppWrapper) {
   EXPECT_EQ(options->GetVtcmSize(), 0);
   options->SetVtcmSize(4);
   EXPECT_EQ(options->GetVtcmSize(), 4);
+
+  EXPECT_EQ(options->GetHtpDeviceId(), 0);
+  options->SetHtpDeviceId(1);
+  EXPECT_EQ(options->GetHtpDeviceId(), 1);
 
   EXPECT_EQ(options->GetNumHvxThreads(), 0);
   options->SetNumHvxThreads(4);

--- a/litert/cc/options/litert_qualcomm_options.h
+++ b/litert/cc/options/litert_qualcomm_options.h
@@ -411,6 +411,18 @@ class QualcommOptions : public ConcreteOptionsBase {
     return val;
   }
 
+  void SetHtpDeviceId(std::uint32_t htp_device_id) {
+    LrtQualcommOptionsSetHtpDeviceId(options_, htp_device_id);
+  }
+  std::uint32_t GetHtpDeviceId() {
+    std::uint32_t val;
+    auto status = LrtQualcommOptionsGetHtpDeviceId(options_, &val);
+    if (status == kLiteRtStatusErrorNotFound) {
+      return 0;
+    }
+    return val;
+  }
+
   void SetNumHvxThreads(std::uint32_t num_hvx_threads) {
     LrtQualcommOptionsSetNumHvxThreads(options_, num_hvx_threads);
   }

--- a/litert/tools/flags/vendors/qualcomm_flags.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags.cc
@@ -441,6 +441,10 @@ ABSL_FLAG(uint32_t, qualcomm_vtcm_size, 0,
           "The vtcm size of the target device. If this option is set to 0, the "
           "max size of vtcm size will be used.");
 
+ABSL_FLAG(uint32_t, qualcomm_htp_device_id, 0,
+          "The HTP device id to target for compile and dispatch. Defaults to 0 "
+          "(the primary device).");
+
 ABSL_FLAG(uint32_t, qualcomm_num_hvx_thread, 0,
           "The number of hvx threads for the target device. If this option is "
           "set to 0, the max number of hvx threads will be used.");
@@ -875,6 +879,9 @@ Expected<void> UpdateQualcommOptionsFromFlags(QualcommOptions& opts) {
 
   const auto vtcm_size = absl::GetFlag(FLAGS_qualcomm_vtcm_size);
   opts.SetVtcmSize(vtcm_size);
+
+  const auto htp_device_id = absl::GetFlag(FLAGS_qualcomm_htp_device_id);
+  opts.SetHtpDeviceId(htp_device_id);
 
   const auto num_hvx_threads = absl::GetFlag(FLAGS_qualcomm_num_hvx_thread);
   opts.SetNumHvxThreads(num_hvx_threads);

--- a/litert/tools/flags/vendors/qualcomm_flags.h
+++ b/litert/tools/flags/vendors/qualcomm_flags.h
@@ -89,6 +89,7 @@ ABSL_DECLARE_FLAG(std::string, qualcomm_saver_output_dir);
 ABSL_DECLARE_FLAG(std::string, qualcomm_schematic_dir);
 
 ABSL_DECLARE_FLAG(uint32_t, qualcomm_vtcm_size);
+ABSL_DECLARE_FLAG(uint32_t, qualcomm_htp_device_id);
 
 ABSL_DECLARE_FLAG(uint32_t, qualcomm_num_hvx_thread);
 

--- a/litert/tools/flags/vendors/qualcomm_flags_test.cc
+++ b/litert/tools/flags/vendors/qualcomm_flags_test.cc
@@ -701,6 +701,7 @@ TEST(QualcommOptionsFromFlagsTest, DefaultValue) {
             QualcommOptions::DspPerfCtrlMode::kManual);
   EXPECT_TRUE(options.Value().GetDumpTensorIds().empty());
   EXPECT_EQ(options.Value().GetVtcmSize(), 0);
+  EXPECT_EQ(options.Value().GetHtpDeviceId(), 0);
   EXPECT_EQ(options.Value().GetNumHvxThreads(), 0);
   EXPECT_EQ(options.Value().GetOptimizationLevel(),
             QualcommOptions::OptimizationLevel::kOptimizeForInferenceO3);

--- a/litert/vendors/qualcomm/common.h
+++ b/litert/vendors/qualcomm/common.h
@@ -143,6 +143,7 @@ inline LiteRtStatus InitQnnOptions(
   qnn_options.SetDlcDir(qualcomm_options.GetDlcDir());
   qnn_options.SetGraphTransform(qualcomm_options.GetGraphTransform());
   qnn_options.SetVtcmSize(qualcomm_options.GetVtcmSize());
+  qnn_options.SetHtpDeviceId(qualcomm_options.GetHtpDeviceId());
   qnn_options.SetNumHvxThreads(qualcomm_options.GetNumHvxThreads());
   qnn_options.SetOptimizationLevel(static_cast<::qnn::OptimizationLevel>(
       qualcomm_options.GetOptimizationLevel()));

--- a/litert/vendors/qualcomm/core/backends/htp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.cc
@@ -71,7 +71,9 @@ Qnn_Priority_t GetGraphPriorityValue(GraphPriority graph_priority) {
 // HTP PERF CONTROL /////////////////////////////////////////////////////////
 class HtpBackend::HtpPerfControl {
  public:
-  explicit HtpPerfControl(const QNN_INTERFACE_VER_TYPE* api) : api_(api) {}
+  explicit HtpPerfControl(const QNN_INTERFACE_VER_TYPE* api,
+                          std::uint32_t device_id = 0)
+      : api_(api), device_id_(device_id) {}
 
   ~HtpPerfControl() {
     DownVote();
@@ -110,7 +112,7 @@ class HtpBackend::HtpPerfControl {
 
     if (power_config_id_ == 0) {
       if (error = htp_perf_infra_->perfInfra.createPowerConfigId(
-              /*device_id=*/0, /*core_id=*/0, &power_config_id_);
+              device_id_, /*core_id=*/0, &power_config_id_);
           error != QNN_SUCCESS) {
         QNN_LOG_ERROR("HTP backend unable to create power config. Error %d",
                       QNN_GET_ERROR_CODE(error));
@@ -447,6 +449,7 @@ class HtpBackend::HtpPerfControl {
 
   // Performance control
   const QNN_INTERFACE_VER_TYPE* api_{nullptr};
+  std::uint32_t device_id_{0};
   std::uint32_t power_config_id_{0};
   QnnDevice_Infrastructure_t htp_perf_infra_{nullptr};
   // Last successfully-applied mode, used to skip a redundant re-vote.
@@ -510,6 +513,20 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
   // this API is called during offline preparation. However, it will always
   // return the default SoC info (SM8350). If user specifies a SoC, we will
   // override the default.
+  auto device_platform_info = CreateDevicePlatformInfo();
+
+  // Validate the requested HTP device id against the enumerated devices
+  // whenever platform info is available (on-device, or the test mock).
+  if (device_platform_info) {
+    const std::uint32_t device_id = options.GetHtpDeviceId();
+    const std::uint32_t num_hw_devices = device_platform_info->v1.numHwDevices;
+    if (device_id >= num_hw_devices) {
+      QNN_LOG_ERROR("Found %u HTP devices but got device_id=%u.",
+                    num_hw_devices, device_id);
+      return false;
+    }
+  }
+
   if (soc_info.has_value()) {
     QNN_LOG_INFO("Using provided SoC info. SoC name: %s.",
                  soc_info->soc_name.data());
@@ -518,10 +535,10 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
 #if defined(__x86_64__) || defined(_M_X64)
     // Offline compilation on desktop hosts cannot query the target device.
 #else
-    if (auto device_platform_info = CreateDevicePlatformInfo();
-        device_platform_info) {
-      const auto device_info = device_platform_info->v1.hwDevices->v1
-                                   .deviceInfoExtension->onChipDevice;
+    if (device_platform_info) {
+      const auto device_info =
+          device_platform_info->v1.hwDevices[options.GetHtpDeviceId()]
+              .v1.deviceInfoExtension->onChipDevice;
       soc_info_ = SocInfo("Online SoC", device_info.socModel);
     }
 #endif
@@ -576,7 +593,8 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
   if (performance_mode != HtpPerformanceMode::kDefault) {
     QNN_LOG_INFO("Set HTP performance mode: %d", performance_mode);
 
-    htp_perf_control_ = std::make_unique<HtpPerfControl>(QnnApi());
+    htp_perf_control_ =
+        std::make_unique<HtpPerfControl>(QnnApi(), options.GetHtpDeviceId());
     if (!htp_perf_control_->Init(performance_mode)) {
       QNN_LOG_ERROR(
           "Failed to initialize HTP performance Control, using default "

--- a/litert/vendors/qualcomm/core/backends/htp_backend_test.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend_test.cc
@@ -413,6 +413,30 @@ TEST_F(HtpBackendPerfBaseTest, DefaultModeSchedulesDownvote) {
   EXPECT_GT(captured_configs->size(), configs_after_init);
 }
 
+TEST_F(HtpBackendPerfBaseTest, ValidHtpDeviceIdInitializes) {
+  Options options;
+  options.SetHtpDeviceId(0);
+  HtpBackend backend(&qnn_api_copy_);
+
+#if defined(__x86_64__) || defined(_M_X64)
+  EXPECT_TRUE(backend.Init(options, kSocInfos[8]));
+#else
+  EXPECT_TRUE(backend.Init(options, std::nullopt));
+#endif
+}
+
+TEST_F(HtpBackendPerfBaseTest, OutOfRangeHtpDeviceIdFailsInit) {
+  Options options;
+  options.SetHtpDeviceId(1);  // mock platform info exposes numHwDevices = 1
+  HtpBackend backend(&qnn_api_copy_);
+
+#if defined(__x86_64__) || defined(_M_X64)
+  EXPECT_FALSE(backend.Init(options, kSocInfos[8]));
+#else
+  EXPECT_FALSE(backend.Init(options, std::nullopt));
+#endif
+}
+
 TEST_F(HtpBackendPerfBaseTest, AutoModeChangesAcrossExecutes) {
   Options options;
   options.SetHtpPerformanceMode(HtpPerformanceMode::kPowerSaver);

--- a/litert/vendors/qualcomm/core/common.cc
+++ b/litert/vendors/qualcomm/core/common.cc
@@ -547,6 +547,12 @@ std::uint32_t Options::GetVtcmSize() const { return vtcm_size_; }
 
 void Options::SetVtcmSize(std::uint32_t vtcm_size) { vtcm_size_ = vtcm_size; }
 
+std::uint32_t Options::GetHtpDeviceId() const { return htp_device_id_; }
+
+void Options::SetHtpDeviceId(std::uint32_t htp_device_id) {
+  htp_device_id_ = htp_device_id;
+}
+
 std::uint32_t Options::GetNumHvxThreads() const { return num_hvx_threads_; }
 
 void Options::SetNumHvxThreads(std::uint32_t num_hvx_threads) {
@@ -706,6 +712,7 @@ std::string Options::Dump() const {
   field(2, "HtpPerformanceMode", htp_performance_mode_);
   field(2, "HtpPerfCtrlMode", htp_perf_ctrl_mode_);
   field(2, "VtcmSize", vtcm_size_);
+  field(2, "HtpDeviceId", htp_device_id_);
   field(2, "NumHvxThreads", num_hvx_threads_);
   field(2, "OptimizationLevel", optimization_level_);
 

--- a/litert/vendors/qualcomm/core/common.h
+++ b/litert/vendors/qualcomm/core/common.h
@@ -203,6 +203,9 @@ class Options {
   std::uint32_t GetVtcmSize() const;
   void SetVtcmSize(std::uint32_t vtcm_size);
 
+  std::uint32_t GetHtpDeviceId() const;
+  void SetHtpDeviceId(std::uint32_t htp_device_id);
+
   std::uint32_t GetNumHvxThreads() const;
   void SetNumHvxThreads(std::uint32_t num_hvx_threads);
 
@@ -276,6 +279,7 @@ class Options {
   std::string dlc_dir_;
   std::string graph_transform_;
   std::uint32_t vtcm_size_ = 0;
+  std::uint32_t htp_device_id_ = 0;
   std::uint32_t num_hvx_threads_ = 0;
   OptimizationLevel optimization_level_ =
       OptimizationLevel::kHtpOptimizeForInferenceO3;

--- a/litert/vendors/qualcomm/core/common_test.cc
+++ b/litert/vendors/qualcomm/core/common_test.cc
@@ -273,6 +273,15 @@ TEST(QnnOptionTest, SetVtcmSize) {
   EXPECT_EQ(options.GetVtcmSize(), 0);
 }
 
+TEST(QnnOptionTest, SetHtpDeviceId) {
+  Options options;
+  EXPECT_EQ(options.GetHtpDeviceId(), 0);
+  options.SetHtpDeviceId(1);
+  EXPECT_EQ(options.GetHtpDeviceId(), 1);
+  options.SetHtpDeviceId(0);
+  EXPECT_EQ(options.GetHtpDeviceId(), 0);
+}
+
 TEST(QnnOptionTest, SetHvxThread) {
   Options options;
   options.SetNumHvxThreads(4);
@@ -373,6 +382,7 @@ TEST(QnnOptionTest, Default) {
   EXPECT_TRUE(options.GetDlcDir().empty());
   EXPECT_TRUE(options.GetGraphTransform().empty());
   EXPECT_EQ(options.GetVtcmSize(), 0);
+  EXPECT_EQ(options.GetHtpDeviceId(), 0);
   EXPECT_EQ(options.GetNumHvxThreads(), 0);
   EXPECT_EQ(options.GetOptimizationLevel(),
             OptimizationLevel::kHtpOptimizeForInferenceO3);


### PR DESCRIPTION
Summary:
- Add --qualcomm_htp_device_id option to select the target HTP device for compile and dispatch.
- Add related tests.