### PR TITLE
[Intel OV] Disable NPUW online partitioning

### DIFF
--- a/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
+++ b/litert/vendors/intel_openvino/compiler/openvino_compile_context.cc
@@ -172,6 +172,7 @@ void OpenVinoCompileContext::ConfigureForNpuWeightSharing() {
   configs_map_["NPUW_WEIGHTS_BANK"] = "shared";
   configs_map_["NPUW_CWAI"] = "YES";
   configs_map_["NPUW_FUNCALL_FOR_ALL"] = "YES";
+  configs_map_["NPUW_ONLINE_PIPELINE"] = "NONE";
   LITERT_LOG(LITERT_INFO,
              "NPU weight sharing: enabled NPUW/CWAI weightless compile knobs");
 }


### PR DESCRIPTION
NPUW by default enables online partitioning for partitioning-driven optimizations. 
The current CWAI path uses NPUW for weight sharing only and the partitioning reduces the decode speed.

Decode speed regresses by ~8.8% with the CWAI path enabled.
Disabling the online pipeline helps to reduce this gap by ~4%.

Online pipeline can be enabled once the partition optimizations can be enabled via the intel_openvino compiler plugin.

Verified the performance via litertlm on Gemma4 models.