### PR TITLE
cmake: benchmark: require protobuf through find_package

### DIFF
--- a/tflite/tools/benchmark/CMakeLists.txt
+++ b/tflite/tools/benchmark/CMakeLists.txt
@@ -16,6 +16,10 @@
 
 # The benchmark tool for Tensorflow Lite.
 
+if(NOT TARGET protobuf::libprotobuf)
+  find_package(Protobuf REQUIRED)
+endif()
+
 populate_source_vars("${TFLITE_SOURCE_DIR}/tools/benchmark"
   TFLITE_BENCHMARK_SRCS
   FILTER "(_test|_plus_flex_main|_performance_options.*)\\.cc$"


### PR DESCRIPTION
The benchmark tool requires protobuf headers and libraries,
but protobuf may not be discovered when building LiteRT
standalone.

This change adds a guarded protobuf lookup:

  if(NOT TARGET protobuf::libprotobuf)
    find_package(Protobuf REQUIRED)
  endif()

This allows standalone builds to locate protobuf while
remaining compatible with parent projects that already
provide protobuf targets through FetchContent, add_subdirectory,
or another package manager.