### PR TITLE
Scope example proto binary dir to the current build directory

### DIFF
--- a/tflite/CMakeLists.txt
+++ b/tflite/CMakeLists.txt
@@ -815,7 +815,7 @@ add_subdirectory(${TFLITE_SOURCE_DIR}/profiling/proto)
 add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark/proto)
 
 # Add the tf example directory.
-add_subdirectory(${TF_SOURCE_DIR}/core/example ${CMAKE_BINARY_DIR}/example_proto_generated)
+add_subdirectory(${TF_SOURCE_DIR}/core/example ${CMAKE_CURRENT_BINARY_DIR}/example_proto_generated)
 
 # The benchmark tool.
 add_subdirectory(${TFLITE_SOURCE_DIR}/tools/benchmark)


### PR DESCRIPTION
When LiteRT is consumed as a subproject via add_subdirectory or FetchContent, ${CMAKE_BINARY_DIR} resolves to the top-level project's build directory, so the generated example protos land in the parent's build root and can collide with its own directories.

The other add_subdirectory calls in this file already avoid this by omitting the binary directory and letting CMake derive it. That isn't possible here because ${TF_SOURCE_DIR}/core/example lives outside the current source directory, so the binary directory must be given explicitly.

Verified with a parent project consuming LiteRT via add_subdirectory: example_proto_generated/ now lands under the LiteRT binary directory instead of the parent's build root.

Originally submitted as tensorflow/tensorflow#115494 and redirected here.