### PR TITLE
Qualcomm AI Engine Direct - Register Atan2 in ShapeInferenceEngine.

### DIFF
--- a/litert/core/model/ops/simple_binary.h
+++ b/litert/core/model/ops/simple_binary.h
@@ -78,6 +78,7 @@ inline LiteRtStatus InferElementwiseBinary(absl::Span<Dims> input_shapes,
   }
 
 DEFINE_SIMPLE_BINARY_INFER(Add)
+DEFINE_SIMPLE_BINARY_INFER(Atan2)
 DEFINE_SIMPLE_BINARY_INFER(Div)
 DEFINE_SIMPLE_BINARY_INFER(Equal)
 DEFINE_SIMPLE_BINARY_INFER(FloorDiv)

--- a/litert/core/model/shape_inference.cc
+++ b/litert/core/model/shape_inference.cc
@@ -223,6 +223,8 @@ void ShapeInferenceEngine::RegisterStandardOps() {
   RegisterInferrer(kLiteRtOpCodeTflSquaredDifference,
                    AdaptToStatelessOpInferrer(InferSquaredDifference));
   RegisterInferrer(kLiteRtOpCodeTflAdd, AdaptToStatelessOpInferrer(InferAdd));
+  RegisterInferrer(kLiteRtOpCodeTflAtan2,
+                   AdaptToStatelessOpInferrer(InferAtan2));
   RegisterInferrer(kLiteRtOpCodeTflArgMax,
                    AdaptToStatelessOpInferrer(InferArgMinMax));
   RegisterInferrer(kLiteRtOpCodeTflArgMin,


### PR DESCRIPTION
# What
- This change registers **Atan2** in LiteRT's **ShapeInferenceEngine** so that shape inference works correctly for the **Atan2** op.

# Verification
- [x] Developer Verified

# Test
- Passed x86 unit test.
```
2026-09-15T10:24:38.5223166Z ======================== Test Summary ========================
2026-09-15T10:24:38.5223322Z //litert/c/options:litert_qualcomm_options_test
2026-09-15T10:24:38.5223531Z //litert/c/options:litert_qualcomm_options_test                 (cached) PASSED in 0.0s
2026-09-15T10:24:38.5223677Z 
2026-09-15T10:24:38.5223742Z //litert/tools/flags/vendors:qualcomm_flags_test
2026-09-15T10:24:38.5223937Z //litert/tools/flags/vendors:qualcomm_flags_test                (cached) PASSED in 0.1s
2026-09-15T10:24:38.5224082Z 
2026-09-15T10:24:38.5224139Z //litert/vendors/qualcomm:qnn_manager_test
2026-09-15T10:24:38.5224323Z //litert/vendors/qualcomm:qnn_manager_test                      (cached) PASSED in 0.2s
2026-09-15T10:24:38.5224460Z 
2026-09-15T10:24:38.5224544Z //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
2026-09-15T10:24:38.5224762Z //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test              PASSED in 57.6s
2026-09-15T10:24:38.5224910Z 
2026-09-15T10:24:38.5224985Z //litert/vendors/qualcomm/compiler:qnn_compose_graph_test
2026-09-15T10:24:38.5225237Z //litert/vendors/qualcomm/compiler:qnn_compose_graph_test                PASSED in 0.0s
2026-09-15T10:24:38.5225376Z 
2026-09-15T10:24:38.5225435Z //litert/vendors/qualcomm/core:common_test
2026-09-15T10:24:38.5225632Z //litert/vendors/qualcomm/core:common_test                      (cached) PASSED in 0.0s
2026-09-15T10:24:38.5225773Z 
2026-09-15T10:24:38.5225831Z //litert/vendors/qualcomm/core:tensor_pool_test
2026-09-15T10:24:38.5226036Z //litert/vendors/qualcomm/core:tensor_pool_test                 (cached) PASSED in 0.0s
2026-09-15T10:24:38.5226178Z 
2026-09-15T10:24:38.5226253Z //litert/vendors/qualcomm/core/backends:backend_factory_test
2026-09-15T10:24:38.5226534Z //litert/vendors/qualcomm/core/backends:backend_factory_test    (cached) PASSED in 0.0s
2026-09-15T10:24:38.5226681Z 
2026-09-15T10:24:38.5226758Z //litert/vendors/qualcomm/core/backends:backend_utils_test
2026-09-15T10:24:38.5226967Z //litert/vendors/qualcomm/core/backends:backend_utils_test      (cached) PASSED in 0.6s
2026-09-15T10:24:38.5227116Z 
2026-09-15T10:24:38.5227192Z //litert/vendors/qualcomm/core/backends:dsp_backend_test
2026-09-15T10:24:38.5227396Z //litert/vendors/qualcomm/core/backends:dsp_backend_test        (cached) PASSED in 0.0s
2026-09-15T10:24:38.5227538Z 
2026-09-15T10:24:38.5227610Z //litert/vendors/qualcomm/core/backends:gpu_backend_test
2026-09-15T10:24:38.5227819Z //litert/vendors/qualcomm/core/backends:gpu_backend_test        (cached) PASSED in 0.0s
2026-09-15T10:24:38.5227955Z 
2026-09-15T10:24:38.5228043Z //litert/vendors/qualcomm/core/backends:graph_config_builder_test
2026-09-15T10:24:38.5228277Z //litert/vendors/qualcomm/core/backends:graph_config_builder_test (cached) PASSED in 0.0s
2026-09-15T10:24:38.5228427Z 
2026-09-15T10:24:38.5228494Z //litert/vendors/qualcomm/core/backends:htp_backend_test
2026-09-15T10:24:38.5228702Z //litert/vendors/qualcomm/core/backends:htp_backend_test        (cached) PASSED in 1.1s
2026-09-15T10:24:38.5228844Z 
2026-09-15T10:24:38.5228914Z //litert/vendors/qualcomm/core/backends:ir_backend_test
2026-09-15T10:24:38.5229118Z //litert/vendors/qualcomm/core/backends:ir_backend_test         (cached) PASSED in 0.0s
2026-09-15T10:24:38.5229254Z 
2026-09-15T10:24:38.5229327Z //litert/vendors/qualcomm/core/backends:lpai_backend_test
2026-09-15T10:24:38.5229530Z //litert/vendors/qualcomm/core/backends:lpai_backend_test       (cached) PASSED in 0.0s
2026-09-15T10:24:38.5229674Z 
2026-09-15T10:24:38.5229742Z //litert/vendors/qualcomm/core/dump:dump_graph_test
2026-09-15T10:24:38.5229940Z //litert/vendors/qualcomm/core/dump:dump_graph_test             (cached) PASSED in 0.0s
2026-09-15T10:24:38.5230082Z 
2026-09-15T10:24:38.5230152Z //litert/vendors/qualcomm/core/schema:soc_table_test
2026-09-15T10:24:38.5230350Z //litert/vendors/qualcomm/core/schema:soc_table_test            (cached) PASSED in 0.0s
2026-09-15T10:24:38.5230491Z 
2026-09-15T10:24:38.5230581Z //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
2026-09-15T10:24:38.5230825Z //litert/vendors/qualcomm/core/transformation:embedding_gemma_test (cached) PASSED in 0.0s
2026-09-15T10:24:38.5230977Z 
2026-09-15T10:24:38.5231069Z //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
2026-09-15T10:24:38.5231306Z //litert/vendors/qualcomm/core/transformation:graph_to_graph_test (cached) PASSED in 0.0s
2026-09-15T10:24:38.5231458Z 
2026-09-15T10:24:38.5231541Z //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
2026-09-15T10:24:38.5231781Z //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test (cached) PASSED in 0.0s
2026-09-15T10:24:38.5231961Z 
2026-09-15T10:24:38.5232043Z //litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test
2026-09-15T10:24:38.5232265Z //litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test    (cached) PASSED in 0.0s
2026-09-15T10:24:38.5232410Z 
2026-09-15T10:24:38.5232474Z //litert/vendors/qualcomm/core/utils:utils_test
2026-09-15T10:24:38.5232668Z //litert/vendors/qualcomm/core/utils:utils_test                 (cached) PASSED in 0.0s
2026-09-15T10:24:38.5232851Z 
2026-09-15T10:24:38.5232936Z //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
2026-09-15T10:24:38.5233157Z //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test   (cached) PASSED in 0.0s
2026-09-15T10:24:38.5233306Z 
2026-09-15T10:24:38.5233391Z //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
2026-09-15T10:24:38.5233628Z //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test (cached) PASSED in 0.0s
2026-09-15T10:24:38.5233775Z 
2026-09-15T10:24:38.5233876Z //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
2026-09-15T10:24:38.5234145Z //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test (cached) PASSED in 0.0s
2026-09-15T10:24:38.5234353Z 
2026-09-15T10:24:38.5234438Z //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
2026-09-15T10:24:38.5234701Z //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test (cached) PASSED in 0.0s
2026-09-15T10:24:38.5234860Z 
2026-09-15T10:24:38.5234934Z //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
2026-09-15T10:24:38.5235145Z //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test                PASSED in 0.3s
2026-09-15T10:24:38.5235279Z 
2026-09-15T10:24:38.5235380Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:depthwise_conv2d_test
2026-09-15T10:24:38.5235637Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:depthwise_conv2d_test PASSED in 0.3s
2026-09-15T10:24:38.5235792Z 
2026-09-15T10:24:38.5235881Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
2026-09-15T10:24:38.5236121Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test PASSED in 0.4s
2026-09-15T10:24:38.5236263Z 
2026-09-15T10:24:38.5236363Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
2026-09-15T10:24:38.5236610Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test PASSED in 0.2s
2026-09-15T10:24:38.5236763Z 
2026-09-15T10:24:38.5236869Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
2026-09-15T10:24:38.5237127Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test PASSED in 0.4s
2026-09-15T10:24:38.5237288Z 
2026-09-15T10:24:38.5237386Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_test
2026-09-15T10:24:38.5237635Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_test PASSED in 0.4s
2026-09-15T10:24:38.5237896Z 
2026-09-15T10:24:38.5238002Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:hadamard_transform_test
2026-09-15T10:24:38.5238265Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:hadamard_transform_test PASSED in 0.2s
2026-09-15T10:24:38.5238425Z 
2026-09-15T10:24:38.5238512Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:onehot_test
2026-09-15T10:24:38.5238746Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:onehot_test      PASSED in 0.2s
2026-09-15T10:24:38.5238892Z 
2026-09-15T10:24:38.5238973Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
2026-09-15T10:24:38.5239200Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test        PASSED in 0.3s
2026-09-15T10:24:38.5239344Z 
2026-09-15T10:24:38.5239431Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:pad_test
2026-09-15T10:24:38.5239654Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:pad_test         PASSED in 0.4s
2026-09-15T10:24:38.5239796Z 
2026-09-15T10:24:38.5239880Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
2026-09-15T10:24:38.5240098Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test        PASSED in 0.1s
2026-09-15T10:24:38.5240243Z 
2026-09-15T10:24:38.5240350Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
2026-09-15T10:24:38.5240618Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test PASSED in 0.2s
2026-09-15T10:24:38.5240776Z 
2026-09-15T10:24:38.5240880Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test
2026-09-15T10:24:38.5242400Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test PASSED in 0.2s
2026-09-15T10:24:38.5242559Z 
2026-09-15T10:24:38.5242641Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
2026-09-15T10:24:38.5242911Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test      PASSED in 0.4s
2026-09-15T10:24:38.5243059Z 
2026-09-15T10:24:38.5243148Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:squeeze_test
2026-09-15T10:24:38.5243375Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:squeeze_test     PASSED in 0.4s
2026-09-15T10:24:38.5243816Z 
2026-09-15T10:24:38.5243959Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
2026-09-15T10:24:38.5244204Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test        PASSED in 0.2s
2026-09-15T10:24:38.5244347Z 
2026-09-15T10:24:38.5244447Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:transpose_conv_test
2026-09-15T10:24:38.5245043Z //litert/vendors/qualcomm/qnn_backend_test/builder_test:transpose_conv_test PASSED in 0.6s
```
- Passed android unit test. (HTP)
```
2026-09-15T10:21:07.7385193Z ======================== Test Summary ========================
2026-09-15T10:21:07.7385263Z SM8750: //litert/c/options:litert_qualcomm_options_test
2026-09-15T10:21:07.7385314Z [==========] 27 tests from 2 test suites ran. (1 ms total)
2026-09-15T10:21:07.7385355Z [  PASSED  ] 27 tests.
2026-09-15T10:21:07.7385357Z 
2026-09-15T10:21:07.7385420Z SM8750: //litert/cc:_litert_compiled_model_qualcomm_test
2026-09-15T10:21:07.7385471Z [==========] 2 tests from 1 test suite ran. (367 ms total)
2026-09-15T10:21:07.7385510Z [  PASSED  ] 2 tests.
2026-09-15T10:21:07.7385512Z 
2026-09-15T10:21:07.7385569Z SM8750: //litert/tools/flags/vendors:qualcomm_flags_test
2026-09-15T10:21:07.7385623Z [==========] 24 tests from 15 test suites ran. (0 ms total)
2026-09-15T10:21:07.7385663Z [  PASSED  ] 24 tests.
2026-09-15T10:21:07.7385666Z 
2026-09-15T10:21:07.7385734Z SM8750: //litert/vendors/qualcomm:qnn_manager_test
2026-09-15T10:21:07.7385786Z [==========] 9 tests from 2 test suites ran. (11 ms total)
2026-09-15T10:21:07.7385820Z [  PASSED  ] 9 tests.
2026-09-15T10:21:07.7385822Z 
2026-09-15T10:21:07.7385898Z SM8750: //litert/vendors/qualcomm/compiler:qnn_compiler_plugin_test
2026-09-15T10:21:07.7385967Z [==========] 268 tests from 4 test suites ran. (60227 ms total)
2026-09-15T10:21:07.7386016Z [  PASSED  ] 252 tests.
2026-09-15T10:21:07.7386018Z 
2026-09-15T10:21:07.7386091Z SM8750: //litert/vendors/qualcomm/compiler:qnn_compose_graph_test
2026-09-15T10:21:07.7386139Z [==========] 7 tests from 1 test suite ran. (0 ms total)
2026-09-15T10:21:07.7386178Z [  PASSED  ] 7 tests.
2026-09-15T10:21:07.7386180Z 
2026-09-15T10:21:07.7386236Z SM8750: //litert/vendors/qualcomm/core:common_test
2026-09-15T10:21:07.7386286Z [==========] 31 tests from 2 test suites ran. (0 ms total)
2026-09-15T10:21:07.7386323Z [  PASSED  ] 31 tests.
2026-09-15T10:21:07.7386338Z 
2026-09-15T10:21:07.7386402Z SM8750: //litert/vendors/qualcomm/core:tensor_pool_test
2026-09-15T10:21:07.7386452Z [==========] 19 tests from 2 test suites ran. (1 ms total)
2026-09-15T10:21:07.7386490Z [  PASSED  ] 19 tests.
2026-09-15T10:21:07.7386492Z 
2026-09-15T10:21:07.7386570Z SM8750: //litert/vendors/qualcomm/core/backends:backend_factory_test
2026-09-15T10:21:07.7386620Z [==========] 5 tests from 1 test suite ran. (488 ms total)
2026-09-15T10:21:07.7386654Z [  PASSED  ] 3 tests.
2026-09-15T10:21:07.7386656Z 
2026-09-15T10:21:07.7386729Z SM8750: //litert/vendors/qualcomm/core/backends:backend_utils_test
2026-09-15T10:21:07.7386783Z [==========] 5 tests from 2 test suites ran. (614 ms total)
2026-09-15T10:21:07.7386819Z [  PASSED  ] 5 tests.
2026-09-15T10:21:07.7386820Z 
2026-09-15T10:21:07.7386892Z SM8750: //litert/vendors/qualcomm/core/backends:dsp_backend_test
2026-09-15T10:21:07.7386940Z [==========] 29 tests from 3 test suites ran. (5 ms total)
2026-09-15T10:21:07.7386980Z [  PASSED  ] 0 tests.
2026-09-15T10:21:07.7386983Z 
2026-09-15T10:21:07.7387051Z SM8750: //litert/vendors/qualcomm/core/backends:gpu_backend_test
2026-09-15T10:21:07.7387101Z [==========] 2 tests from 1 test suite ran. (0 ms total)
2026-09-15T10:21:07.7387137Z [  PASSED  ] 0 tests.
2026-09-15T10:21:07.7387139Z 
2026-09-15T10:21:07.7387219Z SM8750: //litert/vendors/qualcomm/core/backends:graph_config_builder_test
2026-09-15T10:21:07.7387267Z [==========] 5 tests from 1 test suite ran. (0 ms total)
2026-09-15T10:21:07.7387305Z [  PASSED  ] 5 tests.
2026-09-15T10:21:07.7387307Z 
2026-09-15T10:21:07.7387374Z SM8750: //litert/vendors/qualcomm/core/backends:htp_backend_test
2026-09-15T10:21:07.7387429Z [==========] 27 tests from 7 test suites ran. (3912 ms total)
2026-09-15T10:21:07.7387463Z [  PASSED  ] 27 tests.
2026-09-15T10:21:07.7387465Z 
2026-09-15T10:21:07.7387536Z SM8750: //litert/vendors/qualcomm/core/backends:ir_backend_test
2026-09-15T10:21:07.7387585Z [==========] 3 tests from 2 test suites ran. (9 ms total)
2026-09-15T10:21:07.7387623Z [  PASSED  ] 3 tests.
2026-09-15T10:21:07.7387625Z 
2026-09-15T10:21:07.7387696Z SM8750: //litert/vendors/qualcomm/core/backends:lpai_backend_test
2026-09-15T10:21:07.7387742Z [==========] 6 tests from 1 test suite ran. (0 ms total)
2026-09-15T10:21:07.7387779Z [  PASSED  ] 6 tests.
2026-09-15T10:21:07.7387781Z 
2026-09-15T10:21:07.7387845Z SM8750: //litert/vendors/qualcomm/core/dump:dump_graph_test
2026-09-15T10:21:07.7387892Z [==========] 5 tests from 1 test suite ran. (2 ms total)
2026-09-15T10:21:07.7387932Z [  PASSED  ] 5 tests.
2026-09-15T10:21:07.7387933Z 
2026-09-15T10:21:07.7387995Z SM8750: //litert/vendors/qualcomm/core/schema:soc_table_test
2026-09-15T10:21:07.7388044Z [==========] 2 tests from 1 test suite ran. (0 ms total)
2026-09-15T10:21:07.7388080Z [  PASSED  ] 2 tests.
2026-09-15T10:21:07.7388081Z 
2026-09-15T10:21:07.7388170Z SM8750: //litert/vendors/qualcomm/core/transformation:embedding_gemma_test
2026-09-15T10:21:07.7388219Z [==========] 1 test from 1 test suite ran. (1 ms total)
2026-09-15T10:21:07.7388269Z [  PASSED  ] 1 test.
2026-09-15T10:21:07.7388271Z 
2026-09-15T10:21:07.7388357Z SM8750: //litert/vendors/qualcomm/core/transformation:graph_to_graph_test
2026-09-15T10:21:07.7388408Z [==========] 17 tests from 6 test suites ran. (19 ms total)
2026-09-15T10:21:07.7388445Z [  PASSED  ] 17 tests.
2026-09-15T10:21:07.7388447Z 
2026-09-15T10:21:07.7388546Z SM8750: //litert/vendors/qualcomm/core/transformation:kv_swapped_attn_test
2026-09-15T10:21:07.7388608Z [==========] 1 test from 1 test suite ran. (2 ms total)
2026-09-15T10:21:07.7388644Z [  PASSED  ] 1 test.
2026-09-15T10:21:07.7388646Z 
2026-09-15T10:21:07.7388720Z SM8750: //litert/vendors/qualcomm/core/utils:flexbuffer_helpers_test
2026-09-15T10:21:07.7388770Z [==========] 21 tests from 3 test suites ran. (0 ms total)
2026-09-15T10:21:07.7388809Z [  PASSED  ] 21 tests.
2026-09-15T10:21:07.7388810Z 
2026-09-15T10:21:07.7388865Z SM8750: //litert/vendors/qualcomm/core/utils:utils_test
2026-09-15T10:21:07.7388932Z [==========] 16 tests from 3 test suites ran. (5 ms total)
2026-09-15T10:21:07.7388970Z [  PASSED  ] 16 tests.
2026-09-15T10:21:07.7388971Z 
2026-09-15T10:21:07.7389053Z SM8750: //litert/vendors/qualcomm/core/wrappers/tests:op_wrapper_test
2026-09-15T10:21:07.7389105Z [==========] 24 tests from 2 test suites ran. (0 ms total)
2026-09-15T10:21:07.7389139Z [  PASSED  ] 24 tests.
2026-09-15T10:21:07.7389144Z 
2026-09-15T10:21:07.7389229Z SM8750: //litert/vendors/qualcomm/core/wrappers/tests:param_wrapper_test
2026-09-15T10:21:07.7389284Z [==========] 31 tests from 17 test suites ran. (0 ms total)
2026-09-15T10:21:07.7389322Z [  PASSED  ] 31 tests.
2026-09-15T10:21:07.7389324Z 
2026-09-15T10:21:07.7389424Z SM8750: //litert/vendors/qualcomm/core/wrappers/tests:quantize_params_wrapper_test
2026-09-15T10:21:07.7389471Z [==========] 67 tests from 9 test suites ran. (1 ms total)
2026-09-15T10:21:07.7389507Z [  PASSED  ] 67 tests.
2026-09-15T10:21:07.7389508Z 
2026-09-15T10:21:07.7389592Z SM8750: //litert/vendors/qualcomm/core/wrappers/tests:tensor_wrapper_test
2026-09-15T10:21:07.7389642Z [==========] 39 tests from 3 test suites ran. (1 ms total)
2026-09-15T10:21:07.7389678Z [  PASSED  ] 39 tests.
2026-09-15T10:21:07.7389680Z 
2026-09-15T10:21:07.7389763Z SM8750: //litert/vendors/qualcomm/dispatch:_dispatch_api_qualcomm_test
2026-09-15T10:21:07.7389809Z [==========] 5 tests from 1 test suite ran. (391 ms total)
2026-09-15T10:21:07.7389846Z [  PASSED  ] 5 tests.
2026-09-15T10:21:07.7389849Z 
2026-09-15T10:21:07.7389921Z SM8750: //litert/vendors/qualcomm/qnn_backend_test:qnn_model_test
2026-09-15T10:21:07.7389973Z [==========] 1 test from 1 test suite ran. (236 ms total)
2026-09-15T10:21:07.7390007Z [  PASSED  ] 1 test.
2026-09-15T10:21:07.7390012Z 
2026-09-15T10:21:07.7390111Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:depthwise_conv2d_test
2026-09-15T10:21:07.7390160Z [==========] 2 tests from 1 test suite ran. (550 ms total)
2026-09-15T10:21:07.7390197Z [  PASSED  ] 2 tests.
2026-09-15T10:21:07.7390200Z 
2026-09-15T10:21:07.7390293Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:elementwise_test
2026-09-15T10:21:07.7390345Z [==========] 5 tests from 1 test suite ran. (1260 ms total)
2026-09-15T10:21:07.7390378Z [  PASSED  ] 5 tests.
2026-09-15T10:21:07.7390380Z 
2026-09-15T10:21:07.7390477Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:embedding_lookup_test
2026-09-15T10:21:07.7390528Z [==========] 2 tests from 1 test suite ran. (553 ms total)
2026-09-15T10:21:07.7390564Z [  PASSED  ] 2 tests.
2026-09-15T10:21:07.7390565Z 
2026-09-15T10:21:07.7390668Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_int2_test
2026-09-15T10:21:07.7390718Z [==========] 5 tests from 1 test suite ran. (1235 ms total)
2026-09-15T10:21:07.7390755Z [  PASSED  ] 5 tests.
2026-09-15T10:21:07.7390757Z 
2026-09-15T10:21:07.7390854Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:fully_connected_test
2026-09-15T10:21:07.7390915Z [==========] 3 tests from 1 test suite ran. (696 ms total)
2026-09-15T10:21:07.7390953Z [  PASSED  ] 2 tests.
2026-09-15T10:21:07.7390955Z 
2026-09-15T10:21:07.7391051Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:hadamard_transform_test
2026-09-15T10:21:07.7391100Z [==========] 1 test from 1 test suite ran. (294 ms total)
2026-09-15T10:21:07.7391135Z [  PASSED  ] 1 test.
2026-09-15T10:21:07.7391137Z 
2026-09-15T10:21:07.7391234Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:onehot_test
2026-09-15T10:21:07.7391295Z [==========] 1 test from 1 test suite ran. (304 ms total)
2026-09-15T10:21:07.7391328Z [  PASSED  ] 1 test.
2026-09-15T10:21:07.7391330Z 
2026-09-15T10:21:07.7391410Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pack_test
2026-09-15T10:21:07.7391456Z [==========] 3 tests from 1 test suite ran. (640 ms total)
2026-09-15T10:21:07.7391491Z [  PASSED  ] 3 tests.
2026-09-15T10:21:07.7391492Z 
2026-09-15T10:21:07.7391571Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:pad_test
2026-09-15T10:21:07.7391634Z [==========] 7 tests from 2 test suites ran. (910 ms total)
2026-09-15T10:21:07.7391668Z [  PASSED  ] 7 tests.
2026-09-15T10:21:07.7391670Z 
2026-09-15T10:21:07.7391747Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:relu_test
2026-09-15T10:21:07.7391794Z [==========] 1 test from 1 test suite ran. (127 ms total)
2026-09-15T10:21:07.7391845Z [  PASSED  ] 0 tests.
2026-09-15T10:21:07.7391847Z 
2026-09-15T10:21:07.7391949Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_nd_test
2026-09-15T10:21:07.7391996Z [==========] 2 tests from 1 test suite ran. (566 ms total)
2026-09-15T10:21:07.7392031Z [  PASSED  ] 2 tests.
2026-09-15T10:21:07.7392033Z 
2026-09-15T10:21:07.7392131Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:spatial_transform_test
2026-09-15T10:21:07.7392177Z [==========] 2 tests from 1 test suite ran. (556 ms total)
2026-09-15T10:21:07.7392209Z [  PASSED  ] 2 tests.
2026-09-15T10:21:07.7392211Z 
2026-09-15T10:21:07.7392299Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:splitv_test
2026-09-15T10:21:07.7392347Z [==========] 5 tests from 1 test suite ran. (1219 ms total)
2026-09-15T10:21:07.7392384Z [  PASSED  ] 5 tests.
2026-09-15T10:21:07.7392386Z 
2026-09-15T10:21:07.7392472Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:squeeze_test
2026-09-15T10:21:07.7392518Z [==========] 4 tests from 1 test suite ran. (1129 ms total)
2026-09-15T10:21:07.7392556Z [  PASSED  ] 4 tests.
2026-09-15T10:21:07.7392557Z 
2026-09-15T10:21:07.7392638Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:topk_test
2026-09-15T10:21:07.7392685Z [==========] 1 test from 1 test suite ran. (314 ms total)
2026-09-15T10:21:07.7392721Z [  PASSED  ] 1 test.
2026-09-15T10:21:07.7392723Z 
2026-09-15T10:21:07.7392813Z SM8750: //litert/vendors/qualcomm/qnn_backend_test/builder_test:transpose_conv_test
2026-09-15T10:21:07.7392859Z [==========] 5 tests from 1 test suite ran. (866 ms total)
2026-09-15T10:21:07.7392896Z [  PASSED  ] 5 tests.
```