### PR TITLE
Gate extended per-channel quant4/int32 Neuron tensor types by SDK ver…

### DIFF
--- a/litert/vendors/mediatek/compiler/compiler_plugin.cc
+++ b/litert/vendors/mediatek/compiler/compiler_plugin.cc
@@ -442,12 +442,13 @@ CreateNeuronAdapterApi(const char* soc_model,
 }
 
 // TODO update this function to match the new legalizations.
-bool IsOpSupported(const litert::compiler::Op& op) {
+bool IsOpSupported(const litert::compiler::Op& op,
+                   const NeuronAdapterApi& neuron_adapter_api) {
   // NOTE: Currently we are demoing by just mapping simple f32 mul ops.  Use a
   // very loose guard for now -- only checking if op code is supported.
   for (auto supported_op : kSupportedOps) {
     if (op.Code() == supported_op &&
-        litert::mediatek::VerifyCommonOp(op, op.Code())) {
+        litert::mediatek::VerifyCommonOp(op, op.Code(), neuron_adapter_api)) {
       return true;
     }
   }
@@ -497,7 +498,7 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
       !neuron_adapter_api->IsFeatureEnabled(
           litert::mediatek::NeuronFeatureType::NEURON_FEATURE_UNKNOWN_OP)) {
     for (const auto& op : ops) {
-      if (!IsOpSupported(op)) {
+      if (!IsOpSupported(op, *neuron_adapter_api)) {
         continue;
       }
       LITERT_RETURN_IF_ERROR(op.ctx()->push_op(selected_ops, op.Get(), 0));
@@ -511,7 +512,7 @@ LiteRtStatus LiteRtCompilerPluginPartition(LiteRtCompilerPlugin compiler_plugin,
   std::unordered_set<int> unknown_op_indices;
   for (int op_idx = 0; op_idx < num_ops; ++op_idx) {
     const auto& op = ops[op_idx];
-    if (!IsOpSupported(op)) {
+    if (!IsOpSupported(op, *neuron_adapter_api)) {
       LITERT_LOG(LITERT_ERROR, "Unlegalized op: %d", op.Code());
       unknown_op_indices.insert(op_idx);
     }

--- a/litert/vendors/mediatek/compiler/legalizations/common_op_legalization.cc
+++ b/litert/vendors/mediatek/compiler/legalizations/common_op_legalization.cc
@@ -29,11 +29,12 @@
 
 namespace litert::mediatek {
 
-bool VerifyCommonOp(const litert::compiler::Op& op, LiteRtOpCode op_code) {
+bool VerifyCommonOp(const litert::compiler::Op& op, LiteRtOpCode op_code,
+                    const NeuronAdapterApi& neuron_adapter_api) {
   // Do some common check
   auto check_tensor_types = [&](const auto& tensors) {
     for (const auto& tensor : tensors) {
-      auto mtk_type = GetNeuronTensorType(tensor);
+      auto mtk_type = GetNeuronTensorType(tensor, neuron_adapter_api);
       if (!mtk_type) {
         LITERT_LOG(LITERT_ERROR, "%s", mtk_type.Error().Message().c_str());
         return false;

--- a/litert/vendors/mediatek/compiler/legalizations/common_op_legalization.h
+++ b/litert/vendors/mediatek/compiler/legalizations/common_op_legalization.h
@@ -23,7 +23,8 @@
 
 namespace litert::mediatek {
 
-bool VerifyCommonOp(const litert::compiler::Op& op, LiteRtOpCode op_code);
+bool VerifyCommonOp(const litert::compiler::Op& op, LiteRtOpCode op_code,
+                    const NeuronAdapterApi& neuron_adapter_api);
 
 template <typename T>
 inline Expected<NeuronOperationType> ResolveOpType(

--- a/litert/vendors/mediatek/compiler/legalizations/fully_connected_op_legalization.cc
+++ b/litert/vendors/mediatek/compiler/legalizations/fully_connected_op_legalization.cc
@@ -83,7 +83,8 @@ Expected<void> LegalizeFullyConnectedOp(
   }
   input_indices.push_back(*fused_activation_operand_index);
 
-  auto output_operand = OperandType::Create(op.Outputs()[0]);
+  auto output_operand =
+      OperandType::Create(op.Outputs()[0], neuron_adapter_api);
   std::vector<uint32_t> output_indices;
 
   if (!neuron_adapter_api.IsFeatureEnabled(

--- a/litert/vendors/mediatek/compiler/legalizations/neuron_utils.cc
+++ b/litert/vendors/mediatek/compiler/legalizations/neuron_utils.cc
@@ -51,11 +51,16 @@ bool PerTensorZeroPointIsZero(const litert::compiler::Tensor& t) {
 }  // namespace
 
 Expected<NeuronTensorType> GetNeuronTensorType(
-    const litert::compiler::Tensor& t, int32_t tensor_flags) {
+    const litert::compiler::Tensor& t, const NeuronAdapterApi& neuron_adapter_api,
+    int32_t tensor_flags) {
   auto element_type = t.ElementType();
 
   const bool use_int8_asymm_signed =
       tensor_flags & NN_TENSOR_FLAG_USE_INT8_ASYMM_SIGNED;
+  // Extended per-channel quant4/int32 types require Neuron SDK major >= 8.
+  const bool ext_quant4_int32_per_channel_supported =
+      neuron_adapter_api.IsFeatureEnabled(
+          NeuronFeatureType::NEURON_FEATURE_EXT_QUANT4_INT32_PER_CHANNEL);
 
   int32_t mtk_type = -1;
   switch (element_type) {
@@ -67,12 +72,9 @@ Expected<NeuronTensorType> GetNeuronTensorType(
       break;
     case ElementType::Int32:
       if (t.QTypeId() == kLiteRtQuantizationPerChannel) {
-        if (!PerChannelZeroPointsAreAllZero(t)) {
-          return Error(kLiteRtStatusErrorRuntimeFailure,
-                       "Int32 per-channel quantization only supports "
-                       "symmetric zero points.");
-        }
-        mtk_type = NEURON_EXT_TENSOR_INT32_SYMM_PER_CHANNEL;
+        mtk_type = ext_quant4_int32_per_channel_supported
+                       ? NEURON_EXT_TENSOR_INT32_SYMM_PER_CHANNEL
+                       : NEURON_TENSOR_INT32;
       } else {
         mtk_type = NEURON_TENSOR_INT32;
       }
@@ -124,9 +126,15 @@ Expected<NeuronTensorType> GetNeuronTensorType(
                        ? NEURON_EXT_TENSOR_QUANT4_SYMM
                        : NEURON_EXT_TENSOR_QUANT4_ASYMM_SIGNED;
       } else if (t.QTypeId() == kLiteRtQuantizationPerChannel) {
-        mtk_type = PerChannelZeroPointsAreAllZero(t)
-                       ? NEURON_EXT_TENSOR_QUANT4_SYMM_PER_CHANNEL
-                       : NEURON_TENSOR_QUANT4_ASYMM_SIGNED_PER_CHANNEL;
+        if (ext_quant4_int32_per_channel_supported) {
+          mtk_type = PerChannelZeroPointsAreAllZero(t)
+                         ? NEURON_EXT_TENSOR_QUANT4_SYMM_PER_CHANNEL
+                         : NEURON_TENSOR_QUANT4_ASYMM_SIGNED_PER_CHANNEL;
+        } else {
+          mtk_type = PerChannelZeroPointsAreAllZero(t)
+                         ? NEURON_EXT_TENSOR_QUANT4_SYMM
+                         : NEURON_EXT_TENSOR_QUANT4_ASYMM_SIGNED;
+        }
       } else {
         return Error(kLiteRtStatusErrorRuntimeFailure,
                      "Int4 is not supported.");
@@ -141,7 +149,9 @@ Expected<NeuronTensorType> GetNeuronTensorType(
             t.QTypeId() == kLiteRtQuantizationNone) {
           mtk_type = NEURON_TENSOR_INT32;
         } else if (t.QTypeId() == kLiteRtQuantizationPerChannel) {
-          mtk_type = NEURON_EXT_TENSOR_INT32_SYMM_PER_CHANNEL;
+          mtk_type = ext_quant4_int32_per_channel_supported
+                         ? NEURON_EXT_TENSOR_INT32_SYMM_PER_CHANNEL
+                         : NEURON_TENSOR_INT32;
         } else {
           return Error(kLiteRtStatusErrorRuntimeFailure,
                        "Int64 is not supported.");
@@ -237,6 +247,21 @@ Expected<bool> IsQuantizedType(NeuronTensorType type) {
       return true;
   }
   return false;
+}
+
+bool IsPerChannelQuantizedType(NeuronTensorType type) {
+  switch (type) {
+    case NEURON_TENSOR_QUANT8_SYMM_PER_CHANNEL:
+    case NEURON_EXT_TENSOR_QUANT8_ASYMM_PER_CHANNEL:
+    case NEURON_EXT_TENSOR_QUANT8_ASYMM_SIGNED_PER_CHANNEL:
+    case NEURON_EXT_TENSOR_QUANT4_SYMM_PER_CHANNEL:
+    case NEURON_EXT_TENSOR_QUANT4_ASYMM_PER_CHANNEL:
+    case NEURON_TENSOR_QUANT4_ASYMM_SIGNED_PER_CHANNEL:
+    case NEURON_EXT_TENSOR_INT32_SYMM_PER_CHANNEL:
+      return true;
+    default:
+      return false;
+  }
 }
 
 NeuronReturnCode ModelAddOperation(const NeuronAdapterApi& api,

--- a/litert/vendors/mediatek/compiler/legalizations/neuron_utils.h
+++ b/litert/vendors/mediatek/compiler/legalizations/neuron_utils.h
@@ -44,11 +44,16 @@ struct OemOperandValue {
 };
 
 Expected<NeuronTensorType> GetNeuronTensorType(
-    const litert::compiler::Tensor& t, int32_t tensor_flags = 0);
+    const litert::compiler::Tensor& t, const NeuronAdapterApi& neuron_adapter_api,
+    int32_t tensor_flags = 0);
 
 Expected<uint32_t> GetNeuronDataSize(NeuronTensorType type);
 
 Expected<bool> IsQuantizedType(NeuronTensorType type);
+
+// Returns true if `type` is one of the Neuron per-channel-quantized tensor
+// types.
+bool IsPerChannelQuantizedType(NeuronTensorType type);
 
 NeuronReturnCode ModelAddOperation(const NeuronAdapterApi& api,
                                    NeuronModel* model, NeuronOperationType type,

--- a/litert/vendors/mediatek/compiler/legalizations/operand_map.cc
+++ b/litert/vendors/mediatek/compiler/legalizations/operand_map.cc
@@ -134,7 +134,7 @@ Expected<uint32_t> OperandMap::Register(const NeuronOperandType& operand_type) {
 
 Expected<uint32_t> OperandMap::Register(const litert::compiler::Tensor& t,
                                         int32_t tensor_flags) {
-  auto operand_type = OperandType::Create(t, tensor_flags);
+  auto operand_type = OperandType::Create(t, neuron_adapter_api_, tensor_flags);
   if (!operand_type) {
     return operand_type.Error();
   }
@@ -149,7 +149,11 @@ Expected<uint32_t> OperandMap::Register(const litert::compiler::Tensor& t,
 
   if (t.HasWeights()) {
     auto weights = t.Weights().Bytes();
-    if (t.QTypeId() == kLiteRtQuantizationPerChannel) {
+    // The resolved Neuron type may have fallen back to a non-per-channel
+    // type (e.g. on older Neuron SDK versions), in which case per-channel
+    // quant params must not be set.
+    if (t.QTypeId() == kLiteRtQuantizationPerChannel &&
+        IsPerChannelQuantizedType(operand_type->GetNeuronType())) {
       LITERT_RETURN_IF_ERROR(SetPerChannelQuantParams(
           neuron_adapter_api_, model_, *operand_index,
           operand_type->GetNeuronType(), t.PerChannelQuantization()));

--- a/litert/vendors/mediatek/compiler/legalizations/operand_map.h
+++ b/litert/vendors/mediatek/compiler/legalizations/operand_map.h
@@ -42,6 +42,7 @@ namespace litert::mediatek {
 class OperandType : public NeuronOperandType {
  public:
   static Expected<OperandType> Create(const litert::compiler::Tensor& t,
+                                      const NeuronAdapterApi& neuron_adapter_api,
                                       int32_t tensor_flags = 0) {
     auto ranked_tensor_type = t.RankedTensorType();
     if (!ranked_tensor_type) {
@@ -67,7 +68,7 @@ class OperandType : public NeuronOperandType {
                    "Doesn't support BlockWise quantize now");
     }
 
-    auto mtk_type = GetNeuronTensorType(t, tensor_flags);
+    auto mtk_type = GetNeuronTensorType(t, neuron_adapter_api, tensor_flags);
     bool has_unsupported_element_type = false;
     if (!mtk_type) {
       // Fallback path for unrepresentable element types: only used for

--- a/litert/vendors/mediatek/neuron_adapter_api.h
+++ b/litert/vendors/mediatek/neuron_adapter_api.h
@@ -78,11 +78,16 @@ enum {
 
 typedef enum {
   NEURON_FEATURE_UNKNOWN_OP,
+  // Gates NEURON_EXT_TENSOR_QUANT4_SYMM_PER_CHANNEL (9011),
+  // NEURON_TENSOR_QUANT4_ASYMM_SIGNED_PER_CHANNEL (9013), and
+  // NEURON_EXT_TENSOR_INT32_SYMM_PER_CHANNEL (9014).
+  NEURON_FEATURE_EXT_QUANT4_INT32_PER_CHANNEL,
   NEURON_FEATURE_COUNT,
 } NeuronFeatureType;
 
 const NeuronRuntimeVersion kNeuronFeatureMinVersion[NEURON_FEATURE_COUNT] = {
     {8, 2, 24},  // NEURON_FEATURE_UNKNOWN_OP
+    {8, 2, 28},   // NEURON_FEATURE_EXT_QUANT4_INT32_PER_CHANNEL
 };
 
 using NeuronModelPtr = std::unique_ptr<NeuronModel, void (*)(NeuronModel*)>;


### PR DESCRIPTION
…sion

Gates the extended per-channel quant4/int32 Neuron tensor type support behind an SDK version check, and bumps the required SDK version for this feature to 8.2.28.