### PR TITLE
Make LiteRT Python runtime bindings safe for free-threaded Python

### DIFF
--- a/tflite/python/analyzer_wrapper/analyzer_wrapper.cc
+++ b/tflite/python/analyzer_wrapper/analyzer_wrapper.cc
@@ -18,7 +18,7 @@ limitations under the License.
 #include "pybind11/pybind11.h"  // from @pybind11
 #include "tflite/python/analyzer_wrapper/model_analyzer.h"
 
-PYBIND11_MODULE(_pywrap_analyzer_wrapper, m) {
+PYBIND11_MODULE(_pywrap_analyzer_wrapper, m, pybind11::mod_gil_not_used()) {
   m.def(
       "ModelAnalyzer",
       [](const std::string& model_path, bool input_is_filepath,

--- a/tflite/python/interpreter_wrapper/BUILD
+++ b/tflite/python/interpreter_wrapper/BUILD
@@ -28,6 +28,7 @@ cc_library(
     hdrs = ["numpy.h"],
     compatible_with = get_compatible_with_portable(),
     deps = [
+        "@com_google_absl//absl/base",
         "//tflite:string_util",
         "//tflite/core/c:c_api_types",
         "//tflite/core/c:common",
@@ -44,6 +45,7 @@ cc_library(
     ],
     compatible_with = get_compatible_with_portable(),
     deps = [
+        "@com_google_absl//absl/synchronization",
         ":numpy",
         ":python_error_reporter",
         ":python_utils",
@@ -115,6 +117,7 @@ pybind_extension(
     wrap_py_init = True,
     deps = [
         ":interpreter_wrapper_lib",
+        "@com_google_absl//absl/synchronization",
         "//tflite:framework",
         "//tflite/core:framework_stable",
         "@org_tensorflow//tensorflow/python/lib/core:pybind11_lib",

--- a/tflite/python/interpreter_wrapper/interpreter_wrapper.cc
+++ b/tflite/python/interpreter_wrapper/interpreter_wrapper.cc
@@ -83,6 +83,35 @@ namespace interpreter_wrapper {
 
 namespace {
 
+// Waiting for the per-interpreter mutex while holding the legacy GIL can
+// deadlock with Invoke(), because Invoke intentionally releases the GIL while
+// keeping this native mutex held. On GIL builds, release the GIL only while
+// waiting for the mutex. Free-threaded Python has no global GIL to release.
+class ScopedInterpreterLock {
+ public:
+  explicit ScopedInterpreterLock(absl::Mutex* mu) : mu_(mu) {
+#ifndef Py_GIL_DISABLED
+    Py_BEGIN_ALLOW_THREADS
+    mu_->Lock();
+    Py_END_ALLOW_THREADS
+#else
+    mu_->Lock();
+#endif
+  }
+
+  ~ScopedInterpreterLock() { mu_->Unlock(); }
+
+  ScopedInterpreterLock(const ScopedInterpreterLock&) = delete;
+  ScopedInterpreterLock& operator=(const ScopedInterpreterLock&) = delete;
+
+ private:
+  absl::Mutex* const mu_;
+};
+
+}  // namespace
+
+namespace {
+
 using python_utils::PyDecrefDeleter;
 
 std::unique_ptr<Interpreter> CreateInterpreter(
@@ -448,6 +477,7 @@ InterpreterWrapper::~InterpreterWrapper() = default;
 static constexpr int kUndeterminedSubgraphIndex = -1;
 // LINT.ThenChange(//tflite/python/interpreter_wrapper/interpreter_wrapper_pybind11.cc)
 PyObject* InterpreterWrapper::AllocateTensors(int subgraph_index) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   if (subgraph_index == kUndeterminedSubgraphIndex) {
     TFLITE_PY_CHECK(interpreter_->AllocateTensors());
@@ -462,6 +492,7 @@ PyObject* InterpreterWrapper::AllocateTensors(int subgraph_index) {
 }
 
 PyObject* InterpreterWrapper::Invoke(int subgraph_index) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_BOUNDS_CHECK(subgraph_index);
 
@@ -485,6 +516,7 @@ PyObject* InterpreterWrapper::Invoke(int subgraph_index) {
 }
 
 PyObject* InterpreterWrapper::InputIndices() const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   PyObject* np_array = PyArrayFromIntVector(interpreter_->inputs().data(),
                                             interpreter_->inputs().size());
@@ -493,6 +525,7 @@ PyObject* InterpreterWrapper::InputIndices() const {
 }
 
 PyObject* InterpreterWrapper::OutputIndices() const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   PyObject* np_array = PyArrayFromIntVector(interpreter_->outputs().data(),
                                             interpreter_->outputs().size());
 
@@ -530,6 +563,7 @@ PyObject* InterpreterWrapper::ResizeInputTensorImpl(int i, PyObject* value) {
 PyObject* InterpreterWrapper::ResizeInputTensor(int i, PyObject* value,
                                                 bool strict,
                                                 int subgraph_index) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_BOUNDS_CHECK(subgraph_index);
 
@@ -554,6 +588,7 @@ PyObject* InterpreterWrapper::ResizeInputTensor(int i, PyObject* value,
 }
 
 int InterpreterWrapper::NumTensors(int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   if (!interpreter_) {
     return 0;
   }
@@ -561,6 +596,7 @@ int InterpreterWrapper::NumTensors(int subgraph_index) const {
 }
 
 int InterpreterWrapper::NumSubgraphs() const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   if (interpreter_ == nullptr) {
     return 0;
   }
@@ -569,6 +605,7 @@ int InterpreterWrapper::NumSubgraphs() const {
 
 std::string InterpreterWrapper::TensorName(int tensor_index,
                                            int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   const Subgraph* subgraph = interpreter_->subgraph(subgraph_index);
   if (!interpreter_ || tensor_index >= subgraph->tensors_size() ||
       tensor_index < 0) {
@@ -581,6 +618,7 @@ std::string InterpreterWrapper::TensorName(int tensor_index,
 
 PyObject* InterpreterWrapper::TensorType(int tensor_index,
                                          int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -601,6 +639,7 @@ PyObject* InterpreterWrapper::TensorType(int tensor_index,
 
 PyObject* InterpreterWrapper::TensorSize(int tensor_index,
                                          int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -618,6 +657,7 @@ PyObject* InterpreterWrapper::TensorSize(int tensor_index,
 
 PyObject* InterpreterWrapper::TensorSizeSignature(int tensor_index,
                                                   int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -632,6 +672,7 @@ PyObject* InterpreterWrapper::TensorSizeSignature(int tensor_index,
 
 PyObject* InterpreterWrapper::TensorSparsityParameters(
     int tensor_index, int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -646,6 +687,7 @@ PyObject* InterpreterWrapper::TensorSparsityParameters(
 
 PyObject* InterpreterWrapper::TensorQuantization(int tensor_index,
                                                  int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -656,6 +698,7 @@ PyObject* InterpreterWrapper::TensorQuantization(int tensor_index,
 
 PyObject* InterpreterWrapper::TensorQuantizationParameters(
     int tensor_index, int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
 
@@ -722,6 +765,7 @@ PyObject* InterpreterWrapper::TensorQuantizationParameters(
 
 PyObject* InterpreterWrapper::SetTensor(int tensor_index, PyObject* value,
                                         int subgraph_index) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_SUBGRAPH_BOUNDS_CHECK(subgraph_index);
   TFLITE_PY_SUBGRAPH_TENSOR_BOUNDS_CHECK(tensor_index, subgraph_index);
@@ -810,6 +854,7 @@ PyObject* InterpreterWrapper::SetTensor(int tensor_index, PyObject* value,
 }
 
 int InterpreterWrapper::NumNodes() const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   if (!interpreter_) {
     return 0;
   }
@@ -817,6 +862,7 @@ int InterpreterWrapper::NumNodes() const {
 }
 
 PyObject* InterpreterWrapper::NodeInputs(int i) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_NODES_BOUNDS_CHECK(i);
 
@@ -827,6 +873,7 @@ PyObject* InterpreterWrapper::NodeInputs(int i) const {
 }
 
 PyObject* InterpreterWrapper::NodeOutputs(int i) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_NODES_BOUNDS_CHECK(i);
 
@@ -837,6 +884,7 @@ PyObject* InterpreterWrapper::NodeOutputs(int i) const {
 }
 
 std::string InterpreterWrapper::NodeName(int i) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   if (!interpreter_ || i >= interpreter_->nodes_size() || i < 0) {
     return "";
   }
@@ -894,6 +942,7 @@ PyObject* CheckGetTensorArgs(Interpreter* interpreter_, int tensor_index,
 }  // namespace
 
 PyObject* InterpreterWrapper::GetSignatureDefs() const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   PyObject* result = PyDict_New();
   if (result == nullptr) return nullptr;
 
@@ -960,6 +1009,7 @@ PyObject* InterpreterWrapper::GetSignatureDefs() const {
 
 PyObject* InterpreterWrapper::GetSubgraphIndexFromSignature(
     const char* signature_key) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
 
   int32_t subgraph_index =
@@ -974,6 +1024,7 @@ PyObject* InterpreterWrapper::GetSubgraphIndexFromSignature(
 
 PyObject* InterpreterWrapper::GetTensor(int tensor_index,
                                         int subgraph_index) const {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   // Sanity check accessor
   TfLiteTensor* tensor = nullptr;
   int type_num = 0;
@@ -1103,6 +1154,7 @@ PyObject* InterpreterWrapper::GetTensor(int tensor_index,
 
 PyObject* InterpreterWrapper::tensor(PyObject* base_object, int tensor_index,
                                      int subgraph_index) {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   // Sanity check accessor
   TfLiteTensor* tensor = nullptr;
   int type_num = 0;
@@ -1199,6 +1251,7 @@ InterpreterWrapper* InterpreterWrapper::CreateWrapperCPPFromBuffer(
 }
 
 PyObject* InterpreterWrapper::ResetVariableTensors() {
+  ScopedInterpreterLock lock(&interpreter_mu_);
   TFLITE_PY_ENSURE_VALID_INTERPRETER();
   TFLITE_PY_CHECK(interpreter_->ResetVariableTensors());
   Py_RETURN_NONE;

--- a/tflite/python/interpreter_wrapper/interpreter_wrapper.h
+++ b/tflite/python/interpreter_wrapper/interpreter_wrapper.h
@@ -27,6 +27,7 @@ limitations under the License.
 // automatically move <Python.h> before <locale>.
 #include <Python.h>
 
+#include "absl/synchronization/mutex.h"
 #include "tflite/core/interpreter.h"
 
 struct TfLiteDelegate;
@@ -157,6 +158,12 @@ class InterpreterWrapper {
   // The public functions which creates `InterpreterWrapper` should ensure all
   // these member variables are initialized successfully. Otherwise it should
   // report the error and return `nullptr`.
+  // Serializes access to the mutable TFLite Interpreter owned by this wrapper.
+  //
+  // The lock must remain held across Invoke(), including while Invoke()
+  // temporarily detaches from the Python thread state.
+  mutable absl::Mutex interpreter_mu_;
+
   const std::unique_ptr<Model> model_;
   const std::unique_ptr<PythonErrorReporter> error_reporter_;
   const std::unique_ptr<tflite::MutableOpResolver> resolver_;

--- a/tflite/python/interpreter_wrapper/interpreter_wrapper_pybind11.cc
+++ b/tflite/python/interpreter_wrapper/interpreter_wrapper_pybind11.cc
@@ -29,7 +29,7 @@ limitations under the License.
 namespace py = pybind11;
 using tflite::interpreter_wrapper::InterpreterWrapper;
 
-PYBIND11_MODULE(_pywrap_litert_interpreter_wrapper, m) {
+PYBIND11_MODULE(_pywrap_litert_interpreter_wrapper, m, py::mod_gil_not_used()) {
   m.doc() = R"pbdoc(
     _pywrap_litert_interpreter_wrapper
     -----

--- a/tflite/python/interpreter_wrapper/numpy.cc
+++ b/tflite/python/interpreter_wrapper/numpy.cc
@@ -17,6 +17,8 @@ limitations under the License.
 #include <cstdint>
 #include <memory>
 
+#include "absl/base/call_once.h"
+
 #define TFLITE_IMPORT_NUMPY  // See numpy.h for explanation.
 #include "tflite/core/c/c_api_types.h"
 #include "tflite/core/c/common.h"
@@ -25,7 +27,12 @@ limitations under the License.
 namespace tflite {
 namespace python {
 
-void ImportNumpy() { import_array1(); }
+void ImportNumpy() {
+  static absl::once_flag flag;
+  absl::call_once(flag, []() {
+    import_array1();
+  });
+}
 
 }  // namespace python
 

--- a/tflite/python/metrics/BUILD
+++ b/tflite/python/metrics/BUILD
@@ -34,6 +34,7 @@ cc_library(
     compatible_with = get_compatible_with_portable(),
     visibility = ["//visibility:private"],
     deps = [
+        "@com_google_absl//absl/synchronization",
         "@xla//third_party/python_runtime:headers",
     ] + if_portable(
         if_false = [
@@ -60,6 +61,7 @@ pybind_extension(
     wrap_py_init = True,
     deps = [
         ":metrics_wrapper_lib",
+        "@com_google_absl//absl/synchronization",
         "@com_google_protobuf//:protobuf",
         "@org_tensorflow//tensorflow/python/lib/core:pybind11_lib",
         "@pybind11",

--- a/tflite/python/metrics/wrapper/metrics_wrapper.h
+++ b/tflite/python/metrics/wrapper/metrics_wrapper.h
@@ -25,6 +25,8 @@ limitations under the License.
 // automatically move <Python.h> before <locale>.
 #include <Python.h>
 
+#include "absl/synchronization/mutex.h"
+
 // We forward declare TFLite classes here to avoid exposing them to SWIG.
 namespace tensorflow {
 namespace monitoring {
@@ -49,6 +51,7 @@ class MetricsWrapper {
  private:
   explicit MetricsWrapper(std::unique_ptr<MetricsExporter> exporter);
 
+  absl::Mutex exporter_mu_;
   const std::unique_ptr<MetricsExporter> exporter_;
 };
 

--- a/tflite/python/metrics/wrapper/metrics_wrapper_nonportable.cc
+++ b/tflite/python/metrics/wrapper/metrics_wrapper_nonportable.cc
@@ -18,6 +18,7 @@ limitations under the License.
 #include <vector>
 
 #include "learning/brain/google/monitoring/metrics_exporter.h"
+#include "absl/synchronization/mutex.h"
 #include "tflite/python/metrics/wrapper/metrics_wrapper.h"
 
 namespace tflite {
@@ -54,7 +55,10 @@ PyObject* MetricsWrapper::ExportMetrics() {
     return nullptr;
   }
 
-  exporter_->ExportMetrics();
+  {
+    absl::MutexLock lock(&exporter_mu_);
+    exporter_->ExportMetrics();
+  }
 
   Py_RETURN_NONE;
 }

--- a/tflite/python/metrics/wrapper/metrics_wrapper_portable.cc
+++ b/tflite/python/metrics/wrapper/metrics_wrapper_portable.cc
@@ -16,6 +16,8 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
+#include "absl/synchronization/mutex.h"
+
 #include "tflite/python/metrics/wrapper/metrics_wrapper.h"
 
 namespace tensorflow {
@@ -50,7 +52,10 @@ PyObject* MetricsWrapper::ExportMetrics() {
     return nullptr;
   }
 
-  exporter_->ExportMetrics();
+  {
+    absl::MutexLock lock(&exporter_mu_);
+    exporter_->ExportMetrics();
+  }
 
   Py_RETURN_NONE;
 }

--- a/tflite/python/metrics/wrapper/metrics_wrapper_pybind11.cc
+++ b/tflite/python/metrics/wrapper/metrics_wrapper_pybind11.cc
@@ -24,7 +24,8 @@ limitations under the License.
 namespace py = pybind11;
 using tflite::metrics_wrapper::MetricsWrapper;
 
-PYBIND11_MODULE(_pywrap_tensorflow_lite_metrics_wrapper, m) {
+PYBIND11_MODULE(_pywrap_tensorflow_lite_metrics_wrapper, m,
+                py::mod_gil_not_used()) {
   m.doc() = R"pbdoc(
     _pywrap_tensorflow_lite_metrics_wrapper
     -----


### PR DESCRIPTION
## Summary

Make the LiteRT Python runtime bindings safe for CPython free-threaded execution.

This work was originally submitted in tensorflow/tensorflow#125644. TensorFlow review requested that TFLite / LiteRT runtime changes be moved to the dedicated `google-ai-edge/LiteRT` repository. This PR contains only the LiteRT runtime changes; no TensorFlow fuzzing tests are included.

## Changes

- Mark the analyzer, interpreter, and metrics pybind modules with `py::mod_gil_not_used()`.
- Add per-interpreter synchronization around mutable interpreter access.
- Avoid waiting on the interpreter mutex while holding the legacy GIL on GIL-enabled Python builds.
- Make NumPy C API initialization thread-safe with `absl::call_once`.
- Serialize metrics exporter access.
- Add the required Abseil synchronization/base BUILD dependencies.

## Scope

Runtime-only changes under:

- `tflite/python/analyzer_wrapper`
- `tflite/python/interpreter_wrapper`
- `tflite/python/metrics`

TensorFlow fuzzing tests are intentionally excluded, per review guidance on tensorflow/tensorflow#125644.

## Validation

- `git diff --check` passes.
- The corresponding TensorFlow-side implementation was previously reviewed and iterated on before the repository transition request.

A full local LiteRT build was not rerun as part of this repository migration.