### PR TITLE
Fix CMake proto generation paths after LiteRT migration

### DIFF
--- a/tflite/CMakeLists.txt
+++ b/tflite/CMakeLists.txt
@@ -67,6 +67,7 @@ set(TF_SOURCE_DIR "${TENSORFLOW_SOURCE_DIR}/tensorflow")
 set(TSL_SOURCE_DIR "${TENSORFLOW_SOURCE_DIR}/third_party/xla/third_party/tsl")
 set(XLA_SOURCE_DIR "${TENSORFLOW_SOURCE_DIR}/third_party/xla/")
 set(TFLITE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+get_filename_component(LITERT_SOURCE_DIR "${TFLITE_SOURCE_DIR}/.." ABSOLUTE)
 set(CMAKE_MODULE_PATH
   "${TFLITE_SOURCE_DIR}/tools/cmake/modules"
   ${CMAKE_MODULE_PATH}

--- a/tflite/profiling/proto/CMakeLists.txt
+++ b/tflite/profiling/proto/CMakeLists.txt
@@ -17,8 +17,8 @@ find_package(Protobuf REQUIRED)
 add_library(profiling_info_proto profiling_info.proto)
 
 list(APPEND profiling_info_generated_files
-    ${CMAKE_BINARY_DIR}/tensorflow/lite/profiling/proto/profiling_info.pb.cc
-    ${CMAKE_BINARY_DIR}/tensorflow/lite/profiling/proto/profiling_info.pb.h)
+    ${CMAKE_BINARY_DIR}/tflite/profiling/proto/profiling_info.pb.cc
+    ${CMAKE_BINARY_DIR}/tflite/profiling/proto/profiling_info.pb.h)
 
 # Generate profiling_info.pb.cc and profiling_info.pb.h from
 # profiling_info.proto using protoc. Once the protobuf package version is
@@ -26,7 +26,7 @@ list(APPEND profiling_info_generated_files
 add_custom_command(
     OUTPUT ${profiling_info_generated_files}
     COMMAND ${Protobuf_PROTOC_EXECUTABLE}
-    ARGS --cpp_out=${CMAKE_BINARY_DIR} --proto_path=${TENSORFLOW_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/profiling_info.proto
+    ARGS --cpp_out=${CMAKE_BINARY_DIR} --proto_path=${LITERT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/profiling_info.proto
     DEPENDS ${Protobuf_PROTOC_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/profiling_info.proto
 )
 
@@ -37,8 +37,8 @@ target_include_directories(profiling_info_proto PUBLIC ${CMAKE_BINARY_DIR})
 
 add_library(model_runtime_info_proto model_runtime_info.proto)
 list(APPEND model_runtime_info_generated_files
-    ${CMAKE_BINARY_DIR}/tensorflow/lite/profiling/proto/model_runtime_info.pb.cc
-    ${CMAKE_BINARY_DIR}/tensorflow/lite/profiling/proto/model_runtime_info.pb.h
+    ${CMAKE_BINARY_DIR}/tflite/profiling/proto/model_runtime_info.pb.cc
+    ${CMAKE_BINARY_DIR}/tflite/profiling/proto/model_runtime_info.pb.h
 )
 
 # Generate model_runtime_info.pb.cc and model_runtime_info.pb.h from
@@ -47,7 +47,7 @@ list(APPEND model_runtime_info_generated_files
 add_custom_command(
     OUTPUT ${model_runtime_info_generated_files}
     COMMAND ${Protobuf_PROTOC_EXECUTABLE}
-    ARGS --cpp_out=${CMAKE_BINARY_DIR} --proto_path=${TENSORFLOW_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/model_runtime_info.proto
+    ARGS --cpp_out=${CMAKE_BINARY_DIR} --proto_path=${LITERT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/model_runtime_info.proto
     DEPENDS ${Protobuf_PROTOC_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/model_runtime_info.proto ${profiling_info_generated_files}
 )
 

--- a/tflite/tools/benchmark/proto/CMakeLists.txt
+++ b/tflite/tools/benchmark/proto/CMakeLists.txt
@@ -17,8 +17,8 @@ find_package(Protobuf REQUIRED)
 add_library(benchmark_result_proto benchmark_result.proto)
 
 list(APPEND benchmark_result_generated_files
-    ${CMAKE_BINARY_DIR}/tensorflow/lite/tools/benchmark/proto/benchmark_result.pb.cc
-    ${CMAKE_BINARY_DIR}/tensorflow/lite/tools/benchmark/proto/benchmark_result.pb.h)
+    ${CMAKE_BINARY_DIR}/tflite/tools/benchmark/proto/benchmark_result.pb.cc
+    ${CMAKE_BINARY_DIR}/tflite/tools/benchmark/proto/benchmark_result.pb.h)
 
 # Generate benchmark_result.pb.cc and benchmark_result.pb.h from
 # benchmark_result.proto using protoc. Once the protobuf package version is
@@ -26,7 +26,7 @@ list(APPEND benchmark_result_generated_files
 add_custom_command(
     OUTPUT ${benchmark_result_generated_files}
     COMMAND ${Protobuf_PROTOC_EXECUTABLE}
-    ARGS --cpp_out=${CMAKE_BINARY_DIR} --proto_path=${TENSORFLOW_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_result.proto
+    ARGS --cpp_out=${CMAKE_BINARY_DIR} --proto_path=${LITERT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_result.proto
     DEPENDS ${Protobuf_PROTOC_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/benchmark_result.proto
 )
 


### PR DESCRIPTION
The CMake build currently fails when generating the profiling and benchmark protos with: `File does not reside within any path specified using --proto_path (or -I)`.

Both proto `CMakeLists.txt` files still pass `--proto_path=${TENSORFLOW_SOURCE_DIR}`, which points at the TensorFlow tree fetched via FetchContent. The `.proto` files now live in this repository under `tflite/`, so the path is not a prefix of the file being compiled and protoc rejects it.

The generated outputs were also still written to `tensorflow/lite/...`, which no longer matches how the C++ sources include them (`#include "tflite/profiling/proto/profiling_info.pb.h"`).

This adds `LITERT_SOURCE_DIR` (the repository root), uses it as the proto path, and updates the generated file paths from `tensorflow/lite/` to `tflite/`.

Verified on Linux (GCC 15.2, CMake 4.1): clean build from scratch completes successfully, generated files land in `build/tflite/profiling/proto/` and `build/tflite/tools/benchmark/proto/`, and consuming LiteRT from a parent project via `add_subdirectory` also works.