### PR TITLE
Security: fix heap out-of-bounds read in BatchMatMul (rank-1 operand corrupts TfLiteIntArray size)

### DIFF
--- a/tflite/kernels/batch_matmul.cc
+++ b/tflite/kernels/batch_matmul.cc
@@ -121,6 +121,18 @@ TfLiteStatus InitializeTemporaries(TfLiteContext* context, TfLiteNode* node,
   OpData* op_data = reinterpret_cast<OpData*>(node->user_data);
   const TfLiteTensor* lhs = op_context->lhs;
   const TfLiteTensor* rhs = op_context->rhs;
+  // The temporaries are sized from the two innermost dimensions of each
+  // operand, so both must be at least rank 2 before any dimension is read.
+  // Prepare() also checks this, but only after this function has run.
+  // `NumDimensions()` dereferences `dims`, so check it first.
+  TF_LITE_ENSURE_MSG(context, lhs->dims != nullptr,
+                     "BatchMatMul: LHS tensor has no dimensions.");
+  TF_LITE_ENSURE_MSG(context, NumDimensions(lhs) >= 2,
+                     "BatchMatMul: LHS must have at least 2 dimensions.");
+  TF_LITE_ENSURE_MSG(context, rhs->dims != nullptr,
+                     "BatchMatMul: RHS tensor has no dimensions.");
+  TF_LITE_ENSURE_MSG(context, NumDimensions(rhs) >= 2,
+                     "BatchMatMul: RHS must have at least 2 dimensions.");
   TfLiteIntArrayFree(node->temporaries);
   // For "hybrid" quantization, we impose the constraint that the LHS
   // is float (typically an activation from a prior layer) and the RHS

--- a/tflite/kernels/batch_matmul_test.cc
+++ b/tflite/kernels/batch_matmul_test.cc
@@ -84,6 +84,23 @@ class BatchMatMulOpModel : public SingleOpModel {
   int output_id_;
 };
 
+#if GTEST_HAS_DEATH_TEST
+// InitializeTemporaries sizes the scratch buffers from the two innermost
+// dimensions of each operand, so a rank-1 operand must be rejected before any
+// dimension is read.
+TEST(BatchMatMulOpTest, RejectsRankOneLhs) {
+  EXPECT_DEATH(BatchMatMulOpModel<float>({TensorType_FLOAT32, {4}},
+                                         {TensorType_FLOAT32, {4, 2}}),
+               "LHS must have at least 2 dimensions");
+}
+
+TEST(BatchMatMulOpTest, RejectsRankOneRhs) {
+  EXPECT_DEATH(BatchMatMulOpModel<float>({TensorType_FLOAT32, {2, 4}},
+                                         {TensorType_FLOAT32, {4}}),
+               "RHS must have at least 2 dimensions");
+}
+#endif  // GTEST_HAS_DEATH_TEST
+
 TEST(BatchMatMulOpTest, Float32Test_Ones) {
   BatchMatMulOpModel<float> model({TensorType_FLOAT32, {3, 2, 1, 4}},
                                   {TensorType_FLOAT32, {3, 1, 4, 1}});


### PR DESCRIPTION
Redirected here from **[tensorflow/tensorflow#126163](https://github.com/tensorflow/tensorflow/pull/126163)**. @dmiltr3 reviewed and approved it there, then asked for it to be re-submitted upstream:

> The file(s) modified in this PR: `tensorflow/lite/kernels/batch_matmul.cc` → `kernels/batch_matmul.cc` in google-ai-edge/LiteRT [...] are maintained and developed in the upstream LiteRT (formerly TensorFlow Lite) repository and mirrored into TensorFlow. Because these components belong to a separate upstream repository, changes made directly here cannot be imported into the internal codebase.

Same change, rebased onto LiteRT `main` (the files live under `tflite/kernels/` here). The defect is still present on `main`.

## Security impact

Heap out-of-bounds read (CWE-125) with a caller-controlled length, caused by an out-of-bounds write that overwrites a `TfLiteIntArray`'s own size field.

## Root cause

`Prepare()` checks that both operands have at least 2 dimensions, but does so 57 lines **after** calling `InitializeTemporaries()`, which already reads the two innermost dimensions of each operand (`tflite/kernels/batch_matmul.cc`):

```c
const int lhs_rank = NumDimensions(lhs);
...
TfLiteIntArray* scratch_buffer_size = TfLiteIntArrayCreate(lhs_rank);
scratch_buffer_size->data[lhs_rank - 2] = lhs->dims->data[lhs_rank - 1];
```

With a rank-1 operand `lhs_rank - 2` is `-1`, and

```c
typedef struct TfLiteIntArray { int size; int data[]; } TfLiteIntArray;
```

so `data[-1]` aliases the `size` field. The write replaces the array's own length with the operand's first dimension. `ResizeTensor()` then walks that many entries of an array that has one. The same pattern is repeated for the RHS a few lines below.

## First invalid access (ASan)

```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 4
    #0 tflite::BytesRequired(...)                util.cc:220
    #1 tflite::Subgraph::ResizeTensorImpl(...)   subgraph.cc:2083
    #2 tflite::Subgraph::ResizeTensor(...)       subgraph.cc:1858
    #3 batch_matmul::InitializeTemporaries(...)  batch_matmul.cc:162
    #4 batch_matmul::Prepare(...)                batch_matmul.cc:297

located 0 bytes after an 8-byte region allocated by TfLiteIntArrayCreate
```

The number of ints read is the operand's first dimension — chosen by whoever supplies the operand shape.

Scope, stated plainly: the corrupted length is consumed by `BytesRequired()`, which fails afterwards, so the read does not reach an output tensor. It is a genuine out-of-bounds access with an attacker-chosen length, not a disclosure primitive.

## The fix

Check the rank at the top of `InitializeTemporaries`, before `node->temporaries` is freed — checking before the free means an early return cannot leave a dangling pointer. `Prepare()`'s existing checks are unaffected; this only moves enforcement ahead of the first read. `NumDimensions()` dereferences `dims`, so `dims` is checked first (this null guard was added on the TensorFlow PR at the Gemini reviewer's request, and matches the idiom in `pad.cc`, `reduce.cc` and `dilate.cc`).

The change is purely additive (29 insertions, 0 deletions). Operands of rank >= 2 take exactly the path they took before.

## Tests

Two regression tests guarded by `GTEST_HAS_DEATH_TEST` — the model constructor allocates immediately, so a rejected `Prepare` aborts rather than returning.

Not compile-tested locally (no Bazel environment) — please run CI. On the TensorFlow PR, `//tensorflow/lite/kernels:batch_matmul_test` was reported by the reviewer as compiling and passing cleanly, and all non-Windows CI platforms passed.
