### PR TITLE
Allow INT32 input for ARG_MAX in the ml_drift GPU delegate

### DIFF
--- a/ml_drift_delegate/tflite/model_builder.cc
+++ b/ml_drift_delegate/tflite/model_builder.cc
@@ -7183,6 +7183,7 @@ TfLiteIntArray* GetOpsToReplaceWithOptions(
       allowed_out_types.push_back(kTfLiteUInt8);
     }
     if (registration->builtin_code == kTfLiteBuiltinArgMax) {
+      allowed_in_types.push_back(kTfLiteInt32);
       allowed_out_types = {kTfLiteInt32};
     }
     if (registration->builtin_code == kTfLiteBuiltinReduceAll ||


### PR DESCRIPTION
ARG_MAX was restricted to floating-point inputs, so a graph indexing an integer tensor fell back to CPU and split the delegated partition. This is common in text encoders, e.g. Stable Diffusion 1.5's CLIP text encoder [1], where argMax over int32 token ids locates the EOS position.

No kernel change is needed. MAX_INDEX lowers to Reduce with Type::kMaximumIndex, which is already type-polymorphic: GetAccumType() maps INT32/INT16/INT8 to an INT32 accumulator with a <int> read template, and the max-index reducer seeds from the first element rather than a float sentinel, so an integer input needs no float-specific handling.

Add kTfLiteInt32 to the accepted input types. The output type list is unchanged and still pinned to INT32.

[1]: https://issues.chromium.org/issues/534847488