### PR TITLE
Qualcomm AI Engine Direct - Remove redundant PlatformInfo usage in AOT/JIT flow.

### DIFF
--- a/litert/vendors/qualcomm/core/backends/htp_backend.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend.cc
@@ -497,52 +497,24 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
   }
 
   // Backend Handle
-  std::array<const QnnBackend_Config_t*, 1> backend_configs = {nullptr};
-
-  auto local_backend_handle = CreateBackendHandle(
-      local_log_handle.get(), absl::MakeSpan(backend_configs));
+  auto local_backend_handle = CreateBackendHandle(local_log_handle.get(), {});
   if (!local_backend_handle) {
     QNN_LOG_ERROR("Failed to create backend handle.");
     return false;
   }
 
-  // Starting from QAIRT 2.39, platform information will be available even when
-  // this API is called during offline preparation. However, it will always
-  // return the default SoC info (SM8350). If user specifies a SoC, we will
-  // override the default.
   if (soc_info.has_value()) {
     QNN_LOG_INFO("Using provided SoC info. SoC name: %s.",
                  soc_info->soc_name.data());
     soc_info_ = *soc_info;
-  } else {
-#if defined(__x86_64__) || defined(_M_X64)
-    // Offline compilation on desktop hosts cannot query the target device.
-#else
-    if (auto device_platform_info = CreateDevicePlatformInfo();
-        device_platform_info) {
-      const auto device_info = device_platform_info->v1.hwDevices->v1
-                                   .deviceInfoExtension->onChipDevice;
-      soc_info_ = SocInfo("Online SoC", device_info.socModel);
-    }
-#endif
-#if defined(_WIN32) && defined(_M_ARM64)
-    if (soc_info_.soc_model == 0) {
-      QNN_LOG_WARNING(
-          "Unable to map Windows ARM64 QNN platform info; using SC8380XP "
-          "fallback for Snapdragon X Elite.");
-      static constexpr auto kSC8380XP = FindSocInfo("SC8380XP");
-      static_assert(kSC8380XP.has_value(), "SC8380XP missing from soc_table");
-      soc_info_ = *kSC8380XP;
-    }
-#endif
   }
+#if defined(__x86_64__) || defined(_M_X64)
   if (soc_info_.soc_model == 0) {
     QNN_LOG_ERROR("SoC info was not configured successfully.")
     return false;
   }
   QNN_LOG_INFO("Initializing QNN backend for SoC model: %d",
                soc_info_.soc_model);
-
   // Device Handle
   std::vector<QnnDevice_CustomConfig_t> device_custom_configs;
   QnnHtpDevice_CustomConfig_t* htp_device_custom_config =
@@ -563,9 +535,11 @@ bool HtpBackend::Init(const Options& options, std::optional<SocInfo> soc_info) {
   }
   // null terminated
   device_configs.emplace_back(nullptr);
-
   auto local_device_handle = CreateDeviceHandle(local_log_handle.get(),
                                                 absl::MakeSpan(device_configs));
