### PR TITLE
Point Java doc comments and READMEs at the current LiteRT docs

### DIFF
--- a/litert/kotlin/src/copied_from_tflite/java/org/tensorflow/lite/InterpreterApi.java
+++ b/litert/kotlin/src/copied_from_tflite/java/org/tensorflow/lite/InterpreterApi.java
@@ -137,7 +137,7 @@ public interface InterpreterApi extends AutoCloseable {
      * Advanced: Set if the interpreter is able to be cancelled.
      *
      * <p>Interpreters may have an experimental API <a
-     * href="https://www.tensorflow.org/lite/api_docs/java/org/tensorflow/lite/Interpreter#setCancelled(boolean)">setCancelled(boolean)</a>.
+     * href="https://developers.google.com/edge/api/tflite/java/org/tensorflow/lite/Interpreter#setCancelled(boolean)">setCancelled(boolean)</a>.
      * If this interpreter is cancellable and such a method is invoked, a cancellation flag will be
      * set to true. The interpreter will check the flag between Op invocations, and if it's {@code
      * true}, the interpreter will stop execution. The interpreter will remain a cancelled state
@@ -152,7 +152,7 @@ public interface InterpreterApi extends AutoCloseable {
      * Advanced: Returns whether the interpreter is able to be cancelled.
      *
      * <p>Interpreters may have an experimental API <a
-     * href="https://www.tensorflow.org/lite/api_docs/java/org/tensorflow/lite/Interpreter#setCancelled(boolean)">setCancelled(boolean)</a>.
+     * href="https://developers.google.com/edge/api/tflite/java/org/tensorflow/lite/Interpreter#setCancelled(boolean)">setCancelled(boolean)</a>.
      * If this interpreter is cancellable and such a method is invoked, a cancellation flag will be
      * set to true. The interpreter will check the flag between Op invocations, and if it's {@code
      * true}, the interpreter will stop execution. The interpreter will remain a cancelled state
