### PR TITLE
[MLDrift] Fix GATHER with 1-D constant indices

### DIFF
--- a/ml_drift_delegate/tflite/convert/convert_aux.cc
+++ b/ml_drift_delegate/tflite/convert/convert_aux.cc
@@ -62,8 +62,11 @@ template <typename TensorType>
   const TfLiteTensor* tfl_tensor = context.tensors + tensor_id;
   PopulateTensor<TensorType>(tfl_tensor, tensor_id, &t,
                              PopulateTensorFlags::kNoExtraBytes);
-  const ::ml_drift::BHWC shape =
-      GetShape(t.shape, layout, tfl_tensor->dims->size);
+  // Apply the layout to the tensor itself, not just to the IrTensor: the
+  // constant is uploaded from `attr` and its shape is checked against the
+  // IrTensor's, so the two have to agree.
+  t.shape = GetShape(t.shape, layout, tfl_tensor->dims->size);
+  const ::ml_drift::BHWC& shape = t.shape;
   ::ml_drift::ir::IrTensor* tensor = ir_model.add_tensor(
       t.kType, ::ml_drift::BHWDC(shape.b, shape.h, shape.w, 1, shape.c));
   attr.tensor = std::move(t);

--- a/ml_drift_delegate/tflite/convert/convert_aux_test.cc
+++ b/ml_drift_delegate/tflite/convert/convert_aux_test.cc
@@ -362,6 +362,43 @@ TEST(ConvertAuxTest, AddConstInputInt32) {
   TfLiteIntArrayFree(tfl_tensor.dims);
 }
 
