### PR TITLE
Qualcomm AI Engine Direct - Avoid options override when using IrBackend.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -557,16 +557,17 @@ LiteRtStatus LiteRtCompilerPluginCompile(
         "Overriding graph IO tensor mem type to Raw because Saver is enabled.");
     options.SetGraphIOTensorMemType(::qnn::GraphIOTensorMemType::kRaw);
   }
-  const bool ir_backend_override =
-      !options.GetDlcDir().empty() &&
-      options.GetBackendType() != ::qnn::BackendType::kIrBackend;
-  if (ir_backend_override) {
+  const ::qnn::BackendType compile_backend_type =
+      !options.GetDlcDir().empty()
+          ? ::qnn::BackendType::kIrBackend
+          : options.GetBackendType();
+  if (compile_backend_type == ::qnn::BackendType::kIrBackend &&
+      options.GetBackendType() != ::qnn::BackendType::kIrBackend) {
     LITERT_LOG(LITERT_WARNING,
-               "Overriding backend type to IR Backend because DLC dir is set.");
-    options.SetBackendType(::qnn::BackendType::kIrBackend);
+               "Using IR Backend for compilation because DLC dir is set.");
   }
 
-  if (options.GetBackendType() == ::qnn::BackendType::kIrBackend) {
+  if (compile_backend_type == ::qnn::BackendType::kIrBackend) {
     std::string dlc_dir(options.GetDlcDir());
     if (!dlc_dir.empty()) {
       std::error_code ec;
@@ -579,12 +580,14 @@ LiteRtStatus LiteRtCompilerPluginCompile(
     }
   }
 
-  QnnManager* qnn_manager = compiler_plugin->GetOrCreateQnnManager(options);
+  auto manager_options = options;
+  manager_options.SetBackendType(compile_backend_type);
+  QnnManager* qnn_manager = compiler_plugin->GetOrCreateQnnManager(manager_options);
   if (!qnn_manager) {
     return kLiteRtStatusErrorRuntimeFailure;
   }
   ::qnn::QnnBackend* qnn_backend =
-      compiler_plugin->GetOrCreateQnnBackend(options, opt_soc_model);
+      compiler_plugin->GetOrCreateQnnBackend(manager_options, opt_soc_model);
   if (!qnn_backend) {
     return kLiteRtStatusErrorRuntimeFailure;
   }
@@ -626,7 +629,7 @@ LiteRtStatus LiteRtCompilerPluginCompile(
       LITERT_LOG(LITERT_INFO, "%s", "Creating context handle");
       auto context_configs = QnnManager::DefaultContextConfigs();
       if (options.GetEnableWeightSharing()) {
-        if (options.GetBackendType() != ::qnn::BackendType::kHtpBackend) {
+        if (compile_backend_type != ::qnn::BackendType::kHtpBackend) {
           LITERT_LOG(LITERT_ERROR,
                      "Weight sharing is only supported in HTP backend.");
           return kLiteRtStatusErrorInvalidArgument;
@@ -640,7 +643,7 @@ LiteRtStatus LiteRtCompilerPluginCompile(
                      "Disable weight sharing feature. Only support with "
                      "multiple partitions and on x86-64 host");
         }
-      } else if (options.GetBackendType() == ::qnn::BackendType::kGpuBackend) {
+      } else if (compile_backend_type == ::qnn::BackendType::kGpuBackend) {
         if (options.GetGpuPerformanceMode() !=
             ::qnn::GpuPerformanceMode::kDefault) {
           context_configs = QnnManager::GpuPerformanceContextConfigs(
@@ -711,7 +714,7 @@ LiteRtStatus LiteRtCompilerPluginCompile(
     return kLiteRtStatusOk;
   }
 
-  if (options.GetBackendType() == ::qnn::BackendType::kIrBackend) {
+  if (compile_backend_type == ::qnn::BackendType::kIrBackend) {
     LITERT_LOG(LITERT_WARNING,
                "Since IR backend is enabled, functional context binaries are "
                "excluded from the compiled TFLite.");


### PR DESCRIPTION
# What
- Use a local `manager_options` copy (with `kIrBackend` set) only for **QnnManager** and **QnnBackend** initialization. The three guard sites (weight-sharing, GPU performance mode, DLC output branch) also check the copy.
- Leave `compiler_plugin->Options()` unchanged so **ComposeGraph** always sees the original user-specified backend type.

# Verification
- [x] Developer Verified

# Test
- Passed x86 unit test.
```
2026-08-31T07:44:14.2976399Z ======================== Test Summary ========================
2026-08-31T07:44:14.2976555Z //litert/c/options:litert_qualcomm_options_test
2026-08-31T07:44:14.2976759Z //litert/c/options:litert_qualcomm_options_test                          PASSED in 0.0s
2026-08-31T07:44:14.2976896Z 
2026-08-31T07:44:14.2976963Z //litert/tools/flags/vendors:qualcomm_flags_test
2026-08-31T07:44:14.2977168Z //litert/tools/flags/vendors:qualcomm_flags_test                         PASSED in 0.1s
2026-08-31T07:44:14.2977313Z 
2026-08-31T07:44:14.2977364Z //litert/vendors/qualcomm:qnn_manager_test
2026-08-31T07:44:14.2977557Z //litert/vendors/qualcomm:qnn_manager_test                               PASSED in 0.2s
2026-08-31T07:44:14.2977694Z 
2026-08-31T07:44:14.2977777Z //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
2026-08-31T07:44:14.2978000Z //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 55.8s
2026-08-31T07:44:14.2978151Z 
2026-08-31T07:44:14.2978227Z //litert/vendors/qualcomm/compiler:qnn_compose_graph_test
2026-08-31T07:44:14.2978437Z //litert/vendors/qualcomm/compiler:qnn_compose_graph_test                PASSED in 0.0s
2026-08-31T07:44:14.2978583Z 
2026-08-31T07:44:14.2978639Z //litert/vendors/qualcomm/core:common_test
2026-08-31T07:44:14.2978826Z //litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s
2026-08-31T07:44:14.2978966Z 
2026-08-31T07:44:14.2979078Z //litert/vendors/qualcomm/core:tensor_pool_test
2026-08-31T07:44:14.2979259Z //litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s
2026-08-31T07:44:14.2979387Z 
2026-08-31T07:44:14.2979467Z //litert/vendors/qualcomm/core/backends:backend_factory_test
2026-08-31T07:44:14.2979691Z //litert/vendors/qualcomm/core/backends:backend_factory_test             PASSED in 0.0s
2026-08-31T07:44:14.2979834Z 
2026-08-31T07:44:14.2979905Z //litert/vendors/qualcomm/core/backends:backend_utils_test
2026-08-31T07:44:14.2980122Z //litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s
2026-08-31T07:44:14.2980265Z 
2026-08-31T07:44:14.2980334Z //litert/vendors/qualcomm/core/backends:dsp_backend_test
2026-08-31T07:44:14.2980546Z //litert/vendors/qualcomm/core/backends:dsp_backend_test        (cached) PASSED in 0.0s
2026-08-31T07:44:14.2980687Z 
2026-08-31T07:44:14.2980757Z //litert/vendors/qualcomm/core/backends:gpu_backend_test
2026-08-31T07:44:14.2980961Z //litert/vendors/qualcomm/core/backends:gpu_backend_test        (cached) PASSED in 0.0s
2026-08-31T07:44:14.2981103Z 
2026-08-31T07:44:14.2981191Z //litert/vendors/qualcomm/core/backends:graph_config_builder_test
2026-08-31T07:44:14.2981418Z //litert/vendors/qualcomm/core/backends:graph_config_builder_test (cached) PASSED in 0.0s
2026-08-31T07:44:14.2981568Z 
2026-08-31T07:44:14.2981681Z //litert/vendors/qualcomm/core/backends:htp_backend_test
2026-08-31T07:44:14.2981902Z //litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 1.1s
2026-08-31T07:44:14.2982046Z 
2026-08-31T07:44:14.2982119Z //litert/vendors/qualcomm/core/backends:ir_backend_test
2026-08-31T07:44:14.2982324Z //litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s
2026-08-31T07:44:14.2982462Z 
2026-08-31T07:44:14.2982536Z //litert/vendors/qualcomm/core/backends:lpai_backend_test
2026-08-31T07:44:14.2982749Z //litert/vendors/qualcomm/core/backends:lpai_backend_test       (cached) PASSED in 0.0s
2026-08-31T07:44:14.2982895Z 
2026-08-31T07:44:14.2982956Z //litert/vendors/qualcomm/core/dump:dump_graph_test
2026-08-31T07:44:14.2983162Z //litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s
2026-08-31T07:44:14.2983305Z 
2026-08-31T07:44:14.2983372Z //litert/vendors/qualcomm/core/schema:soc_table_test
2026-08-31T07:44:14.2983572Z //litert/vendors/qualcomm/core/schema:soc_table_test            (cached) PASSED in 0.0s
2026-08-31T07:44:14.2983716Z 
2026-08-31T07:44:14.2983809Z //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
2026-08-31T07:44:14.2984055Z //litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
2026-08-31T07:44:14.2984216Z 
2026-08-31T07:44:14.2984306Z //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
2026-08-31T07:44:14.2984540Z //litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
2026-08-31T07:44:14.2984697Z 
2026-08-31T07:44:14.2984786Z //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
2026-08-31T07:44:14.2985030Z //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s
2026-08-31T07:44:14.2985181Z 
2026-08-31T07:44:14.2985260Z //litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test
2026-08-31T07:44:14.2985483Z //litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test    (cached) PASSED in 0.0s
2026-08-31T07:44:14.2985629Z 
2026-08-31T07:44:14.2985687Z //litert/vendors/qualcomm/core/utils:utils_test
2026-08-31T07:44:14.2985885Z //litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s
2026-08-31T07:44:14.2986028Z 
2026-08-31T07:44:14.2986112Z //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
2026-08-31T07:44:14.2986337Z //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s
2026-08-31T07:44:14.2986485Z 
2026-08-31T07:44:14.2986572Z //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
2026-08-31T07:44:14.2986843Z //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s
2026-08-31T07:44:14.2986992Z 
2026-08-31T07:44:14.2987093Z //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
2026-08-31T07:44:14.2987354Z //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s
2026-08-31T07:44:14.2987522Z 
2026-08-31T07:44:14.2987609Z //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
2026-08-31T07:44:14.2987860Z //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s
2026-08-31T07:44:14.2988017Z 
2026-08-31T07:44:14.2988090Z //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
2026-08-31T07:44:14.2988294Z //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s
2026-08-31T07:44:14.2988432Z 
2026-08-31T07:44:14.2988527Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
2026-08-31T07:44:14.2988755Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.3s
2026-08-31T07:44:14.2988899Z 
2026-08-31T07:44:14.2989000Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
2026-08-31T07:44:14.2989251Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test PASSED in 0.2s
2026-08-31T07:44:14.2989400Z 
2026-08-31T07:44:14.2989541Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
2026-08-31T07:44:14.2989812Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.3s
2026-08-31T07:44:14.2989973Z 
2026-08-31T07:44:14.2990070Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:hadamard_transform_test
2026-08-31T07:44:14.2990331Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:hadamard_transform_test PASSED in 0.2s
2026-08-31T07:44:14.2990488Z 
2026-08-31T07:44:14.2990576Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:onehot_test
2026-08-31T07:44:14.2990799Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:onehot_test      PASSED in 0.2s
2026-08-31T07:44:14.2990944Z 
2026-08-31T07:44:14.2991030Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
2026-08-31T07:44:14.2991248Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test        PASSED in 0.2s
2026-08-31T07:44:14.2991390Z 
2026-08-31T07:44:14.2991477Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:pad_test
2026-08-31T07:44:14.2991701Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:pad_test         PASSED in 0.3s
2026-08-31T07:44:14.2991853Z 
2026-08-31T07:44:14.2991941Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
2026-08-31T07:44:14.2992169Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.1s
2026-08-31T07:44:14.2992315Z 
2026-08-31T07:44:14.2992415Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
2026-08-31T07:44:14.2992681Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test PASSED in 0.2s
2026-08-31T07:44:14.2992848Z 
2026-08-31T07:44:14.2992945Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test
2026-08-31T07:44:14.2993207Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test PASSED in 0.2s
2026-08-31T07:44:14.2993367Z 
2026-08-31T07:44:14.2993456Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
2026-08-31T07:44:14.2993681Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test      PASSED in 0.3s
2026-08-31T07:44:14.2993825Z 
2026-08-31T07:44:14.2993912Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
2026-08-31T07:44:14.2994130Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.2s
2026-08-31T07:44:14.2994273Z 
2026-08-31T07:44:14.2994374Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:transpose_conv_test
2026-08-31T07:44:14.2994630Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:transpose_conv_test PASSED in 0.5s
```
- Passed android unit test. (HTP)
```
2026-08-31T07:48:57.3747868Z ======================== Test Summary ========================
2026-08-31T07:48:57.3747929Z SM8750: //litert/c/options:litert_qualcomm_options_test
2026-08-31T07:48:57.3747983Z [==========] 27 tests from 2 test suites ran. (1 ms total)
2026-08-31T07:48:57.3748020Z [  PASSED  ] 27 tests.
2026-08-31T07:48:57.3748022Z 
2026-08-31T07:48:57.3748085Z SM8750: //litert/cc:_litert_compiled_model_qualcomm_test
2026-08-31T07:48:57.3748135Z [==========] 2 tests from 1 test suite ran. (378 ms total)
2026-08-31T07:48:57.3748172Z [  PASSED  ] 2 tests.
2026-08-31T07:48:57.3748174Z 
2026-08-31T07:48:57.3748231Z SM8750: //litert/tools/flags/vendors:qualcomm_flags_test
2026-08-31T07:48:57.3748282Z [==========] 24 tests from 15 test suites ran. (0 ms total)
2026-08-31T07:48:57.3748319Z [  PASSED  ] 24 tests.
2026-08-31T07:48:57.3748321Z 
2026-08-31T07:48:57.3748373Z SM8750: //litert/vendors/qualcomm:qnn_manager_test
2026-08-31T07:48:57.3748426Z [==========] 9 tests from 2 test suites ran. (8 ms total)
2026-08-31T07:48:57.3748461Z [  PASSED  ] 9 tests.
2026-08-31T07:48:57.3748463Z 
2026-08-31T07:48:57.3748534Z SM8750: //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
2026-08-31T07:48:57.3748593Z [==========] 268 tests from 4 test suites ran. (59534 ms total)
2026-08-31T07:48:57.3748628Z [  PASSED  ] 252 tests.
2026-08-31T07:48:57.3748630Z 
2026-08-31T07:48:57.3748713Z SM8750: //litert/vendors/qualcomm/compiler:qnn_compose_graph_test
2026-08-31T07:48:57.3748764Z [==========] 7 tests from 1 test suite ran. (0 ms total)
2026-08-31T07:48:57.3748798Z [  PASSED  ] 7 tests.
2026-08-31T07:48:57.3748800Z 
2026-08-31T07:48:57.3748864Z SM8750: //litert/vendors/qualcomm/core:common_test
2026-08-31T07:48:57.3748916Z [==========] 31 tests from 2 test suites ran. (0 ms total)
2026-08-31T07:48:57.3748953Z [  PASSED  ] 31 tests.
2026-08-31T07:48:57.3748954Z 
2026-08-31T07:48:57.3749014Z SM8750: //litert/vendors/qualcomm/core:tensor_pool_test
2026-08-31T07:48:57.3749075Z [==========] 19 tests from 2 test suites ran. (1 ms total)
2026-08-31T07:48:57.3749111Z [  PASSED  ] 19 tests.
2026-08-31T07:48:57.3749113Z 
2026-08-31T07:48:57.3749190Z SM8750: //litert/vendors/qualcomm/core/backends:backend_factory_test
2026-08-31T07:48:57.3749252Z [==========] 5 tests from 1 test suite ran. (511 ms total)
2026-08-31T07:48:57.3749289Z [  PASSED  ] 3 tests.
2026-08-31T07:48:57.3749290Z 
2026-08-31T07:48:57.3749361Z SM8750: //litert/vendors/qualcomm/core/backends:backend_utils_test
2026-08-31T07:48:57.3749413Z [==========] 5 tests from 2 test suites ran. (614 ms total)
2026-08-31T07:48:57.3749451Z [  PASSED  ] 5 tests.
2026-08-31T07:48:57.3749452Z 
2026-08-31T07:48:57.3749524Z SM8750: //litert/vendors/qualcomm/core/backends:dsp_backend_test
2026-08-31T07:48:57.3749572Z [==========] 29 tests from 3 test suites ran. (3 ms total)
2026-08-31T07:48:57.3749605Z [  PASSED  ] 0 tests.
2026-08-31T07:48:57.3749606Z 
2026-08-31T07:48:57.3749675Z SM8750: //litert/vendors/qualcomm/core/backends:gpu_backend_test
2026-08-31T07:48:57.3749726Z [==========] 2 tests from 1 test suite ran. (0 ms total)
2026-08-31T07:48:57.3749762Z [  PASSED  ] 0 tests.
2026-08-31T07:48:57.3749764Z 
2026-08-31T07:48:57.3749847Z SM8750: //litert/vendors/qualcomm/core/backends:graph_config_builder_test
2026-08-31T07:48:57.3749893Z [==========] 5 tests from 1 test suite ran. (0 ms total)
2026-08-31T07:48:57.3749928Z [  PASSED  ] 5 tests.
2026-08-31T07:48:57.3749929Z 
2026-08-31T07:48:57.3749998Z SM8750: //litert/vendors/qualcomm/core/backends:htp_backend_test
2026-08-31T07:48:57.3750051Z [==========] 26 tests from 6 test suites ran. (4067 ms total)
2026-08-31T07:48:57.3750089Z [  PASSED  ] 26 tests.
2026-08-31T07:48:57.3750091Z 
2026-08-31T07:48:57.3750156Z SM8750: //litert/vendors/qualcomm/core/backends:ir_backend_test
2026-08-31T07:48:57.3750208Z [==========] 3 tests from 2 test suites ran. (18 ms total)
2026-08-31T07:48:57.3750243Z [  PASSED  ] 3 tests.
2026-08-31T07:48:57.3750245Z 
2026-08-31T07:48:57.3750316Z SM8750: //litert/vendors/qualcomm/core/backends:lpai_backend_test
2026-08-31T07:48:57.3750363Z [==========] 6 tests from 1 test suite ran. (0 ms total)
2026-08-31T07:48:57.3750396Z [  PASSED  ] 6 tests.
2026-08-31T07:48:57.3750402Z 
2026-08-31T07:48:57.3750462Z SM8750: //litert/vendors/qualcomm/core/dump:dump_graph_test
2026-08-31T07:48:57.3750508Z [==========] 5 tests from 1 test suite ran. (1 ms total)
2026-08-31T07:48:57.3750543Z [  PASSED  ] 5 tests.
2026-08-31T07:48:57.3750545Z 
2026-08-31T07:48:57.3750607Z SM8750: //litert/vendors/qualcomm/core/schema:soc_table_test
2026-08-31T07:48:57.3750651Z [==========] 2 tests from 1 test suite ran. (0 ms total)
2026-08-31T07:48:57.3750687Z [  PASSED  ] 2 tests.
2026-08-31T07:48:57.3750689Z 
2026-08-31T07:48:57.3750775Z SM8750: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
2026-08-31T07:48:57.3750824Z [==========] 1 test from 1 test suite ran. (1 ms total)
2026-08-31T07:48:57.3750861Z [  PASSED  ] 1 test.
2026-08-31T07:48:57.3750864Z 
2026-08-31T07:48:57.3750944Z SM8750: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
2026-08-31T07:48:57.3750991Z [==========] 17 tests from 6 test suites ran. (22 ms total)
2026-08-31T07:48:57.3751028Z [  PASSED  ] 17 tests.
2026-08-31T07:48:57.3751030Z 
2026-08-31T07:48:57.3751114Z SM8750: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
2026-08-31T07:48:57.3751161Z [==========] 1 test from 1 test suite ran. (0 ms total)
2026-08-31T07:48:57.3751211Z [  PASSED  ] 1 test.
2026-08-31T07:48:57.3751217Z 
2026-08-31T07:48:57.3751292Z SM8750: //litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test
2026-08-31T07:48:57.3751354Z [==========] 21 tests from 3 test suites ran. (0 ms total)
2026-08-31T07:48:57.3751392Z [  PASSED  ] 21 tests.
2026-08-31T07:48:57.3751394Z 
2026-08-31T07:48:57.3751453Z SM8750: //litert/vendors/qualcomm/core/utils:utils_test
2026-08-31T07:48:57.3751502Z [==========] 16 tests from 3 test suites ran. (4 ms total)
2026-08-31T07:48:57.3751538Z [  PASSED  ] 16 tests.
2026-08-31T07:48:57.3751559Z 
2026-08-31T07:48:57.3751644Z SM8750: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
2026-08-31T07:48:57.3751696Z [==========] 24 tests from 2 test suites ran. (0 ms total)
2026-08-31T07:48:57.3751748Z [  PASSED  ] 24 tests.
2026-08-31T07:48:57.3751751Z 
2026-08-31T07:48:57.3751852Z SM8750: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
2026-08-31T07:48:57.3751902Z [==========] 31 tests from 17 test suites ran. (0 ms total)
2026-08-31T07:48:57.3751940Z [  PASSED  ] 31 tests.
2026-08-31T07:48:57.3751942Z 
2026-08-31T07:48:57.3752039Z SM8750: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
2026-08-31T07:48:57.3752090Z [==========] 66 tests from 9 test suites ran. (0 ms total)
2026-08-31T07:48:57.3752126Z [  PASSED  ] 66 tests.
2026-08-31T07:48:57.3752128Z 
2026-08-31T07:48:57.3752211Z SM8750: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
2026-08-31T07:48:57.3752261Z [==========] 38 tests from 3 test suites ran. (1 ms total)
2026-08-31T07:48:57.3752300Z [  PASSED  ] 38 tests.
2026-08-31T07:48:57.3752302Z 
2026-08-31T07:48:57.3752382Z SM8750: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
2026-08-31T07:48:57.3752431Z [==========] 5 tests from 1 test suite ran. (420 ms total)
2026-08-31T07:48:57.3752465Z [  PASSED  ] 5 tests.
2026-08-31T07:48:57.3752467Z 
2026-08-31T07:48:57.3752536Z SM8750: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
2026-08-31T07:48:57.3752586Z [==========] 1 test from 1 test suite ran. (291 ms total)
2026-08-31T07:48:57.3752622Z [  PASSED  ] 1 test.
2026-08-31T07:48:57.3752623Z 
2026-08-31T07:48:57.3752715Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
2026-08-31T07:48:57.3752765Z [==========] 5 tests from 1 test suite ran. (1226 ms total)
2026-08-31T07:48:57.3752801Z [  PASSED  ] 5 tests.
2026-08-31T07:48:57.3752802Z 
2026-08-31T07:48:57.3752899Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
2026-08-31T07:48:57.3752950Z [==========] 2 tests from 1 test suite ran. (564 ms total)
2026-08-31T07:48:57.3752987Z [  PASSED  ] 2 tests.
2026-08-31T07:48:57.3752989Z 
2026-08-31T07:48:57.3753091Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
2026-08-31T07:48:57.3753141Z [==========] 5 tests from 1 test suite ran. (1219 ms total)
2026-08-31T07:48:57.3753176Z [  PASSED  ] 5 tests.
2026-08-31T07:48:57.3753178Z 
2026-08-31T07:48:57.3753278Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:hadamard_transform_test
2026-08-31T07:48:57.3753327Z [==========] 1 test from 1 test suite ran. (330 ms total)
2026-08-31T07:48:57.3753362Z [  PASSED  ] 1 test.
2026-08-31T07:48:57.3753364Z 
2026-08-31T07:48:57.3753448Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:onehot_test
2026-08-31T07:48:57.3753493Z [==========] 1 test from 1 test suite ran. (339 ms total)
2026-08-31T07:48:57.3753528Z [  PASSED  ] 1 test.
2026-08-31T07:48:57.3753531Z 
2026-08-31T07:48:57.3753609Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
2026-08-31T07:48:57.3753652Z [==========] 3 tests from 1 test suite ran. (672 ms total)
2026-08-31T07:48:57.3753688Z [  PASSED  ] 3 tests.
2026-08-31T07:48:57.3753690Z 
2026-08-31T07:48:57.3753769Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pad_test
2026-08-31T07:48:57.3753819Z [==========] 7 tests from 2 test suites ran. (929 ms total)
2026-08-31T07:48:57.3753876Z [  PASSED  ] 7 tests.
2026-08-31T07:48:57.3753878Z 
2026-08-31T07:48:57.3753957Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
2026-08-31T07:48:57.3754029Z [==========] 1 test from 1 test suite ran. (133 ms total)
2026-08-31T07:48:57.3754066Z [  PASSED  ] 0 tests.
2026-08-31T07:48:57.3754067Z 
2026-08-31T07:48:57.3754167Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
2026-08-31T07:48:57.3754214Z [==========] 2 tests from 1 test suite ran. (533 ms total)
2026-08-31T07:48:57.3754264Z [  PASSED  ] 2 tests.
2026-08-31T07:48:57.3754266Z 
2026-08-31T07:48:57.3754360Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test
2026-08-31T07:48:57.3754425Z [==========] 2 tests from 1 test suite ran. (554 ms total)
2026-08-31T07:48:57.3754460Z [  PASSED  ] 2 tests.
2026-08-31T07:48:57.3754461Z 
2026-08-31T07:48:57.3754546Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
2026-08-31T07:48:57.3754593Z [==========] 5 tests from 1 test suite ran. (1232 ms total)
2026-08-31T07:48:57.3754628Z [  PASSED  ] 5 tests.
2026-08-31T07:48:57.3754630Z 
2026-08-31T07:48:57.3754708Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
2026-08-31T07:48:57.3754754Z [==========] 1 test from 1 test suite ran. (329 ms total)
2026-08-31T07:48:57.3754791Z [  PASSED  ] 1 test.
2026-08-31T07:48:57.3754793Z 
2026-08-31T07:48:57.3754883Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:transpose_conv_test
2026-08-31T07:48:57.3754929Z [==========] 5 tests from 1 test suite ran. (881 ms total)
2026-08-31T07:48:57.3754963Z [  PASSED  ] 5 tests.
```