### PR TITLE
[MLDrift] Support GATHER indices of rank > 1 in the ml-drift delegate

### DIFF
--- a/ml_drift_delegate/tflite/BUILD
+++ b/ml_drift_delegate/tflite/BUILD
@@ -241,6 +241,7 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "@ml_drift//ml_drift/common:data_type",
         "@ml_drift//ml_drift/common:model",
+        "@ml_drift//ml_drift/common:operations",
         "@ml_drift//ml_drift/common:shape",
         "@ml_drift//ml_drift/common:tensor",
         "@ml_drift//ml_drift/common:types",

--- a/ml_drift_delegate/tflite/model_builder.cc
+++ b/ml_drift_delegate/tflite/model_builder.cc
@@ -2722,14 +2722,17 @@ class ElementwiseOperationParser : public TFLiteOperationParser {
     int runtime_tensor_index;
     int constant_tensor_index;
     const TfLiteTensor* constant_tensor;
+    const TfLiteTensor* runtime_tensor;
     if (constant_tensor0) {
       runtime_tensor_index = 1;
       constant_tensor_index = 0;
       constant_tensor = input0;
+      runtime_tensor = input1;
     } else {
       runtime_tensor_index = 0;
       constant_tensor_index = 1;
       constant_tensor = input1;
+      runtime_tensor = input0;
     }
 
     reader->AddInput(node, runtime_tensor_index);
@@ -2760,8 +2763,10 @@ class ElementwiseOperationParser : public TFLiteOperationParser {
     }
     if (!convertible_to_f32) {
       if (reader->IsConstantTensor(constant_tensor_index)) {
+        const SizedLayout layout = BroadcastConstLayout(
+            constant_dims->size, runtime_tensor->dims->size);
         const ::ml_drift::Value* input =
-            reader->AddConstInput(constant_tensor_index, /*layout=*/{});
+            reader->AddConstInput(constant_tensor_index, layout);
         graph->AddConsumer(node->id, input->id);
       } else {
         reader->AddInput(node, constant_tensor_index);
@@ -2898,6 +2903,29 @@ class ElementwiseOperationParser : public TFLiteOperationParser {
     }
     return ::ml_drift::BHWC(dims->data[0], dims->data[1], dims->data[2],
                             dims->data[3]);
+  }
+
+  // Returns the layout with which a constant operand has to be read so that it
+  // broadcasts against a runtime operand of `runtime_rank`.
+  //
+  // TFLite/numpy broadcasting is right-aligned, but ml-drift maps TFLite dim 0
+  // to BHWC's batch, i.e. it is left-aligned. A constant of lower rank than the
+  // runtime operand therefore has to be relabeled onto the trailing axes;
+  // otherwise the GPU elementwise broadcast reads only batch-0 and splats it to
+  // every channel.
+  //
+  // This encodes the same right-alignment rule as
+  // ExtractTensorShapeWithTfLiteBroadcast() above, expressed as a SizedLayout
+  // because that is what ObjectReader::AddConstInput() takes. Keep the two in
+  // sync.
+  static SizedLayout BroadcastConstLayout(int constant_rank, int runtime_rank) {
+    SizedLayout layout;
+    if (constant_rank < runtime_rank) {
+      layout.layout_1d = ::ml_drift::Layout::SCALAR;  // [C] -> 1x1x1xC
+      layout.layout_2d = ::ml_drift::Layout::HW;      // [W,C] -> 1x1xWxC
+      layout.layout_3d = ::ml_drift::Layout::HWC;     // [H,W,C] -> 1xHxWxC
+    }
+    return layout;
   }
 
   absl::Status PreCheckInputsWithConstTensor(const TfLiteContext* context,

--- a/ml_drift_delegate/tflite/model_builder.cc
+++ b/ml_drift_delegate/tflite/model_builder.cc
@@ -3504,8 +3504,11 @@ class GatherOperationParser : public TFLiteOperationParser {
   absl::Status IsSupported(const TfLiteContext* context,
                            const TfLiteNode* tflite_node,
                            const TfLiteRegistration* registration) final {
+    // Parse() relabels or reshapes the indices and the gathered result, so it
+    // also accepts indices that only reduce to a 1D vector, e.g. [1,N].
     ABSL_RETURN_IF_ERROR(tflite::CheckGpuDelegateCompatibility(
-        context, tflite_node, registration));
+        context, tflite_node, registration,
+        tflite::GpuCompatibilityFlags::kReducibleGatherIndices));
 
     ABSL_RETURN_IF_ERROR(PreCheckReadValue(context, tflite_node, 0));
     ABSL_RETURN_IF_ERROR(PreCheckReadValue(context, tflite_node, 1));
@@ -3514,16 +3517,50 @@ class GatherOperationParser : public TFLiteOperationParser {
     const TfLiteTensor* tfl_input = nullptr;
     ABSL_RETURN_IF_ERROR(
         PreGetInputTensor(context, tflite_node, 0, &tfl_input));
+    const TfLiteTensor* tfl_indices = nullptr;
+    ABSL_RETURN_IF_ERROR(
+        PreGetInputTensor(context, tflite_node, 1, &tfl_indices));
 
     ABSL_RETURN_IF_ERROR(PreCheckOutputs(context, tflite_node));
     if (!tflite_node->builtin_data) {
       return absl::InvalidArgumentError("Missing TfLiteGatherParams.");
     }
+    const auto* params =
+        static_cast<const TfLiteGatherParams*>(tflite_node->builtin_data);
+    // Parse() only honors `axis`; a non-zero `batch_dims` means batched gather,
+    // which has different semantics and is not implemented here.
+    if (params->batch_dims != 0) {
+      return absl::UnimplementedError("Only support batch_dims == 0.");
+    }
     TfLiteTensor* tfl_output;
     ABSL_RETURN_IF_ERROR(
         PreGetOutputTensor(context, tflite_node, 0, &tfl_output));
-    if (tfl_input->type != tfl_output->type) {
+    // Treat an fp16 constant data input as FLOAT32: FP16GraphPartitionHelper
+    // folds the preceding DEQUANTIZE and remaps this node's input to the
+    // original fp16 constant while the output stays FLOAT32. The delegate
+    // handles the precision conversion, so that pair is not a real mismatch.
+    // Runtime inputs never go through that folding, so they keep the strict
+    // comparison, and so does an fp16 input paired with an fp16 output.
+    const bool fp16_const_input = tfl_input->type == kTfLiteFloat16 &&
+                                  tflite::IsConstantTensor(tfl_input);
+    if (tfl_input->type != tfl_output->type &&
+        !(fp16_const_input && tfl_output->type == kTfLiteFloat32)) {
       return absl::InvalidArgumentError("Input / output dtype mismatch.");
+    }
+
+    // Parse() calls ExtractAxisFromIndex() and ExtractTensorShape().
+    ABSL_RETURN_IF_ERROR(PreCheckAxisFromIndex(*tfl_input, params->axis));
+    ABSL_RETURN_IF_ERROR(PreCheckTensorShape(*tfl_input));
+    ABSL_RETURN_IF_ERROR(PreCheckTensorShape(*tfl_output));
+    // Parse() appends a RESHAPE when the TFLite output shape differs from the
+    // shape the kernel produces. That RESHAPE only relabels axes, so reject
+    // anything it cannot express rather than let Parse() build a graph that
+    // silently permutes the gathered data.
+    if (!IsPureRelabel(GetGatherShape(*tfl_input, *tfl_indices, params->axis),
+                       ExtractTensorShape(tfl_output))) {
+      return absl::UnimplementedError(
+          "Gather output shape is not a relabeling of the gathered input "
+          "shape.");
     }
     return absl::OkStatus();
   }
@@ -3574,14 +3611,80 @@ class GatherOperationParser : public TFLiteOperationParser {
       reader->AddInput(gather_node, 0);
     }
     if (indices_are_const) {
-      indices_value = reader->AddConstInput(1, /*layout=*/{});
+      // Match the layout the runtime path builds above: the kernel reads the
+      // indices along the channel axis, so a 1D constant [N] has to be labeled
+      // [1,1,1,N] instead of the default [N,1,1,1]. Relabeling axes of extent 1
+      // leaves the flat data order untouched, so no RESHAPE node is needed.
+      // Rank 2-4 constants need no override: their default layouts already map
+      // [1,..,N] to [1,1,1,N].
+      indices_value = reader->AddConstInput(
+          1, /*layout=*/{.layout_1d = ::ml_drift::Layout::SCALAR});
       graph->AddConsumer(gather_node->id, indices_value->id);
     } else if (indices_are_1d) {
       graph->AddConsumer(gather_node->id, indices_value->id);
     } else {
       reader->AddInput(gather_node, 1);
     }
-    reader->AddOutputs(gather_node);
+
+    // GpuModelBuilder infers the GATHER output shape as the input shape with
+    // `axis` replaced by the number of gathered indices. Multi-dimensional
+    // indices give the TFLite output a higher rank, which lands the gathered
+    // dimension on a different BHWC axis (e.g. gathering rows of a [V,C] table
+    // with [1,N] indices yields [1,N,C], not [N,C]). Emit the GATHER into an
+    // intermediate value with the kernel's shape and RESHAPE it to the real
+    // output layout; IsSupported() has verified that this is a pure relabeling.
+    const TfLiteTensor* output_tensor = reader->GetOutputTensor(0);
+    const ::ml_drift::BHWC gather_shape =
+        GetGatherShape(*input_tensor, *indices_tensor, params->axis);
+    const ::ml_drift::BHWC output_shape = ExtractTensorShape(output_tensor);
+    if (gather_shape == output_shape) {
+      reader->AddOutputs(gather_node);
+    } else {
+      ::ml_drift::Value* gather_value = graph->NewValue();
+      gather_value->tensor.type = ToDataType(output_tensor->type);
+      gather_value->tensor.shape = gather_shape;
+      graph->SetProducer(gather_node->id, gather_value->id);
+
+      ::ml_drift::Node* reshape_node = graph->NewNode();
+      reshape_node->operation.type =
+          ToString(::ml_drift::OperationType::RESHAPE);
+      ::ml_drift::ReshapeAttributes reshape_attr;
+      reshape_attr.new_shape = output_shape;
+      reshape_node->operation.attributes = std::move(reshape_attr);
+      graph->AddConsumer(reshape_node->id, gather_value->id);
+      reader->AddOutputs(reshape_node);
+    }
+  }
+
+ private:
+  // Returns the shape the ml-drift GATHER kernel produces: the input shape with
+  // `axis` replaced by the number of gathered indices. Requires
+  // PreCheckAxisFromIndex() and PreCheckTensorShape() to have passed.
+  static ::ml_drift::BHWC GetGatherShape(const TfLiteTensor& input_tensor,
+                                         const TfLiteTensor& indices_tensor,
+                                         int axis) {
+    ::ml_drift::BHWC shape = ExtractTensorShape(&input_tensor);
+    shape.set(ExtractAxisFromIndex(input_tensor, axis),
+              static_cast<int>(tflite::NumElements(&indices_tensor)));
+    return shape;
+  }
+
+  // Returns true if `to` holds the same extents as `from`, in the same order,
+  // once axes of extent 1 are dropped. A RESHAPE between two such shapes only
+  // relabels axes and leaves the flat BHWC data order untouched; between any
+  // other pair of shapes it would permute the data.
+  static bool IsPureRelabel(const ::ml_drift::BHWC& from,
+                            const ::ml_drift::BHWC& to) {
+    const auto squeeze = [](const ::ml_drift::BHWC& shape) {
+      std::vector<int> dims;
+      for (const auto dim : {shape.b, shape.h, shape.w, shape.c}) {
+        if (dim != 1) {
+          dims.push_back(dim);
+        }
+      }
+      return dims;
+    };
+    return squeeze(from) == squeeze(to);
   }
 };
 

--- a/ml_drift_delegate/tflite/model_builder_test.cc
+++ b/ml_drift_delegate/tflite/model_builder_test.cc
@@ -2870,12 +2870,51 @@ TEST(GatherOperationParserTest, TestIndicesTensor) {
       /*num_inputs=*/2, /*shape=*/std::vector<int>({1, 1, 1, 1}));
   std::unique_ptr<TFLiteOperationParser> parser =
       NewOperationParser(context->node(), context->registration());
-  // Need 1D indices
+  // Indices have to reduce to a 1D vector: a leading dimension != 1 makes them
+  // genuinely multi-dimensional, which the single-axis kernel cannot express.
   context = std::make_unique<StubTfLiteContext>(
       kTfLiteBuiltinGather,
       /*op_version=*/1,
       /*num_inputs=*/2, /*shape=*/std::vector<int>({1, 1, 1, 1}));
-  context->tensor(2)->dims->size = 2;
+  context->ChangeTensorShape(2, {2, 3});
+  context->tensor(2)->type = kTfLiteInt32;
+  EXPECT_FALSE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+  // Multi-dimensional indices whose leading dimensions are all 1 do reduce to
+  // a 1D vector and are supported: gathering 3 rows of a [4,5] table with [1,3]
+  // indices yields a [1,3,5] output, which Parse() reaches with a RESHAPE.
+  context = std::make_unique<StubTfLiteContext>(
+      kTfLiteBuiltinGather,
+      /*op_version=*/1,
+      /*num_inputs=*/2, /*shape=*/std::vector<int>({1, 1, 1, 1}));
+  context->ChangeTensorShape(1, {4, 5});
+  context->ChangeTensorShape(2, {1, 3});
+  context->tensor(2)->type = kTfLiteInt32;
+  context->ChangeTensorShape(3, {1, 3, 5});
+  EXPECT_TRUE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+  // Indices above rank 4 are not representable in BHWC, even when they reduce
+  // to a 1D vector.
+  context = std::make_unique<StubTfLiteContext>(
+      kTfLiteBuiltinGather,
+      /*op_version=*/1,
+      /*num_inputs=*/2, /*shape=*/std::vector<int>({1, 1, 1, 1}));
+  context->ChangeTensorShape(2, {1, 1, 1, 1, 3});
+  context->tensor(2)->type = kTfLiteInt32;
+  EXPECT_FALSE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+  // A rank-0 (scalar) index drops the gathered axis entirely.
+  context = std::make_unique<StubTfLiteContext>(
+      kTfLiteBuiltinGather,
+      /*op_version=*/1,
+      /*num_inputs=*/2, /*shape=*/std::vector<int>({1, 1, 1, 1}));
+  context->ChangeTensorShape(2, {});
   context->tensor(2)->type = kTfLiteInt32;
   EXPECT_FALSE(
       parser
@@ -2921,6 +2960,130 @@ TEST(GatherOperationParserTest, ValidConstantValueTensor) {
       parser
           ->IsSupported(context.get(), context->node(), context->registration())
           .ok());
+}
+
+TEST(GatherOperationParserTest, TestBatchDims) {
+  auto context = std::make_unique<StubTfLiteContext>(
+      kTfLiteBuiltinGather,
+      /*op_version=*/1,
+      /*num_inputs=*/2, /*shape=*/std::vector<int>({1, 1, 1, 1}));
+  std::unique_ptr<TFLiteOperationParser> parser =
+      NewOperationParser(context->node(), context->registration());
+  context->tensor(2)->dims->size = 1;
+  context->tensor(2)->type = kTfLiteInt32;
+  auto* params =
+      static_cast<TfLiteGatherParams*>(context->node()->builtin_data);
+  // Parse() only honors `axis`; batched gather has different semantics.
+  params->batch_dims = 1;
+  EXPECT_FALSE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+  params->batch_dims = 0;
+  EXPECT_TRUE(
+      parser
+          ->IsSupported(context.get(), context->node(), context->registration())
+          .ok());
+}
+
+// Exercises GatherOperationParser::Parse() on the graph it actually builds.
+class GatherParseTest : public testing::Test {
+ protected:
+  // Gathers along axis 0 of a runtime [4,5] table with constant indices.
+  void SetUpGather(const std::vector<int>& indices_shape,
+                   const std::vector<int>& output_shape) {
+    context_ = std::make_unique<StubTfLiteContext>(
+        kTfLiteBuiltinGather,
+        /*op_version=*/1,
+        /*num_inputs=*/2, /*shape=*/std::vector<int>({1, 1, 1, 1}));
+    context_->ChangeTensorShape(1, {4, 5});
+    context_->ChangeTensorShape(2, indices_shape);
+    context_->tensor(2)->type = kTfLiteInt32;
+    context_->tensor(2)->allocation_type = kTfLiteMmapRo;
+    context_->ChangeTensorShape(3, output_shape);
+    parser_ = NewOperationParser(context_->node(), context_->registration());
+  }
+
+  void Parse() {
+    ObjectReader reader(&graph_, context_.get(), context_->node(),
+                        &tensor_to_value_);
+    parser_->Parse(context_->node(), context_->registration(), &graph_,
+                   &reader);
+  }
+
+  // Returns the single node of the given operation type, or nullptr.
+  const ::ml_drift::Node* FindNode(::ml_drift::OperationType type) {
+    for (const ::ml_drift::Node* node : graph_.nodes()) {
+      if (::ml_drift::OperationTypeFromString(node->operation.type) == type) {
+        return node;
+      }
+    }
+    return nullptr;
+  }
+
+  std::unique_ptr<StubTfLiteContext> context_;
+  std::unique_ptr<TFLiteOperationParser> parser_;
+  ::ml_drift::GraphFloat32 graph_;
+  absl::flat_hash_map<int, ::ml_drift::Value*> tensor_to_value_;
+};
+
+// The kernel reads the indices along the channel axis, so a 1D constant [3]
+// has to enter the graph as [1,1,1,3], not as the default [3,1,1,1].
+TEST_F(GatherParseTest, ConstIndicesAreLaidOutAlongChannels) {
+  SetUpGather(/*indices_shape=*/{3}, /*output_shape=*/{3, 5});
+  ASSERT_TRUE(parser_
+                  ->IsSupported(context_.get(), context_->node(),
+                                context_->registration())
+                  .ok());
+  Parse();
+
+  const ::ml_drift::Node* gather = FindNode(::ml_drift::OperationType::GATHER);
+  ASSERT_NE(gather, nullptr);
+  const auto inputs = graph_.FindInputs(gather->id);
+  ASSERT_EQ(inputs.size(), 2);
+  EXPECT_EQ(inputs[0]->tensor.shape, ::ml_drift::BHWC(4, 1, 1, 5));
+  EXPECT_EQ(inputs[1]->tensor.shape, ::ml_drift::BHWC(1, 1, 1, 3));
+
+  // The gathered shape already matches the TFLite output, so no RESHAPE.
+  EXPECT_EQ(FindNode(::ml_drift::OperationType::RESHAPE), nullptr);
+  ASSERT_EQ(graph_.outputs().size(), 1);
+  EXPECT_EQ(graph_.outputs()[0]->tensor.shape, ::ml_drift::BHWC(3, 1, 1, 5));
+}
+
+// [1,3] indices push the gathered dimension onto another BHWC axis: the kernel
+// still writes [3,1,1,5], so a RESHAPE has to relabel it to the [1,3,5] output.
+TEST_F(GatherParseTest, MultiDimIndicesGetReshapedOutput) {
+  SetUpGather(/*indices_shape=*/{1, 3}, /*output_shape=*/{1, 3, 5});
+  ASSERT_TRUE(parser_
+                  ->IsSupported(context_.get(), context_->node(),
+                                context_->registration())
+                  .ok());
+  Parse();
+
+  const ::ml_drift::Node* gather = FindNode(::ml_drift::OperationType::GATHER);
+  ASSERT_NE(gather, nullptr);
+  const auto gather_outputs = graph_.FindOutputs(gather->id);
+  ASSERT_EQ(gather_outputs.size(), 1);
+  EXPECT_EQ(gather_outputs[0]->tensor.shape, ::ml_drift::BHWC(3, 1, 1, 5));
+
+  const ::ml_drift::Node* reshape =
+      FindNode(::ml_drift::OperationType::RESHAPE);
+  ASSERT_NE(reshape, nullptr);
+  const auto reshape_inputs = graph_.FindInputs(reshape->id);
+  ASSERT_EQ(reshape_inputs.size(), 1);
+  EXPECT_EQ(reshape_inputs[0]->id, gather_outputs[0]->id);
+  ASSERT_EQ(graph_.outputs().size(), 1);
+  EXPECT_EQ(graph_.outputs()[0]->tensor.shape, ::ml_drift::BHWC(1, 1, 3, 5));
+}
+
+// An output shape that is not a relabeling of the gathered shape would make the
+// RESHAPE permute the data, so the node must not be delegated at all.
+TEST_F(GatherParseTest, PermutedOutputShapeIsRejected) {
+  SetUpGather(/*indices_shape=*/{1, 3}, /*output_shape=*/{5, 3});
+  EXPECT_FALSE(parser_
+                   ->IsSupported(context_.get(), context_->node(),
+                                 context_->registration())
+                   .ok());
 }
 
 TEST(HardSwishOperationParserTest, TestIsSupported) {

--- a/ml_drift_delegate/tflite/model_builder_test.cc
+++ b/ml_drift_delegate/tflite/model_builder_test.cc
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <memory>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "testing/base/public/gmock.h"
@@ -2513,6 +2514,110 @@ TEST(ArithmeticBinaryElementwiseOperationParserTest, TestIsSupported) {
       parser
           ->IsSupported(context.get(), context->node(), context->registration())
           .ok());
+}
+
+// A constant operand of an elementwise op has to be re-aligned onto BHWC's
+// trailing axes when its rank is lower than the runtime operand's, because
+// TFLite broadcasting is right-aligned while ml-drift maps TFLite dim 0 to
+// batch. Without it the GPU elementwise broadcast reads batch-0 only and splats
+// it across the channels, silently corrupting the result.
+class ElementwiseConstOperandTest : public testing::Test {
+ public:
+  // StubTfLiteContext wires tensors {1, 2} as the inputs of the node under
+  // test.
+  enum { kRuntimeTensorIdx = 1, kConstTensorIdx = 2 };
+
+ protected:
+  // Builds a MINIMUM node with an INT32 runtime operand of shape
+  // `runtime_dims` and an INT32 constant operand of shape `const_dims`. INT32
+  // keeps the constant out of the float paths, which convert it to a Linear or
+  // BHWC attribute instead of a CONSTANT node.
+  void SetUpTensors(const std::vector<int>& runtime_dims,
+                    const std::vector<int>& const_dims) {
+    context_ = std::make_unique<StubTfLiteContext>(kTfLiteBuiltinMinimum,
+                                                   /*op_version=*/1,
+                                                   /*num_inputs=*/2,
+                                                   /*shape=*/runtime_dims);
+    context_->ChangeTensorShape(kConstTensorIdx, const_dims);
+    context_->SetTensorType(kRuntimeTensorIdx, kTfLiteInt32, kTfLiteArenaRw);
+    context_->SetTensorType(kConstTensorIdx, kTfLiteInt32, kTfLiteMmapRo);
+    parser_ = NewOperationParser(context_->node(), context_->registration());
+    ASSERT_NE(parser_, nullptr);
+  }
+
+  // Parses the node and returns the shape its constant operand ended up with.
+  ::ml_drift::BHWC ParseAndGetConstShape() {
+    ObjectReader reader(&graph_, context_.get(), context_->node(),
+                        &tensor_to_value_, /*quant_conversion_map=*/nullptr,
+                        /*tensor_to_buffer_id_map=*/nullptr,
+                        /*tensor_to_external_buffer_id_map=*/nullptr,
+                        /*shared_tensor_map=*/nullptr);
+    // Parse() returns void; a rejected node simply leaves no CONSTANT node
+    // behind, which the ADD_FAILURE() at the bottom reports.
+    parser_->Parse(context_->node(), context_->registration(), &graph_,
+                   &reader);
+    for (::ml_drift::Node* node : graph_.nodes()) {
+      if (node->operation.type !=
+          ToString(::ml_drift::OperationType::CONSTANT)) {
+        continue;
+      }
+      const std::vector<::ml_drift::Value*> outputs =
+          graph_.FindOutputs(node->id);
+      if (outputs.size() != 1) {
+        ADD_FAILURE() << "The CONSTANT node produces " << outputs.size()
+                      << " values, expected 1.";
+        return ::ml_drift::BHWC();
+      }
+      // The constant data has to carry the very same shape as the Value:
+      // ml-drift's ReserveGraphTensors() rejects the model otherwise.
+      const auto* attr = std::any_cast<::ml_drift::ConstTensorAttributes>(
+          &node->operation.attributes);
+      EXPECT_NE(attr, nullptr);
+      if (attr != nullptr) {
+        EXPECT_EQ(
+            std::visit([](const auto& t) { return t.shape; }, attr->tensor),
+            outputs[0]->tensor.shape);
+      }
+      return outputs[0]->tensor.shape;
+    }
+    ADD_FAILURE() << "The parsed graph holds no CONSTANT node.";
+    return ::ml_drift::BHWC();
+  }
+
+  std::unique_ptr<StubTfLiteContext> context_;
+  std::unique_ptr<TFLiteOperationParser> parser_;
+  ::ml_drift::GraphFloat32 graph_;
+  absl::flat_hash_map<int, ::ml_drift::Value*> tensor_to_value_;
+};
+
+TEST_F(ElementwiseConstOperandTest, Rank1ConstantAgainstRank4RuntimeUsesC) {
+  SetUpTensors(/*runtime_dims=*/{1, 1, 1, 3}, /*const_dims=*/{3});
+  EXPECT_EQ(ParseAndGetConstShape(), ::ml_drift::BHWC(1, 1, 1, 3));
+}
+
+TEST_F(ElementwiseConstOperandTest, Rank1ConstantAgainstRank2RuntimeUsesC) {
+  SetUpTensors(/*runtime_dims=*/{2, 3}, /*const_dims=*/{3});
+  EXPECT_EQ(ParseAndGetConstShape(), ::ml_drift::BHWC(1, 1, 1, 3));
+}
+
+TEST_F(ElementwiseConstOperandTest, Rank2ConstantAgainstRank4RuntimeUsesWC) {
+  SetUpTensors(/*runtime_dims=*/{1, 1, 2, 3}, /*const_dims=*/{2, 3});
+  EXPECT_EQ(ParseAndGetConstShape(), ::ml_drift::BHWC(1, 1, 2, 3));
+}
+
+TEST_F(ElementwiseConstOperandTest, Rank3ConstantAgainstRank4RuntimeUsesHWC) {
+  SetUpTensors(/*runtime_dims=*/{1, 2, 3, 4}, /*const_dims=*/{2, 3, 4});
+  EXPECT_EQ(ParseAndGetConstShape(), ::ml_drift::BHWC(1, 2, 3, 4));
+}
+
+TEST_F(ElementwiseConstOperandTest, Rank1ConstantAgainstRank1RuntimeKeepsB) {
+  SetUpTensors(/*runtime_dims=*/{3}, /*const_dims=*/{3});
+  EXPECT_EQ(ParseAndGetConstShape(), ::ml_drift::BHWC(3, 1, 1, 1));
+}
+
+TEST_F(ElementwiseConstOperandTest, Rank2ConstantAgainstRank2RuntimeKeepsB) {
+  SetUpTensors(/*runtime_dims=*/{2, 3}, /*const_dims=*/{2, 3});
+  EXPECT_EQ(ParseAndGetConstShape(), ::ml_drift::BHWC(2, 1, 1, 3));
 }
 
 class FullyConnectedOperationParserTest : public testing::Test {

--- a/ml_drift_delegate/tflite/object_reader.cc
+++ b/ml_drift_delegate/tflite/object_reader.cc
@@ -59,8 +59,12 @@ void SetValueAndAttrFromTfLiteTensor(const TfLiteTensor* tfl_tensor,
                                      ::ml_drift::ConstTensorAttributes& attr) {
   TensorType t;
   TfLiteTensorToTensorCopyData(tfl_tensor, &t, ReadTensorFlags::kNoExtraBytes);
+  // The requested layout has to be applied to the constant data as well as to
+  // the Value: ReserveGraphTensors() cross-checks the two shapes and rejects
+  // the model if they disagree.
+  t.shape = GetShape(t.shape, layout, tfl_tensor->dims->size);
   value->tensor.type = t.kType;
-  value->tensor.shape = GetShape(t.shape, layout, tfl_tensor->dims->size);
+  value->tensor.shape = t.shape;
   attr.tensor = std::move(t);
 }
 

--- a/ml_drift_delegate/tflite/object_reader_test.cc
+++ b/ml_drift_delegate/tflite/object_reader_test.cc
@@ -14,11 +14,14 @@
 
 #include "ml_drift_delegate/tflite/object_reader.h"
 
+#include <any>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "testing/base/public/gmock.h"
@@ -28,6 +31,7 @@
 #include "absl/types/span.h"  // from @com_google_absl
 #include "ml_drift/common/data_type.h"  // from @ml_drift
 #include "ml_drift/common/model.h"  // from @ml_drift
+#include "ml_drift/common/operations.h"  // from @ml_drift
 #include "ml_drift/common/shape.h"  // from @ml_drift
 #include "ml_drift/common/tensor.h"  // from @ml_drift
 #include "ml_drift/common/types.h"  // from @ml_drift
@@ -212,6 +216,103 @@ TEST_F(ObjectBuilderSharingTest, SetSharedTensorWorks) {
                                      .global_id = kGlobalBufferId,
                                      .dequant_forced = false};
   EXPECT_EQ(shared_tensor_map_.at(kFakeGraphNodeId), kExpected);
+}
+
+// Tests for AddConstInput(). The layout requested by the caller must reach both
+// the Value and the constant data held by the CONSTANT node's attributes:
+// ml-drift's ReserveGraphTensors() cross-checks the two shapes and rejects the
+// model if they disagree.
+class AddConstInputTest : public testing::Test {
+ public:
+  // StubTfLiteContext wires tensors {1, 2} as the inputs of the node under
+  // test.
+  enum { kConstTensorIdx = 2, kConstInputPos = 1 };
+
+ protected:
+  // Turns the constant input into an INT32 tensor of shape `dims` holding
+  // `data`.
+  void SetUpConstInt32Tensor(const std::vector<int>& dims,
+                             const std::vector<int32_t>& data) {
+    context_->ChangeTensorShape(kConstTensorIdx, dims);
+    TfLiteTensor* tensor = context_->tensor(kConstTensorIdx);
+    tensor->type = kTfLiteInt32;
+    tensor->allocation_type = kTfLiteMmapRo;
+    ASSERT_EQ(tensor->bytes, data.size() * sizeof(int32_t));
+    std::memcpy(tensor->data.raw, data.data(), tensor->bytes);
+  }
+
+  // Returns the constant tensor stored in the attributes of the CONSTANT node
+  // producing `value`.
+  const ::ml_drift::TensorInt32* GetConstAttrTensor(
+      const ::ml_drift::Value* value) {
+    ::ml_drift::Node* producer = graph_.FindProducer(value->id);
+    if (producer == nullptr) return nullptr;
+    const auto* attr = std::any_cast<::ml_drift::ConstTensorAttributes>(
+        &producer->operation.attributes);
+    if (attr == nullptr) return nullptr;
+    return std::get_if<::ml_drift::TensorInt32>(&attr->tensor);
+  }
+
+  std::unique_ptr<StubTfLiteContext> context_ =
+      std::make_unique<StubTfLiteContext>(kTfLiteBuiltinMinimum,
+                                          /*op_version=*/1,
+                                          /*num_inputs=*/2,
+                                          /*shape=*/std::vector<int>({1, 3}));
+  ::ml_drift::GraphFloat32 graph_;
+  absl::flat_hash_map<int, ::ml_drift::Value*> tensor_to_value_;
+  ObjectReader reader_ = ObjectReader(
+      &graph_, context_.get(), context_->node(), &tensor_to_value_,
+      /*quant_conversion_map=*/nullptr, /*tensor_to_buffer_id_map=*/nullptr,
+      /*tensor_to_external_buffer_id_map=*/nullptr,
+      /*shared_tensor_map=*/nullptr);
+};
+
+TEST_F(AddConstInputTest, DefaultLayoutPutsFirstDimensionInBatch) {
+  SetUpConstInt32Tensor(/*dims=*/{3}, /*data=*/{0, 7, 126});
+
+  const ::ml_drift::Value* value =
+      reader_.AddConstInput(kConstInputPos, /*layout=*/{});
+
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(value->tensor.shape, ::ml_drift::BHWC(3, 1, 1, 1));
+  const ::ml_drift::TensorInt32* t = GetConstAttrTensor(value);
+  ASSERT_NE(t, nullptr);
+  EXPECT_EQ(t->shape, value->tensor.shape);
+  EXPECT_THAT(t->data, testing::ElementsAre(0, 7, 126));
+}
+
+TEST_F(AddConstInputTest, Layout1dScalarMovesLengthToChannelsInValueAndAttr) {
+  SetUpConstInt32Tensor(/*dims=*/{3}, /*data=*/{0, 7, 126});
+
+  SizedLayout layout;
+  layout.layout_1d = ::ml_drift::Layout::SCALAR;
+  const ::ml_drift::Value* value =
+      reader_.AddConstInput(kConstInputPos, layout);
+
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(value->tensor.shape, ::ml_drift::BHWC(1, 1, 1, 3));
+  const ::ml_drift::TensorInt32* t = GetConstAttrTensor(value);
+  ASSERT_NE(t, nullptr);
+  // The attributes must carry the very same shape, and relabeling axes of
+  // extent 1 must not reorder the data.
+  EXPECT_EQ(t->shape, value->tensor.shape);
+  EXPECT_THAT(t->data, testing::ElementsAre(0, 7, 126));
+}
+
+TEST_F(AddConstInputTest, Layout2dHwMovesDimensionsToWidthAndChannels) {
+  SetUpConstInt32Tensor(/*dims=*/{2, 3}, /*data=*/{0, 1, 2, 3, 4, 5});
+
+  SizedLayout layout;
+  layout.layout_2d = ::ml_drift::Layout::HW;
+  const ::ml_drift::Value* value =
+      reader_.AddConstInput(kConstInputPos, layout);
+
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(value->tensor.shape, ::ml_drift::BHWC(1, 1, 2, 3));
+  const ::ml_drift::TensorInt32* t = GetConstAttrTensor(value);
+  ASSERT_NE(t, nullptr);
+  EXPECT_EQ(t->shape, value->tensor.shape);
+  EXPECT_THAT(t->data, testing::ElementsAre(0, 1, 2, 3, 4, 5));
 }
 
 TEST(TfLiteTensorToTensorTest, Float2D) {

--- a/tflite/tools/versioning/gpu_compatibility.cc
+++ b/tflite/tools/versioning/gpu_compatibility.cc
@@ -36,6 +36,25 @@ namespace tflite {
 
 namespace {
 
+// Maximum tensor rank representable in the BHWC layout used by the GPU
+// delegates.
+constexpr size_t kMaxBhwcDims = 4;
+
+bool HasFlag(GpuCompatibilityFlags flags, GpuCompatibilityFlags flag) {
+  return (static_cast<int>(flags) & static_cast<int>(flag)) != 0;
+}
+
+// Returns true if `dims` describes a tensor that reduces to a 1D vector, i.e.
+// every dimension except the last one has extent 1 (a 1D tensor trivially
+// qualifies). An empty (rank-0) `dims` returns false.
+bool ReducesTo1DVector(const std::vector<int32_t>& dims) {
+  if (dims.empty()) return false;
+  for (size_t i = 0; i + 1 < dims.size(); ++i) {
+    if (dims[i] != 1) return false;
+  }
+  return true;
+}
+
 std::string GetOpName(const OpSignature& op_sig) {
   if (op_sig.op == tflite::BuiltinOperator_CUSTOM) {
     return op_sig.custom_name;
@@ -496,7 +515,7 @@ absl::Status CheckAddMulBroadcastCompatibility(
     }
 
     bool is_broadcastable = false;
-    if (flags == GpuCompatibilityFlags::kEnhancedBroadcast) {
+    if (HasFlag(flags, GpuCompatibilityFlags::kEnhancedBroadcast)) {
       is_broadcastable = CheckIsBroadcastable(longer_dims, shorter_dims);
     } else {
       if (longer_dims->size() == 4 && shorter_dims->size() == 3 &&
@@ -830,7 +849,7 @@ absl::Status CheckGpuDelegateCompatibility(const OpSignature& op_sig,
       return absl::OkStatus();
     }
 
-    case kTfLiteBuiltinGather:
+    case kTfLiteBuiltinGather: {
       if (!CheckInputsConstsOutputs(op_sig, /*required_runtime_inputs=*/2,
                                     /*required_const_inputs=*/0,
                                     /*required_outputs=*/1)
@@ -842,12 +861,35 @@ absl::Status CheckGpuDelegateCompatibility(const OpSignature& op_sig,
         return absl::InvalidArgumentError(
             "Op can only handle 1 or 2 operand(s).");
       }
-      if (op_sig.inputs[1].dims.size() != 1) {
+      // Every tensor has to be representable in BHWC: a higher-rank shape gets
+      // silently truncated to its four leading dimensions downstream, which
+      // would drop the gathered dimension without reporting an error.
+      for (const auto* spec : {&op_sig.inputs.at(0), &op_sig.inputs.at(1),
+                               &op_sig.outputs.at(0)}) {
+        if (spec->dims.size() > kMaxBhwcDims) {
+          return absl::UnimplementedError(
+              "Gather only supports up to 4D input, indices and output.");
+        }
+      }
+      // The gather kernels consume indices as a 1D vector laid out along the
+      // channel axis, and derive the output shape from the input shape with
+      // `axis` replaced by the number of indices. Indices of rank > 1 therefore
+      // only work on a backend that relabels the indices and reshapes the
+      // gathered result, which kReducibleGatherIndices advertises -- and even
+      // then only when they reduce to that same 1D vector.
+      if (HasFlag(flags, GpuCompatibilityFlags::kReducibleGatherIndices)) {
+        if (!ReducesTo1DVector(op_sig.inputs.at(1).dims)) {
+          return absl::UnimplementedError(
+              "Only support indices that reduce to a 1D vector (all leading "
+              "dimensions must be 1)");
+        }
+      } else if (op_sig.inputs.at(1).dims.size() != 1) {
         return absl::UnimplementedError("Only support 1D indices");
       }
       return op_sig.inputs.at(1).type == kTfLiteInt32
                  ? absl::OkStatus()
                  : absl::UnimplementedError("Only accept INT32 indices");
+    }
 
     case kTfLiteBuiltinHardSwish:
       return CheckInputsOutputs(op_sig, /*required_runtime_inputs=*/1,

--- a/tflite/tools/versioning/gpu_compatibility.h
+++ b/tflite/tools/versioning/gpu_compatibility.h
@@ -27,6 +27,12 @@ namespace tflite {
 enum class GpuCompatibilityFlags {
   kStandard = 0,
   kEnhancedBroadcast = 1 << 0,  // Set when backend supports enhanced broadcast.
+  // Set when the backend accepts GATHER indices that are stored
+  // multi-dimensionally but reduce to a 1D vector, i.e. every dimension except
+  // the last one has extent 1 (e.g. [1,N]). Such a backend has to relabel or
+  // reshape both the indices and the gathered result itself; backends without
+  // this flag only accept genuinely 1D indices.
+  kReducibleGatherIndices = 1 << 1,
 };
 
 // Check if the given op signature is compatible with GPU delegate.

--- a/tflite/tools/versioning/gpu_compatibility_test.cc
+++ b/tflite/tools/versioning/gpu_compatibility_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "tflite/tools/versioning/gpu_compatibility.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -54,6 +55,24 @@ absl::Status CheckGpuDelegateCompatibility(const tflite::Model* model) {
     }
   }
   return absl::OkStatus();
+}
+
+// Builds a signature for gathering `indices_dims` rows out of a [4,5] table.
+OpSignature GatherOpSignature(const std::vector<int32_t>& indices_dims,
+                              const std::vector<int32_t>& output_dims) {
+  OpSignature op_sig = OpSignature();
+  op_sig.op = BuiltinOperator_GATHER;
+  op_sig.inputs = std::vector<OpSignatureTensorSpec>(2);
+  op_sig.inputs[0].is_const = false;
+  op_sig.inputs[0].type = kTfLiteFloat32;
+  op_sig.inputs[0].dims = {4, 5};
+  op_sig.inputs[1].is_const = false;
+  op_sig.inputs[1].type = kTfLiteInt32;
+  op_sig.inputs[1].dims = indices_dims;
+  op_sig.outputs = std::vector<OpSignatureTensorSpec>(1);
+  op_sig.outputs[0].type = kTfLiteFloat32;
+  op_sig.outputs[0].dims = output_dims;
+  return op_sig;
 }
 
 }  // namespace
@@ -299,6 +318,53 @@ TEST(CheckGpuDelegateCompatibility, ResamplerInvalidChannels) {
   EXPECT_THAT(
       CheckGpuDelegateCompatibility(op_sig),
       StatusIs(absl::StatusCode::kInvalidArgument, HasSubstr("warp.c < 2")));
+}
+
+TEST(CheckGpuDelegateCompatibility, GatherMultiDimIndicesNeedFlag) {
+  const OpSignature op_sig = GatherOpSignature(/*indices_dims=*/{1, 3},
+                                               /*output_dims=*/{1, 3, 5});
+
+  // Indices of rank > 1 require the backend to relabel them into the 1D vector
+  // the kernel reads, which only kReducibleGatherIndices backends do.
+  EXPECT_THAT(CheckGpuDelegateCompatibility(op_sig),
+              StatusIs(absl::StatusCode::kUnimplemented,
+                       HasSubstr("Only support 1D indices")));
+  EXPECT_THAT(CheckGpuDelegateCompatibility(
+                  op_sig, GpuCompatibilityFlags::kReducibleGatherIndices),
+              IsOk());
+}
+
+TEST(CheckGpuDelegateCompatibility, Gather1DIndicesNeedNoFlag) {
+  const OpSignature op_sig = GatherOpSignature(/*indices_dims=*/{3},
+                                               /*output_dims=*/{3, 5});
+
+  EXPECT_THAT(CheckGpuDelegateCompatibility(op_sig), IsOk());
+  EXPECT_THAT(CheckGpuDelegateCompatibility(
+                  op_sig, GpuCompatibilityFlags::kReducibleGatherIndices),
+              IsOk());
+}
+
+TEST(CheckGpuDelegateCompatibility, GatherIndicesWithNonUnitLeadingDim) {
+  const OpSignature op_sig = GatherOpSignature(/*indices_dims=*/{2, 3},
+                                               /*output_dims=*/{2, 3, 5});
+
+  EXPECT_THAT(CheckGpuDelegateCompatibility(
+                  op_sig, GpuCompatibilityFlags::kReducibleGatherIndices),
+              StatusIs(absl::StatusCode::kUnimplemented,
+                       HasSubstr("reduce to a 1D vector")));
+}
+
+TEST(CheckGpuDelegateCompatibility, GatherIndicesAboveBhwcRank) {
+  // The leading dimensions are all 1, so the indices do reduce to a 1D vector,
+  // but rank 5 would be truncated to its four leading dimensions downstream,
+  // silently dropping the gathered dimension.
+  const OpSignature op_sig = GatherOpSignature(/*indices_dims=*/{1, 1, 1, 1, 3},
+                                               /*output_dims=*/{1, 1, 1, 3, 5});
+
+  EXPECT_THAT(CheckGpuDelegateCompatibility(
+                  op_sig, GpuCompatibilityFlags::kReducibleGatherIndices),
+              StatusIs(absl::StatusCode::kUnimplemented,
+                       HasSubstr("up to 4D input, indices and output")));
 }
 
 }  // namespace tflite


### PR DESCRIPTION
## Problem
GATHER previously required strictly 1D indices. This adds support for indices of higher rank whose leading dimensions are all 1 (e.g. `[1,N]`, common after a reshape upstream): they hold the same vector the kernel reads, so the delegate can now relabel them instead of rejecting the op and falling back to CPU.

Because such indices give the TFLite output a higher rank than the input, the gathered dimension lands on a different BHWC axis — gathering rows of a `[V,C]` table with `[1,N]` indices yields `[1,N,C]`, not `[N,C]`. The parser now emits the GATHER with the shape the kernel produces and appends a RESHAPE to reach the real output layout.

see chromium issue: https://issues.chromium.org/issues/534893138