### PR TITLE
[MLDrift] Bound the input rank in the CUMSUM support check and make ExtractAxisFromIndex() reject out-of-range axes

### DIFF
--- a/ml_drift_delegate/tflite/convert/convert_aux.cc
+++ b/ml_drift_delegate/tflite/convert/convert_aux.cc
@@ -454,10 +454,13 @@ void PopulateBlockwiseQuantizedFullyConnected(
                      ::ml_drift::Axis::WIDTH, ::ml_drift::Axis::DEPTH,
                      ::ml_drift::Axis::CHANNELS};
   }
-  // The table above tops out at the 5 BHWDC axes, so a tensor of rank 6 or
-  // more can produce an `index` past its end. Return UNKNOWN instead of
-  // indexing out of bounds so that the failure surfaces downstream during
-  // kernel selection rather than as a memory error.
+  // `index_to_axis` has one entry per axis of this tensor, capped at the 5
+  // BHWDC axes, so an out-of-range axis indexes past its end. Callers are
+  // expected to reject those in their Is*Supported() check, but that is
+  // enforced per-op and these checks might be missing in some places,
+  // so this is a form of defense-in-depth. Return UNKNOWN instead of
+  // reading out of bounds so that the failure surfaces during kernel
+  // selection rather than as a memory error.
   if (index < 0 || index >= static_cast<int>(index_to_axis.size())) {
     return ::ml_drift::Axis::UNKNOWN;
   }

--- a/ml_drift_delegate/tflite/convert/convert_aux.cc
+++ b/ml_drift_delegate/tflite/convert/convert_aux.cc
@@ -454,6 +454,13 @@ void PopulateBlockwiseQuantizedFullyConnected(
                      ::ml_drift::Axis::WIDTH, ::ml_drift::Axis::DEPTH,
                      ::ml_drift::Axis::CHANNELS};
   }
+  // The table above tops out at the 5 BHWDC axes, so a tensor of rank 6 or
+  // more can produce an `index` past its end. Return UNKNOWN instead of
+  // indexing out of bounds so that the failure surfaces downstream during
+  // kernel selection rather than as a memory error.
+  if (index < 0 || index >= static_cast<int>(index_to_axis.size())) {
+    return ::ml_drift::Axis::UNKNOWN;
+  }
   return index_to_axis[index];
 }
 

