### PR TITLE
Accept a float16 GATHER input feeding a float32 output

### DIFF
--- a/ml_drift_delegate/tflite/model_builder.cc
+++ b/ml_drift_delegate/tflite/model_builder.cc
@@ -3495,7 +3495,17 @@ class GatherOperationParser : public TFLiteOperationParser {
     ABSL_RETURN_IF_ERROR(
         PreGetOutputTensor(context, tflite_node, 0, &tfl_output));
     if (tfl_input->type != tfl_output->type) {
-      return absl::InvalidArgumentError("Input / output dtype mismatch.");
+      // A folded fp16 weight (e.g. Chromium emits fp16 constants behind a
+      // DEQUANTIZE that this delegate folds away) legitimately feeds an fp32
+      // destination. The kernel converts to the destination type, so allow a
+      // float/float difference; anything else is still a real mismatch.
+      const bool both_float = (tfl_input->type == kTfLiteFloat16 ||
+                               tfl_input->type == kTfLiteFloat32) &&
+                              (tfl_output->type == kTfLiteFloat16 ||
+                               tfl_output->type == kTfLiteFloat32);
+      if (!both_float) {
+        return absl::InvalidArgumentError("Input / output dtype mismatch.");
+      }
     }
     return absl::OkStatus();
   }


### PR DESCRIPTION
GATHER required its input and output tensors to have identical types, so a float16 table feeding a float32 destination was rejected and the node ran on CPU, splitting the delegated partition.

A framework, e.g. Chromium WebNN LiteRT backend [1], emits fp16 weights as a float16 constant behind a DEQUANTIZE, this delegate folds the DEQUANTIZE away, and the GATHER is then left reading a float16 table into the float32 destination the graph declared.

[1]: https://source.chromium.org/chromium/chromium/src/+/main:services/webnn/tflite/graph_builder_tflite.cc;l=1288;drc=f71ffcd5aa26177023677965711de7f223b41d42