### PR TITLE
Qualcomm AI Engine Direct - Allow A8W2 FC on HTP by relaxing op validation checks.

### DIFF
--- a/litert/vendors/qualcomm/qnn_manager.cc
+++ b/litert/vendors/qualcomm/qnn_manager.cc
@@ -450,9 +450,9 @@ LiteRtStatus QnnManager::ValidateOp(::qnn::QnnBackend& qnn_backend,
       op.GetInputTensor(1).IsQuantBitwidth(::qnn::kQuantBitWidth2) &&
       op.GetOutputTensor(0).IsQuantI8() &&
       SdkVersion{2, 47, 0} <= sdk_version &&
-      sdk_version < SdkVersion{2, 48, 0}) {
+      sdk_version < SdkVersion{2, 49, 0}) {
     LITERT_LOG(LITERT_WARNING,
-               "SDK version is in [2.47.0, 2.48.0); A8W2 FC OP validation is "
+               "SDK version is in [2.47.0, 2.49.0); A8W2 FC OP validation is "
                "bypassed.");
     return kLiteRtStatusOk;
   }


### PR DESCRIPTION
x86 test:
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.4s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 1.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/tools:tensor_utils_test
//litert/tools:tensor_utils_test                                (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core/schema:soc_table_test
//litert/vendors/qualcomm/core/schema:soc_table_test            (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test     (cached) PASSED in 74.1s
```

on-device test:
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 27 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 27 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 24 tests from 15 test suites ran. (2 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (9 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 39 tests from 3 test suites ran. (2 ms total)
[  PASSED  ] 39 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 67 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 67 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 31 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 17 tests from 6 test suites ran. (19 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (498 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (213 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (751 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (438 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1625 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1620 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (952 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1595 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (15 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (616 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 27 tests from 7 test suites ran. (5458 ms total)
[  PASSED  ] 27 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (7 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/tools:tensor_utils_test
[==========] 23 tests from 1 test suite ran. (83 ms total)
[  PASSED  ] 23 tests.

SM8650: //litert/vendors/qualcomm/core/schema:soc_table_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (15 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (815 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (429 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (455 ms total)
[  PASSED  ] 2 tests.
```