--- a/ml_drift_delegate/tflite/support/support_cumsum.cc
+++ b/ml_drift_delegate/tflite/support/support_cumsum.cc
@@ -25,6 +25,8 @@
 
 namespace litert::ml_drift::ir {
 
+constexpr int kMaxDims = 5;
+
 bool IsCumsumSupported(const TfLiteContext* absl_nonnull context,
                        const TfLiteNode* absl_nonnull node,
                        const TfLiteRegistration* absl_nonnull registration,
@@ -86,6 +88,11 @@ bool IsCumsumSupported(const TfLiteContext* absl_nonnull context,
     return false;
   }
   if (!CheckIsConstant(axis, "inputs[1]", *error)) {
+    return false;
+  }
+  // Check input shape.
+  if (!CheckTensorDims(input, /*min_dims=*/1, /*max_dims=*/kMaxDims,
+                       "inputs[0]", *error)) {
     return false;
   }
   // Check axis value.

--- a/ml_drift_delegate/tflite/support/support_cumsum_test.cc
+++ b/ml_drift_delegate/tflite/support/support_cumsum_test.cc
@@ -346,5 +346,73 @@ TEST_F(CumsumDimsTest, RejectsTooLargeAxis) {
   EXPECT_THAT(GetSupportedNodes(context, kDefaultOptions), IsEmpty());
 }
 
+// A rank-5 input maps onto the full BHWDC layout, so it stays supported. Axis 3
+// maps to DEPTH, which only exists at rank 5.
+TEST_F(CumsumDimsTest, Supports5dInput) {
+  constexpr std::array<int, 1> kAxisData = {3};
+  StubContextBuilder context_builder;
+  const int input = context_builder.AddTensor(kDefaultDtype, {2, 3, 4, 5, 6});
+  const int axis =
+      context_builder.AddConst1dTensor<int>(kTfLiteInt32, kAxisData);
+  const int output = context_builder.AddTensor(kDefaultDtype, {2, 3, 4, 5, 6});
+  context_builder.SetOp(kTfLiteBuiltinCumsum, /*version=*/1,
+                        /*params=*/nullptr,
+                        /*inputs=*/{input, axis},
+                        /*outputs=*/{output});
+  TfLiteContext* context = context_builder.Build();
+  ASSERT_THAT(context, NotNull());
+  EXPECT_THAT(GetSupportedNodes(context, kDefaultOptions), ElementsAre(0));
+}
+
+// The negative-axis boundary shifts with the rank: -6 is the first value that
+// no longer resolves into range on a rank-5 input.
+TEST_F(CumsumDimsTest, Rejects5dInputTooSmallNegAxis) {
+  constexpr std::array<int, 1> kAxisData = {-6};
+  StubContextBuilder context_builder;
+  const int input = context_builder.AddTensor(kDefaultDtype, {2, 3, 4, 5, 6});
+  const int axis =
+      context_builder.AddConst1dTensor<int>(kTfLiteInt32, kAxisData);
+  const int output = context_builder.AddTensor(kDefaultDtype, {2, 3, 4, 5, 6});
+  context_builder.SetOp(kTfLiteBuiltinCumsum, /*version=*/1,
+                        /*params=*/nullptr,
+                        /*inputs=*/{input, axis},
+                        /*outputs=*/{output});
+  TfLiteContext* context = context_builder.Build();
+  ASSERT_THAT(context, NotNull());
+  EXPECT_THAT(GetSupportedNodes(context, kDefaultOptions), IsEmpty());
+}
+
+// A rank-6 input has no BHWDC representation.
+TEST_F(CumsumDimsTest, Rejects6dInput) {
+  StubContextBuilder context_builder;
+  const int input =
+      context_builder.AddTensor(kDefaultDtype, {2, 3, 4, 5, 6, 7});
+  const int axis = context_builder.AddConst1dTensor<int>(kTfLiteInt32, {5});
+  const int output =
+      context_builder.AddTensor(kDefaultDtype, {2, 3, 4, 5, 6, 7});
+  context_builder.SetOp(kTfLiteBuiltinCumsum, /*version=*/1,
+                        /*params=*/nullptr,
+                        /*inputs=*/{input, axis},
+                        /*outputs=*/{output});
+  TfLiteContext* context = context_builder.Build();
+  ASSERT_THAT(context, NotNull());
+  EXPECT_THAT(GetSupportedNodes(context, kDefaultOptions), IsEmpty());
+}
+
+// Rank 0 leaves no valid axis to accumulate over.
+TEST_F(CumsumDimsTest, RejectsScalarInput) {
+  StubContextBuilder context_builder;
+  const int input = context_builder.AddTensor(kDefaultDtype, {});
+  const int axis = context_builder.AddConst1dTensor<int>(kTfLiteInt32, {0});
+  const int output = context_builder.AddTensor(kDefaultDtype, {});
+  context_builder.SetOp(kTfLiteBuiltinCumsum, /*version=*/1,
+                        /*params=*/nullptr,
+                        /*inputs=*/{input, axis},
+                        /*outputs=*/{output});
+  TfLiteContext* context = context_builder.Build();
+  ASSERT_THAT(context, NotNull());
+  EXPECT_THAT(GetSupportedNodes(context, kDefaultOptions), IsEmpty());
+}
+
 }  // namespace
 }  // namespace litert::ml_drift::ir


### PR DESCRIPTION
`IsCumsumSupported()` never validated the rank of `inputs[0]`. It now requires rank 1..5, matching what the IR's BHWDC layout can represent. `ExtractAxisFromIndex()` indexed its lookup table without a bounds check. The table holds `min(rank, 5)` entries, so any axis outside `[-rank, rank)` read past its end. It now returns `Axis::UNKNOWN` instead. Add related tests for the changes.

see chromium issue: https://issues.chromium.org/issues/500050511