@@ -316,7 +316,7 @@ public interface InterpreterApi extends AutoCloseable {
    *     that it is set the appropriate write position. A null value is allowed, and is useful for
    *     certain cases, e.g., if the caller is using a {@link Delegate} that allows buffer handle
    *     interop, and such a buffer has been bound to the output {@link Tensor} (see also <a
-   *     href="https://www.tensorflow.org/lite/api_docs/java/org/tensorflow/lite/Interpreter.Options#setAllowBufferHandleOutput(boolean)">Interpreter.Options#setAllowBufferHandleOutput(boolean)</a>),
+   *     href="https://developers.google.com/edge/api/tflite/java/org/tensorflow/lite/Interpreter.Options#setAllowBufferHandleOutput(boolean)">Interpreter.Options#setAllowBufferHandleOutput(boolean)</a>),
    *     or if the graph has dynamically shaped outputs and the caller must query the output {@link
    *     Tensor} shape after inference has been invoked, fetching the data directly from the output
    *     tensor (via {@link Tensor#asReadOnlyBuffer()}).

--- a/litert/support_lib/java/com/google/ai/edge/litert/support/image/TensorImage.java
+++ b/litert/support_lib/java/com/google/ai/edge/litert/support/image/TensorImage.java
@@ -247,7 +247,7 @@ public class TensorImage {
    *
    * <p>The main usage of this method is to load an {@link android.media.Image} object as model
    * input to the <a href="TFLite Task
-   * Library">https://www.tensorflow.org/lite/inference_with_metadata/task_library/overview</a>.
+   * Library">https://developers.google.com/edge/litert/libraries/task_library/overview</a>.
    * {@link TensorImage} backed by {@link android.media.Image} is not supported by {@link
    * ImageProcessor}.
    *

--- a/litert/support_lib/metadata/README.md
+++ b/litert/support_lib/metadata/README.md
@@ -7,9 +7,9 @@ TensorFlow Lite metadata provides a structured framework for storing metadata
 to convey information for both the developer that will utilitised the model and
 code generators which can create wrapper around the model. For information on
 how to populate model metadata, please refer to the [TensorFlow Lite Metadata 
-documentation](https://www.tensorflow.org/lite/convert/metadata).
+documentation](https://developers.google.com/edge/litert/conversion/tensorflow/metadata).
 
 The first code generator which takes advantage of this metadata format is the
 TensorFlow Lite Android Code Generator. For more information on how to use this
 generator, please refer to the [TensorFlow Lite Android wrapper code generator
-documentation](https://www.tensorflow.org/lite/guide/codegen).
+documentation](https://developers.google.com/edge/litert/android/metadata/codegen).

--- a/tflite/converter/quantization/common/quantization_lib/quantization.td
+++ b/tflite/converter/quantization/common/quantization_lib/quantization.td
@@ -70,7 +70,7 @@ def QI32 : QuantizedType<"Uniform", [32], 1>;
 // TFL native op traits (for quantization).
 //
 // Ops in this link should have those traits specified:
-// https://www.tensorflow.org/lite/performance/quantization_spec
+// https://developers.google.com/edge/litert/conversion/tensorflow/quantization/quantization_spec
 //===----------------------------------------------------------------------===//
 
 def FixedOutputRangeInterface : OpInterface<

--- a/tflite/delegates/gpu/README.md
+++ b/tflite/delegates/gpu/README.md
@@ -53,7 +53,7 @@ TFLite on GPU supports the following ops in 16-bit and 32-bit float precision:
 
 **Note:** Following section describes the example usage for Android GPU delegate
 with C++. For other languages and platforms, please see
-[the documentation](https://www.tensorflow.org/lite/performance/gpu).
+[the documentation](https://developers.google.com/edge/litert/performance/gpu).
 
 Using TFLite on GPU is as simple as getting the GPU delegate via
 `TfLiteGpuDelegateV2Create()` and then passing it to
@@ -160,7 +160,7 @@ performs FP16 calculation internally, and set `wait_type` to
   that 4-channel input is significantly faster as a memory copy (from 3-channel
   RGB to 4-channel RGBX) can be avoided.
 
-* For performance [best practices](https://www.tensorflow.org/lite/performance/best_practices), do not hesitate to re-train your classifier with
+* For performance [best practices](https://developers.google.com/edge/litert/conversion/tensorflow/build/best_practices), do not hesitate to re-train your classifier with
   mobile-optimized network architecture.  That is a significant part of
   optimization for on-device inference.
 

--- a/tflite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
+++ b/tflite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegate.java
@@ -262,7 +262,7 @@ public class NnApiDelegate implements Delegate, AutoCloseable {
   /**
    * Returns the latest error code returned by an NNAPI call or zero if NO calls to NNAPI failed.
    * The error code is reset when the delegate is associated with an <a
-   * href=https://www.tensorflow.org/lite/api_docs/java/org/tensorflow/lite/Interpreter>interpreter</a>.
+   * href=https://developers.google.com/edge/api/tflite/java/org/tensorflow/lite/Interpreter>interpreter</a>.
    *
    * <p>For details on NNAPI error codes see <a
    * href="https://developer.android.com/ndk/reference/group/neural-networks#resultcode">the NNAPI
@@ -280,7 +280,7 @@ public class NnApiDelegate implements Delegate, AutoCloseable {
 
   /**
    * Returns true if any NNAPI call failed since this delegate was associated with an <a
-   * href=https://www.tensorflow.org/lite/api_docs/java/org/tensorflow/lite/Interpreter>interpreter</a>.
+   * href=https://developers.google.com/edge/api/tflite/java/org/tensorflow/lite/Interpreter>interpreter</a>.
    *
    * @throws IllegalStateException if the method is called after {@link #close() close}.
    */

--- a/tflite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegateImpl.java
+++ b/tflite/delegates/nnapi/java/src/main/java/org/tensorflow/lite/nnapi/NnApiDelegateImpl.java
@@ -69,7 +69,7 @@ public class NnApiDelegateImpl implements NnApiDelegate.PrivateInterface, Delega
   /**
    * Returns the latest error code returned by an NNAPI call or zero if NO calls to NNAPI failed.
    * The error code is reset when the delegate is associated with an <a
-   * href=https://www.tensorflow.org/lite/api_docs/java/org/tensorflow/lite/Interpreter>interpreter</a>.
+   * href=https://developers.google.com/edge/api/tflite/java/org/tensorflow/lite/Interpreter>interpreter</a>.
    *
    * <p>For details on NNAPI error codes see <a
    * href="https://developer.android.com/ndk/reference/group/neural-networks#resultcode">the NNAPI

--- a/tflite/delegates/xnnpack/README.md
+++ b/tflite/delegates/xnnpack/README.md
@@ -14,7 +14,7 @@ floating-point inference.
 ### Enable XNNPACK via Java API on Android (recommended on Android)
 
 Pre-built
-[nightly TensorFlow Lite binaries for Android](https://www.tensorflow.org/lite/guide/android#use_the_tensorflow_lite_aar_from_mavencentral)
+[nightly TensorFlow Lite binaries for Android](https://developers.google.com/edge/litert/android/lite_build#use_nightly_snapshots)
 include XNNPACK, albeit it is disabled by default. Use the `setUseXNNPACK`
 method in `Interpreter.Options` class to enable it:
 

--- a/tflite/delegates/xnnpack/README.md
+++ b/tflite/delegates/xnnpack/README.md
@@ -27,7 +27,7 @@ Interpreter interpreter = new Interpreter(model, interpreterOptions);
 ### Enable XNNPACK via Swift/Objective-C API on iOS (recommended on iOS)
 
 Pre-built
-[nightly TensorFlow Lite CocoaPods](https://www.tensorflow.org/lite/guide/ios#specifying_versions)
+[nightly TensorFlow Lite CocoaPods](https://developers.google.com/edge/litert/ios/quickstart#specifying_versions)
 include XNNPACK, but do not enable it by default. Swift developers can use
 `InterpreterOptions` object to enable XNNPACK:
 

--- a/tflite/java/src/main/java/org/tensorflow/lite/InterpreterApi.java
+++ b/tflite/java/src/main/java/org/tensorflow/lite/InterpreterApi.java
@@ -163,7 +163,7 @@ public interface InterpreterApi extends AutoCloseable {
      * Advanced: Set if the interpreter is able to be cancelled.
      *
      * <p>Interpreters may have an experimental API <a
-     * href="https://www.tensorflow.org/lite/api_docs/java/org/tensorflow/lite/Interpreter#setCancelled(boolean)">setCancelled(boolean)</a>.
+     * href="https://developers.google.com/edge/api/tflite/java/org/tensorflow/lite/Interpreter#setCancelled(boolean)">setCancelled(boolean)</a>.
      * If this interpreter is cancellable and such a method is invoked, a cancellation flag will be
      * set to true. The interpreter will check the flag between Op invocations, and if it's {@code
      * true}, the interpreter will stop execution. The interpreter will remain a cancelled state
@@ -178,7 +178,7 @@ public interface InterpreterApi extends AutoCloseable {
      * Advanced: Returns whether the interpreter is able to be cancelled.
      *
      * <p>Interpreters may have an experimental API <a
-     * href="https://www.tensorflow.org/lite/api_docs/java/org/tensorflow/lite/Interpreter#setCancelled(boolean)">setCancelled(boolean)</a>.
+     * href="https://developers.google.com/edge/api/tflite/java/org/tensorflow/lite/Interpreter#setCancelled(boolean)">setCancelled(boolean)</a>.
      * If this interpreter is cancellable and such a method is invoked, a cancellation flag will be
      * set to true. The interpreter will check the flag between Op invocations, and if it's {@code
      * true}, the interpreter will stop execution. The interpreter will remain a cancelled state
@@ -403,7 +403,7 @@ public interface InterpreterApi extends AutoCloseable {
    *     that it is set the appropriate write position. A null value is allowed, and is useful for
    *     certain cases, e.g., if the caller is using a {@link Delegate} that allows buffer handle
    *     interop, and such a buffer has been bound to the output {@link Tensor} (see also <a
-   *     href="https://www.tensorflow.org/lite/api_docs/java/org/tensorflow/lite/Interpreter.Options#setAllowBufferHandleOutput(boolean)">Interpreter.Options#setAllowBufferHandleOutput(boolean)</a>),
+   *     href="https://developers.google.com/edge/api/tflite/java/org/tensorflow/lite/Interpreter.Options#setAllowBufferHandleOutput(boolean)">Interpreter.Options#setAllowBufferHandleOutput(boolean)</a>),
    *     or if the graph has dynamically shaped outputs and the caller must query the output {@link
    *     Tensor} shape after inference has been invoked, fetching the data directly from the output
    *     tensor (via {@link Tensor#asReadOnlyBuffer()}).

--- a/tflite/kernels/hashtable.md
+++ b/tflite/kernels/hashtable.md
@@ -47,7 +47,7 @@ Supported mapping type: string → int64, int64 → string
    </td>
    <td rowspan="2" colspan="5" >Supported natively when num_oov_buckets=0 and dtype=dtypes.string.
 <p>
-For the oov concept, you will need a <a href="https://www.tensorflow.org/lite/guide/ops_select" title="Select TensorFlow operators to use in TensorFlow Lite">Flex delegate</a>.
+For the oov concept, you will need a <a href="https://developers.google.com/edge/litert/conversion/tensorflow/ops_select" title="Select TensorFlow operators to use in TensorFlow Lite">Flex delegate</a>.
    </td>
   </tr>
   <tr>
@@ -55,9 +55,9 @@ For the oov concept, you will need a <a href="https://www.tensorflow.org/lite/gu
   <tr>
    <td>tf.lookup.StaticVocabularyTable
    </td>
-   <td colspan="5" >Supported but you will need a <a href="https://www.tensorflow.org/lite/guide/ops_select" title="Select TensorFlow operators to use in TensorFlow Lite">Flex delegate</a>.
+   <td colspan="5" >Supported but you will need a <a href="https://developers.google.com/edge/litert/conversion/tensorflow/ops_select" title="Select TensorFlow operators to use in TensorFlow Lite">Flex delegate</a>.
 <p>
-Use tf.index_table_from_tensor or tf.index_to_string_table_from_tensor instead if possible if you don’t want to use <a href="https://www.tensorflow.org/lite/guide/ops_select" title="Select TensorFlow operators to use in TensorFlow Lite">Flex delegate</a>.
+Use tf.index_table_from_tensor or tf.index_to_string_table_from_tensor instead if possible if you don’t want to use <a href="https://developers.google.com/edge/litert/conversion/tensorflow/ops_select" title="Select TensorFlow operators to use in TensorFlow Lite">Flex delegate</a>.
    </td>
   </tr>
   <tr>
@@ -73,7 +73,7 @@ tf.contrib.lookup.MutableDenseHashTable
   <tr>
    <td>tf.lookup.IdTableWithHashBuckets
    </td>
-   <td colspan="5" >Supported but you need a <a href="https://www.tensorflow.org/lite/guide/ops_select" title="Select TensorFlow operators to use in TensorFlow Lite">Flex delegate</a>.
+   <td colspan="5" >Supported but you need a <a href="https://developers.google.com/edge/litert/conversion/tensorflow/ops_select" title="Select TensorFlow operators to use in TensorFlow Lite">Flex delegate</a>.
    </td>
   </tr>
 </table>

--- a/tflite/tools/benchmark/README.md
+++ b/tflite/tools/benchmark/README.md
@@ -292,7 +292,7 @@ or other custom ops are used in the model, please see the section [below](#build
 
 ### On Android:
 
-(0) Refer to https://www.tensorflow.org/lite/guide/build_android to edit the
+(0) Refer to https://developers.google.com/edge/litert/android/lite_build to edit the
 `WORKSPACE` to configure the android NDK/SDK.
 
 (1) Build for your specific platform, e.g.:
@@ -484,7 +484,7 @@ some additional parameters as detailed below.
 
 If you see an error that says: `ERROR: Select TensorFlow op(s), included in the
 given model, is(are) not supported by this interpreter.` you will need to
-build with [Tensorflow operators support](https://www.tensorflow.org/lite/guide/ops_select).
+build with [Tensorflow operators support](https://developers.google.com/edge/litert/conversion/tensorflow/ops_select).
 
 Having Tensorflow ops in the TFLite file works when the benchmark tool is built
 with Tensorflow ops support. It doesn't require any additional option to use it.

--- a/tflite/tools/make/README.md
+++ b/tflite/tools/make/README.md
@@ -4,6 +4,6 @@
 Aug 2021.**
 
 Please use CMake or Bazel instead. Please refer to the
-[Build TensorFlow Lite with CMake](https://www.tensorflow.org/lite/guide/build_cmake)
-and [Build TensorFlow Lite for ARM boards](https://www.tensorflow.org/lite/guide/build_arm)
+[Build TensorFlow Lite with CMake](https://developers.google.com/edge/litert/build/cmake)
+and [Build TensorFlow Lite for ARM boards](https://developers.google.com/edge/litert/build/arm)
 for the details.

--- a/tflite/tools/optimize/debugging/README.md
+++ b/tflite/tools/optimize/debugging/README.md
@@ -23,7 +23,7 @@ for debugging purposes only (and not for inference).
 ### Produce a debug model
 
 Modify the
-[TFLite full integer (int8) quantization steps](https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization)
+[TFLite full integer (int8) quantization steps](https://developers.google.com/edge/litert/conversion/tensorflow/quantization/post_training_quantization#full_integer_quantization)
 as shown below to produce a debug model (used for debugging purposes only, and
 not inference)
 


### PR DESCRIPTION
Thanks for the doc pointers in the Java API comments and the READMEs. All but one of the old links still resolve, which made it easy to trace where each one lands today.

I build Android apps on the LiteRT runtime, and the `InterpreterApi` javadoc and the delegate and build READMEs are where I look up cancellation, delegate setup, and the build steps. After #9787, #9789, #9790, and #9791, the `tensorflow.org/lite` links left outside `third_party` are in Java doc comments, markdown, and a few schema and build-file comments. This PR takes the 26 whose current page exists: 26 lines in 13 files, doc comments, markdown, and one comment in a `.td` file. Text only. The remaining 12 lines mostly point at pages that were retired or replaced by a different topic, and I left them for a separate look.

The Java comments reach readers through the published API reference. The `InterpreterApi.Options` page at `developers.google.com/edge/api/tflite/java/org/tensorflow/lite/InterpreterApi.Options` says this today under `setCancellable`:

```
Interpreters may have an experimental API setCancelled(boolean).
```

The `setCancelled(boolean)` link goes to `www.tensorflow.org/lite/api_docs/java/org/tensorflow/lite/Interpreter#setCancelled(boolean)`, three redirects away from the `Interpreter` page next to it on the same site. `InterpreterApi.run` links to `Interpreter.Options#setAllowBufferHandleOutput(boolean)` the same way. One README link lands on the wrong page: in `tflite/tools/make/README.md`, "Build TensorFlow Lite with CMake" redirects to `.../litert/build/arm`, the same ARM boards page as the link next to it, while the CMake page exists at `.../litert/build/cmake`.

The change:

- `tflite/java/.../InterpreterApi.java` and its copy under `litert/kotlin/src/copied_from_tflite/`: the `setCancelled(boolean)` and `setAllowBufferHandleOutput(boolean)` links point to `developers.google.com/edge/api/tflite/java/org/tensorflow/lite/Interpreter` and `Interpreter.Options`, anchors kept. I could not find a script that generates one file from the other, and their code differs, so both are edited.
- `tflite/delegates/nnapi/.../NnApiDelegate.java` and `NnApiDelegateImpl.java`: the three `Interpreter` links point to the same reference page. The unquoted `href=` form stays as it was.
- `litert/support_lib/.../TensorImage.java`: the Task Library link points to `.../litert/libraries/task_library/overview`. The `href` and the link text on that line are swapped; I left that as it is to keep this PR to URL strings, and can swap them here if you prefer.
- `litert/support_lib/metadata/README.md`: the metadata link points to `.../conversion/tensorflow/metadata`. The code generator link, `guide/codegen`, returns 404 today; it now points to `.../android/metadata/codegen`, "Generate model interfaces using metadata", the current page for the Android wrapper code generator.
- `tflite/tools/make/README.md`: the CMake link points to `.../build/cmake` and the ARM link to `.../build/arm`.
- `tflite/delegates/xnnpack/README.md`: the nightly Android binaries link pointed at the Maven Central section of the old Android guide, and the page it redirects to today has no such section; it now points to the Nightly Snapshots section of the build page, `.../android/lite_build#use_nightly_snapshots`.
- `tflite/delegates/gpu/README.md`, `tflite/delegates/xnnpack/README.md`, `tflite/kernels/hashtable.md`, `tflite/tools/benchmark/README.md`, and `tflite/tools/optimize/debugging/README.md`: the GPU delegate, best practices, iOS quickstart, select TF ops, Android build, and post-training quantization links point to their current pages. The `#specifying_versions` and `#full_integer_quantization` anchors are kept.
- `tflite/converter/quantization/common/quantization_lib/quantization.td`: the quantization spec comment points to the same page as `fully_connected.h` in #9791.
- Apart from the codegen, CMake, and nightly links, each new URL is the page the old one redirects to and matches that page's canonical link. All five anchors exist on the new pages. Link text is unchanged.

No test matches these strings, so nothing else changes. If you would rather use `ai.google.dev/edge/litert`, I will switch these right away. Thanks for taking a look.
