### PR TITLE
Point doc comments and docstrings at the current LiteRT docs

### DIFF
--- a/litert/support_lib/metadata/cc/metadata_extractor.h
+++ b/litert/support_lib/metadata/cc/metadata_extractor.h
@@ -28,7 +28,7 @@ namespace metadata {
 // Extracts and provides easy access to the TFLite ModelMetadata [1] and
 // corresponding associated files packed into a TFLite FlatBuffer, if any.
 //
-// [1]: https://www.tensorflow.org/lite/convert/metadata
+// [1]: https://developers.google.com/edge/litert/conversion/tensorflow/metadata
 class ModelMetadataExtractor {
  public:
   // Creates a ModelMetadataExtractor from the provided TFLite Model FlatBuffer

--- a/litert/support_lib/metadata/cc/metadata_populator.h
+++ b/litert/support_lib/metadata/cc/metadata_populator.h
@@ -33,7 +33,7 @@ namespace metadata {
 //
 // This class is NOT thread-safe.
 //
-// [1]: https://www.tensorflow.org/lite/convert/metadata
+// [1]: https://developers.google.com/edge/litert/conversion/tensorflow/metadata
 class ModelMetadataPopulator {
  public:
   // Creates a ModelMetadataPopulator from the provided TFLite Model FlatBuffer

--- a/litert/support_lib/metadata/python/metadata_writer_for_task.py
+++ b/litert/support_lib/metadata/python/metadata_writer_for_task.py
@@ -253,7 +253,7 @@ class Writer:
       The Writer instance, can be used for chained operation.
 
     [1]:
-    https://www.tensorflow.org/lite/convert/metadata#normalization_and_quantization_parameters
+    https://developers.google.com/edge/litert/conversion/tensorflow/metadata#normalization_and_quantization_parameters
     [2]:
     https://github.com/tensorflow/tflite-support/blob/b80289c4cd1224d0e1836c7654e82f070f9eefaa/tensorflow_lite_support/metadata/metadata_schema.fbs#L172
     """

--- a/litert/support_lib/metadata/python/metadata_writers/image_classifier.py
+++ b/litert/support_lib/metadata/python/metadata_writers/image_classifier.py
@@ -107,7 +107,7 @@ class MetadataWriter(metadata_writer.MetadataWriter):
       score_calibration_md: information of the score calibration operation [3]
         in the classification tensor. Optional if the model does not use score
         calibration. [1]:
-        https://www.tensorflow.org/lite/convert/metadata#normalization_and_quantization_parameters
+        https://developers.google.com/edge/litert/conversion/tensorflow/metadata#normalization_and_quantization_parameters
           [2]:
         https://github.com/tensorflow/tflite-support/blob/b80289c4cd1224d0e1836c7654e82f070f9eefaa/tensorflow_lite_support/metadata/metadata_schema.fbs#L95
           [3]:

--- a/litert/support_lib/metadata/python/metadata_writers/image_segmenter.py
+++ b/litert/support_lib/metadata/python/metadata_writers/image_segmenter.py
@@ -130,7 +130,7 @@ class MetadataWriter(metadata_writer.MetadataWriter):
       input_norm_std: the std value used in the input tensor normalizarion [1].
       label_file_paths: paths to the label files [2] in the category tensor.
         Pass in an empty list If the model does not have any label file. [1]:
-        https://www.tensorflow.org/lite/convert/metadata#normalization_and_quantization_parameters
+        https://developers.google.com/edge/litert/conversion/tensorflow/metadata#normalization_and_quantization_parameters
           [2]:
         https://github.com/tensorflow/tflite-support/blob/b80289c4cd1224d0e1836c7654e82f070f9eefaa/tensorflow_lite_support/metadata/metadata_schema.fbs#L108
 

--- a/litert/support_lib/metadata/python/metadata_writers/metadata_info.py
+++ b/litert/support_lib/metadata/python/metadata_writers/metadata_info.py
@@ -405,7 +405,7 @@ class InputImageTensorMd(TensorMd):
       norm_std must have the same dimension.
     color_space_type: the color space type of the input image [2].
     [1]:
-      https://www.tensorflow.org/lite/convert/metadata#normalization_and_quantization_parameters
+      https://developers.google.com/edge/litert/conversion/tensorflow/metadata#normalization_and_quantization_parameters
     [2]:
       https://github.com/tensorflow/tflite-support/blob/b80289c4cd1224d0e1836c7654e82f070f9eefaa/tensorflow_lite_support/metadata/metadata_schema.fbs#L172
   """
@@ -434,7 +434,7 @@ class InputImageTensorMd(TensorMd):
       color_space_type: the color space type of the input image [2].
       tensor_type: data type of the tensor.
       [1]:
-        https://www.tensorflow.org/lite/convert/metadata#normalization_and_quantization_parameters
+        https://developers.google.com/edge/litert/conversion/tensorflow/metadata#normalization_and_quantization_parameters
       [2]:
       https://github.com/tensorflow/tflite-support/blob/b80289c4cd1224d0e1836c7654e82f070f9eefaa/tensorflow_lite_support/metadata/metadata_schema.fbs#L172
 

--- a/litert/support_lib/metadata/python/metadata_writers/object_detector.py
+++ b/litert/support_lib/metadata/python/metadata_writers/object_detector.py
@@ -261,7 +261,7 @@ class MetadataWriter(metadata_writer.MetadataWriter):
       score_calibration_md: information of the score calibration operation [3]
         in the classification tensor. Optional if the model does not use score
         calibration. [1]:
-        https://www.tensorflow.org/lite/convert/metadata#normalization_and_quantization_parameters
+        https://developers.google.com/edge/litert/conversion/tensorflow/metadata#normalization_and_quantization_parameters
           [2]:
         https://github.com/tensorflow/tflite-support/blob/b80289c4cd1224d0e1836c7654e82f070f9eefaa/tensorflow_lite_support/metadata/metadata_schema.fbs#L108
           [3]:

--- a/tflite/core/c/c_api.h
+++ b/tflite/core/c/c_api.h
@@ -127,7 +127,7 @@ typedef struct TfLiteTensor TfLiteTensor;
 ///   * Outputs: A list of names, each mapped to an output tensor of a signature
 ///
 /// To learn more about signatures in TFLite, refer to:
-/// https://www.tensorflow.org/lite/guide/signatures
+/// https://developers.google.com/edge/litert/conversion/tensorflow/signatures
 ///
 /// Using the TfLiteSignatureRunner, for a particular signature, you can set its
 /// inputs, invoke (i.e. execute) the computation, and retrieve its outputs.
@@ -274,8 +274,9 @@ TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsSetErrorReporter(
 /// TFLite Interpreter via C API. Calling this function ensures that any
 /// `TfLiteInterpreter` created with the specified `options` can execute models
 /// that use the custom operator specified in `registration`.
-/// Please refer https://www.tensorflow.org/lite/guide/ops_custom for custom op
-/// support.
+/// Please refer
+/// https://developers.google.com/edge/litert/conversion/tensorflow/ops_custom
+/// for custom op support.
 /// \note The caller retains ownership of the TfLiteOperator object
 /// and should ensure that it remains valid for the duration of any created
 /// interpreter's lifetime.

--- a/tflite/core/c/operator.h
+++ b/tflite/core/c/operator.h
@@ -72,7 +72,7 @@ typedef struct TfLiteOperator TfLiteOperator;
 ///                     If `custom_name` is non-null, then `builtin_code` should
 ///                     be `TfLiteBuiltinCustom`.
 /// \param version      Version of the op.  See
-///                     https://www.tensorflow.org/lite/guide/ops_version
+///                     https://developers.google.com/edge/litert/conversion/tensorflow/ops_version
 /// \param user_data    Opaque pointer passed to the operator's callbacks set
 ///                     with functions such as `TfLiteOperatorSetXXXWithData`.
 ///                     The user is expected to manage the memory pointed by

--- a/tflite/kernels/internal/reference/integer_ops/fully_connected.h
+++ b/tflite/kernels/internal/reference/integer_ops/fully_connected.h
@@ -26,7 +26,7 @@ namespace reference_integer_ops {
 
 // For per-channel functions, since it is defined in quantization spec that
 // weights are symmetric
-// (https://www.tensorflow.org/lite/performance/quantization_spec#symmetric_vs_asymmetric),
+// (https://developers.google.com/edge/litert/conversion/tensorflow/quantization/quantization_spec#symmetric_vs_asymmetric),
 // zero_point (params.weights_offset) is always 0.
 // However, for per-tensor functions, params.weights_offset is still applied for
 // backward compatibility.

--- a/tflite/python/interpreter.py
+++ b/tflite/python/interpreter.py
@@ -161,7 +161,7 @@ def load_delegate(library, options=None):
 
   Args:
     library: Name of shared library containing the
-      [TfLiteDelegate](https://www.tensorflow.org/lite/performance/delegates).
+      [TfLiteDelegate](https://developers.google.com/edge/litert/performance/delegates).
     options: Dictionary of options that are required to load the delegate. All
       keys and values in the dictionary should be convertible to str. Consult
       the documentation of the specific delegate for required and legal options.
@@ -419,7 +419,7 @@ class Interpreter:
       model_path: Path to TF-Lite Flatbuffer file.
       model_content: Content of model.
       experimental_delegates: Experimental. Subject to change. List of
-        [TfLiteDelegate](https://www.tensorflow.org/lite/performance/delegates)
+        [TfLiteDelegate](https://developers.google.com/edge/litert/performance/delegates)
         objects returned by lite.load_delegate().
       num_threads: Sets the number of threads used by the interpreter and
         available to CPU kernels. If not set, the interpreter will use an


### PR DESCRIPTION
Thanks for the doc pointers in the C API headers and the Python docstrings. The old links still resolve, which made it easy to trace where each one lands today.

I build apps on the LiteRT runtime, and these headers and docstrings are where I look up custom op registration, delegates, and model metadata. After #9787, #9789, and #9790, these fourteen doc comments and docstrings are the remaining `tensorflow.org/lite` links in the C, C++, and Python sources outside `third_party`. Each reaches its LiteRT page only after two to four redirects. This PR points them at the final pages. Comment text only: 14 lines in 11 files.

What `tflite/core/c/c_api.h` says today above `TfLiteInterpreterOptionsAddOperator`, the function that registers a custom op after the runtime reports one as unresolved (#9787):

```
/// Please refer https://www.tensorflow.org/lite/guide/ops_custom for custom op
/// support.
```

That link reaches the current custom operators page through three redirects, and nothing in the comment says where it ends up.

The change:

- `tflite/core/c/c_api.h` and `tflite/core/c/operator.h`: the signatures, custom ops, and op version links point to `developers.google.com/edge/litert/conversion/tensorflow/{signatures,ops_custom,ops_version}`. The custom op comment is re-wrapped so the URL stays whole.
- `tflite/kernels/internal/reference/integer_ops/fully_connected.h`: the quantization spec link keeps its `#symmetric_vs_asymmetric` anchor and points to `.../conversion/tensorflow/quantization/quantization_spec`.
- `tflite/python/interpreter.py`: the two `TfLiteDelegate` links point to `.../performance/delegates`.
- `litert/support_lib/metadata/`: the metadata link in the two C++ headers and the six Python docstrings points to `.../conversion/tensorflow/metadata`. The six docstrings keep their `#normalization_and_quantization_parameters` anchor.
- Each new URL is the page the old one redirects to and matches that page's canonical link. Both anchors exist on the new pages. Where a longer URL no longer fits in 80 columns, the line keeps it whole, as the markdown links in `lite.py` and the version note at the top of `operator.h` already do.

No test matches these strings, so nothing else changes. If you would rather use `ai.google.dev/edge/litert`, as the existing links in `interpreter.py` and `lite.py` do, I will switch these right away. Thanks for taking a look.
