### PR TITLE
Fix gemma option-bundle selection to use else-if branching

### DIFF
--- a/litert/vendors/mediatek/compiler/compile_model.cc
+++ b/litert/vendors/mediatek/compiler/compile_model.cc
@@ -65,10 +65,10 @@ Expected<NeuronCompilationPtr> CompileModel(
   if (gemma_compiler_optimizations) {
     if (subgraph_index == kDecodePartitionIndex) {
       compile_options = " --option-bundle=gemma-decode-accuracy";
-    }
-
-    if (subgraph_index == kPrefillPartitionIndex) {
+    } else if (subgraph_index == kPrefillPartitionIndex) {
       compile_options = " --option-bundle=gemma-prefill-accuracy";
+    } else {
+      compile_options = " --option-bundle=gemma-decode-accuracy";
     }
   }
 


### PR DESCRIPTION
Previously the decode-accuracy branch fell through and got overwritten whenever prefill also matched, and non-decode/non-prefill subgraphs had no bundle set; use else-if/else so each subgraph gets the correct option bundle.