### PR TITLE
Qualcomm AI Engine Direct - Reorder parameters to match QNN TFLite Delegate.

### DIFF
--- a/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/conv2d_op_builder.cc
@@ -130,15 +130,6 @@ std::vector<OpWrapper> BuildConv2dOp(
       stride_data.data());
   conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_STRIDE, stride_tensor);
 
-  // dilation param
-  const std::array<std::uint32_t, 2> dilation_data{dilation_h, dilation_w};
-  const std::vector<std::uint32_t> dilation_shape{2};
-  auto& dilation_tensor = tensor_pool.CreateStaticTensor(
-      QNN_DATATYPE_UINT_32, QuantizeParamsWrapperVariant{}, dilation_shape,
-      sizeof(decltype(dilation_data)::value_type) * dilation_data.size(),
-      dilation_data.data());
-  conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_DILATION, dilation_tensor);
-
   // padding param
   const auto [padding_before_height, padding_after_height] =
       ComputePaddingBeforeAfter(input_tensor.GetDimension(kHeightIndex),
@@ -157,6 +148,15 @@ std::vector<OpWrapper> BuildConv2dOp(
       sizeof(decltype(padding_data)::value_type) * padding_data.size(),
       padding_data.data());
   conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_PAD_AMOUNT, padding_tensor);
+
+  // dilation param
+  const std::array<std::uint32_t, 2> dilation_data{dilation_h, dilation_w};
+  const std::vector<std::uint32_t> dilation_shape{2};
+  auto& dilation_tensor = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, QuantizeParamsWrapperVariant{}, dilation_shape,
+      sizeof(decltype(dilation_data)::value_type) * dilation_data.size(),
+      dilation_data.data());
+  conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_DILATION, dilation_tensor);
 
   // group param
   if ((input_tensor.GetDimension(kChannelIndex) %

--- a/litert/vendors/qualcomm/core/builders/depthwise_conv2d_op_builder.cc
+++ b/litert/vendors/qualcomm/core/builders/depthwise_conv2d_op_builder.cc
@@ -83,14 +83,6 @@ std::vector<OpWrapper> BuildDepthwiseConv2dOp(
       sizeof(decltype(stride_data)::value_type) * stride_data.size(),
       stride_data.data());
 
-  // dilation param
-  const std::array<std::uint32_t, 2> dilation_data{dilation_h, dilation_w};
-  const std::vector<std::uint32_t> dilation_shape{2};
-  auto& dilation_tensor = tensor_pool.CreateStaticTensor(
-      QNN_DATATYPE_UINT_32, QuantizeParamsWrapperVariant{}, dilation_shape,
-      sizeof(decltype(dilation_data)::value_type) * dilation_data.size(),
-      dilation_data.data());
-
   // padding param
   const auto [padding_before_height, padding_after_height] =
       ComputePaddingBeforeAfter(input_tensor.GetDimension(kHeightIndex),
@@ -109,6 +101,14 @@ std::vector<OpWrapper> BuildDepthwiseConv2dOp(
       sizeof(decltype(padding_data)::value_type) * padding_data.size(),
       padding_data.data());
 
+  // dilation param
+  const std::array<std::uint32_t, 2> dilation_data{dilation_h, dilation_w};
+  const std::vector<std::uint32_t> dilation_shape{2};
+  auto& dilation_tensor = tensor_pool.CreateStaticTensor(
+      QNN_DATATYPE_UINT_32, QuantizeParamsWrapperVariant{}, dilation_shape,
+      sizeof(decltype(dilation_data)::value_type) * dilation_data.size(),
+      dilation_data.data());
+
   if (ShouldUseGroupedConv2d(filter_tensor, stride_h, stride_w)) {
     OpWrapper& conv_op = CreateOpWrapper(res, QNN_OP_CONV_2D);
     conv_op.AddInputTensor(input_tensor);
@@ -120,8 +120,8 @@ std::vector<OpWrapper> BuildDepthwiseConv2dOp(
     conv_op.AddScalarParam<std::uint32_t>(
         QNN_OP_CONV_2D_PARAM_GROUP, input_tensor.GetDimension(kChannelIndex));
     conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_STRIDE, stride_tensor);
-    conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_DILATION, dilation_tensor);
     conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_PAD_AMOUNT, padding_tensor);
+    conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_DILATION, dilation_tensor);
   } else {
     OpWrapper& conv_op = CreateOpWrapper(res, QNN_OP_DEPTH_WISE_CONV_2D);
     conv_op.AddInputTensor(input_tensor);
@@ -132,9 +132,9 @@ std::vector<OpWrapper> BuildDepthwiseConv2dOp(
     conv_op.AddOutputTensor(outputs[kOutputIndex]);
     conv_op.AddTensorParam(QNN_OP_DEPTH_WISE_CONV_2D_PARAM_STRIDE,
                            stride_tensor);
+    conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_PAD_AMOUNT, padding_tensor);
     conv_op.AddTensorParam(QNN_OP_DEPTH_WISE_CONV_2D_PARAM_DILATION,
                            dilation_tensor);
-    conv_op.AddTensorParam(QNN_OP_CONV_2D_PARAM_PAD_AMOUNT, padding_tensor);
   }
   return res;
 }


