### PR TITLE
Point the PyPI package homepage at the current LiteRT site

### DIFF
--- a/ci/setup_with_binary.py
+++ b/ci/setup_with_binary.py
@@ -31,7 +31,7 @@ setup(
     version=PACKAGE_VERSION,
     description=DOCLINES[0],
     long_description='\n'.join(DOCLINES[2:]),
-    url='https://www.tensorflow.org/lite/',
+    url='https://developers.google.com/edge/litert',
     author='Google AI Edge Authors',
     author_email='packages@tensorflow.org',
     license='Apache 2.0',

--- a/ci/tools/python/vendor_sdk/google_tensor/setup.py
+++ b/ci/tools/python/vendor_sdk/google_tensor/setup.py
@@ -277,7 +277,7 @@ setuptools.setup(
     description='Google Tensor ML SDK for AI Edge LiteRT',
     long_description='Google Tensor ML SDK for AI Edge LiteRT.',
     long_description_content_type='text/markdown',
-    url='https://www.tensorflow.org/lite/',
+    url='https://developers.google.com/edge/litert',
     author='Google AI Edge Authors',
     author_email='packages@tensorflow.org',
     license='Apache 2.0',

--- a/ci/tools/python/vendor_sdk/intel/setup.py
+++ b/ci/tools/python/vendor_sdk/intel/setup.py
@@ -356,7 +356,7 @@ setuptools.setup(
     description='Intel OpenVINO SDK for AI Edge LiteRT',
     long_description='Intel OpenVINO SDK for AI Edge LiteRT.',
     long_description_content_type='text/markdown',
-    url='https://www.tensorflow.org/lite/',
+    url='https://developers.google.com/edge/litert',
     author='Google AI Edge Authors',
     author_email='packages@tensorflow.org',
     license='Apache 2.0',

--- a/ci/tools/python/vendor_sdk/mediatek/setup.py
+++ b/ci/tools/python/vendor_sdk/mediatek/setup.py
@@ -203,7 +203,7 @@ setuptools.setup(
     description='MediaTek NeuroPilot SDK for AI Edge LiteRT',
     long_description='MediaTek NeuroPilot SDK for AI Edge LiteRT.',
     long_description_content_type='text/markdown',
-    url='https://www.tensorflow.org/lite/',
+    url='https://developers.google.com/edge/litert',
     author='Google AI Edge Authors',
     author_email='packages@tensorflow.org',
     license='Apache 2.0',

--- a/ci/tools/python/vendor_sdk/qualcomm/setup.py
+++ b/ci/tools/python/vendor_sdk/qualcomm/setup.py
@@ -204,7 +204,7 @@ setuptools.setup(
     description='Qualcomm SDK for AI Edge LiteRT',
     long_description='Qualcomm SDK for AI Edge LiteRT.',
     long_description_content_type='text/markdown',
-    url='https://www.tensorflow.org/lite/',
+    url='https://developers.google.com/edge/litert',
     author='Google AI Edge Authors',
     author_email='packages@tensorflow.org',
     license='Apache 2.0',

--- a/ci/tools/python/vendor_sdk/samsung/setup.py
+++ b/ci/tools/python/vendor_sdk/samsung/setup.py
@@ -203,7 +203,7 @@ setuptools.setup(
     description='Samsung SDK for AI Edge LiteRT',
     long_description='Samsung SDK (Exynos AI Litecore) for AI Edge LiteRT.',
     long_description_content_type='text/markdown',
-    url='https://www.tensorflow.org/lite/',
+    url='https://developers.google.com/edge/litert',
     author='Google AI Edge Authors',
     author_email='packages@tensorflow.org',
     license='Apache 2.0',

--- a/ci/tools/python/wheel/converter_setup_with_binary.py
+++ b/ci/tools/python/wheel/converter_setup_with_binary.py
@@ -91,7 +91,7 @@ setuptools.setup(
     description=DOCLINES[0],
     long_description='\n'.join(DOCLINES[2:]),
     long_description_content_type='text/plain',
-    url='https://www.tensorflow.org/lite/',
+    url='https://developers.google.com/edge/litert',
     author='Google AI Edge Authors',
     author_email='packages@tensorflow.org',
     license='Apache 2.0',

--- a/ci/tools/python/wheel/setup_with_binary.py
+++ b/ci/tools/python/wheel/setup_with_binary.py
@@ -148,7 +148,7 @@ setuptools.setup(
     description=DOCLINES[0],
     long_description='\n'.join(DOCLINES[2:]),
     long_description_content_type='text/plain',
-    url='https://www.tensorflow.org/lite/',
+    url='https://developers.google.com/edge/litert',
     author='Google AI Edge Authors',
     author_email='packages@tensorflow.org',
     license='Apache 2.0',

--- a/tflite/tools/pip_package/setup_with_binary.py
+++ b/tflite/tools/pip_package/setup_with_binary.py
@@ -33,7 +33,7 @@ setup(
     version=PACKAGE_VERSION,
     description=DOCLINES[0],
     long_description='\n'.join(DOCLINES[2:]),
-    url='https://www.tensorflow.org/lite/',
+    url='https://developers.google.com/edge/litert',
     author='Google, LLC',
     author_email='packages@tensorflow.org',
     license='Apache 2.0',


### PR DESCRIPTION
Thanks for keeping every wheel's `setup()` together under `ci/`; that made this a one-value change.

I install `ai-edge-litert` from PyPI for apps on the LiteRT runtime. Its PyPI page carries a single project link, the Homepage entry, and that still reads `https://www.tensorflow.org/lite/`, which reaches the LiteRT site through two redirects. The nightly and the vendor SDK packages show the same link. This PR changes the `url=` value in each `setup()` call to `https://developers.google.com/edge/litert`, the page the old URL redirects to. Value only; no other metadata changes.

What the PyPI page for `ai-edge-litert` 2.2.0 shows today under Project links:

```
Homepage  https://www.tensorflow.org/lite/
```

The change:

- `ci/tools/python/wheel/setup_with_binary.py`, `ci/tools/python/wheel/converter_setup_with_binary.py`, `ci/setup_with_binary.py`, the five `ci/tools/python/vendor_sdk/*/setup.py`, and `tflite/tools/pip_package/setup_with_binary.py`: `url=` now reads `https://developers.google.com/edge/litert`. None of them set `project_urls`, so this value is the whole Homepage entry.
- `https://developers.google.com/edge/litert` is where `https://www.tensorflow.org/lite/` ends up after its two redirects (via `ai.google.dev/edge/litert`), and it matches that page's canonical link.
- Once a release is built from this, the Homepage link on the PyPI pages for `ai-edge-litert`, `ai-edge-litert-nightly`, and the published `ai-edge-litert-sdk-*` packages changes to the LiteRT site. Nothing else on those pages moves.

If you would rather use `ai.google.dev/edge/litert`, as the README and the litert POM on Google Maven do, I will change the value right away. Thanks for taking a look.