+#else
+  auto local_device_handle = CreateDeviceHandle(local_log_handle.get(), {});
+#endif
   if (!local_device_handle) {
     QNN_LOG_ERROR("Failed to create device handle.");
     return false;

--- a/litert/vendors/qualcomm/core/backends/htp_backend_test.cc
+++ b/litert/vendors/qualcomm/core/backends/htp_backend_test.cc
@@ -38,6 +38,10 @@ static_assert(kFp16SocInfo.has_value());
 QnnDevice_GetInfrastructureFn_t real_device_get_infrastructure = nullptr;
 QnnDevice_GetPlatformInfoFn_t real_device_get_platform_info = nullptr;
 QnnDevice_FreeFn_t real_device_free = nullptr;
+bool backend_create_called = false;
+const QnnBackend_Config_t** captured_backend_configs = nullptr;
+bool device_create_called = false;
+absl::NoDestructor<std::vector<QnnDevice_Config_t>> captured_device_configs;
 absl::NoDestructor<
     std::vector<std::vector<QnnHtpPerfInfrastructure_PowerConfig_t>>>
     captured_configs;
@@ -98,12 +102,34 @@ Qnn_ErrorHandle_t MockDeviceGetPlatformInfo(
   return QNN_SUCCESS;
 }
 
-Qnn_ErrorHandle_t MockDeviceFree(void* handle) {
-  if (handle == &kTestDevicePlatformInfo) {
-    return QNN_SUCCESS;
+Qnn_ErrorHandle_t MockDeviceCreate(Qnn_LogHandle_t,
+                                   const QnnDevice_Config_t** configs,
+                                   Qnn_DeviceHandle_t* device) {
+  device_create_called = true;
+  captured_device_configs->clear();
+  if (configs) {
+    for (size_t i = 0; configs[i] != nullptr; ++i) {
+      captured_device_configs->emplace_back(*configs[i]);
+    }
   }
-  return QNN_COMMON_ERROR_GENERAL;
+  static int fake_device_handle;
+  *device = &fake_device_handle;
+  return QNN_SUCCESS;
 }
+
+Qnn_ErrorHandle_t MockDeviceFree(Qnn_DeviceHandle_t) { return QNN_SUCCESS; }
+
+Qnn_ErrorHandle_t MockBackendCreateNoConfigs(
+    Qnn_LogHandle_t, const QnnBackend_Config_t** configs,
+    Qnn_BackendHandle_t* backend) {
+  backend_create_called = true;
+  captured_backend_configs = configs;
+  static int fake_backend_handle;
+  *backend = &fake_backend_handle;
+  return QNN_SUCCESS;
+}
+
+Qnn_ErrorHandle_t MockBackendFree(Qnn_BackendHandle_t) { return QNN_SUCCESS; }
 
 struct HtpPerfParams {
   HtpPerformanceMode mode;
@@ -333,6 +359,45 @@ TEST_F(HtpBackendTest, DISABLED_InitializeWithLogLevelVerboseTest) {
   ASSERT_TRUE(backend_->GetBackendHandle());
   ASSERT_TRUE(backend_->GetLogHandle());
   EXPECT_EQ(backend_->GetSocInfo().soc_model, kFp16SocInfo->soc_model);
+}
+
+TEST(HtpBackendInitTest, CreatesBackendAndDevice) {
+  backend_create_called = false;
+  captured_backend_configs = nullptr;
+  device_create_called = false;
+  captured_device_configs->clear();
+
+  QNN_INTERFACE_VER_TYPE api{};
+  api.backendCreate = MockBackendCreateNoConfigs;
+  api.backendFree = MockBackendFree;
+  api.deviceCreate = MockDeviceCreate;
+  api.deviceFree = MockDeviceFree;
+
+  Options options;
+  options.SetLogLevel(LogLevel::kOff);
+  HtpBackend backend(&api);
+
+#if defined(__x86_64__) || defined(_M_X64)
+  ASSERT_TRUE(backend.Init(options, kFp16SocInfo));
+#else
+  ASSERT_TRUE(backend.Init(options, std::nullopt));
+#endif
+
+  EXPECT_TRUE(backend_create_called);
+  EXPECT_EQ(captured_backend_configs, nullptr);
+  EXPECT_TRUE(device_create_called);
+#if defined(__x86_64__) || defined(_M_X64)
+  ASSERT_EQ(captured_device_configs->size(), 1);
+  EXPECT_EQ(captured_device_configs->at(0).option,
+            QNN_DEVICE_CONFIG_OPTION_CUSTOM);
+  const auto* htp_config = static_cast<const QnnHtpDevice_CustomConfig_t*>(
+      captured_device_configs->at(0).customConfig);
+  ASSERT_NE(htp_config, nullptr);
+  EXPECT_EQ(htp_config->option, QNN_HTP_DEVICE_CONFIG_OPTION_SOC);
+  EXPECT_EQ(htp_config->socModel, kFp16SocInfo->soc_model);
+#else
+  EXPECT_TRUE(captured_device_configs->empty());
+#endif
 }
 
 // SETPERFORMANCEMODE /////////////////////////////////////////////////////////


### PR DESCRIPTION
x86:
```
Executed 0 out of 1 test: 1 test passes.

======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.2s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.1s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.4s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test (cached) PASSED in 0.6s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.4s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 1.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 1.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.6s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test (cached) PASSED in 1.2s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 0.9s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/tools:tensor_utils_test
//litert/tools:tensor_utils_test                                (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core/schema:soc_table_test
//litert/vendors/qualcomm/core/schema:soc_table_test            (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 83.2s

```

on-device:
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 27 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 27 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 24 tests from 15 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (10 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 38 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 38 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 66 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 31 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 17 tests from 6 test suites ran. (19 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (646 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (250 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (859 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (494 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1986 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1897 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (1138 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1900 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (14 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (629 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 27 tests from 7 test suites ran. (6400 ms total)
[  PASSED  ] 27 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (8 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/tools:tensor_utils_test
[==========] 21 tests from 1 test suite ran. (56 ms total)
[  PASSED  ] 21 tests.

SM8650: //litert/vendors/qualcomm/core/schema:soc_table_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (9 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (1000 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (414 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (481 ms total)
[  PASSED  ] 2 tests.
```