### PR TITLE
Point converter op-support messages at the current LiteRT docs

### DIFF
--- a/litert/compiler/mlir/flatbuffer_export.cc
+++ b/litert/compiler/mlir/flatbuffer_export.cc
@@ -4344,10 +4344,11 @@ absl::Status Translator::TranslateInternal() {
         GetOpsSummary(flex_ops_, /*summary_title=*/"Flex");
     LOG(WARNING) << "TFLite interpreter needs to link Flex delegate in order "
                     "to run the model since it contains the following Select TF"
-                    "op(s):\n"
+                    " op(s):\n"
                  << flex_ops_summary
                  << "\nSee instructions: "
-                    "https://www.tensorflow.org/lite/guide/ops_select";
+                    "https://developers.google.com/edge/litert/conversion/"
+                    "tensorflow/ops_select";
   }
 
   if (!custom_ops_.empty()) {
@@ -4357,7 +4358,8 @@ absl::Status Translator::TranslateInternal() {
                     "implementation(s):\n"
                  << custom_ops_summary
                  << "\nSee instructions: "
-                    "https://www.tensorflow.org/lite/guide/ops_custom";
+                    "https://developers.google.com/edge/litert/conversion/"
+                    "tensorflow/ops_custom";
   }
 
   if (first_failed_func != -1) {
@@ -4371,13 +4373,15 @@ absl::Status Translator::TranslateInternal() {
           "\nSome ops are not supported by the native TFLite runtime, you "
           "can "
           "enable TF kernels fallback using TF Select. See instructions: "
-          "https://www.tensorflow.org/lite/guide/ops_select \n" +
+          "https://developers.google.com/edge/litert/conversion/"
+          "tensorflow/ops_select \n" +
           failed_flex_ops_summary + "\n";
     if (!failed_custom_ops_.empty())
       err +=
           "\nSome ops in the model are custom ops, "
           "See instructions to implement "
-          "custom ops: https://www.tensorflow.org/lite/guide/ops_custom \n" +
+          "custom ops: https://developers.google.com/edge/litert/conversion/"
+          "tensorflow/ops_custom \n" +
           failed_custom_ops_summary + "\n";
 
     auto& failed_region = named_regions[first_failed_func];

--- a/tflite/converter/flatbuffer_export.cc
+++ b/tflite/converter/flatbuffer_export.cc
@@ -4351,10 +4351,11 @@ absl::Status Translator::TranslateInternal() {
         GetOpsSummary(flex_ops_, /*summary_title=*/"Flex");
     LOG(WARNING) << "TFLite interpreter needs to link Flex delegate in order "
                     "to run the model since it contains the following Select TF"
-                    "op(s):\n"
+                    " op(s):\n"
                  << flex_ops_summary
                  << "\nSee instructions: "
-                    "https://www.tensorflow.org/lite/guide/ops_select";
+                    "https://developers.google.com/edge/litert/conversion/"
+                    "tensorflow/ops_select";
   }
 
   if (!custom_ops_.empty()) {
@@ -4364,7 +4365,8 @@ absl::Status Translator::TranslateInternal() {
                     "implementation(s):\n"
                  << custom_ops_summary
                  << "\nSee instructions: "
-                    "https://www.tensorflow.org/lite/guide/ops_custom";
+                    "https://developers.google.com/edge/litert/conversion/"
+                    "tensorflow/ops_custom";
   }
 
   if (first_failed_func != -1) {
@@ -4378,13 +4380,15 @@ absl::Status Translator::TranslateInternal() {
           "\nSome ops are not supported by the native TFLite runtime, you "
           "can "
           "enable TF kernels fallback using TF Select. See instructions: "
-          "https://www.tensorflow.org/lite/guide/ops_select \n" +
+          "https://developers.google.com/edge/litert/conversion/"
+          "tensorflow/ops_select \n" +
           failed_flex_ops_summary + "\n";
     if (!failed_custom_ops_.empty())
       err +=
           "\nSome ops in the model are custom ops, "
           "See instructions to implement "
-          "custom ops: https://www.tensorflow.org/lite/guide/ops_custom \n" +
+          "custom ops: https://developers.google.com/edge/litert/conversion/"
+          "tensorflow/ops_custom \n" +
           failed_custom_ops_summary + "\n";
 
     auto& failed_region = named_regions[first_failed_func];

--- a/tflite/python/op_hint.py
+++ b/tflite/python/op_hint.py
@@ -89,8 +89,8 @@ from tensorflow.python.util.tf_export import tf_export as _tf_export
 @_deprecation.deprecated(
     None,
     "Please follow instructions under "
-    "https://www.tensorflow.org/lite/convert/operation_fusion for operation"
-    "fusion in tflite."
+    "https://developers.google.com/edge/litert/conversion/tensorflow/"
+    "operation_fusion for operation fusion in tflite."
 )
 class OpHint:
   """A class that helps build tflite function invocations.
@@ -1293,8 +1293,8 @@ def is_ophint_converted(graph_def):
 @_deprecation.deprecated(
     None,
     "Please follow instructions under "
-    "https://www.tensorflow.org/lite/convert/operation_fusion for operation"
-    "fusion in tflite."
+    "https://developers.google.com/edge/litert/conversion/tensorflow/"
+    "operation_fusion for operation fusion in tflite."
 )
 def convert_op_hints_to_stubs(session=None,
                               graph_def=None,


### PR DESCRIPTION
Thanks for the doc pointers that already sit in the converter's op-support messages. The old links still resolve, which made it easy to trace where each one lands today.

I convert models for apps on the LiteRT runtime, and lately coding agents write the first version of that pipeline. In #9787 one of them left LiteRT after reading the runtime's unresolved-op message, without opening its link, and the converter prints the same kind of message one step earlier. So this PR does for the converter what #9787 does for the runtime: the Select TF ops and custom ops messages, and the OpHint deprecation notice, now link straight to the current pages. Text only: ten strings, no logic.

What the converter prints today when a model needs Select TF ops:

```
TFLite interpreter needs to link Flex delegate in order to run the model since it contains the following Select TFop(s):
Flex ops: ...
Details:
	...
See instructions: https://www.tensorflow.org/lite/guide/ops_select
```

That link reaches the LiteRT page through three redirects (four for the OpHint page), and nothing in the string says where it ends up.

The change:

- `tflite/converter/flatbuffer_export.cc` and `litert/compiler/mlir/flatbuffer_export.cc` carry the same four messages, two warnings and two error strings. Both now link to `developers.google.com/edge/litert/conversion/tensorflow/ops_select` and `.../ops_custom`. I could not find a script that generates one file from the other, so both are edited.
- The OpHint deprecation notice in `tflite/python/op_hint.py` links to `.../conversion/tensorflow/operation_fusion`.
- Two missing spaces in the same messages are added: "Select TFop(s)" and "operationfusion".
- Each new URL is the page the old one redirects to, and matches that page's canonical link.

No test matches these strings, so nothing else changes. If any wording should read differently, or a check I cannot run locally breaks, I will fix it right away. Thanks for taking a look.
