### PR TITLE
Error text for unresolved custom ops: current doc links and a MediaPipe hint

### DIFF
--- a/tflite/core/subgraph.cc
+++ b/tflite/core/subgraph.cc
@@ -1198,6 +1198,31 @@ bool AnyTensorOfTypeResource(const std::vector<TfLiteTensor>& tensors,
   return false;
 }
 
+// Returns an extra sentence for the "unresolved custom op" error when
+// `custom_name` is one of the custom ops that ship with MediaPipe
+// (mediapipe/util/tflite/operations), or "" otherwise. Models distributed for
+// MediaPipe Tasks use these ops, and a plain interpreter cannot resolve them.
+const char* UnresolvedCustomOpHint(const char* custom_name) {
+  static constexpr const char* kMediaPipeCustomOps[] = {
+      "Convolution2DTransposeBias",
+      "Landmarks2TransformMatrix",
+      "MaxPoolingWithArgmax2D",
+      "MaxUnpooling2D",
+      "Resampler",
+      "TransformLandmarks",
+      "TransformTensor",
+      "TransformTensorBilinear",
+  };
+  if (custom_name == nullptr) return "";
+  for (const char* name : kMediaPipeCustomOps) {
+    if (strcmp(custom_name, name) == 0) {
+      return " This is a MediaPipe custom op. Run the model with MediaPipe "
+             "Tasks, or register MediaPipe's custom ops with the interpreter.";
+    }
+  }
+  return "";
+}
+
 }  // namespace
 
 bool Subgraph::OpMightHaveSideEffect(
@@ -1382,9 +1407,11 @@ TfLiteStatus Subgraph::OpPrepare(const TfLiteRegistration& op_reg,
       if (referenced_registration->prepare == nullptr) {
         if (IsUnresolvedCustomOp(op_reg)) {
           ReportError(
-              "Encountered unresolved custom op: %s.\nSee instructions: "
-              "https://www.tensorflow.org/lite/guide/ops_custom ",
-              op_reg.custom_name ? op_reg.custom_name : "UnknownOp");
+              "Encountered unresolved custom op: %s.%s\nSee instructions: "
+              "https://developers.google.com/edge/litert/conversion/"
+              "tensorflow/ops_custom ",
+              op_reg.custom_name ? op_reg.custom_name : "UnknownOp",
+              UnresolvedCustomOpHint(op_reg.custom_name));
           return kTfLiteUnresolvedOps;
         } else {
           // Resolved ops can have a null Prepare function.
@@ -1417,12 +1444,15 @@ TfLiteStatus Subgraph::OpPrepare(const TfLiteRegistration& op_reg,
             "delegate before inference. For the Android, it can be resolved by "
             "adding \"org.tensorflow:tensorflow-lite-select-tf-ops\" "
             "dependency. See instructions: "
-            "https://www.tensorflow.org/lite/guide/ops_select");
+            "https://developers.google.com/edge/litert/conversion/"
+            "tensorflow/ops_select");
       } else {
         ReportError(
-            "Encountered unresolved custom op: %s.\nSee instructions: "
-            "https://www.tensorflow.org/lite/guide/ops_custom ",
-            op_reg.custom_name ? op_reg.custom_name : "UnknownOp");
+            "Encountered unresolved custom op: %s.%s\nSee instructions: "
+            "https://developers.google.com/edge/litert/conversion/"
+            "tensorflow/ops_custom ",
+            op_reg.custom_name ? op_reg.custom_name : "UnknownOp",
+            UnresolvedCustomOpHint(op_reg.custom_name));
       }
       return kTfLiteUnresolvedOps;
     }

--- a/tflite/util.cc
+++ b/tflite/util.cc
@@ -40,7 +40,9 @@ namespace {
 TfLiteStatus UnresolvedOpInvoke(TfLiteContext* context, TfLiteNode* node) {
   TF_LITE_KERNEL_LOG(context,
                      "Encountered an unresolved custom op. Did you miss "
-                     "a custom op or delegate?");
+                     "a custom op or delegate? See instructions: "
+                     "https://developers.google.com/edge/litert/conversion/"
+                     "tensorflow/ops_custom");
   return kTfLiteError;
 }
 


### PR DESCRIPTION
Thanks for the doc pointer that already sits in the `Encountered unresolved custom op` message. The old link still resolves, which made it easy to trace where it lands today.

I build apps on the LiteRT runtime, and lately I let coding agents write the first version. This message is where one of them left LiteRT for MediaPipe Tasks, so this PR makes the message carry its own next step: a direct link to the current page, and one extra sentence when the missing op is a MediaPipe custom op. The change is text only: four error strings, no logic.

What the agent saw when it loaded a MediaPipe-distributed `.tflite` on the plain interpreter:

```
Encountered unresolved custom op: Convolution2DTransposeBias.
See instructions: https://www.tensorflow.org/lite/guide/ops_custom
```

Nothing on that path says the missing piece is MediaPipe. The message names only the op, and the page behind the link, three redirects later, is about writing your own custom op. The agent moved the whole app on this message alone, without opening the link.

The change:

- The two `Encountered unresolved custom op` messages and the select TF ops message in `tflite/core/subgraph.cc`, plus the invoke-time message in `tflite/util.cc`, now link straight to the current pages under `developers.google.com/edge/litert/`.
- When the missing op is one of the custom ops MediaPipe registers from `mediapipe/util/tflite/operations` (eight names, copied from MediaPipe's `op_resolver.cc` and `cpu_op_resolver.cc`), the message adds one sentence: this is a MediaPipe custom op; run the model with MediaPipe Tasks, or register MediaPipe's custom ops with the interpreter.
- The Maven coordinate in the select TF ops message stays as it is. `org.tensorflow:tensorflow-lite-select-tf-ops` is the only one I could find on Maven Central or Google Maven, and the current page still names it.

`NativeInterpreterWrapperTest` matches the message up to the op name, so it passes unchanged. If any wording should read differently, or a check I cannot run locally breaks, I will fix it right away. Thanks for taking a look.