+TEST(ConvertAuxTest, AddConstInputInt32ScalarLayout) {
+  TfLiteTensor tfl_tensor;
+  tfl_tensor.type = kTfLiteInt32;
+  tfl_tensor.dims = TfLiteIntArrayCreate(1);
+  tfl_tensor.dims->data[0] = 2;
+  std::vector<int32_t> tensor_data = {10, 20};
+  tfl_tensor.data.i32 = tensor_data.data();
+  tfl_tensor.bytes = tensor_data.size() * sizeof(int32_t);
+  tfl_tensor.allocation_type = kTfLiteMmapRo;
+
+  TfLiteContext context;
+  context.tensors = &tfl_tensor;
+
+  ::ml_drift::ir::IrModel model;
+  SizedLayout layout;
+  layout.layout_1d = ::ml_drift::Layout::SCALAR;
+  ::ml_drift::ir::IrTensor* tensor = AddConstInput(context, 0, model, layout);
+
+  // SCALAR moves the 1-D extent off the batch axis and onto channels.
+  ASSERT_NE(tensor, nullptr);
+  EXPECT_EQ(tensor->desc.GetBHWCShape(), ::ml_drift::BHWC(1, 1, 1, 2));
+
+  const ::ml_drift::ir::IrOp* op = model.op(0);
+  const ::ml_drift::ConstTensorAttributes* attr =
+      std::any_cast<::ml_drift::ConstTensorAttributes>(&op->attr);
+  ASSERT_TRUE(attr);
+  const auto* t = std::get_if<::ml_drift::TensorInt32>(&attr->tensor);
+  ASSERT_TRUE(t);
+  // The payload has to carry the same shape as the IrTensor: the constant is
+  // uploaded from it, and ReserveGraphTensors() rejects the model when the two
+  // disagree.
+  EXPECT_EQ(t->shape, ::ml_drift::BHWC(1, 1, 1, 2));
+  EXPECT_THAT(t->data, testing::ElementsAre(10, 20));
+
+  TfLiteIntArrayFree(tfl_tensor.dims);
+}
+
 TEST(ConvertAuxTest, AddConstInputBool) {
   TfLiteTensor tfl_tensor;
   tfl_tensor.type = kTfLiteBool;

--- a/ml_drift_delegate/tflite/convert/convert_gather.cc
+++ b/ml_drift_delegate/tflite/convert/convert_gather.cc
@@ -50,8 +50,16 @@ void ConvertGather(
 
   ::ml_drift::ir::IrTensorId final_indices_id = tensor_map[indices_id];
   if (indices_are_const) {
+    // The gather kernel reads the indices along the channels axis, but a 1-D
+    // tensor [N] is auto-expanded to {N,1,1,1}, which puts N on the batch
+    // axis. Ask for {1,1,1,N} instead -- the constant equivalent of the
+    // RESHAPE inserted for runtime indices below.
+    SizedLayout indices_layout;
+    if (indices_are_1d) {
+      indices_layout.layout_1d = ::ml_drift::Layout::SCALAR;
+    }
     ::ml_drift::ir::IrTensor* const_tensor =
-        AddConstInput(context, indices_id, ir_model, {});
+        AddConstInput(context, indices_id, ir_model, indices_layout);
     final_indices_id = const_tensor->id;
   } else if (indices_are_1d) {
     ::ml_drift::ir::IrOp* reshape_op = ir_model.add_op();

--- a/ml_drift_delegate/tflite/convert/convert_gather_test.cc
+++ b/ml_drift_delegate/tflite/convert/convert_gather_test.cc
@@ -167,6 +167,15 @@ TEST_P(ConvertGatherTest, Indices1D_WithReshapeOp) {
   const auto* attr = std::any_cast<::ml_drift::GatherAttributes>(&op->attr);
   ASSERT_TRUE(attr);
   EXPECT_EQ(attr->axis, ::ml_drift::Axis::WIDTH);
+
+  // The gather kernel reads its indices along the channels axis, so a 1-D [N]
+  // index tensor has to reach it as {1,1,1,N} however it was produced -- via
+  // the RESHAPE for runtime indices, or via the requested layout for constant
+  // ones. Auto-expansion would put N on the batch axis and the kernel would
+  // fail to build.
+  const ::ml_drift::ir::IrTensor* indices = ir_model->tensor(op->inputs[1]);
+  ASSERT_TRUE(indices);
+  EXPECT_EQ(indices->desc.GetBHWCShape(), ::ml_drift::BHWC(1, 1, 1, 2));
 }
 
 INSTANTIATE_TEST_SUITE_P(ConvertGatherTest, ConvertGatherTest,

--- a/ml_drift_delegate/tflite/model_builder.cc
+++ b/ml_drift_delegate/tflite/model_builder.cc
@@ -3545,7 +3545,15 @@ class GatherOperationParser : public TFLiteOperationParser {
       reader->AddInput(gather_node, 0);
     }
     if (indices_are_const) {
-      indices_value = reader->AddConstInput(1, /*layout=*/{});
+      // The gather kernel reads the indices along the channels axis, but a 1-D
+      // tensor [N] is auto-expanded to {N,1,1,1}, which puts N on the batch
+      // axis. Ask for {1,1,1,N} instead -- the constant equivalent of the
+      // RESHAPE inserted for runtime indices above.
+      SizedLayout indices_layout;
+      if (indices_are_1d) {
+        indices_layout.layout_1d = ::ml_drift::Layout::SCALAR;
+      }
+      indices_value = reader->AddConstInput(1, indices_layout);
       graph->AddConsumer(gather_node->id, indices_value->id);
     } else if (indices_are_1d) {
       graph->AddConsumer(gather_node->id, indices_value->id);

--- a/ml_drift_delegate/tflite/object_reader.cc
+++ b/ml_drift_delegate/tflite/object_reader.cc
@@ -59,8 +59,12 @@ void SetValueAndAttrFromTfLiteTensor(const TfLiteTensor* tfl_tensor,
                                      ::ml_drift::ConstTensorAttributes& attr) {
   TensorType t;
   TfLiteTensorToTensorCopyData(tfl_tensor, &t, ReadTensorFlags::kNoExtraBytes);
+  // Apply the layout to the tensor itself, not just to the value: the constant
+  // is uploaded from `attr` and its shape is checked against the value's, so
+  // the two have to agree.
+  t.shape = GetShape(t.shape, layout, tfl_tensor->dims->size);
   value->tensor.type = t.kType;
-  value->tensor.shape = GetShape(t.shape, layout, tfl_tensor->dims->size);
+  value->tensor.shape = t.shape;
   attr.tensor = std::move(t);
 }
 


### PR DESCRIPTION
The gather kernel reads its indices along the channels axis, but a 1-D indices tensor [N] is auto-expanded to {N,1,1,1}, putting N on the batch axis, where the kernel cannot see it. ConvertGather() already reshapes 1-D *runtime* indices to {1,1,1,N} for exactly this reason; constant indices took the AddConstInput() branch with an empty layout and got no equivalent, so the kernel addressed a channels extent of 1 and failed to build.

Request Layout::SCALAR for 1-D constant indices -- the constant equivalent of the RESHAPE the runtime branch inserts. Depends on the preceding change, which makes the requested layout reach the uploaded data as well as the IrTensor.

 Also apply the requested constant layout to the tensor data. AddConstInput() takes a SizedLayout and applies it when sizing the IrTensor, but moves the populated tensor into ConstTensorAttributes still carrying the shape derived from the TFLite dims. The two then disagree and ReserveGraphTensors() rejects the model before uploading anything.

TensorDescriptor::UploadData() assigns shape_ from the source tensor and lays the data out against it, so a payload that kept the pre-layout shape would silently discard the requested layout even if the cross-check did not exist.

Writing the laid-out shape back into the tensor is what makes the `layout` parameter mean anything for the data as well as for the graph.