### PR DESCRIPTION
Summary:
- Align the padding and dilation tensor parameter ordering for CONV_2D and DEPTHWISE_CONV_2D between LiteRT and the TFLite Delegate implementation.

x86 test:
```
======================== Test Summary ========================
//litert/c/options:litert_qualcomm_options_test
//litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s

//litert/tools/flags/vendors:qualcomm_flags_test
//litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/utils:utils_test
//litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.1s

//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
//litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:common_test
//litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core:tensor_pool_test
//litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s

//litert/vendors/qualcomm/core/transformation:all
//litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
//litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s

//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
//litert/vendors/qualcomm/qnn_backend_test:qnn_model_test       (cached) PASSED in 0.4s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test (cached) PASSED in 0.2s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test (cached) PASSED in 0.3s

//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
//litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test (cached) PASSED in 0.5s

//litert/vendors/qualcomm/core/dump:dump_graph_test
//litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s

//litert/vendors/qualcomm:qnn_manager_test
//litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core/backends:backend_utils_test
//litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s

//litert/vendors/qualcomm/core/backends:htp_backend_test
//litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 1.1s

//litert/vendors/qualcomm/core/backends:ir_backend_test
//litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s

//litert/tools:tensor_utils_test
//litert/tools:tensor_utils_test                                (cached) PASSED in 0.2s

//litert/vendors/qualcomm/core/schema:soc_table_test
//litert/vendors/qualcomm/core/schema:soc_table_test            (cached) PASSED in 0.0s

//litert/c:litert_op_options_test
//litert/c:litert_op_options_test                               (cached) PASSED in 0.1s

//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
//litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 77.4s
```

on-device test:
```
======================== Test Summary ========================
SM8650: //litert/c/options:litert_qualcomm_options_test
[==========] 27 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 27 tests.

SM8650: //litert/tools/flags/vendors:qualcomm_flags_test
[==========] 24 tests from 15 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/utils:utils_test
[==========] 16 tests from 3 test suites ran. (8 ms total)
[  PASSED  ] 16 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
[==========] 24 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 24 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
[==========] 39 tests from 3 test suites ran. (1 ms total)
[  PASSED  ] 39 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
[==========] 31 tests from 17 test suites ran. (1 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
[==========] 67 tests from 9 test suites ran. (1 ms total)
[  PASSED  ] 67 tests.

SM8650: //litert/vendors/qualcomm/core:common_test
[==========] 31 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 31 tests.

SM8650: //litert/vendors/qualcomm/core:tensor_pool_test
[==========] 19 tests from 2 test suites ran. (1 ms total)
[  PASSED  ] 19 tests.

SM8650: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
[==========] 17 tests from 6 test suites ran. (12 ms total)
[  PASSED  ] 17 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
[==========] 1 test from 1 test suite ran. (496 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
[==========] 1 test from 1 test suite ran. (203 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
[==========] 2 tests from 1 test suite ran. (703 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
[==========] 1 test from 1 test suite ran. (459 ms total)
[  PASSED  ] 1 test.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
[==========] 5 tests from 1 test suite ran. (1554 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
[==========] 5 tests from 1 test suite ran. (1497 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
[==========] 3 tests from 1 test suite ran. (954 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
[==========] 5 tests from 1 test suite ran. (1562 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/core/dump:dump_graph_test
[==========] 5 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm:qnn_manager_test
[==========] 9 tests from 2 test suites ran. (10 ms total)
[  PASSED  ] 9 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_utils_test
[==========] 5 tests from 2 test suites ran. (615 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/vendors/qualcomm/core/backends:htp_backend_test
[==========] 27 tests from 7 test suites ran. (5485 ms total)
[  PASSED  ] 27 tests.

SM8650: //litert/vendors/qualcomm/core/backends:ir_backend_test
[==========] 3 tests from 2 test suites ran. (7 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/tools:tensor_utils_test
[==========] 23 tests from 1 test suite ran. (48 ms total)
[  PASSED  ] 23 tests.

SM8650: //litert/vendors/qualcomm/core/schema:soc_table_test
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.

SM8650: //litert/vendors/qualcomm/core/backends:dsp_backend_test
[==========] 29 tests from 3 test suites ran. (6 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:gpu_backend_test
[==========] 2 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 0 tests.

SM8650: //litert/vendors/qualcomm/core/backends:backend_factory_test
[==========] 5 tests from 1 test suite ran. (802 ms total)
[  PASSED  ] 3 tests.

SM8650: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
[==========] 5 tests from 1 test suite ran. (416 ms total)
[  PASSED  ] 5 tests.

SM8650: //litert/cc:_litert_compiled_model_qualcomm_test
[==========] 2 tests from 1 test suite ran. (458 ms total)
[  PASSED  ] 2 tests.
```