### PR TITLE
Qualcomm AI Engine Direct - Enable user to input LPAI version.

### DIFF
--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin.cc
@@ -79,6 +79,31 @@ constexpr LiteRtParamIndex kDefaultPartitionNum = 1;
 
 static constexpr absl::string_view kEntryPointNameFmt = "qnn_partition_%d";
 
+LiteRtStatus ResolveTargetSocInfo(const ::qnn::Options& options,
+                                  const char* soc_model,
+                                  std::optional<::qnn::SocInfo>& soc_info) {
+  if (options.GetBackendType() == ::qnn::BackendType::kLpaiBackend) {
+    const auto requested_soc_info = ::qnn::FindOrCreateSocInfo(soc_model);
+    if (requested_soc_info.has_value() &&
+        requested_soc_info->lpai_hw_version !=
+            ::qnn::LpaiHardwareVersion::kUnknown) {
+      soc_info = *requested_soc_info;
+      return kLiteRtStatusOk;
+    }
+
+    LITERT_LOG(LITERT_ERROR, "Invalid LPAI target: %s.",
+               soc_model != nullptr ? soc_model : "(unset)");
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+
+  soc_info = ::qnn::FindOrCreateSocInfo(soc_model);
+  if (soc_model != nullptr && !soc_info.has_value()) {
+    LITERT_LOG(LITERT_ERROR, "Unexpected SoC model: %s", soc_model);
+    return kLiteRtStatusErrorInvalidArgument;
+  }
+  return kLiteRtStatusOk;
+}
+
 bool IsWeightSharingSupported() {
 #if defined(__x86_64__) || defined(_M_X64)
   // TODO(jiunkaiy): Enable weight sharing only on SoCs v73 and later.
@@ -451,11 +476,9 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
                                            LiteRtSubgraph subgraph,
                                            LiteRtOpList selected_ops) {
   ::litert::compiler::Subgraph graph(compiler_plugin->ctx(), subgraph);
-  const auto opt_soc_model = ::qnn::FindOrCreateSocInfo(soc_model);
-  if (soc_model && !opt_soc_model) {
-    LITERT_LOG(LITERT_ERROR, "Unexpected SoC model: %s", soc_model);
-    return kLiteRtStatusErrorInvalidArgument;
-  }
+  std::optional<::qnn::SocInfo> opt_soc_model;
+  LITERT_RETURN_IF_ERROR(ResolveTargetSocInfo(compiler_plugin->Options(),
+                                              soc_model, opt_soc_model));
   QnnManager* qnn_manager =
       compiler_plugin->GetOrCreateQnnManager(compiler_plugin->Options());
   if (!qnn_manager) {
@@ -525,16 +548,19 @@ LiteRtStatus LiteRtCompilerPluginCompile(
   litert::compiler::Model model(compiler_plugin->ctx(), partitions);
   auto num_partitions = model.NumSubgraphs();
 
-  LITERT_LOG(LITERT_INFO,
-             "Starting QNN Compilation for %d subgraphs, soc_model=%s",
-             num_partitions, soc_model);
+  LITERT_LOG(LITERT_INFO, "Starting QNN compilation for %d subgraphs.",
+             num_partitions);
 
-  const auto opt_soc_model = ::qnn::FindOrCreateSocInfo(soc_model);
-  if (opt_soc_model) {
-    LITERT_LOG(LITERT_INFO, "Compiling QNN SoC model: %s", soc_model);
-  } else if (soc_model) {
-    LITERT_LOG(LITERT_ERROR, "Unexpected SoC model: %s", soc_model);
-    return kLiteRtStatusErrorInvalidArgument;
+  auto options = compiler_plugin->Options();
+  std::optional<::qnn::SocInfo> opt_soc_model;
+  LITERT_RETURN_IF_ERROR(
+      ResolveTargetSocInfo(options, soc_model, opt_soc_model));
+  if (soc_model != nullptr) {
+    LITERT_LOG(LITERT_INFO, "Compiling QNN SoC target: %s", soc_model);
+  }
+  if (options.GetBackendType() == ::qnn::BackendType::kLpaiBackend) {
+    LITERT_LOG(LITERT_INFO, "LPAI HW version: v%d.",
+               static_cast<int>(opt_soc_model->lpai_hw_version));
   }
 
   auto result = std::make_unique<LiteRtCompiledResultT>();
@@ -543,7 +569,6 @@ LiteRtStatus LiteRtCompilerPluginCompile(
   // model.
   result->context_bin.resize(num_partitions);
   result->byte_code_index.resize(num_partitions);
-  auto options = compiler_plugin->Options();
   if (!options.GetSchematicDir().empty()) {
     LITERT_LOG(LITERT_INFO,
                "Schematic directory is set. Enabling optrace profiling. "
@@ -770,12 +795,9 @@ LiteRtStatus LiteRtCompilerPluginCheckCompilerCompatibility(
 
   // Check if the SoC model is supported.
   // TODO(jiunkaiy): Validate SoC support through the global config API.
-  if (::qnn::FindOrCreateSocInfo(soc_model_name)) {
-    LITERT_LOG(LITERT_INFO, "Compiling QNN SoC model: %s", soc_model_name);
-  } else if (soc_model_name) {
-    LITERT_LOG(LITERT_ERROR, "Unexpected SoC model: %s", soc_model_name);
-    return kLiteRtStatusErrorInvalidArgument;
-  }
+  std::optional<::qnn::SocInfo> soc_info;
+  LITERT_RETURN_IF_ERROR(ResolveTargetSocInfo(compiler_plugin->Options(),
+                                              soc_model_name, soc_info));
 
   // Check if the QAIRT SDK version meets the minimum required version.
   QnnManager* qnn_manager =

--- a/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
+++ b/litert/vendors/qualcomm/compiler/qnn_compiler_plugin_test.cc
@@ -395,6 +395,9 @@ TEST(TestQnnPlugin, Compatibility) {
   // Check SoC model.
   LITERT_EXPECT_OK(LiteRtCompilerPluginCheckCompilerCompatibility(
       kApiVersion, plugin.get(), nullptr, nullptr, "SM8750"));
+  // Numeric targets remain valid for non-LPAI backends.
+  LITERT_EXPECT_OK(LiteRtCompilerPluginCheckCompilerCompatibility(
+      kApiVersion, plugin.get(), nullptr, nullptr, "87"));
   LITERT_EXPECT_ERROR(LiteRtCompilerPluginCheckCompilerCompatibility(
       kApiVersion, plugin.get(), nullptr, nullptr, "unsupported_soc"));
 
@@ -419,6 +422,49 @@ TEST(TestQnnPlugin, Compatibility) {
   LITERT_EXPECT_ERROR(LiteRtCompilerPluginCheckCompilerCompatibility(
       {kApiVersion.major + 1, kApiVersion.minor, kApiVersion.patch},
       plugin.get(), nullptr, nullptr, nullptr));
+}
+
+TEST(TestQnnPlugin, LpaiCompatibilityResolvesHardwareVersionTarget) {
+  static constexpr LiteRtApiVersion kApiVersion{LITERT_API_VERSION_MAJOR,
+                                                LITERT_API_VERSION_MINOR,
+                                                LITERT_API_VERSION_PATCH};
+  auto opts = Options::Create();
+  ASSERT_TRUE(opts);
+
+  auto qnn_opts = opts->GetOptions<qualcomm::QualcommOptions>();
+  ASSERT_TRUE(qnn_opts);
+  qnn_opts->SetBackend(qualcomm::QualcommOptions::Backend::kLpai);
+
+  LITERT_ASSERT_OK_AND_ASSIGN(auto env, Environment::Create({}));
+  LITERT_ASSERT_OK_AND_ASSIGN(
+      auto litert_opts,
+      internal::LiteRtOptionsPtrBuilder::Build(*opts, env.GetHolder()));
+  auto plugin =
+      CreatePlugin(LrtGetCompilerContext(), /*env=*/nullptr, litert_opts.get());
+
+  LITERT_EXPECT_OK(LiteRtCompilerPluginCheckCompilerCompatibility(
+      kApiVersion, plugin.get(), nullptr, nullptr, "v5"));
+  LITERT_EXPECT_OK(LiteRtCompilerPluginCheckCompilerCompatibility(
+      kApiVersion, plugin.get(), nullptr, nullptr, "v6"));
+
+  LITERT_EXPECT_OK(LiteRtCompilerPluginCheckCompilerCompatibility(
+      kApiVersion, plugin.get(), nullptr, nullptr, "SM8850"));
+
+  EXPECT_EQ(kLiteRtStatusErrorInvalidArgument,
+            LiteRtCompilerPluginCheckCompilerCompatibility(
+                kApiVersion, plugin.get(), nullptr, nullptr, nullptr));
+  EXPECT_EQ(kLiteRtStatusErrorInvalidArgument,
+            LiteRtCompilerPluginCheckCompilerCompatibility(
+                kApiVersion, plugin.get(), nullptr, nullptr, "SM8250"));
+  EXPECT_EQ(kLiteRtStatusErrorInvalidArgument,
+            LiteRtCompilerPluginCheckCompilerCompatibility(
+                kApiVersion, plugin.get(), nullptr, nullptr, "21"));
+  EXPECT_EQ(kLiteRtStatusErrorInvalidArgument,
+            LiteRtCompilerPluginCheckCompilerCompatibility(
+                kApiVersion, plugin.get(), nullptr, nullptr, "87"));
+  EXPECT_EQ(kLiteRtStatusErrorInvalidArgument,
+            LiteRtCompilerPluginCheckCompilerCompatibility(
+                kApiVersion, plugin.get(), nullptr, nullptr, "v7"));
 }
 
 class QnnPlyginSupportedSocCompilationTest

--- a/litert/vendors/qualcomm/core/backends/lpai_backend_test.cc
+++ b/litert/vendors/qualcomm/core/backends/lpai_backend_test.cc
@@ -8,8 +8,9 @@
 #include <optional>
 #include <vector>
 
-#include "LPAI/QnnLpaiCommon.h"        // from @qairt
-#include "LPAI/QnnLpaiGraph.h"         // from @qairt
+#include "LPAI/QnnLpaiCommon.h"  // from @qairt
+#include "LPAI/QnnLpaiBackend.h"  // from @qairt
+#include "LPAI/QnnLpaiGraph.h"  // from @qairt
 #include "LPAI/QnnLpaiGraphPrepare.h"  // from @qairt
 #include "QnnBackend.h"  // from @qairt
 #include "QnnCommon.h"  // from @qairt
@@ -43,6 +44,11 @@ struct CapturedGraphFinalize {
   Qnn_GraphHandle_t graph = nullptr;
 };
 
+struct CapturedBackendConfig {
+  bool called = false;
+  std::optional<QnnLpaiBackend_CustomConfigHwInfo_t> hw_info;
+};
+
 class LpaiBackendTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -51,9 +57,30 @@ class LpaiBackendTest : public ::testing::Test {
     // before api_ is wired.
     self_ = this;
 
-    api_.backendCreate = [](Qnn_LogHandle_t, const QnnBackend_Config_t**,
+    api_.backendCreate = [](Qnn_LogHandle_t,
+                            const QnnBackend_Config_t** configs,
                             Qnn_BackendHandle_t* backend) -> Qnn_ErrorHandle_t {
-      *backend = self_->fake_handle_;
+      auto& t = *self_;
+      t.captured_backend_config_.called = true;
+      t.captured_backend_config_.hw_info.reset();
+      if (configs != nullptr) {
+        for (size_t i = 0; configs[i] != nullptr; ++i) {
+          const auto* config = configs[i];
+          if (config->option != QNN_BACKEND_CONFIG_OPTION_CUSTOM ||
+              config->customConfig == nullptr) {
+            continue;
+          }
+          const auto* custom =
+              static_cast<QnnLpaiBackend_CustomConfig_t*>(config->customConfig);
+          if (custom->option == QNN_LPAI_BACKEND_CUSTOM_CFG_HW_INFO &&
+              custom->config != nullptr) {
+            t.captured_backend_config_.hw_info =
+                *static_cast<QnnLpaiBackend_CustomConfigHwInfo_t*>(
+                    custom->config);
+          }
+        }
+      }
+      *backend = t.fake_handle_;
       return QNN_SUCCESS;
     };
     api_.backendFree = [](Qnn_BackendHandle_t) -> Qnn_ErrorHandle_t {
@@ -110,6 +137,7 @@ class LpaiBackendTest : public ::testing::Test {
   std::optional<LpaiBackend> backend_;
   CapturedGraphConfig captured_;
   CapturedGraphFinalize captured_finalize_;
+  CapturedBackendConfig captured_backend_config_;
   bool set_config_fail_ = false;
 };
 
@@ -129,6 +157,17 @@ TEST_F(LpaiBackendTest, InitSucceedsForSocWithLpai) {
 }
 
 #if !defined(__ANDROID__)
+TEST_F(LpaiBackendTest, InitConfiguresV6HardwareVersion) {
+  Options options;
+  options.SetLogLevel(LogLevel::kOff);
+  EXPECT_TRUE(
+      backend_->Init(options, SocInfo{"v6", 0, LpaiHardwareVersion::kV6}));
+  ASSERT_TRUE(captured_backend_config_.called);
+  ASSERT_TRUE(captured_backend_config_.hw_info.has_value());
+  EXPECT_EQ(captured_backend_config_.hw_info->hwVersion,
+            QNN_LPAI_BACKEND_HW_VERSION_V6);
+}
+
 TEST_F(LpaiBackendTest, InitFailsForSocWithoutLpaiEntry) {
   Options options;
   options.SetLogLevel(LogLevel::kOff);
@@ -136,11 +175,26 @@ TEST_F(LpaiBackendTest, InitFailsForSocWithoutLpaiEntry) {
   EXPECT_FALSE(backend_->Init(options, FindOrCreateSocInfo("SM8550")));
 }
 
+TEST_F(LpaiBackendTest, InitFailsForNumericSocWithoutLpaiHardwareVersion) {
+  Options options;
+  options.SetLogLevel(LogLevel::kOff);
+  EXPECT_FALSE(backend_->Init(options, FindOrCreateSocInfo("87")));
+}
+
 // Init ignores soc_info on device (see implementation), skipping this test.
 TEST_F(LpaiBackendTest, InitFailsWithoutKnownLpaiHardwareVersion) {
   Options options;
   options.SetLogLevel(LogLevel::kOff);
   EXPECT_FALSE(backend_->Init(options, std::nullopt));
+}
+#else
+TEST_F(LpaiBackendTest, InitIgnoresHardwareVersionOnDevice) {
+  Options options;
+  options.SetLogLevel(LogLevel::kOff);
+  EXPECT_TRUE(
+      backend_->Init(options, SocInfo{"v6", 0, LpaiHardwareVersion::kV6}));
+  ASSERT_TRUE(captured_backend_config_.called);
+  EXPECT_FALSE(captured_backend_config_.hw_info.has_value());
 }
 #endif  // !defined(__ANDROID__)
 
@@ -209,7 +263,7 @@ TEST_F(LpaiBackendTest, ConfigureGraphAfterRetrieveUsesSdkDefaults) {
   ASSERT_EQ(captured_.configs.size(), 2u);
   const auto& perf = captured_.configs[0];
   ASSERT_TRUE(perf.perf.has_value());
-  EXPECT_EQ(perf.perf->fps, 1u);         // QNN_LPAI_GRAPH_PERF_CFG_INIT default
+  EXPECT_EQ(perf.perf->fps, 1u);  // QNN_LPAI_GRAPH_PERF_CFG_INIT default
   EXPECT_EQ(perf.perf->ftrtRatio, 10u);  // QNN_LPAI_GRAPH_PERF_CFG_INIT default
   EXPECT_EQ(perf.perf->clientType, QNN_LPAI_GRAPH_CLIENT_PERF_TYPE_REAL_TIME);
 

--- a/litert/vendors/qualcomm/core/schema/soc_table.h
+++ b/litert/vendors/qualcomm/core/schema/soc_table.h
@@ -179,13 +179,12 @@ constexpr std::optional<SocInfo> FindSocInfo(const char* soc_name) {
   return std::nullopt;
 }
 
-// Resolves a SocInfo from either a SoC name (e.g. "SM8750") or a numeric
-// SoC model (e.g. "43"). Returns nullopt if the input is null or matches
-// neither format. The LPAI hardware version, when known, is carried on the
-// resolved SocInfo.
+// Resolves a SocInfo from a SoC name, numeric model, or LPAI version.
 inline std::optional<SocInfo> FindOrCreateSocInfo(
     const char* soc_name_or_model) {
   if (soc_name_or_model == nullptr) return std::nullopt;
+  static constexpr std::string_view kCustomSoc = "CUSTOM_SOC";
+  static constexpr uint32_t kCustomSocModel = 0;
 
   // Try parsing the whole string as a SoC name.
   if (auto soc_info = FindSocInfo(soc_name_or_model)) return soc_info;
@@ -195,10 +194,18 @@ inline std::optional<SocInfo> FindOrCreateSocInfo(
   uint32_t soc_model = 0;
   auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), soc_model);
   if (ec == std::errc{} && ptr == sv.data() + sv.size()) {
-    return SocInfo{"CUSTOM_SOC", soc_model};
+    return SocInfo{kCustomSoc, soc_model};
+  }
+
+  if (sv == "v5") {
+    return SocInfo{kCustomSoc, kCustomSocModel, LpaiHardwareVersion::kV5};
+  }
+  if (sv == "v6") {
+    return SocInfo{kCustomSoc, kCustomSocModel, LpaiHardwareVersion::kV6};
   }
 
   return std::nullopt;
 }
+
 }  // namespace qnn
 #endif  // ODML_LITERT_LITERT_VENDORS_QUALCOMM_CORE_SCHEMA_SOC_TABLE_H_

--- a/litert/vendors/qualcomm/core/schema/soc_table_test.cc
+++ b/litert/vendors/qualcomm/core/schema/soc_table_test.cc
@@ -37,6 +37,20 @@ TEST(SocTableTest, FindSocInfoTest) {
   EXPECT_FALSE(FindSocInfo(nullptr).has_value());
 }
 
+TEST(SocTableTest, FindOrCreateSocInfoParsesLpaiHardwareVersion) {
+  const auto v5 = FindOrCreateSocInfo("v5");
+  ASSERT_TRUE(v5.has_value());
+  EXPECT_EQ(v5->lpai_hw_version, LpaiHardwareVersion::kV5);
+
+  const auto v6 = FindOrCreateSocInfo("v6");
+  ASSERT_TRUE(v6.has_value());
+  EXPECT_EQ(v6->lpai_hw_version, LpaiHardwareVersion::kV6);
+
+  EXPECT_FALSE(FindOrCreateSocInfo("").has_value());
+  EXPECT_FALSE(FindOrCreateSocInfo("V6").has_value());
+  EXPECT_FALSE(FindOrCreateSocInfo("v7").has_value());
+}
+
 TEST(SocTableTest, CreateSocInfoTest) {
   static constexpr auto kSm8550 = FindSocInfo("SM8550");
   // Test creating an SoC with SoC name.

--- a/litert/vendors/qualcomm/core/utils/test_main.cc
+++ b/litert/vendors/qualcomm/core/utils/test_main.cc
@@ -33,6 +33,8 @@ bool ParseArgs(int argc, char** argv) {
         qnn::SetTestBackend(qnn::BackendType::kDspBackend);
       } else if (backend_str == "gpu") {
         qnn::SetTestBackend(qnn::BackendType::kGpuBackend);
+      } else if (backend_str == "lpai") {
+        qnn::SetTestBackend(qnn::BackendType::kLpaiBackend);
       } else {
         std::cerr << "Unknown backend: " << backend_str << std::endl;
         return false;
@@ -44,7 +46,7 @@ bool ParseArgs(int argc, char** argv) {
       std::cout << "Test specific options:\n"
                 << "  " << kBackendFlag << "[BACKEND_NAME]\n"
                 << "      Specify the backend to run tests against. Supported "
-                   "backends: htp, dsp.\n"
+                   "backends: htp, dsp, gpu, lpai.\n"
                 << "      Default is htp.\n"
                 << "  " << kDispatchLibraryDirFlag << "[PATH]\n"
                 << "      Specify the dispatch library directory.\n"

--- a/litert/vendors/qualcomm/core/utils/test_utils.cc
+++ b/litert/vendors/qualcomm/core/utils/test_utils.cc
@@ -24,6 +24,10 @@ bool IsTestDspBackend() { return GetTestBackend() == BackendType::kDspBackend; }
 
 bool IsTestGpuBackend() { return GetTestBackend() == BackendType::kGpuBackend; }
 
+bool IsTestLpaiBackend() {
+  return GetTestBackend() == BackendType::kLpaiBackend;
+}
+
 void SetTestBackend(BackendType backend_type) {
   GetTestBackend() = backend_type;
 }

--- a/litert/vendors/qualcomm/core/utils/test_utils.h
+++ b/litert/vendors/qualcomm/core/utils/test_utils.h
@@ -19,6 +19,8 @@ bool IsTestDspBackend();
 
 bool IsTestGpuBackend();
 
+bool IsTestLpaiBackend();
+
 // Sets the target backend for testing.
 // This should be called by the test main.
 void SetTestBackend(BackendType backend_type);

--- a/litert/vendors/qualcomm/core/utils/utils_test.cc
+++ b/litert/vendors/qualcomm/core/utils/utils_test.cc
@@ -163,6 +163,11 @@ TEST(MiscTests, IsTestGpuBackendTest) {
   EXPECT_TRUE(qnn::IsTestGpuBackend());
 }
 
+TEST(MiscTests, IsTestLpaiBackendTest) {
+  qnn::SetTestBackend(BackendType::kLpaiBackend);
+  EXPECT_TRUE(qnn::IsTestLpaiBackend());
+}
+
 TEST(MiscTests, UnpackInt2Data) {
   // Single byte: 0xE4 (binary: 11 10 01 00), LSB-first unpacking.
   // bits 0-1: 00 -> 0

--- a/litert/vendors/qualcomm/doc/LPAI_INSTRUCTIONS.md
+++ b/litert/vendors/qualcomm/doc/LPAI_INSTRUCTIONS.md
@@ -49,8 +49,20 @@ Variable         | Description
 `${QAIRT}`       | Root path of the unzipped QAIRT SDK
 `${WORK_DIR}`    | Working directory for your model
 `${MODEL}`       | Path to the source quantized `.tflite` model
-`${SOC_MODEL}`   | Target SoC string (e.g. `SM8850`)
+`${SOC_MODEL}`   | LPAI version, or a mapped SoC name
 `${TEST_FOLDER}` | Test folder on device (e.g. `/data/local/tmp/lpai_run`)
+
+When supplying an LPAI target to the LiteRT Qualcomm compiler plugin,
+`${SOC_MODEL}` accepts `v5` or `v6` directly. It also accepts a Snapdragon SoC
+name with an LPAI entry in the LiteRT SoC table. For example, `SM8850` resolves
+to `v6`. With `apply_plugin_main`, pass it using these flags:
+
+```bash
+--qualcomm_backend=lpai \
+--soc_model=v6
+```
+
+Only LPAI versions `v5` and `v6` are currently supported.
 
 ## Signing Libraries for Production Devices
 

--- a/litert/vendors/qualcomm/doc/OPTIONS_REFERENCE.md
+++ b/litert/vendors/qualcomm/doc/OPTIONS_REFERENCE.md
@@ -65,6 +65,7 @@ flowchart TB
 | **General / SDK** | `log_level`, `backend`, `graph_priority`, `custom_op_package`, `enable_just_in_time`, `graph_io_tensor_mem_type`, `profiling` |
 | **HTP** | `use_conv_hmx`, `use_fold_relu`, `htp_p_point`, `htp_performance_mode`, `optimization_level`, `vtcm_size`, `num_hvx_threads`, `use_int64_bias_as_int32`, `enable_weight_sharing` |
 | **DSP** | `dsp_performance_mode` |
+| **LPAI** | `lpai_target`, `lpai_fps`, `lpai_ftrt_ratio`, `lpai_client_perf_type`, `lpai_core_affinity_type`, `lpai_core_selection` |
 | **IR** | `dlc_dir` |
 | **SAVER** | `saver_output_dir` |
 | **Debug** | `dump_tensor_ids`, `ir_json_dir` |
@@ -143,7 +144,29 @@ target:HTP"
 
 ---
 
-## 6. IR options
+## 6. LPAI options
+
+| Option | CLI flag (`--qualcomm_…`) | Default | Phase | Notes |
+|--------|------|---------|-------|----------------|
+| LPAI target | `lpai_target` | `adsp` | compile | Target environment: `x86`, `arm`, `adsp`, `tensilica`. |
+| LPAI FPS | `lpai_fps` | `1` | compile | Target inference rate. |
+| LPAI FTRT ratio | `lpai_ftrt_ratio` | `10` | compile | Faster-than-real-time ratio. |
+| LPAI client perf type | `lpai_client_perf_type` | `default` | compile | `default`, `real_time`, `non_real_time`. |
+| LPAI core affinity | `lpai_core_affinity_type` | `default` | compile | `default`, `soft`, `hard`. |
+| LPAI core selection | `lpai_core_selection` | `0` | compile | Core-selection bitmask, `0` leaves SDK default. |
+
+LPAI accepts `v5` or `v6` directly through `soc_model`. A Snapdragon SoC name
+with an LPAI entry in the LiteRT SoC table is also accepted. For example,
+`SM8850` resolves to `v6`.
+
+With `apply_plugin_main`, specify the target with:
+
+```bash
+--qualcomm_backend=lpai \
+--soc_model=v6
+```
+
+## 7. IR options
 
 QNN intermediate-representation dumps — diagnostic artifacts produced at compile time.
 
@@ -153,7 +176,7 @@ QNN intermediate-representation dumps — diagnostic artifacts produced at compi
 
 ---
 
-## 7. SAVER options
+## 8. SAVER options
 
 | Option | CLI flag (`--qualcomm_…`) | Default | Phase | Notes |
 |--------|------|---------|-------|----------------|
@@ -161,7 +184,7 @@ QNN intermediate-representation dumps — diagnostic artifacts produced at compi
 
 ---
 
-## 8. Debug options
+## 9. Debug options
 
 | Option | CLI flag (`--qualcomm_…`) | Default | Phase | Notes |
 |--------|------|---------|-------|----------------|
@@ -170,7 +193,7 @@ QNN intermediate-representation dumps — diagnostic artifacts produced at compi
 
 ---
 
-## 9. Deprecated / retired options
+## 10. Deprecated / retired options
 
 These remain as **no-ops** purely to preserve the C ABI contract. Setting them
 does nothing.
@@ -182,7 +205,7 @@ does nothing.
 
 ---
 
-## 10. Worked examples
+## 11. Worked examples
 
 ### CLI — compile (`apply_plugin_main`)
 

--- a/litert/vendors/qualcomm/qnn_manager_test.cc
+++ b/litert/vendors/qualcomm/qnn_manager_test.cc
@@ -52,6 +52,10 @@ std::optional<::qnn::Options> GetOptionsForTarget() {
     options.SetBackendType(::qnn::BackendType::kGpuBackend);
     return options;
   }
+  if (::qnn::IsTestLpaiBackend()) {
+    options.SetBackendType(::qnn::BackendType::kLpaiBackend);
+    return options;
+  }
   return std::nullopt;
 }
 


### PR DESCRIPTION
# What
- Parse LPAI architecture version in --soc_model.
- Add related LPAI test.

# Verification

- [x] Developer-Verified
- Pass LPAI E2E test with traditional mode on sm8850. 

# Test

- Passed x86 unit test. 
- Passed android unit test. (HTP, LPAI)

======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.1s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.1s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.4s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.1s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:graph_config_builder_test
//litert/vendors/qualcomm/core/backends:graph_config_builder_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 1.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/backends:lpai_backend_test
//litert/vendors/qualcomm/core/backends:lpai_backend_test       (cached) PASSED in 0.1s

//litert/tools:tensor_utils_test
//litert/tools:tensor_utils_test                                (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core/schema:soc_table_test
//litert/vendors/qualcomm/core/schema:soc_table_test            (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 70.5s

======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 27 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 27 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 24 tests from 15 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 17 tests from 3 test suites ran. (34 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 38 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 38 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (3 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 31 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 17 tests from 6 test suites ran. (25 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (644 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (153 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (630 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (341 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1445 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1570 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (780 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1475 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (5 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (43 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (610 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:graph_config_builder_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (4817 ms total)
[  PASSED  ] 26 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (82 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:lpai_backend_test
[==========] 7 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 7 tests.

SM8850: //litert/tools:tensor_utils_test
[==========] 21 tests from 1 test suite ran. (31 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/vendors/qualcomm/core/schema:soc_table_test
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (16 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (620 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (557 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (490 ms total)
[  PASSED  ] 2 tests.
======================== Test Summary ========================
SM8850: //litert/c/options:litert_qualcomm_options_test
[==========] 27 tests from 2 test suites ran. (3 ms total)
[  PASSED  ] 27 tests.

SM8850: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 24 tests from 15 test suites ran. (1 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 17 tests from 3 test suites ran. (7 ms total)
[  PASSED  ] 16 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 24 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 38 tests from 3 test suites ran. (7 ms total)
[  PASSED  ] 38 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (2 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 66 tests from 9 test suites ran. (3 ms total)
[  PASSED  ] 66 tests.

SM8850: //litert/vendors/qualcomm/core:common_test
[==========] 31 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8850: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (2 ms total)
[  PASSED  ] 19 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 17 tests from 6 test suites ran. (33 ms total)
[  PASSED  ] 17 tests.

SM8850: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 1 test.

SM8850: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (4 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (42 ms total)
[  PASSED  ] 9 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (616 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:graph_config_builder_test
[==========] 5 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 5 tests.

SM8850: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 26 tests from 6 test suites ran. (16 ms total)
[  PASSED  ] 6 tests.

SM8850: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (61 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:lpai_backend_test
[==========] 7 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 7 tests.

SM8850: //litert/tools:tensor_utils_test
[==========] 21 tests from 1 test suite ran. (33 ms total)
[  PASSED  ] 21 tests.

SM8850: //litert/vendors/qualcomm/core/schema:soc_table_test
[==========] 3 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 3 tests.

SM8850: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (19 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (2 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (28 ms total)
[  PASSED  ] 2 tests.

SM8850: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.

SM8850: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.
